### PR TITLE
Add management command to map press release web URLs to NGM file URLs

### DIFF
--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -279,12 +279,6 @@ class Command(BaseCommand):
                 updated_evidence.append(evidence_entry)
                 continue
 
-                source = source_lookup.get(source_id)
-            if not source:
-                # Source doesn't exist, keep evidence as is
-                updated_evidence.append(evidence_entry)
-                continue
-
             # Check if this is a press release source
             press_release_url = None
             if isinstance(source.url, list):

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -1,0 +1,438 @@
+"""
+Django management command to map CIAA press release web URLs to actual document files.
+
+Maps CIAA press release web page URLs (e.g., https://ciaa.gov.np/pressrelease/3345)
+to actual PDF/DOCX file URLs from the NGM bucket. Creates DocumentSource records
+for each file and updates case evidence accordingly.
+
+Usage:
+    python manage.py map_press_release_files --dry-run  # Test first
+    python manage.py map_press_release_files            # Apply changes
+    python manage.py map_press_release_files --case-id=case-abc123  # Specific case
+    python manage.py map_press_release_files --limit=10  # Process first 10 cases
+"""
+
+import logging
+import requests
+import uuid
+from typing import Optional
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from cases.models import Case, DocumentSource, SourceType
+
+logger = logging.getLogger(__name__)
+
+# NGM root index URL (always fetches latest dated index)
+NGM_ROOT_INDEX_URL = "https://ngm-store.jawafdehi.org/index-v2.json"
+
+
+class Command(BaseCommand):
+    help = "Map CIAA press release web URLs to actual document files from NGM bucket"
+
+    def __init__(self):
+        super().__init__()
+        self.press_release_index = {}
+        self.stats = {
+            "cases_processed": 0,
+            "cases_fixed": 0,
+            "cases_skipped": 0,
+            "sources_created": 0,
+            "evidence_updated": 0,
+            "errors": 0,
+        }
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Run in dry-run mode (no database changes)",
+        )
+        parser.add_argument(
+            "--case-id",
+            type=str,
+            help="Fix specific case by case_id (optional)",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit number of cases to process (optional)",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        case_id = options.get("case_id")
+        limit = options.get("limit")
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"{'[DRY RUN] ' if dry_run else ''}Starting press release mapping..."
+            )
+        )
+
+        # Load NGM press release index
+        if not self.load_press_release_index():
+            self.stdout.write(
+                self.style.ERROR("Failed to load press release index. Aborting.")
+            )
+            return
+
+        # Find cases with press release evidence
+        cases = self.find_cases_with_press_release_evidence(case_id, limit)
+        self.stdout.write(f"Found {len(cases)} case(s) to process")
+
+        # Process each case
+        for case in cases:
+            try:
+                self.process_case(case, dry_run)
+            except Exception as e:
+                self.stats["errors"] += 1
+                logger.exception(f"Error processing case {case.case_id}: {e}")
+                self.stdout.write(
+                    self.style.ERROR(f"✗ Error processing {case.case_id}: {e}")
+                )
+
+        # Print summary
+        self.print_summary(dry_run)
+
+    def load_press_release_index(self) -> bool:
+        """Load press release index from NGM bucket with pagination support."""
+        try:
+            # Get root index to find latest press release index URL
+            self.stdout.write(f"Loading root index from {NGM_ROOT_INDEX_URL}...")
+            response = requests.get(NGM_ROOT_INDEX_URL, timeout=30)
+            response.raise_for_status()
+            root_data = response.json()
+            
+            # Find ciaa-press-releases child and get its $ref URL
+            press_release_url = None
+            for child in root_data.get("children", []):
+                if child.get("name") == "ciaa-press-releases":
+                    press_release_url = child.get("$ref")
+                    break
+            
+            if not press_release_url:
+                self.stdout.write(self.style.ERROR("Could not find ciaa-press-releases in root index"))
+                return False
+            
+            self.stdout.write(f"Found press release index: {press_release_url}")
+            
+            # Load all pages of press releases
+            current_url = press_release_url
+            page_num = 1
+            
+            while current_url:
+                self.stdout.write(f"  Loading page {page_num}...")
+                response = requests.get(current_url, timeout=30)
+                response.raise_for_status()
+                data = response.json()
+
+                # Build index: press_id -> press release data with files
+                for manuscript in data.get("manuscripts", []):
+                    metadata = manuscript.get("metadata", {})
+                    press_id = metadata.get("press_id")
+                    if press_id:
+                        if press_id not in self.press_release_index:
+                            self.press_release_index[press_id] = {
+                                "source_url": metadata.get("source_url"),
+                                "title": metadata.get("title"),
+                                "publication_date": metadata.get("publication_date"),
+                                "files": [],
+                            }
+                        self.press_release_index[press_id]["files"].append(
+                            {
+                                "url": manuscript.get("url"),
+                                "file_name": manuscript.get("file_name"),
+                            }
+                        )
+                
+                # Check for next page
+                current_url = data.get("next")
+                if current_url:
+                    page_num += 1
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"✓ Loaded {len(self.press_release_index)} press releases from {page_num} page(s)"
+                )
+            )
+            return True
+
+        except Exception as e:
+            logger.exception(f"Failed to load press release index: {e}")
+            self.stdout.write(self.style.ERROR(f"Failed to load index: {e}"))
+            return False
+
+    def find_cases_with_press_release_evidence(
+        self, case_id: Optional[str], limit: Optional[int]
+    ) -> list:
+        """Find cases with evidence pointing to CIAA press release URLs."""
+        queryset = Case.objects.all()
+
+        if case_id:
+            queryset = queryset.filter(case_id=case_id)
+
+        # Filter cases with evidence containing ciaa.gov.np/pressrelease URLs
+        cases_with_pr_evidence = []
+        for case in queryset:
+            if not case.evidence:
+                continue
+
+            has_pr_evidence = False
+            for evidence_entry in case.evidence:
+                source_id = evidence_entry.get("source_id")
+                if source_id:
+                    try:
+                        source = DocumentSource.objects.get(
+                            source_id=source_id, is_deleted=False
+                        )
+                        # Check if source URL contains press release URL
+                        if isinstance(source.url, list):
+                            for url in source.url:
+                                if "ciaa.gov.np/pressrelease/" in url:
+                                    has_pr_evidence = True
+                                    break
+                    except DocumentSource.DoesNotExist:
+                        pass
+
+            if has_pr_evidence:
+                cases_with_pr_evidence.append(case)
+
+            if limit and len(cases_with_pr_evidence) >= limit:
+                break
+
+        return cases_with_pr_evidence
+
+    def process_case(self, case: Case, dry_run: bool):
+        """Process a single case and map its press release evidence to actual files."""
+        self.stats["cases_processed"] += 1
+        self.stdout.write(f"\n[{self.stats['cases_processed']}] Processing: {case.case_id} - {case.title[:80]}...")
+
+        if not case.evidence:
+            self.stats["cases_skipped"] += 1
+            self.stdout.write(self.style.WARNING(f"  ⊘ Skipped: No evidence"))
+            return
+
+        updated_evidence = []
+        evidence_changed = False
+
+        for evidence_entry in case.evidence:
+            source_id = evidence_entry.get("source_id")
+            if not source_id:
+                updated_evidence.append(evidence_entry)
+                continue
+
+            try:
+                source = DocumentSource.objects.get(
+                    source_id=source_id, is_deleted=False
+                )
+
+                # Check if this is a press release source
+                press_release_url = None
+                if isinstance(source.url, list):
+                    for url in source.url:
+                        if "ciaa.gov.np/pressrelease/" in url:
+                            press_release_url = url
+                            break
+
+                if not press_release_url:
+                    # Not a press release source, keep as is
+                    updated_evidence.append(evidence_entry)
+                    continue
+
+                # Extract press_id from URL
+                press_id = self.extract_press_id(press_release_url)
+                if not press_id:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  ⊘ Could not extract press_id from {press_release_url}"
+                        )
+                    )
+                    updated_evidence.append(evidence_entry)
+                    continue
+
+                # Find press release files in index
+                pr_data = self.press_release_index.get(press_id)
+                if not pr_data or not pr_data.get("files"):
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  ⊘ No files found for press_id {press_id}"
+                        )
+                    )
+                    updated_evidence.append(evidence_entry)
+                    continue
+
+                self.stdout.write(
+                    f"  → Found {len(pr_data['files'])} file(s) for press release {press_id}"
+                )
+
+                # Create DocumentSource for each file and add to evidence
+                for file_data in pr_data["files"]:
+                    file_url = file_data.get("url")
+                    file_name = file_data.get("file_name", "")
+
+                    if not file_url:
+                        continue
+
+                    if not dry_run:
+                        with transaction.atomic():
+                            file_source = self.get_or_create_file_source(
+                                file_url=file_url,
+                                file_name=file_name,
+                                press_release_url=press_release_url,
+                                title=pr_data.get("title", "CIAA Press Release Document"),
+                                publication_date=pr_data.get("publication_date"),
+                            )
+                            self.stats["sources_created"] += 1
+
+                            # Add to updated evidence
+                            updated_evidence.append(
+                                {
+                                    "source_id": file_source.source_id,
+                                    "description": f"CIAA Press Release Document - {file_name}",
+                                }
+                            )
+                    else:
+                        self.stdout.write(
+                            f"    [DRY RUN] Would create source for: {file_name}"
+                        )
+
+                evidence_changed = True
+
+            except DocumentSource.DoesNotExist:
+                # Source doesn't exist, keep evidence as is
+                updated_evidence.append(evidence_entry)
+
+        # Update case evidence if changed
+        if evidence_changed:
+            if not dry_run:
+                case.evidence = updated_evidence
+                case.save()
+                self.stats["evidence_updated"] += 1
+                self.stats["cases_fixed"] += 1
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  ✓ Mapped: Updated evidence with {len(updated_evidence)} source(s)"
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  [DRY RUN] Would update evidence with {len(updated_evidence)} source(s)"
+                    )
+                )
+        else:
+            self.stats["cases_skipped"] += 1
+            self.stdout.write(self.style.WARNING(f"  ⊘ Skipped: No changes needed"))
+
+    def extract_press_id(self, url: str) -> Optional[int]:
+        """Extract press_id from CIAA press release URL."""
+        try:
+            # URL format: https://ciaa.gov.np/pressrelease/3345
+            parts = url.rstrip("/").split("/")
+            return int(parts[-1])
+        except (ValueError, IndexError):
+            return None
+
+    def get_or_create_file_source(
+        self,
+        file_url: str,
+        file_name: str,
+        press_release_url: str,
+        title: str,
+        publication_date: Optional[str],
+    ) -> DocumentSource:
+        """Get or create DocumentSource for a press release file."""
+        # Check if source already exists by URL (database-agnostic)
+        from django.db import connection
+        
+        if connection.vendor == "postgresql":
+            existing = DocumentSource.objects.filter(
+                url__contains=[file_url], is_deleted=False
+            ).first()
+        else:
+            # Fallback for SQLite and other databases
+            existing = None
+            for source in DocumentSource.objects.filter(is_deleted=False):
+                if isinstance(source.url, list) and file_url in source.url:
+                    existing = source
+                    break
+
+        if existing:
+            logger.debug(f"Reusing existing source: {existing.source_id}")
+            return existing
+
+        source_type = SourceType.LEGAL_PROCEDURAL
+
+        # Parse publication date (BS format: YYYY-MM-DD)
+        pub_date = None
+        if publication_date:
+            try:
+                from nepali.datetime import nepalidate
+
+                parts = publication_date.split("-")
+                if len(parts) == 3:
+                    year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
+                    pub_date = nepalidate(year, month, day).to_datetime().date()
+            except Exception as e:
+                logger.warning(f"Failed to parse publication date {publication_date}: {e}")
+
+        # Build URL list: file URL + press release web page URL
+        url_list = []
+        if file_url and str(file_url).strip():
+            url_list.append(str(file_url).strip())
+        if press_release_url and str(press_release_url).strip():
+            url_list.append(str(press_release_url).strip())
+        
+        if not url_list:
+            logger.error(f"No valid URLs for file {file_name}")
+            raise ValueError(f"No valid URLs for file {file_name}")
+        
+        # Create new source, bypassing custom save() logic
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d")
+        source_id = f"source:{timestamp}:{uuid.uuid4().hex[:8]}"
+        
+        source = DocumentSource(
+            source_id=source_id,
+            title=f"{title[:250]} - {file_name[:50]}"[:300],
+            description=f"Document from CIAA press release: {press_release_url}",
+            source_type=source_type,
+            url=url_list,
+            publication_date=pub_date,
+        )
+        # Skip full_clean() validation and save directly
+        super(DocumentSource, source).save()
+
+        logger.info(f"Created new source: {source.source_id} for {file_name}")
+        return source
+
+    def print_summary(self, dry_run: bool):
+        """Print summary statistics."""
+        self.stdout.write("\n" + "=" * 60)
+        self.stdout.write(
+            self.style.WARNING(f"{'[DRY RUN] ' if dry_run else ''}SUMMARY")
+        )
+        self.stdout.write("=" * 60)
+        self.stdout.write(f"Cases processed:     {self.stats['cases_processed']}")
+        self.stdout.write(
+            self.style.SUCCESS(f"✓ Cases mapped:      {self.stats['cases_fixed']}")
+        )
+        self.stdout.write(
+            self.style.WARNING(f"⊘ Cases skipped:     {self.stats['cases_skipped']}")
+        )
+        self.stdout.write(f"Sources created:     {self.stats['sources_created']}")
+        self.stdout.write(f"Evidence updated:    {self.stats['evidence_updated']}")
+        if self.stats["errors"] > 0:
+            self.stdout.write(
+                self.style.ERROR(f"✗ Errors:            {self.stats['errors']}")
+            )
+        self.stdout.write("=" * 60)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    "\nThis was a dry run. No changes were made to the database."
+                )
+            )
+            self.stdout.write("Run without --dry-run to apply changes.")

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -103,24 +103,26 @@ class Command(BaseCommand):
             response = requests.get(NGM_ROOT_INDEX_URL, timeout=30)
             response.raise_for_status()
             root_data = response.json()
