### PR TITLE
Add publication notes and audit tracking to Case admin

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django import forms
 from django.db import models
 from django.utils.html import format_html
+from django.utils import timezone
 from django.core.exceptions import ValidationError
 from tinymce.widgets import TinyMCE
 from .models import Case, DocumentSource, JawafEntity, CaseState, CaseType, Feedback
@@ -39,33 +40,44 @@ class CaseAdminForm(forms.ModelForm):
     """
     Custom form for Case admin with rich text editor and custom widgets.
     """
-    
+
     key_allegations = MultiTextField(
         required=False,
         button_label="Add Key Allegation",
         label="Key Allegations",
         help_text="List of key allegation statements"
     )
-    
+
     tags = MultiTextField(
         required=False,
         button_label="Add Tag",
         label="Tags",
         help_text="Tags for categorization"
     )
-    
+
     timeline = MultiTimelineField(
         required=False,
         label="Timeline",
         help_text="Timeline of events (add in reverse-chronological order: most recent first)"
     )
-    
+
     evidence = MultiEvidenceField(
         required=False,
         label="Evidence",
         help_text="Evidence entries with source references"
     )
-    
+
+    publication_notes = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 3}),
+        label="Publication / change notes",
+        help_text=(
+            "Optional internal notes about this publication or update "
+            "(e.g. who contributed, what changed). These will appear in the "
+            "case audit history."
+        ),
+    )
+
     class Meta:
         model = Case
         fields = '__all__'
@@ -78,27 +90,27 @@ class CaseAdminForm(forms.ModelForm):
         help_texts = {
             'state': 'Current workflow state: DRAFT (editable), IN_REVIEW (pending approval), PUBLISHED (public), CLOSED (archived)',
         }
-    
+
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request', None)
         super().__init__(*args, **kwargs)
-        
+
         # Populate evidence field with available sources based on user permissions
         if self.request:
             user = self.request.user
             sources_queryset = DocumentSource.objects.filter(is_deleted=False)
-            
+
             # Filter sources based on user role
             if not is_admin_or_moderator(user):
                 # Contributors see sources they're assigned to
                 if is_contributor(user):
                     sources_queryset = sources_queryset.filter(contributors=user)
-                    
+
                     # Also include sources already referenced in this case's evidence
                     if self.instance and self.instance.pk and self.instance.evidence:
                         existing_source_ids = [
-                            entry.get('source_id') 
-                            for entry in self.instance.evidence 
+                            entry.get('source_id')
+                            for entry in self.instance.evidence
                             if entry.get('source_id')
                         ]
                         if existing_source_ids:
@@ -111,15 +123,15 @@ class CaseAdminForm(forms.ModelForm):
                 else:
                     # No role - see nothing
                     sources_queryset = DocumentSource.objects.none()
-            
+
             sources = sources_queryset.values_list('source_id', 'title', 'url')
         else:
             # Fallback if no request (shouldn't happen in normal admin usage)
             sources = DocumentSource.objects.filter(is_deleted=False).values_list('source_id', 'title', 'url')
-        
+
         self.fields['evidence'].sources = list(sources)
         self.fields['evidence'].widget.sources = list(sources)
-        
+
         # Disable PUBLISHED and CLOSED states for Contributors
         if self.request:
             user = self.request.user
@@ -129,58 +141,58 @@ class CaseAdminForm(forms.ModelForm):
                 if state_field:
                     # Create custom choices with disabled options
                     state_field.widget.attrs['class'] = 'contributor-state-field'
-    
+
     def clean(self):
         """
         Validate state transitions, new case state requirements, and required fields.
         """
         cleaned_data = super().clean()
         errors = {}
-        
+
         # For new cases, enforce DRAFT state
         if not self.instance.pk:
             new_state = cleaned_data.get('state')
             if new_state != CaseState.DRAFT:
                 errors['state'] = f"New cases must be created in DRAFT state. Cannot create a new case with state {new_state}."
-        
+
         # Check state transitions for existing cases
         if self.instance.pk:
             old_state = Case.objects.get(pk=self.instance.pk).state
             new_state = cleaned_data.get('state')
-            
+
             if old_state != new_state and self.request:
                 if not can_transition_case_state(self.request.user, self.instance, new_state):
                     errors['state'] = f"You do not have permission to transition from {old_state} to {new_state}. Contributors can only transition between DRAFT and IN_REVIEW states."
-        
+
         # Validate required fields based on state
         new_state = cleaned_data.get('state')
