### PR TITLE
feat: make court case detail endpoint public

### DIFF
--- a/ngm/api_views.py
+++ b/ngm/api_views.py
@@ -192,8 +192,8 @@ class NGMJudicialQueryView(APIView):
     },
 )
 class CourtCaseDetailView(APIView):
-    authentication_classes = [TokenAuthentication]
-    permission_classes = [IsAuthenticated]
+    authentication_classes = []
+    permission_classes = []
     throttle_classes = [NGMQueryRateThrottle]
 
     def get(self, request, case_id):

--- a/ngm/api_views.py
+++ b/ngm/api_views.py
@@ -58,12 +58,15 @@ class NGMQueryRateThrottle(SimpleRateThrottle):
         return super().allow_request(request, view)
 
     def get_cache_key(self, request, view):
+        # For authenticated requests, use token key
         token = getattr(request, "auth", None)
         token_key = getattr(token, "key", None)
-        if not token_key:
-            return None
+        if token_key:
+            return self.cache_format % {"scope": self.scope, "ident": token_key}
 
-        return self.cache_format % {"scope": self.scope, "ident": token_key}
+        # For anonymous requests, use IP address to enforce rate limiting
+        ident = self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
 @extend_schema(

--- a/tests/ngm/test_api.py
+++ b/tests/ngm/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
@@ -20,6 +21,14 @@ def add_user_to_groups(user, *group_names):
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+@pytest.fixture
+def clear_cache():
+    """Clear cache before and after each test to prevent throttle carryover."""
+    cache.clear()
+    yield
+    cache.clear()
 
 
 @pytest.fixture
@@ -206,7 +215,9 @@ def test_query_endpoint_rate_limited_per_token(authenticated_client, monkeypatch
 
 
 @pytest.mark.django_db
-def test_court_case_detail_public_access_and_throttling(api_client, monkeypatch):
+def test_court_case_detail_public_access_and_throttling(
+    api_client, clear_cache, monkeypatch
+):
     """Test that court case detail endpoint is public and throttled."""
 
     # Mock the service to return a valid case
@@ -261,7 +272,7 @@ def test_court_case_detail_public_access_and_throttling(api_client, monkeypatch)
 
 
 @pytest.mark.django_db
-def test_court_case_detail_invalid_format(api_client):
+def test_court_case_detail_invalid_format(api_client, clear_cache):
     response = api_client.get(CASE_DETAIL_URL_TEMPLATE.format(case_id="invalid-format"))
     assert response.status_code == 400
     payload = response.json()
@@ -269,7 +280,7 @@ def test_court_case_detail_invalid_format(api_client):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_not_found(api_client, monkeypatch):
+def test_court_case_detail_not_found(api_client, clear_cache, monkeypatch):
     def fake_get_details(court_identifier, case_number):
         return None
 
@@ -284,7 +295,7 @@ def test_court_case_detail_not_found(api_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_success(api_client, monkeypatch):
+def test_court_case_detail_success(api_client, clear_cache, monkeypatch):
     def fake_get_details(court_identifier, case_number):
         assert court_identifier == "supreme"
         assert case_number == "081-CR-0081"
@@ -369,7 +380,9 @@ def test_court_case_detail_success(api_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_returns_503_when_ngm_not_configured(api_client, monkeypatch):
+def test_court_case_detail_returns_503_when_ngm_not_configured(
+    api_client, clear_cache, monkeypatch
+):
     def raise_not_configured(court_identifier, case_number):
         raise ValueError("NGM database is not configured")
 
@@ -384,7 +397,9 @@ def test_court_case_detail_returns_503_when_ngm_not_configured(api_client, monke
 
 
 @pytest.mark.django_db
-def test_court_case_detail_lowercase_normalization(api_client, monkeypatch):
+def test_court_case_detail_lowercase_normalization(
+    api_client, clear_cache, monkeypatch
+):
     """Test that lowercase case numbers are normalized to uppercase."""
 
     def fake_get_details(court_identifier, case_number):
@@ -424,7 +439,9 @@ def test_court_case_detail_lowercase_normalization(api_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_missing_zeros_normalization(api_client, monkeypatch):
+def test_court_case_detail_missing_zeros_normalization(
+    api_client, clear_cache, monkeypatch
+):
     """Test that case numbers with missing leading zeros are normalized."""
 
     def fake_get_details(court_identifier, case_number):
@@ -464,7 +481,9 @@ def test_court_case_detail_missing_zeros_normalization(api_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_devanagari_normalization(api_client, monkeypatch):
+def test_court_case_detail_devanagari_normalization(
+    api_client, clear_cache, monkeypatch
+):
     """Test that Devanagari numerals are normalized to ASCII."""
 
     def fake_get_details(court_identifier, case_number):
@@ -504,7 +523,7 @@ def test_court_case_detail_devanagari_normalization(api_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_invalid_case_number_format(api_client):
+def test_court_case_detail_invalid_case_number_format(api_client, clear_cache):
     """Test that invalid case number format returns 400."""
     response = api_client.get(
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:invalid-format")
@@ -514,7 +533,7 @@ def test_court_case_detail_invalid_case_number_format(api_client):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_combined_normalization(api_client, monkeypatch):
+def test_court_case_detail_combined_normalization(api_client, clear_cache, monkeypatch):
     """Test normalization with Devanagari, lowercase, and missing zeros."""
 
     def fake_get_details(court_identifier, case_number):

--- a/tests/ngm/test_api.py
+++ b/tests/ngm/test_api.py
@@ -208,6 +208,7 @@ def test_query_endpoint_rate_limited_per_token(authenticated_client, monkeypatch
 @pytest.mark.django_db
 def test_court_case_detail_public_access_and_throttling(api_client, monkeypatch):
     """Test that court case detail endpoint is public and throttled."""
+
     # Mock the service to return a valid case
     def fake_get_details(court_identifier, case_number):
         return {
@@ -261,9 +262,7 @@ def test_court_case_detail_public_access_and_throttling(api_client, monkeypatch)
 
 @pytest.mark.django_db
 def test_court_case_detail_invalid_format(api_client):
-    response = api_client.get(
-        CASE_DETAIL_URL_TEMPLATE.format(case_id="invalid-format")
-    )
+    response = api_client.get(CASE_DETAIL_URL_TEMPLATE.format(case_id="invalid-format"))
     assert response.status_code == 400
     payload = response.json()
     assert "Invalid case_id format" in payload["error"]
@@ -353,7 +352,6 @@ def test_court_case_detail_success(api_client, monkeypatch):
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
     response = api_client.get(
-
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-CR-0081")
     )
 
@@ -371,16 +369,13 @@ def test_court_case_detail_success(api_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_returns_503_when_ngm_not_configured(
-    api_client, monkeypatch
-):
+def test_court_case_detail_returns_503_when_ngm_not_configured(api_client, monkeypatch):
     def raise_not_configured(court_identifier, case_number):
         raise ValueError("NGM database is not configured")
 
     monkeypatch.setattr(api_views, "get_court_case_details", raise_not_configured)
 
     response = api_client.get(
-
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-CR-0081")
     )
     assert response.status_code == 503
@@ -423,16 +418,13 @@ def test_court_case_detail_lowercase_normalization(api_client, monkeypatch):
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
     response = api_client.get(
-
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-cr-0081")
     )
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_court_case_detail_missing_zeros_normalization(
-    api_client, monkeypatch
-):
+def test_court_case_detail_missing_zeros_normalization(api_client, monkeypatch):
     """Test that case numbers with missing leading zeros are normalized."""
 
     def fake_get_details(court_identifier, case_number):
@@ -466,7 +458,6 @@ def test_court_case_detail_missing_zeros_normalization(
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
     response = api_client.get(
-
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:81-cr-81")
     )
     assert response.status_code == 200
@@ -507,7 +498,6 @@ def test_court_case_detail_devanagari_normalization(api_client, monkeypatch):
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
     response = api_client.get(
-
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:०८१-CR-००८१")
     )
     assert response.status_code == 200
@@ -562,4 +552,3 @@ def test_court_case_detail_combined_normalization(api_client, monkeypatch):
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:८१-cr-८१")
     )
     assert response.status_code == 200
-

--- a/tests/ngm/test_api.py
+++ b/tests/ngm/test_api.py
@@ -206,16 +206,62 @@ def test_query_endpoint_rate_limited_per_token(authenticated_client, monkeypatch
 
 
 @pytest.mark.django_db
-def test_court_case_detail_requires_authentication(api_client):
+def test_court_case_detail_public_access_and_throttling(api_client, monkeypatch):
+    """Test that court case detail endpoint is public and throttled."""
+    # Mock the service to return a valid case
+    def fake_get_details(court_identifier, case_number):
+        return {
+            "case": {
+                "case_number": "081-CR-0081",
+                "court_identifier": "supreme",
+                "registration_date_bs": "2081-01-15",
+                "registration_date_ad": None,
+                "case_type": "Criminal",
+                "division": None,
+                "category": None,
+                "section": None,
+                "plaintiff": "State",
+                "defendant": "John Doe",
+                "original_case_number": None,
+                "case_id": "supreme-081-CR-0081",
+                "priority": None,
+                "registration_number": "12345",
+                "case_status": "Pending",
+                "verdict_date_bs": None,
+                "verdict_date_ad": None,
+                "verdict_judge": None,
+                "status": "active",
+            },
+            "hearings": [],
+            "entities": [],
+        }
+
+    monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
+
+    # Test 1: Unauthenticated request should succeed (public endpoint)
     response = api_client.get(
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-CR-0081")
     )
-    assert response.status_code == 401
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["case_number"] == "081-CR-0081"
+
+    # Test 2: Throttling - make many requests to trigger rate limit
+    # NGMQueryRateThrottle default is 60/hour, so we need to exceed that
+    for _ in range(65):
+        response = api_client.get(
+            CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-CR-0081")
+        )
+        if response.status_code == 429:
+            break
+
+    # Should eventually get throttled
+    assert response.status_code == 429
 
 
 @pytest.mark.django_db
-def test_court_case_detail_invalid_format(authenticated_client):
-    response = authenticated_client.get(
+def test_court_case_detail_invalid_format(api_client):
+    response = api_client.get(
         CASE_DETAIL_URL_TEMPLATE.format(case_id="invalid-format")
     )
     assert response.status_code == 400
@@ -224,13 +270,13 @@ def test_court_case_detail_invalid_format(authenticated_client):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_not_found(authenticated_client, monkeypatch):
+def test_court_case_detail_not_found(api_client, monkeypatch):
     def fake_get_details(court_identifier, case_number):
         return None
 
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
-    response = authenticated_client.get(
+    response = api_client.get(
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:999-XX-9999")
     )
     assert response.status_code == 404
@@ -239,7 +285,7 @@ def test_court_case_detail_not_found(authenticated_client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_success(authenticated_client, monkeypatch):
+def test_court_case_detail_success(api_client, monkeypatch):
     def fake_get_details(court_identifier, case_number):
         assert court_identifier == "supreme"
         assert case_number == "081-CR-0081"
@@ -306,7 +352,8 @@ def test_court_case_detail_success(authenticated_client, monkeypatch):
 
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
-    response = authenticated_client.get(
+    response = api_client.get(
+
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-CR-0081")
     )
 
@@ -325,14 +372,15 @@ def test_court_case_detail_success(authenticated_client, monkeypatch):
 
 @pytest.mark.django_db
 def test_court_case_detail_returns_503_when_ngm_not_configured(
-    authenticated_client, monkeypatch
+    api_client, monkeypatch
 ):
     def raise_not_configured(court_identifier, case_number):
         raise ValueError("NGM database is not configured")
 
     monkeypatch.setattr(api_views, "get_court_case_details", raise_not_configured)
 
-    response = authenticated_client.get(
+    response = api_client.get(
+
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-CR-0081")
     )
     assert response.status_code == 503
@@ -341,7 +389,7 @@ def test_court_case_detail_returns_503_when_ngm_not_configured(
 
 
 @pytest.mark.django_db
-def test_court_case_detail_lowercase_normalization(authenticated_client, monkeypatch):
+def test_court_case_detail_lowercase_normalization(api_client, monkeypatch):
     """Test that lowercase case numbers are normalized to uppercase."""
 
     def fake_get_details(court_identifier, case_number):
@@ -374,7 +422,8 @@ def test_court_case_detail_lowercase_normalization(authenticated_client, monkeyp
 
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
-    response = authenticated_client.get(
+    response = api_client.get(
+
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:081-cr-0081")
     )
     assert response.status_code == 200
@@ -382,7 +431,7 @@ def test_court_case_detail_lowercase_normalization(authenticated_client, monkeyp
 
 @pytest.mark.django_db
 def test_court_case_detail_missing_zeros_normalization(
-    authenticated_client, monkeypatch
+    api_client, monkeypatch
 ):
     """Test that case numbers with missing leading zeros are normalized."""
 
@@ -416,14 +465,15 @@ def test_court_case_detail_missing_zeros_normalization(
 
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
-    response = authenticated_client.get(
+    response = api_client.get(
+
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:81-cr-81")
     )
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_court_case_detail_devanagari_normalization(authenticated_client, monkeypatch):
+def test_court_case_detail_devanagari_normalization(api_client, monkeypatch):
     """Test that Devanagari numerals are normalized to ASCII."""
 
     def fake_get_details(court_identifier, case_number):
@@ -456,16 +506,17 @@ def test_court_case_detail_devanagari_normalization(authenticated_client, monkey
 
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
-    response = authenticated_client.get(
+    response = api_client.get(
+
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:०८१-CR-००८१")
     )
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_court_case_detail_invalid_case_number_format(authenticated_client):
+def test_court_case_detail_invalid_case_number_format(api_client):
     """Test that invalid case number format returns 400."""
-    response = authenticated_client.get(
+    response = api_client.get(
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:invalid-format")
     )
     assert response.status_code == 400
@@ -473,7 +524,7 @@ def test_court_case_detail_invalid_case_number_format(authenticated_client):
 
 
 @pytest.mark.django_db
-def test_court_case_detail_combined_normalization(authenticated_client, monkeypatch):
+def test_court_case_detail_combined_normalization(api_client, monkeypatch):
     """Test normalization with Devanagari, lowercase, and missing zeros."""
 
     def fake_get_details(court_identifier, case_number):
@@ -507,7 +558,8 @@ def test_court_case_detail_combined_normalization(authenticated_client, monkeypa
     monkeypatch.setattr(api_views, "get_court_case_details", fake_get_details)
 
     # Test with Devanagari and missing zeros
-    response = authenticated_client.get(
+    response = api_client.get(
         CASE_DETAIL_URL_TEMPLATE.format(case_id="supreme:८१-cr-८१")
     )
     assert response.status_code == 200
+


### PR DESCRIPTION
- Remove authentication from CourtCaseDetailView
- Keep NGMJudicialQueryView authenticated (SQL queries remain protected)
- Court case detail endpoint now accessible without token
- Rate limiting still applies via NGMQueryRateThrottle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * The Court Case Detail endpoint is now publicly accessible without requiring authentication or token credentials. Input validation, data fetching, and rate limiting protections remain fully operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->