-            
+
             # Find ciaa-press-releases child and get its $ref URL
             press_release_url = None
             for child in root_data.get("children", []):
                 if child.get("name") == "ciaa-press-releases":
                     press_release_url = child.get("$ref")
                     break
-            
+
             if not press_release_url:
-                self.stdout.write(self.style.ERROR("Could not find ciaa-press-releases in root index"))
+                self.stdout.write(
+                    self.style.ERROR("Could not find ciaa-press-releases in root index")
+                )
                 return False
-            
+
             self.stdout.write(f"Found press release index: {press_release_url}")
-            
+
             # Load all pages of press releases
             current_url = press_release_url
             page_num = 1
-            
+
             while current_url:
                 self.stdout.write(f"  Loading page {page_num}...")
                 response = requests.get(current_url, timeout=30)
@@ -145,7 +147,7 @@ class Command(BaseCommand):
                                 "file_name": manuscript.get("file_name"),
                             }
                         )
-                
+
                 # Check for next page
                 current_url = data.get("next")
                 if current_url:
@@ -206,11 +208,13 @@ class Command(BaseCommand):
     def process_case(self, case: Case, dry_run: bool):
         """Process a single case and map its press release evidence to actual files."""
         self.stats["cases_processed"] += 1
-        self.stdout.write(f"\n[{self.stats['cases_processed']}] Processing: {case.case_id} - {case.title[:80]}...")
+        self.stdout.write(
+            f"\n[{self.stats['cases_processed']}] Processing: {case.case_id} - {case.title[:80]}..."
+        )
 
         if not case.evidence:
             self.stats["cases_skipped"] += 1
-            self.stdout.write(self.style.WARNING(f"  ⊘ Skipped: No evidence"))
+            self.stdout.write(self.style.WARNING("  ⊘ Skipped: No evidence"))
             return
 
         updated_evidence = []
@@ -267,6 +271,7 @@ class Command(BaseCommand):
                 )
 
                 # Create DocumentSource for each file and add to evidence
+                files_processed = 0
                 for file_data in pr_data["files"]:
                     file_url = file_data.get("url")
                     file_name = file_data.get("file_name", "")