-        
+
         # Always require title
         if not cleaned_data.get('title', '').strip():
             errors['title'] = "Title is required"
-        
+
         # Strict validation for IN_REVIEW and PUBLISHED states
         if new_state in [CaseState.IN_REVIEW, CaseState.PUBLISHED]:
             # Check alleged_entities (m2m field - check form data)
             alleged_entities = cleaned_data.get('alleged_entities')
             if not alleged_entities or alleged_entities.count() == 0:
                 errors['alleged_entities'] = "At least one alleged entity is required for IN_REVIEW or PUBLISHED state"
-            
+
             # Check key_allegations
             key_allegations = cleaned_data.get('key_allegations')
             if not key_allegations or len(key_allegations) == 0:
                 errors['key_allegations'] = "At least one key allegation is required for IN_REVIEW or PUBLISHED state"
-            
+
             # Check description
             description = cleaned_data.get('description', '').strip()
             if not description:
                 errors['description'] = "Description is required for IN_REVIEW or PUBLISHED state"
-        
+
         if errors:
             raise ValidationError(errors)
-        
+
         return cleaned_data
-    
+
 
 
 
@@ -192,7 +204,7 @@ class CaseAdminForm(forms.ModelForm):
 class CaseAdmin(admin.ModelAdmin):
     """
     Django Admin configuration for Case model.
-    
+
     Features:
     - Custom form with rich text editor
     - State transition controls with validation
@@ -200,15 +212,15 @@ class CaseAdmin(admin.ModelAdmin):
     - Contributor assignment
     - Role-based permissions
     """
-    
+
     form = CaseAdminForm
-    
+
     class Media:
         js = ('admin/js/case_admin.js',)
         css = {
             'all': ('admin/css/case_admin.css',)
         }
-    
+
     list_display = [
         'case_id',
         'version',
@@ -218,19 +230,19 @@ class CaseAdmin(admin.ModelAdmin):
         'created_at',
         'updated_at',
     ]
-    
+
     list_filter = [
         'state',
         'case_type',
         'created_at',
     ]
-    
+
     search_fields = [
         'case_id',
         'title',
         'description',
     ]
-    
+
     readonly_fields = [
         'case_id',
         'version',
@@ -238,7 +250,7 @@ class CaseAdmin(admin.ModelAdmin):
         'updated_at',
         'version_info_display',
     ]
-    
+
     fieldsets = (
         ('Basic Information', {
             'fields': (
@@ -285,13 +297,14 @@ class CaseAdmin(admin.ModelAdmin):
                 'created_at',
                 'updated_at',
                 'version_info_display',
+                'publication_notes',
             ),
             'classes': ('collapse',)
         }),
     )
-    
+
     filter_horizontal = ['contributors', 'alleged_entities', 'related_entities', 'locations']
-    
+
     def state_badge(self, obj):
         """Display state as a colored badge."""
         colors = {
@@ -307,92 +320,146 @@ class CaseAdmin(admin.ModelAdmin):
             obj.get_state_display()
         )
     state_badge.short_description = 'State'
-    
+
     def version_info_display(self, obj):
         """Display version info in a readable format."""
         if not obj.versionInfo:
             return "No version info"
-        
+
         info = obj.versionInfo
         html = "<div style='font-family: monospace;'>"
-        
+
         if 'version_number' in info:
             html += f"<strong>Version:</strong> {info['version_number']}<br>"
-        
+
         if 'action' in info:
             html += f"<strong>Action:</strong> {info['action']}<br>"
-        
+
         if 'datetime' in info:
             html += f"<strong>DateTime:</strong> {info['datetime']}<br>"
-        
+
         if 'source_version' in info:
             html += f"<strong>Source Version:</strong> {info['source_version']}<br>"
-        
+
         if 'user_id' in info:
             html += f"<strong>User ID:</strong> {info['user_id']}<br>"
-        
+
         if 'change_summary' in info:
             html += f"<strong>Summary:</strong> {info['change_summary']}<br>"
-        
+
         html += "</div>"
         return format_html(html)
     version_info_display.short_description = 'Version Info'
-    
+
     def get_queryset(self, request):
         """
         Filter queryset based on user role.
-        
+
         - Contributors: Only see assigned cases
         - Moderators/Admins: See all cases
         """
         qs = super().get_queryset(request)
-        
+
         # Admins and Moderators see everything
         if is_admin_or_moderator(request.user):
             return qs
