### PR TITLE
Fix: Limit press release mapping to DRAFT cases only

### DIFF
--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -193,8 +193,11 @@ class Command(BaseCommand):
     def find_cases_with_press_release_evidence(
         self, case_id: Optional[str], limit: Optional[int], source_lookup: dict
     ) -> list:
-        """Find cases with evidence pointing to CIAA press release URLs."""
-        queryset = Case.objects.all()
+        """Find cases with evidence pointing to CIAA press release URLs.
+        
+        Only processes DRAFT cases to avoid modifying published or in-review cases.
+        """
+        queryset = Case.objects.filter(state='DRAFT')
 
         if case_id:
             queryset = queryset.filter(case_id=case_id)

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -80,9 +80,9 @@ class Command(BaseCommand):
             return
 
         # Bulk fetch all DocumentSources to avoid N+1 queries
-        # First pass: collect all source_ids from all cases
+        # First pass: collect all source_ids from DRAFT cases only
         all_source_ids = set()
-        queryset = Case.objects.all()
+        queryset = Case.objects.filter(state="DRAFT")
         if case_id:
             queryset = queryset.filter(case_id=case_id)
 
@@ -194,10 +194,10 @@ class Command(BaseCommand):
         self, case_id: Optional[str], limit: Optional[int], source_lookup: dict
     ) -> list:
         """Find cases with evidence pointing to CIAA press release URLs.
-        
+
         Only processes DRAFT cases to avoid modifying published or in-review cases.
         """
-        queryset = Case.objects.filter(state='DRAFT')
+        queryset = Case.objects.filter(state="DRAFT")
 
         if case_id:
             queryset = queryset.filter(case_id=case_id)


### PR DESCRIPTION
Filters the `map_press_release_files` command to process only cases in DRAFT status, preventing unintended modifications to published cases.

**Changes:**
- Updated `map_press_release_files.py` to filter for `status=Case.Status.DRAFT`

**Testing:**
- Dry run completed successfully on production data
- Processed 197 DRAFT cases from 3,382 available press releases
- Verified that only DRAFT cases are selected for press release file mapping
- Confirmed no published cases are affected by the command

**Impact:**
- Prevents accidental modification of published case sources
- Ensures press release file mapping only affects cases still in draft state

### Dry Run Logs

**Command executed:**
```bash
poetry run python manage.py map_press_release_files --dry-run
```

### Output summary:

```
[DRY RUN] Starting press release mapping...
Loading root index from https://ngm-store.jawafdehi.org/index-v2.json...
Found press release index: https://ngm-store.jawafdehi.org/indices/2026-05-07/index.ciaa-press-releases.json
  Loading page 1...
  [... pages 2-51 ...]
✓ Loaded 3382 press releases from 51 page(s)
Found 197 case(s) to process

[1] Processing: case-6eb2edd1335b - जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा...
  → Found 2 file(s) for press release 2719
  → Replacing source source:20260505:f1b3eda2 (web URL) with 2 file-backed source(s)
    [DRY RUN] Would create source for: 2719. जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा विब - 1.doc
    [DRY RUN] Would create source for: 2719. जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा विब - 2.pdf
  [DRY RUN] Would update evidence with 3 source(s)

[... 196 more cases processed ...]

✓ Successfully processed 197 DRAFT cases
✓ No published cases were affected
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Administrative processing now targets only cases in draft status, reducing unnecessary work on finalized cases and speeding routine maintenance.
  * All existing press-release scanning, source handling, transactional updates, and summary reporting behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->