@@ -280,7 +285,9 @@ class Command(BaseCommand):
                                 file_url=file_url,
                                 file_name=file_name,
                                 press_release_url=press_release_url,
-                                title=pr_data.get("title", "CIAA Press Release Document"),
+                                title=pr_data.get(
+                                    "title", "CIAA Press Release Document"
+                                ),
                                 publication_date=pr_data.get("publication_date"),
                             )
                             self.stats["sources_created"] += 1
@@ -292,12 +299,16 @@ class Command(BaseCommand):
                                     "description": f"CIAA Press Release Document - {file_name}",
                                 }
                             )
+                            files_processed += 1
                     else:
                         self.stdout.write(
                             f"    [DRY RUN] Would create source for: {file_name}"
                         )
+                        files_processed += 1
 
-                evidence_changed = True
+                # Only mark as changed if we actually processed files
+                if files_processed > 0:
+                    evidence_changed = True
 
             except DocumentSource.DoesNotExist:
                 # Source doesn't exist, keep evidence as is
@@ -323,7 +334,7 @@ class Command(BaseCommand):
                 )
         else:
             self.stats["cases_skipped"] += 1
-            self.stdout.write(self.style.WARNING(f"  ⊘ Skipped: No changes needed"))
+            self.stdout.write(self.style.WARNING("  ⊘ Skipped: No changes needed"))
 
     def extract_press_id(self, url: str) -> Optional[int]:
         """Extract press_id from CIAA press release URL."""
@@ -345,7 +356,7 @@ class Command(BaseCommand):
         """Get or create DocumentSource for a press release file."""
         # Check if source already exists by URL (database-agnostic)
         from django.db import connection
-        
+
         if connection.vendor == "postgresql":
             existing = DocumentSource.objects.filter(
                 url__contains=[file_url], is_deleted=False
@@ -375,34 +386,36 @@ class Command(BaseCommand):
                     year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
                     pub_date = nepalidate(year, month, day).to_datetime().date()
             except Exception as e:
-                logger.warning(f"Failed to parse publication date {publication_date}: {e}")
+                logger.warning(
+                    f"Failed to parse publication date {publication_date}: {e}"
+                )
 
         # Build URL list: file URL + press release web page URL
+        from urllib.parse import quote
+        
         url_list = []
         if file_url and str(file_url).strip():
-            url_list.append(str(file_url).strip())
+            # URL-encode spaces and special characters in the file URL
+            file_url_str = str(file_url).strip()
+            # Replace spaces with %20
+            file_url_str = file_url_str.replace(" ", "%20")
+            url_list.append(file_url_str)
+            
         if press_release_url and str(press_release_url).strip():
             url_list.append(str(press_release_url).strip())
-        
+
         if not url_list:
             logger.error(f"No valid URLs for file {file_name}")
             raise ValueError(f"No valid URLs for file {file_name}")
-        
-        # Create new source, bypassing custom save() logic
-        from datetime import datetime
-        timestamp = datetime.now().strftime("%Y%m%d")
-        source_id = f"source:{timestamp}:{uuid.uuid4().hex[:8]}"
-        
-        source = DocumentSource(
-            source_id=source_id,
+
+        # Create new source (save() will generate source_id and validate)
+        source = DocumentSource.objects.create(
             title=f"{title[:250]} - {file_name[:50]}"[:300],
             description=f"Document from CIAA press release: {press_release_url}",
             source_type=source_type,
             url=url_list,
             publication_date=pub_date,
         )
-        # Skip full_clean() validation and save directly
-        super(DocumentSource, source).save()
 
         logger.info(f"Created new source: {source.source_id} for {file_name}")
         return source

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -187,6 +187,18 @@ class Command(BaseCommand):
                         source = DocumentSource.objects.get(
                             source_id=source_id, is_deleted=False
                         )
+                        
+                        # Skip if source is already file-backed (has NGM file URL)
+                        is_file_backed = False
+                        if isinstance(source.url, list):
+                            for url in source.url:
+                                if "ngm-store.jawafdehi.org" in url:
+                                    is_file_backed = True
+                                    break
+                        
+                        if is_file_backed:
+                            continue
+                        
                         # Check if source URL contains press release URL
                         if isinstance(source.url, list):
                             for url in source.url:
@@ -280,7 +292,7 @@ class Command(BaseCommand):
 
                     if not dry_run:
                         with transaction.atomic():
-                            file_source = self.get_or_create_file_source(
+                            file_source, created = self.get_or_create_file_source(
                                 file_url=file_url,
                                 file_name=file_name,
                                 press_release_url=press_release_url,
@@ -289,7 +301,8 @@ class Command(BaseCommand):
                                 ),
                                 publication_date=pr_data.get("publication_date"),
                             )
-                            self.stats["sources_created"] += 1
+                            if created:
+                                self.stats["sources_created"] += 1
 
                             # Add to updated evidence
                             updated_evidence.append(
@@ -302,6 +315,13 @@ class Command(BaseCommand):
                     else:
                         self.stdout.write(
                             f"    [DRY RUN] Would create source for: {file_name}"
+                        )
+                        # In dry-run mode, append synthetic entry to updated_evidence
+                        updated_evidence.append(
+                            {
+                                "source_id": f"dry-run-{file_name}",
+                                "description": f"CIAA Press Release Document - {file_name}",
+                            }
                         )
                         files_processed += 1
 
@@ -351,8 +371,12 @@ class Command(BaseCommand):
         press_release_url: str,
         title: str,
         publication_date: Optional[str],
-    ) -> DocumentSource:
-        """Get or create DocumentSource for a press release file."""
+    ) -> tuple[DocumentSource, bool]:
+        """Get or create DocumentSource for a press release file.
+        
+        Returns:
+            tuple: (DocumentSource, created) where created is True if a new source was created
+        """
         # Check if source already exists by URL (database-agnostic)
         from django.db import connection
 
@@ -370,7 +394,7 @@ class Command(BaseCommand):
 
         if existing:
             logger.debug(f"Reusing existing source: {existing.source_id}")
-            return existing
+            return existing, False
 
         source_type = SourceType.LEGAL_PROCEDURAL
 
@@ -416,7 +440,7 @@ class Command(BaseCommand):
         )
 
         logger.info(f"Created new source: {source.source_id} for {file_name}")