-        
+
         # Contributors only see assigned cases
         if is_contributor(request.user):
             return qs.filter(contributors=request.user)
-        
+
         # No role - see nothing
         return qs.none()
-    
+
     def has_view_permission(self, request, obj=None):
         """
         Check if user can view a case.
-        
+
         - Contributors: Can only view assigned cases
         - Moderators/Admins: Can view all cases
         """
         if obj is None:
             return True
-        
+
         return can_view_case(request.user, obj)
-    
+
     def has_change_permission(self, request, obj=None):
         """
         Check if user can change a case.
-        
+
         - Contributors: Can only change assigned cases
         - Moderators/Admins: Can change all cases
         """
         if obj is None:
             return True
-        
+
         return can_change_case(request.user, obj)
-    
+
     def get_form(self, request, obj=None, **kwargs):
         """Pass request to form for role-based field customization."""
         form_class = super().get_form(request, obj, **kwargs)
-        
+
         class FormWithRequest(form_class):
             def __new__(cls, *args, **kwargs):
                 kwargs['request'] = request
                 return form_class(*args, **kwargs)
-        
+
         return FormWithRequest
-    
+
+    def save_model(self, request, obj, form, change):
+        """
+        Save the Case model and record audit information.
+
+        When a case changes workflow state (e.g. is published), we capture
+        an entry in versionInfo that will surface in the public API
+        audit_history field. Admins and moderators can optionally provide
+        publication notes via the publication_notes form field.
+        """
+        # Determine previous and new state
+        old_state = None
+        if change and obj.pk:
+            try:
+                old_state = Case.objects.get(pk=obj.pk).state
+            except Case.DoesNotExist:
+                old_state = None
+
+        new_state = form.cleaned_data.get('state', obj.state)
+        publication_notes = form.cleaned_data.get('publication_notes', '').strip()
+
+        # Decide what audit action to record
+        action = None
+        if not change:
+            # New cases start as drafts; record creation as draft_created
+            action = 'draft_created'
+        elif old_state != new_state:
+            if new_state == CaseState.IN_REVIEW:
+                action = 'submitted'
+            elif new_state == CaseState.PUBLISHED:
+                action = 'published'
+            elif new_state == CaseState.CLOSED:
+                action = 'deleted'
+
+        if action:
+            info = {
+                'version_number': obj.version,
+                'action': action,
+                'datetime': timezone.now().isoformat(),
+            }
+
+            # Attach user information for traceability
+            if request.user and request.user.is_authenticated:
+                info['user_id'] = str(request.user.id)
+                info['username'] = request.user.get_username()
+
+            # Optional human-readable notes
+            if publication_notes:
+                info['change_summary'] = publication_notes
+
+            obj.versionInfo = info
+
+        # Persist the object
+        super().save_model(request, obj, form, change)
+
     def save_related(self, request, form, formsets, change):
         """
         Save related objects (including many-to-many relationships).
@@ -400,17 +467,17 @@ class CaseAdmin(admin.ModelAdmin):
         """
         # First save the form's many-to-many data
         super().save_related(request, form, formsets, change)
-        
+
         # Then add creator to contributors for new cases
         if not change:
             form.instance.contributors.add(request.user)
-    
+
     def get_actions(self, request):
         """
         Get available actions based on user role.
         """
         actions = super().get_actions(request)
-        
+
         # Add custom actions for state transitions
         if is_admin_or_moderator(request.user):
             # Moderators and Admins can publish and close
@@ -424,9 +491,9 @@ class CaseAdmin(admin.ModelAdmin):
                 'close_cases',
                 'Close selected cases'
             )
-        
+
         return actions
-    
+
     def publish_cases(self, request, queryset):
         """
         Bulk action to publish cases.
@@ -439,10 +506,10 @@ class CaseAdmin(admin.ModelAdmin):
                     count += 1
             except ValidationError:
                 pass
-        
+
         self.message_user(request, f"{count} case(s) published successfully.")
     publish_cases.short_description = "Publish selected cases"
-    
+
     def close_cases(self, request, queryset):
         """
         Bulk action to close cases.
@@ -460,7 +527,7 @@ class DocumentSourceAdminForm(forms.ModelForm):
     """
     Custom form for DocumentSource admin with custom widgets.
     """
-    
+
     # Override url field to set assume_scheme and silence Django 6.0 warning
     url = forms.URLField(
         required=False,
@@ -468,39 +535,39 @@ class DocumentSourceAdminForm(forms.ModelForm):
         assume_scheme='https',
         help_text="Optional URL to the source"
     )
