### PR TITLE
feat(cases): add slug field with slug-based case routing

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -360,7 +360,7 @@ class CaseAdmin(admin.ModelAdmin):
         css = {"all": ("admin/css/case_admin.css",)}
 
     list_display = [
-        "slug_link",
+        "case_link",
         "title",
         "case_type",
         "state_badge",
@@ -464,7 +464,7 @@ class CaseAdmin(admin.ModelAdmin):
 
     state_badge.short_description = "State"
 
-    def slug_link(self, obj):
+    def case_link(self, obj):
         """Display slug as an external link to the public case details page."""
         if not obj.slug:
             return "-"
@@ -474,8 +474,8 @@ class CaseAdmin(admin.ModelAdmin):
             obj.slug,
         )
 
-    slug_link.short_description = "Slug"
-    slug_link.admin_order_field = "slug"
+    case_link.short_description = "Case"
+    case_link.admin_order_field = "slug"
 
     def version_info_display(self, obj):
         """Display version info in a readable format."""

--- a/cases/admin.py
+++ b/cases/admin.py
@@ -244,6 +244,10 @@ class CaseAdminForm(forms.ModelForm):
                     "Description is required for IN_REVIEW or PUBLISHED state"
                 )
 
+        if new_state == CaseState.PUBLISHED:
+            if not (cleaned_data.get("slug") or "").strip():
+                errors["slug"] = "Slug is required before publishing a case"
+
         if errors:
             raise ValidationError(errors)
 
@@ -356,13 +360,14 @@ class CaseAdmin(admin.ModelAdmin):
         css = {"all": ("admin/css/case_admin.css",)}
 
     list_display = [
-        "case_id",
+        "slug_link",
         "title",
         "case_type",
         "state_badge",
         "created_at",
         "updated_at",
     ]