-        return source
+        return source, True
 
     def print_summary(self, dry_run: bool):
         """Print summary statistics."""

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -13,10 +13,13 @@ Usage:
 """
 
 import logging
-import requests
+import urllib.parse
 from typing import Optional
+
+import requests
 from django.core.management.base import BaseCommand
-from django.db import transaction
+from django.db import connection, transaction
+from nepali.datetime import nepalidate
 
 from cases.models import Case, DocumentSource, SourceType
 
@@ -76,13 +79,14 @@ class Command(BaseCommand):
             )
             return
 
-        # Find cases with press release evidence
-        cases = self.find_cases_with_press_release_evidence(case_id, limit)
-        self.stdout.write(f"Found {len(cases)} case(s) to process")
-
-        # Bulk fetch all DocumentSources for these cases to avoid N+1 queries
+        # Bulk fetch all DocumentSources to avoid N+1 queries
+        # First pass: collect all source_ids from all cases
         all_source_ids = set()
-        for case in cases:
+        queryset = Case.objects.all()
+        if case_id:
+            queryset = queryset.filter(case_id=case_id)
+
+        for case in queryset:
             if case.evidence:
                 for evidence_entry in case.evidence:
                     source_id = evidence_entry.get("source_id")
@@ -95,6 +99,12 @@ class Command(BaseCommand):
                 source_id__in=all_source_ids, is_deleted=False
             )
         }
+
+        # Find cases with press release evidence
+        cases = self.find_cases_with_press_release_evidence(
+            case_id, limit, source_lookup
+        )
+        self.stdout.write(f"Found {len(cases)} case(s) to process")
 
         # Process each case
         for case in cases:
@@ -181,7 +191,7 @@ class Command(BaseCommand):
             return False
 
     def find_cases_with_press_release_evidence(
-        self, case_id: Optional[str], limit: Optional[int]
+        self, case_id: Optional[str], limit: Optional[int], source_lookup: dict
     ) -> list:
         """Find cases with evidence pointing to CIAA press release URLs."""
         queryset = Case.objects.all()
@@ -189,24 +199,8 @@ class Command(BaseCommand):
         if case_id:
             queryset = queryset.filter(case_id=case_id)
 
-        # Collect all source_ids from all cases to bulk fetch DocumentSources
-        all_source_ids = set()
-        for case in queryset:
-            if case.evidence:
-                for evidence_entry in case.evidence:
-                    source_id = evidence_entry.get("source_id")
-                    if source_id:
-                        all_source_ids.add(source_id)
-
-        # Bulk fetch all DocumentSources
-        source_lookup = {
-            source.source_id: source
-            for source in DocumentSource.objects.filter(
-                source_id__in=all_source_ids, is_deleted=False
-            )
-        }
-
         # Filter cases with evidence containing ciaa.gov.np/pressrelease URLs
+        # Uses source_lookup passed from handle() to avoid duplicate DB queries
         cases_with_pr_evidence = []
         for case in queryset:
             if not case.evidence:
@@ -316,6 +310,13 @@ class Command(BaseCommand):
                 f"  → Found {len(pr_data['files'])} file(s) for press release {press_id}"
             )
 
+            # Intentionally replace the original web URL source with file-backed sources
+            # The original evidence_entry (web URL) is NOT appended to updated_evidence
+            # This is by design: we want file URLs, not web page URLs, in the final evidence
+            self.stdout.write(
+                f"  → Replacing source {source_id} (web URL) with {len(pr_data['files'])} file-backed source(s)"
+            )
+
             # Create DocumentSource for each file and add to evidence
             files_processed = 0
             for file_data in pr_data["files"]:
@@ -407,8 +408,6 @@ class Command(BaseCommand):
             tuple: (DocumentSource, created) where created is True if a new source was created
         """
         # Check if source already exists by URL (database-agnostic)
-        from django.db import connection
-
         if connection.vendor == "postgresql":
             existing = DocumentSource.objects.filter(
                 url__contains=[file_url], is_deleted=False
@@ -435,8 +434,6 @@ class Command(BaseCommand):
         pub_date = None
         if publication_date:
             try:
-                from nepali.datetime import nepalidate
-
                 parts = publication_date.split("-")
                 if len(parts) == 3:
                     year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
@@ -447,8 +444,6 @@ class Command(BaseCommand):
                 )
 
         # Build URL list: file URL + press release web page URL
-        import urllib.parse
-
         url_list = []
         if file_url and str(file_url).strip():
             # Properly URL-encode the file URL

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -14,7 +14,6 @@ Usage:
 
 import logging
 import requests
-import uuid
 from typing import Optional
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -391,8 +390,7 @@ class Command(BaseCommand):
                 )
 
         # Build URL list: file URL + press release web page URL
-        from urllib.parse import quote
-        
+
         url_list = []
         if file_url and str(file_url).strip():
             # URL-encode spaces and special characters in the file URL
@@ -400,7 +398,7 @@ class Command(BaseCommand):
             # Replace spaces with %20
             file_url_str = file_url_str.replace(" ", "%20")
             url_list.append(file_url_str)
-            
+
         if press_release_url and str(press_release_url).strip():
             url_list.append(str(press_release_url).strip())
 

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -187,7 +187,7 @@ class Command(BaseCommand):
                         source = DocumentSource.objects.get(
                             source_id=source_id, is_deleted=False
                         )
-                        
+
                         # Skip if source is already file-backed (has NGM file URL)
                         is_file_backed = False
                         if isinstance(source.url, list):
@@ -195,10 +195,10 @@ class Command(BaseCommand):
                                 if "ngm-store.jawafdehi.org" in url:
                                     is_file_backed = True
                                     break
-                        
+
                         if is_file_backed:
                             continue
-                        
+
                         # Check if source URL contains press release URL
                         if isinstance(source.url, list):
                             for url in source.url:
@@ -373,7 +373,7 @@ class Command(BaseCommand):
         publication_date: Optional[str],
     ) -> tuple[DocumentSource, bool]:
         """Get or create DocumentSource for a press release file.
-        
+
         Returns:
             tuple: (DocumentSource, created) where created is True if a new source was created
         """

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -80,10 +80,26 @@ class Command(BaseCommand):
         cases = self.find_cases_with_press_release_evidence(case_id, limit)
         self.stdout.write(f"Found {len(cases)} case(s) to process")
 
+        # Bulk fetch all DocumentSources for these cases to avoid N+1 queries
+        all_source_ids = set()
+        for case in cases:
+            if case.evidence:
+                for evidence_entry in case.evidence:
+                    source_id = evidence_entry.get("source_id")
+                    if source_id:
+                        all_source_ids.add(source_id)
+
+        source_lookup = {
+            source.source_id: source
+            for source in DocumentSource.objects.filter(
+                source_id__in=all_source_ids, is_deleted=False
+            )
+        }
+
         # Process each case
         for case in cases:
             try:
-                self.process_case(case, dry_run)
+                self.process_case(case, dry_run, source_lookup)
             except Exception as e:
                 self.stats["errors"] += 1
                 logger.exception(f"Error processing case {case.case_id}: {e}")
@@ -173,6 +189,23 @@ class Command(BaseCommand):
         if case_id:
             queryset = queryset.filter(case_id=case_id)
 
+        # Collect all source_ids from all cases to bulk fetch DocumentSources
+        all_source_ids = set()
+        for case in queryset:
+            if case.evidence:
+                for evidence_entry in case.evidence:
+                    source_id = evidence_entry.get("source_id")
+                    if source_id:
+                        all_source_ids.add(source_id)
+
+        # Bulk fetch all DocumentSources
+        source_lookup = {
+            source.source_id: source
+            for source in DocumentSource.objects.filter(
+                source_id__in=all_source_ids, is_deleted=False
+            )
+        }
+
         # Filter cases with evidence containing ciaa.gov.np/pressrelease URLs
         cases_with_pr_evidence = []
         for case in queryset:
@@ -183,30 +216,27 @@ class Command(BaseCommand):
             for evidence_entry in case.evidence:
                 source_id = evidence_entry.get("source_id")
                 if source_id:
-                    try:
-                        source = DocumentSource.objects.get(
-                            source_id=source_id, is_deleted=False
-                        )
+                    source = source_lookup.get(source_id)
+                    if not source:
+                        continue
 
-                        # Skip if source is already file-backed (has NGM file URL)
-                        is_file_backed = False
-                        if isinstance(source.url, list):
-                            for url in source.url:
-                                if "ngm-store.jawafdehi.org" in url:
-                                    is_file_backed = True
-                                    break
+                    # Skip if source is already file-backed (has NGM file URL)
+                    is_file_backed = False
+                    if isinstance(source.url, list):
+                        for url in source.url:
+                            if "ngm-store.jawafdehi.org" in url:
+                                is_file_backed = True
+                                break
 
-                        if is_file_backed:
-                            continue
+                    if is_file_backed:
+                        continue
 
-                        # Check if source URL contains press release URL
-                        if isinstance(source.url, list):
-                            for url in source.url:
-                                if "ciaa.gov.np/pressrelease/" in url:
-                                    has_pr_evidence = True
-                                    break
-                    except DocumentSource.DoesNotExist:
-                        pass
+                    # Check if source URL contains press release URL
+                    if isinstance(source.url, list):
+                        for url in source.url:
+                            if "ciaa.gov.np/pressrelease/" in url:
+                                has_pr_evidence = True
+                                break
 
             if has_pr_evidence:
                 cases_with_pr_evidence.append(case)
@@ -216,8 +246,14 @@ class Command(BaseCommand):
 
         return cases_with_pr_evidence
 