-    
+
     class Meta:
         model = DocumentSource
         fields = '__all__'
-    
+
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request', None)
         super().__init__(*args, **kwargs)
-        
+
         # Restrict contributors field visibility based on user role
         if self.request:
             user = self.request.user
-            
+
             # Only Moderators and Admins can edit contributors
             if not is_admin_or_moderator(user):
                 # Contributors cannot edit the contributors field
                 if 'contributors' in self.fields:
                     self.fields['contributors'].disabled = True
                     self.fields['contributors'].help_text = 'Only Moderators and Admins can assign contributors'
-    
+
     def clean(self):
         """
         Validate the form.
         """
         cleaned_data = super().clean()
-        
+
         # Validate title is not empty
         title = cleaned_data.get('title')
         if not title or not title.strip():
             raise ValidationError({
                 'title': 'Title is required and cannot be empty'
             })
-        
+
         return cleaned_data
 
 
@@ -508,39 +575,39 @@ class DocumentSourceAdminForm(forms.ModelForm):
 class DocumentSourceAdmin(admin.ModelAdmin):
     """
     Django Admin configuration for DocumentSource model.
-    
+
     Features:
     - Custom form with entity ID validation
     - Soft deletion interface
     - Role-based permissions
     """
-    
+
     form = DocumentSourceAdminForm
-    
+
     list_display = [
         'source_id',
         'title',
         'deletion_status',
         'created_at',
     ]
-    
+
     list_filter = [
         'is_deleted',
         'created_at',
     ]
-    
+
     search_fields = [
         'source_id',
         'title',
         'description',
     ]
-    
+
     readonly_fields = [
         'source_id',
         'created_at',
         'updated_at',
     ]
-    
+
     fieldsets = (
         ('Basic Information', {
             'fields': (
@@ -560,9 +627,9 @@ class DocumentSourceAdmin(admin.ModelAdmin):
             'classes': ('collapse',)
         }),
     )
-    
+
     filter_horizontal = ['related_entities', 'contributors']
-    
+
     def deletion_status(self, obj):
         """Display deletion status as a colored badge."""
         if obj.is_deleted:
@@ -575,30 +642,30 @@ class DocumentSourceAdmin(admin.ModelAdmin):
             'Active'
         )
     deletion_status.short_description = 'Status'
-    
+
     def get_queryset(self, request):
         """
         Filter queryset based on user role.
-        
+
         - Admins: See all sources (including deleted)
         - Moderators: Only see active sources (exclude deleted)
         - Contributors: See active sources they're assigned to OR sources referenced in their assigned cases
         """
         qs = super().get_queryset(request)
-        
+
         # Admins see everything including deleted
         if is_admin(request.user):
             return qs
-        
+
         # Moderators see all active sources
         if is_moderator(request.user):
             return qs.filter(is_deleted=False)
-        
+
         # Contributors see sources they're assigned to OR sources in their cases
         if is_contributor(request.user):
             # Get cases where user is a contributor
             user_cases = Case.objects.filter(contributors=request.user)
-            
+
             # Extract source_ids from evidence of user's cases
             source_ids_from_cases = set()
             for case in user_cases:
@@ -606,76 +673,76 @@ class DocumentSourceAdmin(admin.ModelAdmin):
                     for evidence_item in case.evidence:
                         if isinstance(evidence_item, dict) and 'source_id' in evidence_item:
                             source_ids_from_cases.add(evidence_item['source_id'])
-            
+
             # Return sources where user is contributor OR source is in their cases
             return qs.filter(
                 is_deleted=False
             ).filter(
                 models.Q(contributors=request.user) | models.Q(source_id__in=source_ids_from_cases)
             ).distinct()
-        
+
         # No role - see nothing
         return qs.none()
-    
+
     def get_list_filter(self, request):
         """
         Customize list filters based on user role.
-        
+
         - Admins: See is_deleted and created_at filters
         - Moderators: Only see created_at filter
         - Contributors: Only see created_at filter
         """
         if is_admin(request.user):
             return ['is_deleted', 'created_at']
-        
+
         # Moderators and Contributors only see created_at
         return ['created_at']
-    
+
     def has_view_permission(self, request, obj=None):
         """
         Check if user can view a source.
-        
+
         - Contributors: Can only view sources they're assigned to
         - Moderators/Admins: Can view all sources
         """
         if obj is None:
             return True