+    list_display_links = ["title"]
 
     list_filter = [
         "state",
@@ -371,6 +376,7 @@ class CaseAdmin(admin.ModelAdmin):
     ]
 
     search_fields = [
+        "slug",
         "case_id",
         "title",
         "description",
@@ -389,6 +395,7 @@ class CaseAdmin(admin.ModelAdmin):
             {
                 "fields": (
                     "case_id",
+                    "slug",
                     "title",
                     "short_description",
                     "thumbnail_url",
@@ -456,6 +463,19 @@ class CaseAdmin(admin.ModelAdmin):
         )
 
     state_badge.short_description = "State"
+
+    def slug_link(self, obj):
+        """Display slug as an external link to the public case details page."""
+        if not obj.slug:
+            return "-"
+        return format_html(
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
+            f"https://jawafdehi.org/case/{obj.slug}",
+            obj.slug,
+        )
+
+    slug_link.short_description = "Slug"
+    slug_link.admin_order_field = "slug"
 
     def version_info_display(self, obj):
         """Display version info in a readable format."""

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -5,6 +5,7 @@ See: .kiro/specs/accountability-platform-core/design.md
 """
 
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db import connection, transaction
 from django.http import Http404
 from django.utils import timezone
@@ -39,7 +40,11 @@ from .models import (
     JawafEntity,
     RelationshipType,
 )
-from .rules.predicates import can_change_case, can_view_case
+from .rules.predicates import (
+    can_change_case,
+    can_transition_case_state,
+    can_view_case,
+)
 from .serializers import (
     CaseDetailSerializer,
     CaseSerializer,
@@ -340,7 +345,7 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
         snapshot of the case. The snapshot is validated after patching, then scalar
         fields are saved via a bulk UPDATE and M2M relations are updated with .set().
 
-        Blocked paths (id, case_id, version, state, contributors, timestamps,
+        Blocked paths (id, case_id, version, contributors, timestamps,
         versionInfo) are rejected before the patch is applied.
         """
         try:
@@ -368,6 +373,15 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             path = op.get("path", "")
+
+            if path == "/state" and op.get("op") != "replace":
+                return Response(
+                    {
+                        "detail": "State transition must use a 'replace' operation on '/state'."
+                    },
+                    status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                )
+
             for blocked in BLOCKED_PATH_PREFIXES:
                 if path == blocked or path.startswith(blocked + "/"):
                     return Response(
@@ -389,6 +403,19 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
 
         validated = serializer.validated_data
 
+        target_state = validated.get("state")
+        if target_state is not None and not can_transition_case_state(
+            request.user, case, target_state
+        ):
+            return Response(
+                {"detail": "Permission denied for requested state transition."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        # Note: only IN_REVIEW transitions are supported by this endpoint today.
+        # Admins/moderators may be allowed other transitions in future PRs.
+        # Non-IN_REVIEW targets will be rejected with 422 below even if the
+        # permission check above passes.
+
         # Fields that map directly to Case model columns (updated via bulk UPDATE)
         scalar_fields = frozenset(
             [
@@ -406,43 +433,63 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             ]
         )
 
-        # Persist scalar field changes
-        scalar_updates = {
-            field: validated[field] for field in scalar_fields if field in validated
-        }
-        if scalar_updates:
-            Case.objects.filter(pk=pk).update(**scalar_updates)
+        with transaction.atomic():
+            # Persist scalar field changes
+            scalar_updates = {
+                field: validated[field] for field in scalar_fields if field in validated
+            }
+            if scalar_updates:
+                Case.objects.filter(pk=pk).update(**scalar_updates)
 
-        # Persist entity relationship changes
-        case.refresh_from_db()
-        if "alleged_entity_ids" in validated:
-            case.entity_relationships.filter(
-                relationship_type=RelationshipType.ACCUSED
-            ).delete()
-            for entity_id in validated["alleged_entity_ids"]:
-                CaseEntityRelationship.objects.create(
-                    case=case,
-                    entity_id=entity_id,
-                    relationship_type=RelationshipType.ACCUSED,
-                )
-        if "related_entity_ids" in validated:
-            case.entity_relationships.filter(
-                relationship_type=RelationshipType.RELATED
-            ).delete()
-            for entity_id in validated["related_entity_ids"]:
-                CaseEntityRelationship.objects.create(
-                    case=case,
-                    entity_id=entity_id,
-                    relationship_type=RelationshipType.RELATED,
-                )
+            # Persist entity relationship changes
+            case.refresh_from_db()
+            if "alleged_entity_ids" in validated:
+                case.entity_relationships.filter(
+                    relationship_type=RelationshipType.ACCUSED
+                ).delete()
+                for entity_id in validated["alleged_entity_ids"]:
+                    CaseEntityRelationship.objects.create(
+                        case=case,
+                        entity_id=entity_id,
+                        relationship_type=RelationshipType.ACCUSED,
+                    )
+            if "related_entity_ids" in validated:
+                case.entity_relationships.filter(
+                    relationship_type=RelationshipType.RELATED
+                ).delete()
+                for entity_id in validated["related_entity_ids"]:
+                    CaseEntityRelationship.objects.create(
+                        case=case,
+                        entity_id=entity_id,
+                        relationship_type=RelationshipType.RELATED,
+                    )
 
-        case.refresh_from_db()
+            case.refresh_from_db()
+
+            if target_state is not None and target_state != case.state:
+                if target_state == CaseState.IN_REVIEW:
+                    try:
+                        case.submit()
+                    except ValidationError as exc:
+                        detail = getattr(exc, "message_dict", None) or {
+                            "detail": exc.messages
+                        }
+                        return Response(detail, status=status.HTTP_400_BAD_REQUEST)
+                else:
+                    return Response(
+                        {
+                            "detail": "Only transitions to IN_REVIEW are supported via this endpoint."
+                        },
+                        status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    )
+
         return Response(CaseSerializer(case).data, status=status.HTTP_200_OK)
 
     def _build_snapshot(self, case: Case) -> dict:
         """Return a writable dict representing the patchable surface of a case."""
         return {
             "title": case.title,
+            "state": case.state,
             "short_description": case.short_description,
             "description": case.description,
             "thumbnail_url": case.thumbnail_url,

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -5,8 +5,8 @@ See: .kiro/specs/accountability-platform-core/design.md
 """
 
 from django.core.cache import cache
-from django.core.exceptions import ValidationError
 from django.db import connection, transaction
+from django.http import Http404
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
@@ -39,11 +39,7 @@ from .models import (
     JawafEntity,
     RelationshipType,
 )
-from .rules.predicates import (
-    can_change_case,
-    can_transition_case_state,
-    can_view_case,
-)
+from .rules.predicates import can_change_case, can_view_case
 from .serializers import (
     CaseDetailSerializer,
     CaseSerializer,
@@ -162,6 +158,31 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_fields = ["case_type"]
     search_fields = ["title", "description", "key_allegations"]
     authentication_classes = [TokenAuthentication]
+
+    def get_object(self):
+        """
+        Resolve case by numeric primary key or slug.
+
+        Endpoint compatibility:
+        - /cases/{id}/ for numeric IDs
+        - /cases/{slug}/ for slug-based access
+        """
+        lookup_value = str(self.kwargs.get(self.lookup_field or "pk", "")).strip()
+        queryset = self.filter_queryset(self.get_queryset())
+
+        if not lookup_value:
+            raise Http404
+
+        if lookup_value.isdigit():
+            obj = queryset.filter(pk=int(lookup_value)).first()
+        else:
+            obj = queryset.filter(slug=lookup_value).first()
+
+        if obj is None:
+            raise Http404
+
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     def get_permissions(self):
         """
@@ -319,7 +340,7 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
         snapshot of the case. The snapshot is validated after patching, then scalar
         fields are saved via a bulk UPDATE and M2M relations are updated with .set().
 
-        Blocked paths (id, case_id, version, contributors, timestamps,
+        Blocked paths (id, case_id, version, state, contributors, timestamps,
         versionInfo) are rejected before the patch is applied.
         """
         try:
@@ -347,15 +368,6 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             path = op.get("path", "")
-
-            if path == "/state" and op.get("op") != "replace":
-                return Response(
-                    {
-                        "detail": "State transition must use a 'replace' operation on '/state'."
-                    },
-                    status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                )
-
             for blocked in BLOCKED_PATH_PREFIXES:
                 if path == blocked or path.startswith(blocked + "/"):
                     return Response(
@@ -377,19 +389,6 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
 
         validated = serializer.validated_data
 
-        target_state = validated.get("state")
-        if target_state is not None and not can_transition_case_state(
-            request.user, case, target_state
-        ):
-            return Response(
-                {"detail": "Permission denied for requested state transition."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
-        # Note: only IN_REVIEW transitions are supported by this endpoint today.
-        # Admins/moderators may be allowed other transitions in future PRs.
-        # Non-IN_REVIEW targets will be rejected with 422 below even if the
-        # permission check above passes.
-
         # Fields that map directly to Case model columns (updated via bulk UPDATE)
         scalar_fields = frozenset(
             [
@@ -407,63 +406,43 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             ]
         )
 
-        with transaction.atomic():
-            # Persist scalar field changes
-            scalar_updates = {
-                field: validated[field] for field in scalar_fields if field in validated
-            }
-            if scalar_updates:
-                Case.objects.filter(pk=pk).update(**scalar_updates)
+        # Persist scalar field changes
+        scalar_updates = {
+            field: validated[field] for field in scalar_fields if field in validated
+        }
+        if scalar_updates:
+            Case.objects.filter(pk=pk).update(**scalar_updates)
 
-            # Persist entity relationship changes
-            case.refresh_from_db()
-            if "alleged_entity_ids" in validated:
-                case.entity_relationships.filter(
-                    relationship_type=RelationshipType.ACCUSED
-                ).delete()
-                for entity_id in validated["alleged_entity_ids"]:
-                    CaseEntityRelationship.objects.create(
-                        case=case,
-                        entity_id=entity_id,
-                        relationship_type=RelationshipType.ACCUSED,
-                    )
-            if "related_entity_ids" in validated:
-                case.entity_relationships.filter(
-                    relationship_type=RelationshipType.RELATED
-                ).delete()
-                for entity_id in validated["related_entity_ids"]:
-                    CaseEntityRelationship.objects.create(
-                        case=case,
-                        entity_id=entity_id,
-                        relationship_type=RelationshipType.RELATED,
-                    )
+        # Persist entity relationship changes
+        case.refresh_from_db()
+        if "alleged_entity_ids" in validated:
+            case.entity_relationships.filter(
+                relationship_type=RelationshipType.ACCUSED
+            ).delete()
+            for entity_id in validated["alleged_entity_ids"]:
+                CaseEntityRelationship.objects.create(
+                    case=case,
+                    entity_id=entity_id,
+                    relationship_type=RelationshipType.ACCUSED,
+                )
+        if "related_entity_ids" in validated:
+            case.entity_relationships.filter(
+                relationship_type=RelationshipType.RELATED
+            ).delete()
+            for entity_id in validated["related_entity_ids"]:
+                CaseEntityRelationship.objects.create(
+                    case=case,
+                    entity_id=entity_id,
+                    relationship_type=RelationshipType.RELATED,
+                )
 
-            case.refresh_from_db()
-
-            if target_state is not None and target_state != case.state:
-                if target_state == CaseState.IN_REVIEW:
-                    try:
-                        case.submit()
-                    except ValidationError as exc:
-                        detail = getattr(exc, "message_dict", None) or {
-                            "detail": exc.messages
-                        }
-                        return Response(detail, status=status.HTTP_400_BAD_REQUEST)
-                else:
-                    return Response(
-                        {
-                            "detail": "Only transitions to IN_REVIEW are supported via this endpoint."
-                        },
-                        status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    )
-
+        case.refresh_from_db()
         return Response(CaseSerializer(case).data, status=status.HTTP_200_OK)
 
     def _build_snapshot(self, case: Case) -> dict:
         """Return a writable dict representing the patchable surface of a case."""
         return {
             "title": case.title,
-            "state": case.state,
             "short_description": case.short_description,
             "description": case.description,
             "thumbnail_url": case.thumbnail_url,

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -23,7 +23,6 @@ BLOCKED_PATH_PREFIXES = frozenset(
         "/case_id",
         "/case_type",
         "/version",
-        "/state",
         "/contributors",
         "/created_at",
         "/updated_at",
@@ -142,6 +141,7 @@ class CasePatchSerializer(CaseEntityValidationMixin, serializers.Serializer):
     key_allegations = serializers.ListField(
         child=serializers.CharField(), required=False
     )
+    state = serializers.ChoiceField(choices=CaseState.choices, required=False)
     timeline = TimelineItemSerializer(many=True, required=False)
     evidence = EvidenceItemSerializer(many=True, required=False)
     alleged_entity_ids = serializers.ListField(

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -102,7 +102,7 @@ class CaseCreateSerializer(CaseEntityValidationMixin, serializers.Serializer):
         default=CaseState.DRAFT,
     )
     title = serializers.CharField(max_length=200)
-    slug = serializers.CharField(max_length=50, required=False, allow_blank=True)
+    slug = serializers.CharField(max_length=100, required=False, allow_blank=True)
     short_description = serializers.CharField(required=False, allow_blank=True)
     description = serializers.CharField(required=False, allow_blank=True)
     thumbnail_url = serializers.URLField(
@@ -128,7 +128,7 @@ class CaseCreateSerializer(CaseEntityValidationMixin, serializers.Serializer):
 
 class CasePatchSerializer(CaseEntityValidationMixin, serializers.Serializer):
     title = serializers.CharField(max_length=200)
-    slug = serializers.CharField(max_length=50, required=False, allow_blank=True)
+    slug = serializers.CharField(max_length=100, required=False, allow_blank=True)
     short_description = serializers.CharField(required=False, allow_blank=True)
     description = serializers.CharField(required=False, allow_blank=True)
     thumbnail_url = serializers.URLField(

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -23,6 +23,7 @@ BLOCKED_PATH_PREFIXES = frozenset(
         "/case_id",
         "/case_type",
         "/version",
+        "/state",
         "/contributors",
         "/created_at",
         "/updated_at",
@@ -101,6 +102,7 @@ class CaseCreateSerializer(CaseEntityValidationMixin, serializers.Serializer):
         default=CaseState.DRAFT,
     )
     title = serializers.CharField(max_length=200)
+    slug = serializers.CharField(max_length=50, required=False, allow_blank=True)
     short_description = serializers.CharField(required=False, allow_blank=True)
     description = serializers.CharField(required=False, allow_blank=True)
     thumbnail_url = serializers.URLField(
@@ -125,8 +127,8 @@ class CaseCreateSerializer(CaseEntityValidationMixin, serializers.Serializer):
 
 
 class CasePatchSerializer(CaseEntityValidationMixin, serializers.Serializer):
-    state = serializers.ChoiceField(choices=CaseState.choices, required=False)
     title = serializers.CharField(max_length=200)
+    slug = serializers.CharField(max_length=50, required=False, allow_blank=True)
     short_description = serializers.CharField(required=False, allow_blank=True)
     description = serializers.CharField(required=False, allow_blank=True)
     thumbnail_url = serializers.URLField(

--- a/cases/migrations/0018_case_slug.py
+++ b/cases/migrations/0018_case_slug.py
@@ -16,17 +16,17 @@ class Migration(migrations.Migration):
                 blank=True,
                 db_index=True,
                 help_text=(
-                    "A slug will go in the URL. For CIAA corruption cases, you can prepend the "
-                    "special court case number (e.g. case-case-078-WC-0123-sunil-poudel)."
+                    "A slug will go in the URL. For CIAA corruption cases, prefix with the "
+                    "special court case number (e.g. 078-WC-0123-sunil-poudel)."
                 ),
-                max_length=50,
+                max_length=100,
                 null=True,
                 unique=True,
                 validators=[
                     RegexValidator(
-                        regex=r"^(?!\d)[A-Za-z0-9-]{1,50}$",
+                        regex=r"^(?!\d)[A-Za-z0-9-]{1,100}$",
                         message=(
-                            "Slug must be 1-50 characters, can only use letters, numbers, and '-', "
+                            "Slug must be 1-100 characters, can only use letters, numbers, and '-', "
                             "and cannot start with a digit."
                         ),
                     )

--- a/cases/migrations/0018_case_slug.py
+++ b/cases/migrations/0018_case_slug.py
@@ -1,0 +1,36 @@
+from django.core.validators import RegexValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cases", "0017_feedback_attachment"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="case",
+            name="slug",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text=(
+                    "A slug will go in the URL. For CIAA corruption cases, you can prepend the "
+                    "special court case number (e.g. case-case-078-WC-0123-sunil-poudel)."
+                ),
+                max_length=50,
+                null=True,
+                unique=True,
+                validators=[
+                    RegexValidator(
+                        regex=r"^(?!\d)[A-Za-z0-9-]{1,50}$",
+                        message=(
+                            "Slug must be 1-50 characters, can only use letters, numbers, and '-', "
+                            "and cannot start with a digit."
+                        ),
+                    )
+                ],
+            ),
+        ),
+    ]

--- a/cases/models.py
+++ b/cases/models.py
@@ -416,23 +416,23 @@ class Case(models.Model):
         blank=True, help_text="Short description/summary of the case"
     )
     slug = models.CharField(
-        max_length=50,
+        max_length=100,
         unique=True,
         blank=True,
         null=True,
         db_index=True,
         validators=[
             RegexValidator(
-                regex=r"^(?!\d)[A-Za-z0-9-]{1,50}$",
+                regex=r"^(?!\d)[A-Za-z0-9-]{1,100}$",
                 message=(
-                    "Slug must be 1-50 characters, can only use letters, numbers, and '-', "
+                    "Slug must be 1-100 characters, can only use letters, numbers, and '-', "
                     "and cannot start with a digit."
                 ),
             )
         ],
         help_text=(
-            "A slug will go in the URL. For CIAA corruption cases, you can prepend the "
-            "special court case number (e.g. case-case-078-WC-0123-sunil-poudel)."
+            "A slug will go in the URL. For CIAA corruption cases, prefix with the "
+            "special court case number (e.g. 078-WC-0123-sunil-poudel)."
         ),
     )
     thumbnail_url = models.URLField(

--- a/cases/models.py
+++ b/cases/models.py
@@ -7,9 +7,10 @@ See: .kiro/specs/accountability-platform-core/design.md
 from django.db import models
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
+from django.core.validators import RegexValidator, URLValidator
 from django.utils import timezone
 import mimetypes
+import re
 import uuid
 
 from .fields import (
@@ -414,6 +415,26 @@ class Case(models.Model):
     short_description = models.TextField(
         blank=True, help_text="Short description/summary of the case"
     )
+    slug = models.CharField(
+        max_length=50,
+        unique=True,
+        blank=True,
+        null=True,
+        db_index=True,
+        validators=[
+            RegexValidator(
+                regex=r"^(?!\d)[A-Za-z0-9-]{1,50}$",
+                message=(
+                    "Slug must be 1-50 characters, can only use letters, numbers, and '-', "
+                    "and cannot start with a digit."
+                ),
+            )
+        ],
+        help_text=(
+            "A slug will go in the URL. For CIAA corruption cases, you can prepend the "
+            "special court case number (e.g. case-case-078-WC-0123-sunil-poudel)."
+        ),
+    )
     thumbnail_url = models.URLField(
         blank=True,
         max_length=500,
@@ -447,7 +468,6 @@ class Case(models.Model):
     key_allegations = TextListField(
         blank=True, help_text="List of key allegation statements"
     )
-
     # Structured data fields
     timeline = TimelineListField(help_text="List of timeline entries")
     evidence = EvidenceListField(
@@ -506,6 +526,8 @@ class Case(models.Model):
             # Generate unique case_id for new cases
             self.case_id = f"case-{uuid.uuid4().hex[:12]}"
 
+        self.slug = (self.slug or "").strip() or None
+
         # Validate title is not empty
         if not self.title or not self.title.strip():
             raise ValidationError("Title cannot be empty")
@@ -544,6 +566,15 @@ class Case(models.Model):
             if not self.description or not self.description.strip():
                 errors["description"] = (
                     "Description is required for IN_REVIEW or PUBLISHED state"
+                )
+
+        # Slug is mandatory before publishing.
+        if self.state == CaseState.PUBLISHED:
+            if not self.slug:
+                errors["slug"] = "Slug is required before publishing a case"
+            elif self.slug.isnumeric() or re.match(r"^\d", self.slug):
+                errors["slug"] = (
+                    "Slug cannot be purely numeric and cannot start with a digit"
                 )
 
         if errors:

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -6,7 +6,7 @@ See: .kiro/specs/accountability-platform-core/design.md
 
 import logging
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field, inline_serializer
+from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 from .models import (
     Case,
@@ -28,49 +28,59 @@ class JawafEntitySerializer(serializers.ModelSerializer):
     Uses the unified system to get case relationships.
     """
 
+    alleged_cases = serializers.SerializerMethodField(
+        help_text="List of case IDs where this entity is alleged"
+    )
     related_cases = serializers.SerializerMethodField(
-        help_text="List of related case entries with case_id, relation_type, and notes"
+        help_text="List of case IDs where this entity is related or a location"
     )
 
     class Meta:
         model = JawafEntity
-        fields = ["id", "nes_id", "display_name", "related_cases"]
+        fields = ["id", "nes_id", "display_name", "alleged_cases", "related_cases"]
 
-    @extend_schema_field(
-        inline_serializer(
-            name="RelatedCaseEntry",
-            fields={
-                "case_id": serializers.IntegerField(),
-                "relation_type": serializers.CharField(),
-                "notes": serializers.CharField(allow_null=True),
-            },
-            many=True,
-        )
-    )
-    def get_related_cases(self, obj):
+    @extend_schema_field(OpenApiTypes.OBJECT)
+    def get_alleged_cases(self, obj):
         """
-        Get related case entries for this entity.
+        Get list of case IDs where this entity is alleged.
 
         Only includes PUBLISHED cases. Uses the unified relationship system.
-        Each entry includes relation metadata required by the frontend.
         """
-        relationships = (
-            CaseEntityRelationship.objects.filter(
-                entity=obj,
-                case__state=CaseState.PUBLISHED,
-            )
-            .select_related("case")
-            .order_by("-case_id", "relationship_type")
+        from .models import RelationshipType
+
+        # Get cases where this entity has an 'alleged' relationship
+        cases = Case.objects.filter(
+            entity_relationships__entity=obj,
+            entity_relationships__relationship_type=RelationshipType.ACCUSED,
+            state=CaseState.PUBLISHED,
         )
 
-        return [
-            {
-                "case_id": relationship.case_id,
-                "relation_type": relationship.relationship_type,
-                "notes": relationship.notes,
-            }
-            for relationship in relationships
-        ]
+        return list(cases.values_list("id", flat=True))
+
+    @extend_schema_field(OpenApiTypes.OBJECT)
+    def get_related_cases(self, obj):
+        """
+        Get list of case IDs where this entity is related.
+
+        Only includes PUBLISHED cases. Uses the unified relationship system.
+        Excludes cases where entity is already alleged (to avoid duplicates).
+        """
+        from .models import RelationshipType
+
+        # Get alleged case IDs to exclude
+        alleged_case_ids = Case.objects.filter(
+            entity_relationships__entity=obj,
+            entity_relationships__relationship_type=RelationshipType.ACCUSED,
+            state=CaseState.PUBLISHED,
+        ).values_list("id", flat=True)
+
+        # Get related cases from unified system
+        related_cases = Case.objects.filter(
+            entity_relationships__entity=obj,
+            entity_relationships__relationship_type=RelationshipType.RELATED,
+            state=CaseState.PUBLISHED,
+        ).exclude(id__in=alleged_case_ids)
+        return list(related_cases.values_list("id", flat=True))
 
 
 class CaseEntityRelationshipSerializer(serializers.ModelSerializer):
@@ -219,6 +229,7 @@ class CaseSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "case_id",
+            "slug",
             "case_type",
             "state",
             "title",

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -6,7 +6,7 @@ See: .kiro/specs/accountability-platform-core/design.md
 
 import logging
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, inline_serializer
 from drf_spectacular.types import OpenApiTypes
 from .models import (
     Case,
@@ -28,59 +28,49 @@ class JawafEntitySerializer(serializers.ModelSerializer):
     Uses the unified system to get case relationships.
     """
 
-    alleged_cases = serializers.SerializerMethodField(
-        help_text="List of case IDs where this entity is alleged"
-    )
     related_cases = serializers.SerializerMethodField(
-        help_text="List of case IDs where this entity is related or a location"
+        help_text="List of related case entries with case_id, relation_type, and notes"
     )
 
     class Meta:
         model = JawafEntity
-        fields = ["id", "nes_id", "display_name", "alleged_cases", "related_cases"]
+        fields = ["id", "nes_id", "display_name", "related_cases"]
 
-    @extend_schema_field(OpenApiTypes.OBJECT)
-    def get_alleged_cases(self, obj):
-        """
-        Get list of case IDs where this entity is alleged.
-
-        Only includes PUBLISHED cases. Uses the unified relationship system.
-        """
-        from .models import RelationshipType
-
-        # Get cases where this entity has an 'alleged' relationship
-        cases = Case.objects.filter(
-            entity_relationships__entity=obj,
-            entity_relationships__relationship_type=RelationshipType.ACCUSED,
-            state=CaseState.PUBLISHED,
+    @extend_schema_field(
+        inline_serializer(
+            name="RelatedCaseEntry",
+            fields={
+                "case_id": serializers.IntegerField(),
+                "relation_type": serializers.CharField(),
+                "notes": serializers.CharField(allow_null=True),
+            },
+            many=True,
         )
-
-        return list(cases.values_list("id", flat=True))
-
-    @extend_schema_field(OpenApiTypes.OBJECT)
+    )
     def get_related_cases(self, obj):
         """
-        Get list of case IDs where this entity is related.
+        Get related case entries for this entity.
 
         Only includes PUBLISHED cases. Uses the unified relationship system.
-        Excludes cases where entity is already alleged (to avoid duplicates).
+        Each entry includes relation metadata required by the frontend.
         """
-        from .models import RelationshipType
+        relationships = (
+            CaseEntityRelationship.objects.filter(
+                entity=obj,
+                case__state=CaseState.PUBLISHED,
+            )
+            .select_related("case")
+            .order_by("-case_id", "relationship_type")
+        )
 
-        # Get alleged case IDs to exclude
-        alleged_case_ids = Case.objects.filter(
-            entity_relationships__entity=obj,
-            entity_relationships__relationship_type=RelationshipType.ACCUSED,
-            state=CaseState.PUBLISHED,
-        ).values_list("id", flat=True)
-
-        # Get related cases from unified system
-        related_cases = Case.objects.filter(
-            entity_relationships__entity=obj,
-            entity_relationships__relationship_type=RelationshipType.RELATED,
-            state=CaseState.PUBLISHED,
-        ).exclude(id__in=alleged_case_ids)
-        return list(related_cases.values_list("id", flat=True))
+        return [
+            {
+                "case_id": relationship.case_id,
+                "relation_type": relationship.relationship_type,
+                "notes": relationship.notes,
+            }
+            for relationship in relationships
+        ]
 
 
 class CaseEntityRelationshipSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Summary

Refactor of #41 — **slug only**. All `bigo`, `court_cases`, and `missing_details` changes have been removed.

Closes #41 (supersedes it).

## Changes

**Model (`cases/models.py`)**
- `slug` CharField (max 50, unique, nullable, indexed) with `RegexValidator`: letters/numbers/`-`, cannot start with a digit
- Slug is normalised to `None` when blank on `save()`
- Slug is required before a case can be published (enforced in `clean()`)

**API (`cases/api_views.py`)**
- `CaseViewSet.get_object()` resolves by numeric pk **or** slug — e.g. both `/api/cases/42/` and `/api/cases/sunil-poudel-corruption/` work

**Serializers (`cases/serializers.py`, `cases/caseworker_serializers.py`)**
- `slug` added to `CaseSerializer` (public read output)
- `slug` added to `CaseCreateSerializer` and `CasePatchSerializer` (caseworker write inputs)

**Admin (`cases/admin.py`)**
- Slug shown as a clickable external link to `jawafdehi.org/case/<slug>` in the list view
- Slug added to search fields and case fieldset

**Migration**
- `0018_case_slug` — adds the `slug` field only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cases can now be accessed via URL-friendly slugs.
  * Case links are now displayed in the admin interface for direct external access.

* **API Updates**
  * Slug field is now available in case data and supports slug-based lookups.

* **Enhancement**
  * Slug validation enforced when publishing cases; slug is searchable in admin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->