-    def process_case(self, case: Case, dry_run: bool):
-        """Process a single case and map its press release evidence to actual files."""
+    def process_case(self, case: Case, dry_run: bool, source_lookup: dict):
+        """Process a single case and map its press release evidence to actual files.
+
+        Args:
+            case: The Case instance to process
+            dry_run: Whether to run in dry-run mode
+            source_lookup: Dict mapping source_id to DocumentSource for efficient lookups
+        """
         self.stats["cases_processed"] += 1
         self.stdout.write(
             f"\n[{self.stats['cases_processed']}] Processing: {case.case_id} - {case.title[:80]}..."
@@ -237,107 +273,106 @@ class Command(BaseCommand):
                 updated_evidence.append(evidence_entry)
                 continue
 
-            try:
-                source = DocumentSource.objects.get(
-                    source_id=source_id, is_deleted=False
-                )
+            source = source_lookup.get(source_id)
+            if not source:
+                # Source doesn't exist, keep evidence as is
+                updated_evidence.append(evidence_entry)
+                continue
 
-                # Check if this is a press release source
-                press_release_url = None
-                if isinstance(source.url, list):
-                    for url in source.url:
-                        if "ciaa.gov.np/pressrelease/" in url:
-                            press_release_url = url
-                            break
+                source = source_lookup.get(source_id)
+            if not source:
+                # Source doesn't exist, keep evidence as is
+                updated_evidence.append(evidence_entry)
+                continue
 
-                if not press_release_url:
-                    # Not a press release source, keep as is
-                    updated_evidence.append(evidence_entry)
-                    continue
+            # Check if this is a press release source
+            press_release_url = None
+            if isinstance(source.url, list):
+                for url in source.url:
+                    if "ciaa.gov.np/pressrelease/" in url:
+                        press_release_url = url
+                        break
 
-                # Extract press_id from URL
-                press_id = self.extract_press_id(press_release_url)
-                if not press_id:
-                    self.stdout.write(
-                        self.style.WARNING(
-                            f"  ⊘ Could not extract press_id from {press_release_url}"
-                        )
-                    )
-                    updated_evidence.append(evidence_entry)
-                    continue
+            if not press_release_url:
+                # Not a press release source, keep as is
+                updated_evidence.append(evidence_entry)
+                continue
 
-                # Find press release files in index
-                pr_data = self.press_release_index.get(press_id)
-                if not pr_data or not pr_data.get("files"):
-                    self.stdout.write(
-                        self.style.WARNING(
-                            f"  ⊘ No files found for press_id {press_id}"
-                        )
-                    )
-                    updated_evidence.append(evidence_entry)
-                    continue
-
+            # Extract press_id from URL
+            press_id = self.extract_press_id(press_release_url)
+            if not press_id:
                 self.stdout.write(
-                    f"  → Found {len(pr_data['files'])} file(s) for press release {press_id}"
+                    self.style.WARNING(
+                        f"  ⊘ Could not extract press_id from {press_release_url}"
+                    )
                 )
+                updated_evidence.append(evidence_entry)
+                continue
 
-                # Create DocumentSource for each file and add to evidence
-                files_processed = 0
-                for file_data in pr_data["files"]:
-                    file_url = file_data.get("url")
-                    file_name = file_data.get("file_name", "")
+            # Find press release files in index
+            pr_data = self.press_release_index.get(press_id)
+            if not pr_data or not pr_data.get("files"):
+                self.stdout.write(
+                    self.style.WARNING(f"  ⊘ No files found for press_id {press_id}")
+                )
+                updated_evidence.append(evidence_entry)
+                continue
 
-                    if not file_url:
-                        continue
+            self.stdout.write(
+                f"  → Found {len(pr_data['files'])} file(s) for press release {press_id}"
+            )
 
-                    if not dry_run:
-                        with transaction.atomic():
-                            file_source, created = self.get_or_create_file_source(
-                                file_url=file_url,
-                                file_name=file_name,
-                                press_release_url=press_release_url,
-                                title=pr_data.get(
-                                    "title", "CIAA Press Release Document"
-                                ),
-                                publication_date=pr_data.get("publication_date"),
-                            )
-                            if created:
-                                self.stats["sources_created"] += 1
+            # Create DocumentSource for each file and add to evidence
+            files_processed = 0
+            for file_data in pr_data["files"]:
+                file_url = file_data.get("url")
+                file_name = file_data.get("file_name", "")
 
-                            # Add to updated evidence
-                            updated_evidence.append(
-                                {
-                                    "source_id": file_source.source_id,
-                                    "description": f"CIAA Press Release Document - {file_name}",
-                                }
-                            )
-                            files_processed += 1
-                    else:
-                        self.stdout.write(
-                            f"    [DRY RUN] Would create source for: {file_name}"
+                if not file_url:
+                    continue
+
+                if not dry_run:
+                    with transaction.atomic():
+                        file_source, created = self.get_or_create_file_source(
+                            file_url=file_url,
+                            file_name=file_name,
+                            press_release_url=press_release_url,
+                            title=pr_data.get("title", "CIAA Press Release Document"),
+                            publication_date=pr_data.get("publication_date"),
                         )
-                        # In dry-run mode, append synthetic entry to updated_evidence
+                        if created:
+                            self.stats["sources_created"] += 1
+
+                        # Add to updated evidence
                         updated_evidence.append(
                             {
-                                "source_id": f"dry-run-{file_name}",
+                                "source_id": file_source.source_id,
                                 "description": f"CIAA Press Release Document - {file_name}",
                             }
                         )
                         files_processed += 1
+                else:
+                    self.stdout.write(
+                        f"    [DRY RUN] Would create source for: {file_name}"
+                    )
+                    # In dry-run mode, append synthetic entry to updated_evidence
+                    updated_evidence.append(
+                        {
+                            "source_id": f"dry-run-{file_name}",
+                            "description": f"CIAA Press Release Document - {file_name}",
+                        }
+                    )
+                    files_processed += 1
 
-                # Only mark as changed if we actually processed files
-                if files_processed > 0:
-                    evidence_changed = True
-
-            except DocumentSource.DoesNotExist:
-                # Source doesn't exist, keep evidence as is
-                updated_evidence.append(evidence_entry)
+            # Only mark as changed if we actually processed files
+            if files_processed > 0:
+                evidence_changed = True
 
         # Update case evidence if changed
         if evidence_changed:
             if not dry_run:
                 case.evidence = updated_evidence
-                case.save()
+                case.save(update_fields=["evidence"])
                 self.stats["evidence_updated"] += 1
                 self.stats["cases_fixed"] += 1
                 self.stdout.write(
@@ -385,9 +420,13 @@ class Command(BaseCommand):
                 url__contains=[file_url], is_deleted=False
             ).first()
         else:
-            # Fallback for SQLite and other databases
+            # Fallback for SQLite and other databases - filter candidates at DB level first
             existing = None
-            for source in DocumentSource.objects.filter(is_deleted=False):
+            # Use text containment to narrow down candidates at DB level
+            candidates = DocumentSource.objects.filter(
+                url__icontains=file_url, is_deleted=False
+            )
+            for source in candidates:
                 if isinstance(source.url, list) and file_url in source.url:
                     existing = source
                     break
@@ -414,17 +453,46 @@ class Command(BaseCommand):
                 )
 
         # Build URL list: file URL + press release web page URL
+        import urllib.parse
 
         url_list = []
         if file_url and str(file_url).strip():
-            # URL-encode spaces and special characters in the file URL
+            # Properly URL-encode the file URL
             file_url_str = str(file_url).strip()
-            # Replace spaces with %20
-            file_url_str = file_url_str.replace(" ", "%20")
-            url_list.append(file_url_str)
+            parsed = urllib.parse.urlsplit(file_url_str)
+            # Encode path, query, and fragment components
+            encoded_path = urllib.parse.quote(parsed.path, safe="/")
+            encoded_query = urllib.parse.quote(parsed.query, safe="=&")
+            encoded_fragment = urllib.parse.quote(parsed.fragment, safe="")
+            # Rebuild the URL
+            encoded_url = urllib.parse.urlunsplit(
+                (
+                    parsed.scheme,
+                    parsed.netloc,
+                    encoded_path,
+                    encoded_query,
+                    encoded_fragment,
+                )
+            )
+            url_list.append(encoded_url)
 
         if press_release_url and str(press_release_url).strip():
-            url_list.append(str(press_release_url).strip())
+            # Properly URL-encode the press release URL
+            pr_url_str = str(press_release_url).strip()
+            parsed = urllib.parse.urlsplit(pr_url_str)
+            encoded_path = urllib.parse.quote(parsed.path, safe="/")
+            encoded_query = urllib.parse.quote(parsed.query, safe="=&")
+            encoded_fragment = urllib.parse.quote(parsed.fragment, safe="")
+            encoded_url = urllib.parse.urlunsplit(
+                (
+                    parsed.scheme,
+                    parsed.netloc,
+                    encoded_path,
+                    encoded_query,
+                    encoded_fragment,
+                )
+            )
+            url_list.append(encoded_url)
 
         if not url_list:
             logger.error(f"No valid URLs for file {file_name}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -5013,4 +5013,4 @@ s3 = ["cloudpathlib"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "83c495ec2b3b822f2b4b2f74959ebb769db261be8ff6de1e5ab29228b51c2c10"
+content-hash = "4532c5748d3f03913192bec71be8be5a742d124e7ef7ad509fe870ae9844fb26"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2388,9 +2388,10 @@ resolved_reference = "73f91701ff795271be5b17711ca7aabc3c9a363e"
 name = "nepali"
 version = "1.2.0"
 description = "nepalidatetime compatible with python's datetime feature. Converting nepali date to english, parsing nepali datetime, nepali timezone, and timedelta support in nepali datetime"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"nepali-support\""
 files = [
     {file = "nepali-1.2.0-py3-none-any.whl", hash = "sha256:1f9244b2fcb51e6b9e710cc1c483024f8600954d545a9a12a2accf53213911b1"},
     {file = "nepali-1.2.0.tar.gz", hash = "sha256:75a9d0bd4b3e95d72c7045539b63e84077686ffa12dff5db3fffe6579cbb511d"},
@@ -5020,9 +5021,10 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 
 [extras]
 llm-all = ["langchain", "langchain-google-genai", "langchain-openai", "openai"]
+nepali-support = ["nepali"]
 s3 = ["cloudpathlib"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "51b7bc80702026bd4b3ce9b754ac79682b77f441357bf8baa16a62fde65d4043"
+content-hash = "a89727acf7f105df3b2a4c18f2dffbec981924dada1c3b340564b9fee74b2c57"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2385,6 +2385,18 @@ reference = "HEAD"
 resolved_reference = "73f91701ff795271be5b17711ca7aabc3c9a363e"
 
 [[package]]
+name = "nepali"
+version = "1.2.0"
+description = "nepalidatetime compatible with python's datetime feature. Converting nepali date to english, parsing nepali datetime, nepali timezone, and timedelta support in nepali datetime"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "nepali-1.2.0-py3-none-any.whl", hash = "sha256:1f9244b2fcb51e6b9e710cc1c483024f8600954d545a9a12a2accf53213911b1"},
+    {file = "nepali-1.2.0.tar.gz", hash = "sha256:75a9d0bd4b3e95d72c7045539b63e84077686ffa12dff5db3fffe6579cbb511d"},
+]
+
+[[package]]
 name = "nepali-date-utils"
 version = "0.3.1"
 description = "Convert Nepali to English Dates: Easily switch between Nepali and English dates with this Python package."
@@ -5013,4 +5025,4 @@ s3 = ["cloudpathlib"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "4532c5748d3f03913192bec71be8be5a742d124e7ef7ad509fe870ae9844fb26"
+content-hash = "51b7bc80702026bd4b3ce9b754ac79682b77f441357bf8baa16a62fde65d4043"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2388,10 +2388,9 @@ resolved_reference = "73f91701ff795271be5b17711ca7aabc3c9a363e"
 name = "nepali"
 version = "1.2.0"
 description = "nepalidatetime compatible with python's datetime feature. Converting nepali date to english, parsing nepali datetime, nepali timezone, and timedelta support in nepali datetime"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"nepali-support\""
 files = [
     {file = "nepali-1.2.0-py3-none-any.whl", hash = "sha256:1f9244b2fcb51e6b9e710cc1c483024f8600954d545a9a12a2accf53213911b1"},
     {file = "nepali-1.2.0.tar.gz", hash = "sha256:75a9d0bd4b3e95d72c7045539b63e84077686ffa12dff5db3fffe6579cbb511d"},
@@ -5021,10 +5020,9 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 
 [extras]
 llm-all = ["langchain", "langchain-google-genai", "langchain-openai", "openai"]
-nepali-support = ["nepali"]
 s3 = ["cloudpathlib"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "a89727acf7f105df3b2a4c18f2dffbec981924dada1c3b340564b9fee74b2c57"
+content-hash = "51b7bc80702026bd4b3ce9b754ac79682b77f441357bf8baa16a62fde65d4043"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ langchain-openai = {version = "^0.3.0", optional = true}
 langchain-google-genai = {version = "^4.2.1", optional = true}
 openai = {version = "^1.40.0", optional = true}
 cloudpathlib = {extras = ["s3"], version = "^0.20.0", optional = true}
+nepali-date-utils = "^0.3.1"
 
 [tool.poetry.extras]
 llm-all = ["langchain", "langchain-openai", "langchain-google-genai", "openai"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ langchain-openai = {version = "^0.3.0", optional = true}
 langchain-google-genai = {version = "^4.2.1", optional = true}
 openai = {version = "^1.40.0", optional = true}
 cloudpathlib = {extras = ["s3"], version = "^0.20.0", optional = true}
-nepali-date-utils = "^0.3.1"
+nepali = "^1.2.0"
 
 [tool.poetry.extras]
 llm-all = ["langchain", "langchain-openai", "langchain-google-genai", "openai"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,11 @@ langchain-openai = {version = "^0.3.0", optional = true}
 langchain-google-genai = {version = "^4.2.1", optional = true}
 openai = {version = "^1.40.0", optional = true}
 cloudpathlib = {extras = ["s3"], version = "^0.20.0", optional = true}
-nepali = {version = "^1.2.0", optional = true}
+nepali = "^1.2.0"
 
 [tool.poetry.extras]
 llm-all = ["langchain", "langchain-openai", "langchain-google-genai", "openai"]
 s3 = ["cloudpathlib"]
-nepali-support = ["nepali"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,12 @@ langchain-openai = {version = "^0.3.0", optional = true}
 langchain-google-genai = {version = "^4.2.1", optional = true}
 openai = {version = "^1.40.0", optional = true}
 cloudpathlib = {extras = ["s3"], version = "^0.20.0", optional = true}
-nepali = "^1.2.0"
+nepali = {version = "^1.2.0", optional = true}
 
 [tool.poetry.extras]
 llm-all = ["langchain", "langchain-openai", "langchain-google-genai", "openai"]
 s3 = ["cloudpathlib"]
+nepali-support = ["nepali"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_map_press_release_files.py
+++ b/tests/test_map_press_release_files.py
@@ -1,0 +1,278 @@
+"""Tests for map_press_release_files management command."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from django.core.management import call_command
+from io import StringIO
+
+from cases.models import Case, DocumentSource, CaseState, CaseType, SourceType
+
+
+@pytest.mark.django_db
+class TestMapPressReleaseFiles:
+    """Test suite for map_press_release_files command."""
+
+    @pytest.fixture
+    def mock_press_release_index(self):
+        """Mock NGM press release index response."""
+        return {
+            "name": "ciaa-press-releases",
+            "path": "/ciaa-press-releases",
+            "manuscripts": [
+                {
+                    "url": "https://ngm-store.jawafdehi.org/uploads/ciaa/press-releases/files/3173. test - 1.pdf",
+                    "file_name": "3173. test - 1.pdf",
+                    "metadata": {
+                        "press_id": 3173,
+                        "title": "Test Press Release",
+                        "publication_date": "2082-04-19",
+                        "full_text": "Test content",
+                        "source_url": "https://ciaa.gov.np/pressrelease/3173",
+                        "file_names": [
+                            "3173. test - 1.pdf",
+                            "3173. test - 2.docx",
+                        ],
+                    },
+                },
+                {
+                    "url": "https://ngm-store.jawafdehi.org/uploads/ciaa/press-releases/files/3173. test - 2.docx",
+                    "file_name": "3173. test - 2.docx",
+                    "metadata": {
+                        "press_id": 3173,
+                        "title": "Test Press Release",
+                        "publication_date": "2082-04-19",
+                        "full_text": "Test content",
+                        "source_url": "https://ciaa.gov.np/pressrelease/3173",
+                        "file_names": [
+                            "3173. test - 1.pdf",
+                            "3173. test - 2.docx",
+                        ],
+                    },
+                },
+            ],
+        }
+
+    @pytest.fixture
+    def case_with_press_release_evidence(self):
+        """Create a case with press release evidence."""
+        # Create press release source
+        pr_source = DocumentSource.objects.create(
+            title="CIAA Press Release",
+            url=["https://ciaa.gov.np/pressrelease/3173"],
+            source_type=SourceType.LEGAL_PROCEDURAL,
+        )
+
+        # Create case with evidence pointing to press release
+        case = Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.DRAFT,
+            title="Test Case",
+            evidence=[
+                {
+                    "source_id": pr_source.source_id,
+                    "description": "CIAA Press Release (ID: 3173)",
+                }
+            ],
+        )
+
+        return case, pr_source
+
+    def test_dry_run_mode(self, mock_press_release_index, case_with_press_release_evidence):
+        """Test that dry-run mode doesn't modify database."""
+        case, pr_source = case_with_press_release_evidence
+        original_evidence = case.evidence.copy()
+
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_press_release_index
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            out = StringIO()
+            call_command("map_press_release_files", "--dry-run", stdout=out)
+
+            # Refresh case from database
+            case.refresh_from_db()
+
+            # Evidence should not be changed in dry-run mode
+            assert case.evidence == original_evidence
+
+            # Output should indicate dry-run
+            output = out.getvalue()
+            assert "[DRY RUN]" in output
+
+    def test_map_press_release_evidence(self, mock_press_release_index, case_with_press_release_evidence):
+        """Test that command maps press release evidence to actual files."""
+        case, pr_source = case_with_press_release_evidence
+
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_press_release_index
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            out = StringIO()
+            call_command("map_press_release_files", stdout=out)
+
+            # Refresh case from database
+            case.refresh_from_db()
+
+            # Evidence should be updated with file sources
+            assert len(case.evidence) == 2  # Two files from press release
+
+            # Check that new sources were created
+            for evidence_entry in case.evidence:
+                source = DocumentSource.objects.get(source_id=evidence_entry["source_id"])
+                # Source should have file URL
+                assert any("ngm-store.jawafdehi.org" in url for url in source.url)
+                # Source should also have press release URL for reference
+                assert any("ciaa.gov.np/pressrelease/3173" in url for url in source.url)
+
+            # Output should indicate success
+            output = out.getvalue()
+            assert "✓ Cases fixed:" in output
+
+    def test_skip_cases_without_press_release_evidence(self):
+        """Test that cases without press release evidence are skipped."""
+        # Create case with regular evidence (not press release)
+        regular_source = DocumentSource.objects.create(
+            title="Regular Document",
+            url=["https://example.com/document.pdf"],
+            source_type=SourceType.LEGAL_COURT_ORDER,
+        )
+
+        case = Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.DRAFT,
+            title="Test Case",
+            evidence=[
+                {
+                    "source_id": regular_source.source_id,
+                    "description": "Regular document",
+                }
+            ],
+        )
+
+        original_evidence = case.evidence.copy()
+
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"manuscripts": []}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            out = StringIO()
+            call_command("map_press_release_files", stdout=out)
+
+            # Refresh case from database
+            case.refresh_from_db()
+
+            # Evidence should not be changed
+            assert case.evidence == original_evidence
+
+    def test_specific_case_id(self, mock_press_release_index, case_with_press_release_evidence):
+        """Test mapping a specific case by case_id."""
+        case, pr_source = case_with_press_release_evidence
+
+        # Create another case that should not be processed
+        other_source = DocumentSource.objects.create(
+            title="Other Press Release",
+            url=["https://ciaa.gov.np/pressrelease/9999"],
+            source_type=SourceType.LEGAL_PROCEDURAL,
+        )
+        other_case = Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.DRAFT,
+            title="Other Case",
+            evidence=[
+                {
+                    "source_id": other_source.source_id,
+                    "description": "Other press release",
+                }
+            ],
+        )
+        other_original_evidence = other_case.evidence.copy()
+
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_press_release_index
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            out = StringIO()
+            call_command(
+                "map_press_release_files",
+                f"--case-id={case.case_id}",
+                stdout=out,
+            )
+
+            # Refresh cases from database
+            case.refresh_from_db()
+            other_case.refresh_from_db()
+
+            # Target case should be fixed
+            assert len(case.evidence) == 2
+
+            # Other case should not be changed
+            assert other_case.evidence == other_original_evidence
+
+    def test_limit_option(self, mock_press_release_index):
+        """Test that limit option works correctly."""
+        # Create multiple cases with press release evidence
+        cases = []
+        for i in range(5):
+            pr_source = DocumentSource.objects.create(
+                title=f"Press Release {i}",
+                url=["https://ciaa.gov.np/pressrelease/3173"],
+                source_type=SourceType.LEGAL_PROCEDURAL,
+            )
+            case = Case.objects.create(
+                case_type=CaseType.CORRUPTION,
+                state=CaseState.DRAFT,
+                title=f"Test Case {i}",
+                evidence=[
+                    {
+                        "source_id": pr_source.source_id,
+                        "description": f"Press release {i}",
+                    }
+                ],
+            )
+            cases.append(case)
+
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_press_release_index
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            out = StringIO()
+            call_command("map_press_release_files", "--limit=2", stdout=out)
+
+            # Check that only 2 cases were processed
+            output = out.getvalue()
+            assert "Cases processed:     2" in output
+
+    def test_handle_missing_press_release_in_index(self, case_with_press_release_evidence):
+        """Test handling of press releases not found in NGM index."""
+        case, pr_source = case_with_press_release_evidence
+        original_evidence = case.evidence.copy()
+
+        # Mock empty index (press release not found)
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"manuscripts": []}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            out = StringIO()
+            call_command("map_press_release_files", stdout=out)
+
+            # Refresh case from database
+            case.refresh_from_db()
+
+            # Evidence should not be changed if press release not found
+            assert case.evidence == original_evidence
+
+            # Output should indicate no files found
+            output = out.getvalue()
+            assert "No files found" in output or "Skipped" in output

--- a/tests/test_map_press_release_files.py
+++ b/tests/test_map_press_release_files.py
@@ -53,6 +53,18 @@ class TestMapPressReleaseFiles:
         }
 
     @pytest.fixture
+    def mock_root_index(self):
+        """Mock NGM root index response."""
+        return {
+            "children": [
+                {
+                    "name": "ciaa-press-releases",
+                    "$ref": "https://ngm-store.jawafdehi.org/indices/2026-05-04/index.ciaa-press-releases.json"
+                }
+            ]
+        }
+
+    @pytest.fixture
     def case_with_press_release_evidence(self):
         """Create a case with press release evidence."""
         # Create press release source
@@ -77,14 +89,17 @@ class TestMapPressReleaseFiles:
 
         return case, pr_source
 
-    def test_dry_run_mode(self, mock_press_release_index, case_with_press_release_evidence):
+    def test_dry_run_mode(
+        self, mock_root_index, mock_press_release_index, case_with_press_release_evidence
+    ):
         """Test that dry-run mode doesn't modify database."""
         case, pr_source = case_with_press_release_evidence
         original_evidence = case.evidence.copy()
 
         with patch("requests.get") as mock_get:
             mock_response = MagicMock()
-            mock_response.json.return_value = mock_press_release_index
+            # First call returns root index, second call returns press release index
+            mock_response.json.side_effect = [mock_root_index, mock_press_release_index]
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 
@@ -101,13 +116,16 @@ class TestMapPressReleaseFiles:
             output = out.getvalue()
             assert "[DRY RUN]" in output
 
-    def test_map_press_release_evidence(self, mock_press_release_index, case_with_press_release_evidence):
+    def test_map_press_release_evidence(
+        self, mock_root_index, mock_press_release_index, case_with_press_release_evidence
+    ):
         """Test that command maps press release evidence to actual files."""
         case, pr_source = case_with_press_release_evidence
 
         with patch("requests.get") as mock_get:
             mock_response = MagicMock()
-            mock_response.json.return_value = mock_press_release_index
+            # First call returns root index, second call returns press release index
+            mock_response.json.side_effect = [mock_root_index, mock_press_release_index]
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 
@@ -122,7 +140,9 @@ class TestMapPressReleaseFiles:
 
             # Check that new sources were created
             for evidence_entry in case.evidence:
-                source = DocumentSource.objects.get(source_id=evidence_entry["source_id"])
+                source = DocumentSource.objects.get(
+                    source_id=evidence_entry["source_id"]
+                )
                 # Source should have file URL
                 assert any("ngm-store.jawafdehi.org" in url for url in source.url)
                 # Source should also have press release URL for reference
@@ -130,9 +150,9 @@ class TestMapPressReleaseFiles:
 
             # Output should indicate success
             output = out.getvalue()
-            assert "✓ Cases fixed:" in output
+            assert "✓ Cases mapped:" in output
 
-    def test_skip_cases_without_press_release_evidence(self):
+    def test_skip_cases_without_press_release_evidence(self, mock_root_index):
         """Test that cases without press release evidence are skipped."""
         # Create case with regular evidence (not press release)
         regular_source = DocumentSource.objects.create(
@@ -157,7 +177,8 @@ class TestMapPressReleaseFiles:
 
         with patch("requests.get") as mock_get:
             mock_response = MagicMock()
-            mock_response.json.return_value = {"manuscripts": []}
+            # First call returns root index, second call returns empty press release index
+            mock_response.json.side_effect = [mock_root_index, {"manuscripts": []}]
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 
@@ -170,7 +191,9 @@ class TestMapPressReleaseFiles:
             # Evidence should not be changed
             assert case.evidence == original_evidence
 
-    def test_specific_case_id(self, mock_press_release_index, case_with_press_release_evidence):
+    def test_specific_case_id(
+        self, mock_root_index, mock_press_release_index, case_with_press_release_evidence
+    ):
         """Test mapping a specific case by case_id."""
         case, pr_source = case_with_press_release_evidence
 
@@ -195,7 +218,8 @@ class TestMapPressReleaseFiles:
 
         with patch("requests.get") as mock_get:
             mock_response = MagicMock()
-            mock_response.json.return_value = mock_press_release_index
+            # First call returns root index, second call returns press release index
+            mock_response.json.side_effect = [mock_root_index, mock_press_release_index]
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 
@@ -216,7 +240,7 @@ class TestMapPressReleaseFiles:
             # Other case should not be changed
             assert other_case.evidence == other_original_evidence
 
-    def test_limit_option(self, mock_press_release_index):
+    def test_limit_option(self, mock_root_index, mock_press_release_index):
         """Test that limit option works correctly."""
         # Create multiple cases with press release evidence
         cases = []
@@ -241,7 +265,8 @@ class TestMapPressReleaseFiles:
 
         with patch("requests.get") as mock_get:
             mock_response = MagicMock()
-            mock_response.json.return_value = mock_press_release_index
+            # First call returns root index, second call returns press release index
+            mock_response.json.side_effect = [mock_root_index, mock_press_release_index]
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 
@@ -252,7 +277,9 @@ class TestMapPressReleaseFiles:
             output = out.getvalue()
             assert "Cases processed:     2" in output
 
-    def test_handle_missing_press_release_in_index(self, case_with_press_release_evidence):
+    def test_handle_missing_press_release_in_index(
+        self, mock_root_index, case_with_press_release_evidence
+    ):
         """Test handling of press releases not found in NGM index."""
         case, pr_source = case_with_press_release_evidence
         original_evidence = case.evidence.copy()
@@ -260,7 +287,8 @@ class TestMapPressReleaseFiles:
         # Mock empty index (press release not found)
         with patch("requests.get") as mock_get:
             mock_response = MagicMock()
-            mock_response.json.return_value = {"manuscripts": []}
+            # First call returns root index, second call returns empty press release index
+            mock_response.json.side_effect = [mock_root_index, {"manuscripts": []}]
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 

--- a/tests/test_map_press_release_files.py
+++ b/tests/test_map_press_release_files.py
@@ -59,7 +59,7 @@ class TestMapPressReleaseFiles:
             "children": [
                 {
                     "name": "ciaa-press-releases",
-                    "$ref": "https://ngm-store.jawafdehi.org/indices/2026-05-04/index.ciaa-press-releases.json"
+                    "$ref": "https://ngm-store.jawafdehi.org/indices/2026-05-04/index.ciaa-press-releases.json",
                 }
             ]
         }
@@ -90,7 +90,10 @@ class TestMapPressReleaseFiles:
         return case, pr_source
 
     def test_dry_run_mode(
-        self, mock_root_index, mock_press_release_index, case_with_press_release_evidence
+        self,
+        mock_root_index,
+        mock_press_release_index,
+        case_with_press_release_evidence,
     ):
         """Test that dry-run mode doesn't modify database."""
         case, pr_source = case_with_press_release_evidence
@@ -117,7 +120,10 @@ class TestMapPressReleaseFiles:
             assert "[DRY RUN]" in output
 
     def test_map_press_release_evidence(
-        self, mock_root_index, mock_press_release_index, case_with_press_release_evidence
+        self,
+        mock_root_index,
+        mock_press_release_index,
+        case_with_press_release_evidence,
     ):
         """Test that command maps press release evidence to actual files."""
         case, pr_source = case_with_press_release_evidence
@@ -192,7 +198,10 @@ class TestMapPressReleaseFiles:
             assert case.evidence == original_evidence
 
     def test_specific_case_id(
-        self, mock_root_index, mock_press_release_index, case_with_press_release_evidence
+        self,
+        mock_root_index,
+        mock_press_release_index,
+        case_with_press_release_evidence,
     ):
         """Test mapping a specific case by case_id."""
         case, pr_source = case_with_press_release_evidence


### PR DESCRIPTION
## Problem

Cases imported via `import_ciaa_cases` have evidence pointing to CIAA press release web pages (e.g., `https://ciaa.gov.np/pressrelease/3345`) instead of actual PDF/DOCX file URLs from the NGM bucket.

## Solution

Adds a new management command `map_press_release_files` that:

1. Fetches the NGM press release index from R2 bucket (with pagination support)
2. Finds cases with press release web page URLs in evidence
3. Creates new DocumentSource records with actual file URLs from NGM bucket
4. Updates case evidence to point to the new sources
5. Preserves the original web page URL as a reference

## Key Features

- **Handles multiple files**: Press releases with multiple files (e.g., PDF + DOCX) create separate DocumentSource records for each file
- **Preserves both URLs**: Each DocumentSource includes both the file URL and the web page URL
- **Database-agnostic**: Works with both PostgreSQL and SQLite
- **Safe execution**: Supports `--dry-run` mode for testing
- **Flexible filtering**: Supports `--case-id` and `--limit` options
- **Comprehensive tests**: 6 test cases covering all scenarios

## Usage

```bash
# Test first
poetry run python manage.py map_press_release_files --dry-run

# Apply changes to all cases
poetry run python manage.py map_press_release_files

# Fix specific case
poetry run python manage.py map_press_release_files --case-id=case-abc123

# Process first 10 cases
poetry run python manage.py map_press_release_files --limit=10
```

## Example
**Before:**

DocumentSource URL: ["https://ciaa.gov.np/pressrelease/2719"]

**After:**
DocumentSource 1 URL: ["https://ngm-store.jawafdehi.org/.../2719. title - 1.doc", "https://ciaa.gov.np/pressrelease/2719"]
DocumentSource 2 URL: ["https://ngm-store.jawafdehi.org/.../2719. title - 2.pdf", "https://ciaa.gov.np/pressrelease/2719"]


## Testing
All tests pass:
```bash
poetry run pytest tests/test_map_press_release_files.py -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a management command to map press-release pages to file-backed document sources for case evidence. Supports dry-run, per-case targeting, batch limits, reusing existing sources, parsing publication dates, resilient per-case processing, and prints a summary. Replaces press-release evidence with file-backed references when files are found.

* **Tests**
  * Adds tests covering dry-run behavior, mapping results, case ID filtering, batch limits, skipping unaffected cases, and missing-index handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->