-        
+
         return can_view_source(request.user, obj)
-    
+
     def has_change_permission(self, request, obj=None):
         """
         Check if user can change a source.
-        
+
         - Contributors: Can only change sources they're directly assigned to (not case-based access)
         - Moderators/Admins: Can change all sources
         """
         if obj is None:
             return True
-        
+
         return can_change_source(request.user, obj)
-    
+
     def has_delete_permission(self, request, obj=None):
         """
         Prevent hard deletion - use soft deletion instead.
-        
+
         Hard deletion is disabled to preserve audit history.
         Users should set is_deleted=True instead.
         """
         # Disable hard deletion for all users
         return False
-    
+
     def get_form(self, request, obj=None, **kwargs):
         """Pass request to form for filtering case dropdown."""
         form_class = super().get_form(request, obj, **kwargs)
-        
+
         class FormWithRequest(form_class):
             def __new__(cls, *args, **kwargs):
                 kwargs['request'] = request
                 return form_class(*args, **kwargs)
-        
+
         return FormWithRequest
-    
+
     def save_model(self, request, obj, form, change):
         """
         Save the model with validation.
@@ -686,9 +753,9 @@ class DocumentSourceAdmin(admin.ModelAdmin):
         except ValidationError as e:
             # Re-raise with form context
             raise ValidationError(e.message_dict if hasattr(e, 'message_dict') else str(e))
-        
+
         super().save_model(request, obj, form, change)
-    
+
     def save_related(self, request, form, formsets, change):
         """
         Save related objects (including many-to-many relationships).
@@ -696,21 +763,21 @@ class DocumentSourceAdmin(admin.ModelAdmin):
         """
         # First save the form's many-to-many data
         super().save_related(request, form, formsets, change)
-        
+
         # Then add creator to contributors for new sources
         if not change:
             form.instance.contributors.add(request.user)
-    
+
     def get_actions(self, request):
         """
         Get available actions based on user role.
         """
         actions = super().get_actions(request)
-        
+
         # Remove default delete action (we use soft delete)
         if 'delete_selected' in actions:
             del actions['delete_selected']
-        
+
         # Add soft delete action
         if is_admin_or_moderator(request.user):
             actions['soft_delete_sources'] = (
@@ -723,9 +790,9 @@ class DocumentSourceAdmin(admin.ModelAdmin):
                 'restore_sources',
                 'Restore selected sources'
             )
-        
+
         return actions
-    
+
     def soft_delete_sources(self, request, queryset):
         """
         Bulk action to soft delete sources.
@@ -733,7 +800,7 @@ class DocumentSourceAdmin(admin.ModelAdmin):
         count = queryset.update(is_deleted=True)
         self.message_user(request, f"{count} source(s) marked as deleted.")
     soft_delete_sources.short_description = "Mark selected sources as deleted"
-    
+
     def restore_sources(self, request, queryset):
         """
         Bulk action to restore soft-deleted sources.
@@ -750,55 +817,55 @@ class DocumentSourceAdmin(admin.ModelAdmin):
 class CustomUserAdmin(BaseUserAdmin):
     """
     Custom User admin to prevent Moderators from managing other Moderators.
-    
+
     Property 14: Moderators cannot manage other Moderators in Django Admin
     """
-    
+
     def get_queryset(self, request):
         """
         Filter queryset based on user role.
-        
+
         - Admins: See all users
         - Moderators: See all users except other Moderators
         - Others: See nothing
         """
         qs = super().get_queryset(request)
-        
+
         # Admins see everything
         if is_admin(request.user):
             return qs
-        
+
         # Moderators see all users except other Moderators
         if is_moderator(request.user):
             # Exclude users who are in the Moderator group
             moderator_group_users = User.objects.filter(groups__name='Moderator').values_list('id', flat=True)
             return qs.exclude(id__in=moderator_group_users)
-        
+
         # Others see nothing
         return qs.none()
-    
+
     def has_change_permission(self, request, obj=None):
         """
         Check if user can change another user.
-        
+
         - Admins: Can change all users
         - Moderators: Cannot change other Moderators
         """
         if obj is None:
             return True
-        
+
         return can_manage_user(request.user, obj)
-    
+
     def has_delete_permission(self, request, obj=None):
         """
         Check if user can delete another user.
-        
+
         - Admins: Can delete users
         - Moderators: Cannot delete other Moderators
         """
         if obj is None:
             return True
-        
+
         return can_manage_user(request.user, obj)
 
 
@@ -815,11 +882,11 @@ class JawafEntityAdminForm(forms.ModelForm):
     """
     Custom form for JawafEntity admin with validation.
     """
-    
+
     class Meta:
         model = JawafEntity
         fields = '__all__'
-    
+
     def clean(self):
         """
         Validate entity data.
@@ -827,11 +894,11 @@ class JawafEntityAdminForm(forms.ModelForm):
         cleaned_data = super().clean()
         nes_id = cleaned_data.get('nes_id')
         display_name = cleaned_data.get('display_name')
-        
+
         # Check that at least one is provided
         if not nes_id and not display_name:
             raise ValidationError("Entity must have either NES ID or Display Name")
-        
+
         return cleaned_data
 
 
@@ -840,30 +907,30 @@ class JawafEntityAdmin(admin.ModelAdmin):
     """
     Django Admin configuration for JawafEntity model.
     """
-    
+
     form = JawafEntityAdminForm
-    
+
     list_display = [
         'id',
         'nes_id',
         'display_name',
         'created_at',
     ]
-    
+
     list_filter = [
         'created_at',
     ]
-    
+
     search_fields = [
         'nes_id',
         'display_name',
     ]
-    
+
     readonly_fields = [
         'created_at',
         'updated_at',
     ]
-    
+
     fieldsets = (
         ('Entity Information', {
             'fields': (
@@ -895,7 +962,7 @@ admin.site.index_title = "Welcome to Jawafdehi Contributor Portal"
 @admin.register(Feedback)
 class FeedbackAdmin(admin.ModelAdmin):
     """Admin interface for Feedback model."""
-    
+
     list_display = [
         'id',
         'feedback_type',
@@ -907,7 +974,7 @@ class FeedbackAdmin(admin.ModelAdmin):
     list_filter = ['feedback_type', 'status', 'submitted_at']
     search_fields = ['subject', 'description', 'related_page']
     readonly_fields = ['submitted_at', 'updated_at', 'ip_address', 'user_agent']
-    
+
     fieldsets = (
         ('Feedback Details', {
             'fields': ('feedback_type', 'subject', 'description', 'related_page')
@@ -924,7 +991,7 @@ class FeedbackAdmin(admin.ModelAdmin):
             'classes': ('collapse',)
         }),
     )
-    
+
     def has_contact_info(self, obj):
         """Check if feedback has contact information."""
         return bool(obj.contact_info and obj.contact_info.get('contactMethods'))


### PR DESCRIPTION
# Summary

This pull request enhances the Django Admin workflow for `Case` by automatically capturing structured audit information during case creation and state transitions, and exposing that data through the public API’s `audit_history`.

# Key Changes

## Admin UI Enhancements
- Added a new non-model admin form field: `publication_notes` (textarea).
- Field is displayed under the **Metadata** section of the Case admin.
- Intended for moderators/admins to record publication or state-change context (e.g., “Published by Alice; contributors: Bob, Carol”).

## Automated Audit Tracking on Save
- Updated `CaseAdmin.save_model` to detect state transitions by comparing the previous and new case state.
- On save, `versionInfo` is automatically populated with a structured audit entry.

### Supported Actions
- **New case created** → `draft_created`
- **State → IN_REVIEW** → `submitted`
- **State → PUBLISHED** → `published`
- **State → CLOSED** → `deleted`

### Captured Audit Metadata
Each audit entry written to `versionInfo` includes:
- `version_number`: current `Case.version`
- `action`: derived from the detected state transition
- `datetime`: ISO-8601 timestamp (`timezone.now().isoformat()`)
- `user_id`: ID of the admin user performing the action
- `username`: username of the admin user
- `change_summary`: contents of `publication_notes` (if provided)

## API Behavior
- Because `versionInfo` is now populated on admin-driven saves, `CaseDetailSerializer.get_audit_history()` will include these entries in the `audit_history` field.
- Audit history is now automatically exposed for cases created or transitioned via the Django admin.

# Backward Compatibility / Existing Data
- Existing cases with empty `versionInfo` (e.g., Case 175) will continue to show an empty `audit_history`.
- A new audit entry will be recorded the next time such a case is saved with a qualifying state transition.
- Optional follow-up: a management command can be added to backfill minimal `versionInfo` for previously published cases.

# Result
Admin and moderator actions in Django Admin now produce a consistent, structured, and user-attributed audit trail that is visible via the public API, with optional human-readable change notes.
