### PR TITLE
Create one DocumentSource per press release instead of per file

### DIFF
--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -210,7 +210,7 @@ class Command(BaseCommand):
         cases_with_pr_evidence = []
         skipped_already_mapped = 0
         skipped_no_pr_url = 0
-        
+
         for case in queryset:
             if not case.evidence:
                 continue
@@ -250,9 +250,15 @@ class Command(BaseCommand):
             if limit and len(cases_with_pr_evidence) >= limit:
                 break
 
-        self.stdout.write(f"  - Cases with unmapped press releases: {len(cases_with_pr_evidence)}")
-        self.stdout.write(f"  - Cases already mapped (skipped): {skipped_already_mapped}")
-        self.stdout.write(f"  - Cases without press release URLs (skipped): {skipped_no_pr_url}")
+        self.stdout.write(
+            f"  - Cases with unmapped press releases: {len(cases_with_pr_evidence)}"
+        )
+        self.stdout.write(
+            f"  - Cases already mapped (skipped): {skipped_already_mapped}"
+        )
+        self.stdout.write(
+            f"  - Cases without press release URLs (skipped): {skipped_no_pr_url}"
+        )
 
         return cases_with_pr_evidence
 
@@ -549,7 +555,7 @@ class Command(BaseCommand):
                 # Build complete URL list: merge new URLs with existing ones
                 # Start with existing URLs to preserve any prior URLs
                 url_list = list(existing_urls) if existing_urls else []
-                
+
                 # Encode and add press release web URL first (ensure it's at the beginning)
                 if press_release_url and str(press_release_url).strip():
                     pr_url_str = str(press_release_url).strip()

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -362,18 +362,66 @@ class Command(BaseCommand):
                                 f"    ✓ Created/updated source {combined_source.source_id} with {file_count} file(s)"
                             )
                         )
+                    else:
+                        # No valid file URLs found - preserve original evidence
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"  ⊘ No valid file URLs found for press release {press_id}, preserving original evidence"
+                            )
+                        )
+                        updated_evidence.append(evidence_entry)
             else:
-                # Dry-run mode
+                # Dry-run mode - simulate the same existence check
                 file_count = len(pr_data["files"])
-                self.stdout.write(
-                    f"    [DRY RUN] Would create source with web URL + {file_count} file URL(s)"
-                )
+
+                # Check if source already exists (same logic as get_or_create_press_release_source)
+                if connection.vendor == "postgresql":
+                    existing = DocumentSource.objects.filter(
+                        url__contains=[press_release_url], is_deleted=False
+                    ).first()
+                else:
+                    existing = None
+                    candidates = DocumentSource.objects.filter(
+                        url__icontains=press_release_url, is_deleted=False
+                    )
+                    for source in candidates:
+                        if (
+                            isinstance(source.url, list)
+                            and press_release_url in source.url
+                        ):
+                            existing = source
+                            break
+
+                if existing:
+                    # Check if it would need updating
+                    existing_urls = (
+                        existing.url
+                        if isinstance(existing.url, list)
+                        else [existing.url]
+                    )
+                    file_urls = [f.get("url") for f in pr_data["files"] if f.get("url")]
+                    needs_update = any(
+                        file_url not in existing_urls for file_url in file_urls
+                    )
+
+                    if needs_update:
+                        self.stats["sources_updated"] += 1
+                        self.stdout.write(
+                            f"    [DRY RUN] Would update existing source with {file_count} file URL(s)"
+                        )
+                    else:
+                        self.stdout.write(
+                            "    [DRY RUN] Would reuse existing source (no changes needed)"
+                        )
+                else:
+                    self.stats["sources_created"] += 1
+                    self.stdout.write(
+                        f"    [DRY RUN] Would create source with web URL + {file_count} file URL(s)"
+                    )
+
                 for file_data in pr_data["files"]:
                     file_name = file_data.get("file_name", "")
                     self.stdout.write(f"      - {file_name}")
-
-                # In dry-run, we still need to track what would happen
-                self.stats["sources_created"] += 1  # Assume it would be created
 
                 updated_evidence.append(
                     {

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -203,9 +203,14 @@ class Command(BaseCommand):
         if case_id:
             queryset = queryset.filter(case_id=case_id)
 
+        self.stdout.write(f"Scanning {queryset.count()} DRAFT cases...")
+
         # Filter cases with evidence containing ciaa.gov.np/pressrelease URLs
         # Uses source_lookup passed from handle() to avoid duplicate DB queries
         cases_with_pr_evidence = []
+        skipped_already_mapped = 0
+        skipped_no_pr_url = 0
+        
         for case in queryset:
             if not case.evidence:
                 continue
@@ -227,6 +232,7 @@ class Command(BaseCommand):
                                 break
 
                     if is_file_backed:
+                        skipped_already_mapped += 1
                         continue
 
                     # Check if source URL contains press release URL
@@ -238,9 +244,15 @@ class Command(BaseCommand):
 
             if has_pr_evidence:
                 cases_with_pr_evidence.append(case)
+            elif case.evidence:
+                skipped_no_pr_url += 1
 
             if limit and len(cases_with_pr_evidence) >= limit:
                 break
+
+        self.stdout.write(f"  - Cases with unmapped press releases: {len(cases_with_pr_evidence)}")
+        self.stdout.write(f"  - Cases already mapped (skipped): {skipped_already_mapped}")
+        self.stdout.write(f"  - Cases without press release URLs (skipped): {skipped_no_pr_url}")
 
         return cases_with_pr_evidence
 
@@ -371,8 +383,20 @@ class Command(BaseCommand):
                         )
                         updated_evidence.append(evidence_entry)
             else:
-                # Dry-run mode - simulate the same existence check
-                file_count = len(pr_data["files"])
+                # Dry-run mode - mirror real-run logic
+                # Build file_urls same as real-run
+                file_urls = [f.get("url") for f in pr_data["files"] if f.get("url")]
+                file_count = len(file_urls)
+
+                # If no valid file URLs, log warning and preserve original evidence
+                if not file_urls:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  ⊘ No valid file URLs found for press release {press_id}, preserving original evidence"
+                        )
+                    )
+                    updated_evidence.append(evidence_entry)
+                    continue
 
                 # Check if source already exists (same logic as get_or_create_press_release_source)
                 if connection.vendor == "postgresql":
@@ -399,7 +423,6 @@ class Command(BaseCommand):
                         if isinstance(existing.url, list)
                         else [existing.url]
                     )
-                    file_urls = [f.get("url") for f in pr_data["files"] if f.get("url")]
                     needs_update = any(
                         file_url not in existing_urls for file_url in file_urls
                     )
@@ -420,8 +443,9 @@ class Command(BaseCommand):
                     )
 
                 for file_data in pr_data["files"]:
-                    file_name = file_data.get("file_name", "")
-                    self.stdout.write(f"      - {file_name}")
+                    if file_data.get("url"):  # Only show files with valid URLs
+                        file_name = file_data.get("file_name", "")
+                        self.stdout.write(f"      - {file_name}")
 
                 updated_evidence.append(
                     {
@@ -522,10 +546,11 @@ class Command(BaseCommand):
                     break
 
             if needs_update:
-                # Build complete URL list: web URL first, then all file URLs
-                url_list = []
-
-                # Add press release web URL first
+                # Build complete URL list: merge new URLs with existing ones
+                # Start with existing URLs to preserve any prior URLs
+                url_list = list(existing_urls) if existing_urls else []
+                
+                # Encode and add press release web URL first (ensure it's at the beginning)
                 if press_release_url and str(press_release_url).strip():
                     pr_url_str = str(press_release_url).strip()
                     parsed = urllib.parse.urlsplit(pr_url_str)
@@ -541,9 +566,12 @@ class Command(BaseCommand):
                             encoded_fragment,
                         )
                     )
-                    url_list.append(encoded_url)
+                    # Remove if already exists and prepend to ensure it's first
+                    if encoded_url in url_list:
+                        url_list.remove(encoded_url)
+                    url_list.insert(0, encoded_url)
 
-                # Add all file URLs
+                # Add all file URLs (skip duplicates)
                 for file_url in file_urls:
                     if file_url and str(file_url).strip():
                         file_url_str = str(file_url).strip()
@@ -560,7 +588,9 @@ class Command(BaseCommand):
                                 encoded_fragment,
                             )
                         )
-                        url_list.append(encoded_url)
+                        # Only add if not already present
+                        if encoded_url not in url_list:
+                            url_list.append(encoded_url)
 
                 # Update existing source with complete URL list
                 existing.url = url_list

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -333,7 +333,7 @@ class Command(BaseCommand):
 
                     if file_urls:
                         # Create or update single DocumentSource with all URLs
-                        combined_source, created = (
+                        combined_source, created, updated = (
                             self.get_or_create_press_release_source(
                                 press_release_url=press_release_url,
                                 file_urls=file_urls,
@@ -344,9 +344,9 @@ class Command(BaseCommand):
                         )
                         if created:
                             self.stats["sources_created"] += 1
-                        else:
-                            # Source was updated (not newly created)
+                        elif updated:
                             self.stats["sources_updated"] += 1
+                        # else: reused unchanged — no counter change
 
                         # Add single evidence entry
                         file_count = len(file_urls)
@@ -424,7 +424,7 @@ class Command(BaseCommand):
         title: str,
         publication_date: Optional[str],
         file_names: list[str],
-    ) -> tuple[DocumentSource, bool]:
+    ) -> tuple[DocumentSource, bool, bool]:
         """Get or create DocumentSource for a press release with all its files.
 
         Creates a single DocumentSource containing:
@@ -439,7 +439,10 @@ class Command(BaseCommand):
             file_names: List of file names (for logging)
 
         Returns:
-            tuple: (DocumentSource, created) where created is True if a new source was created
+            tuple: (DocumentSource, created, updated) where:
+                - created is True if a new source was created
+                - updated is True if an existing source was modified
+                - both are False if an existing source was reused unchanged
         """
         # Check if source already exists by press release URL (database-agnostic)
         if connection.vendor == "postgresql":
@@ -524,12 +527,12 @@ class Command(BaseCommand):
                 logger.info(
                     f"Updated existing source {existing.source_id} with {len(file_urls)} file URL(s)"
                 )
-                return existing, True  # Return True to indicate it was updated
+                return existing, False, True  # created=False, updated=True
             else:
                 logger.debug(
                     f"Reusing existing source: {existing.source_id} (already has all file URLs)"
                 )
-                return existing, False
+                return existing, False, False  # created=False, updated=False
 
         source_type = SourceType.LEGAL_PROCEDURAL
 
@@ -606,7 +609,7 @@ class Command(BaseCommand):
         logger.info(
             f"Created new source: {source.source_id} for press release with {file_count} file(s)"
         )
-        return source, True
+        return source, True, False  # created=True, updated=False
 
     def print_summary(self, dry_run: bool):
         """Print summary statistics."""

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
             "cases_fixed": 0,
             "cases_skipped": 0,
             "sources_created": 0,
+            "sources_updated": 0,
             "evidence_updated": 0,
             "errors": 0,
         }
@@ -313,57 +314,73 @@ class Command(BaseCommand):
                 f"  → Found {len(pr_data['files'])} file(s) for press release {press_id}"
             )
 
-            # Intentionally replace the original web URL source with file-backed sources
-            # The original evidence_entry (web URL) is NOT appended to updated_evidence
-            # This is by design: we want file URLs, not web page URLs, in the final evidence
+            # Create ONE DocumentSource containing the web URL + all file URLs
             self.stdout.write(
-                f"  → Replacing source {source_id} (web URL) with {len(pr_data['files'])} file-backed source(s)"
+                f"  → Creating single source with web URL + {len(pr_data['files'])} file URL(s)"
             )
 
-            # Create DocumentSource for each file and add to evidence
-            files_processed = 0
-            for file_data in pr_data["files"]:
-                file_url = file_data.get("url")
-                file_name = file_data.get("file_name", "")
+            if not dry_run:
+                with transaction.atomic():
+                    # Collect all file URLs
+                    file_urls = []
+                    file_names = []
+                    for file_data in pr_data["files"]:
+                        file_url = file_data.get("url")
+                        file_name = file_data.get("file_name", "")
+                        if file_url:
+                            file_urls.append(file_url)
+                            file_names.append(file_name)
 
-                if not file_url:
-                    continue
-
-                if not dry_run:
-                    with transaction.atomic():
-                        file_source, created = self.get_or_create_file_source(
-                            file_url=file_url,
-                            file_name=file_name,
-                            press_release_url=press_release_url,
-                            title=pr_data.get("title", "CIAA Press Release Document"),
-                            publication_date=pr_data.get("publication_date"),
+                    if file_urls:
+                        # Create or update single DocumentSource with all URLs
+                        combined_source, created = (
+                            self.get_or_create_press_release_source(
+                                press_release_url=press_release_url,
+                                file_urls=file_urls,
+                                title=pr_data.get("title", "CIAA Press Release"),
+                                publication_date=pr_data.get("publication_date"),
+                                file_names=file_names,
+                            )
                         )
                         if created:
                             self.stats["sources_created"] += 1
+                        else:
+                            # Source was updated (not newly created)
+                            self.stats["sources_updated"] += 1
 
-                        # Add to updated evidence
+                        # Add single evidence entry
+                        file_count = len(file_urls)
                         updated_evidence.append(
                             {
-                                "source_id": file_source.source_id,
-                                "description": f"CIAA Press Release Document - {file_name}",
+                                "source_id": combined_source.source_id,
+                                "description": f"CIAA Press Release ({file_count} document{'s' if file_count > 1 else ''})",
                             }
                         )
-                        files_processed += 1
-                else:
-                    self.stdout.write(
-                        f"    [DRY RUN] Would create source for: {file_name}"
-                    )
-                    # In dry-run mode, append synthetic entry to updated_evidence
-                    updated_evidence.append(
-                        {
-                            "source_id": f"dry-run-{file_name}",
-                            "description": f"CIAA Press Release Document - {file_name}",
-                        }
-                    )
-                    files_processed += 1
+                        evidence_changed = True
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"    ✓ Created/updated source {combined_source.source_id} with {file_count} file(s)"
+                            )
+                        )
+            else:
+                # Dry-run mode
+                file_count = len(pr_data["files"])
+                self.stdout.write(
+                    f"    [DRY RUN] Would create source with web URL + {file_count} file URL(s)"
+                )
+                for file_data in pr_data["files"]:
+                    file_name = file_data.get("file_name", "")
+                    self.stdout.write(f"      - {file_name}")
 
-            # Only mark as changed if we actually processed files
-            if files_processed > 0:
+                # In dry-run, we still need to track what would happen
+                self.stats["sources_created"] += 1  # Assume it would be created
+
+                updated_evidence.append(
+                    {
+                        "source_id": f"dry-run-pr-{press_id}",
+                        "description": f"CIAA Press Release ({file_count} document{'s' if file_count > 1 else ''})",
+                    }
+                )
                 evidence_changed = True
 
         # Update case evidence if changed
@@ -379,6 +396,9 @@ class Command(BaseCommand):
                     )
                 )
             else:
+                # Dry-run mode - still track what would happen
+                self.stats["evidence_updated"] += 1
+                self.stats["cases_fixed"] += 1
                 self.stdout.write(
                     self.style.SUCCESS(
                         f"  [DRY RUN] Would update evidence with {len(updated_evidence)} source(s)"
@@ -397,39 +417,119 @@ class Command(BaseCommand):
         except (ValueError, IndexError):
             return None
 
-    def get_or_create_file_source(
+    def get_or_create_press_release_source(
         self,
-        file_url: str,
-        file_name: str,
         press_release_url: str,
+        file_urls: list[str],
         title: str,
         publication_date: Optional[str],
+        file_names: list[str],
     ) -> tuple[DocumentSource, bool]:
-        """Get or create DocumentSource for a press release file.
+        """Get or create DocumentSource for a press release with all its files.
+
+        Creates a single DocumentSource containing:
+        - The original web URL (e.g., https://ciaa.gov.np/pressrelease/3294)
+        - All file URLs (e.g., PDF/DOCX files from NGM bucket)
+
+        Args:
+            press_release_url: The CIAA press release web page URL
+            file_urls: List of file URLs from NGM bucket
+            title: Press release title
+            publication_date: Publication date in BS format (YYYY-MM-DD)
+            file_names: List of file names (for logging)
 
         Returns:
             tuple: (DocumentSource, created) where created is True if a new source was created
         """
-        # Check if source already exists by URL (database-agnostic)
+        # Check if source already exists by press release URL (database-agnostic)
         if connection.vendor == "postgresql":
             existing = DocumentSource.objects.filter(
-                url__contains=[file_url], is_deleted=False
+                url__contains=[press_release_url], is_deleted=False
             ).first()
         else:
-            # Fallback for SQLite and other databases - filter candidates at DB level first
+            # Fallback for SQLite and other databases
             existing = None
-            # Use text containment to narrow down candidates at DB level
             candidates = DocumentSource.objects.filter(
-                url__icontains=file_url, is_deleted=False
+                url__icontains=press_release_url, is_deleted=False
             )
             for source in candidates:
-                if isinstance(source.url, list) and file_url in source.url:
+                if isinstance(source.url, list) and press_release_url in source.url:
                     existing = source
                     break
 
         if existing:
-            logger.debug(f"Reusing existing source: {existing.source_id}")
-            return existing, False
+            # Check if existing source needs to be updated with file URLs
+            existing_urls = (
+                existing.url if isinstance(existing.url, list) else [existing.url]
+            )
+            needs_update = False
+
+            # Check if any file URLs are missing
+            for file_url in file_urls:
+                if file_url not in existing_urls:
+                    needs_update = True
+                    break
+
+            if needs_update:
+                # Build complete URL list: web URL first, then all file URLs
+                url_list = []
+
+                # Add press release web URL first
+                if press_release_url and str(press_release_url).strip():
+                    pr_url_str = str(press_release_url).strip()
+                    parsed = urllib.parse.urlsplit(pr_url_str)
+                    encoded_path = urllib.parse.quote(parsed.path, safe="/")
+                    encoded_query = urllib.parse.quote(parsed.query, safe="=&")
+                    encoded_fragment = urllib.parse.quote(parsed.fragment, safe="")
+                    encoded_url = urllib.parse.urlunsplit(
+                        (
+                            parsed.scheme,
+                            parsed.netloc,
+                            encoded_path,
+                            encoded_query,
+                            encoded_fragment,
+                        )
+                    )
+                    url_list.append(encoded_url)
+
+                # Add all file URLs
+                for file_url in file_urls:
+                    if file_url and str(file_url).strip():
+                        file_url_str = str(file_url).strip()
+                        parsed = urllib.parse.urlsplit(file_url_str)
+                        encoded_path = urllib.parse.quote(parsed.path, safe="/")
+                        encoded_query = urllib.parse.quote(parsed.query, safe="=&")
+                        encoded_fragment = urllib.parse.quote(parsed.fragment, safe="")
+                        encoded_url = urllib.parse.urlunsplit(
+                            (
+                                parsed.scheme,
+                                parsed.netloc,
+                                encoded_path,
+                                encoded_query,
+                                encoded_fragment,
+                            )
+                        )
+                        url_list.append(encoded_url)
+
+                # Update existing source with complete URL list
+                existing.url = url_list
+
+                # Update description with file count
+                file_count = len(file_urls)
+                existing.description = f"CIAA Press Release with {file_count} document{'s' if file_count > 1 else ''}: {press_release_url}"[
+                    :500
+                ]
+
+                existing.save(update_fields=["url", "description"])
+                logger.info(
+                    f"Updated existing source {existing.source_id} with {len(file_urls)} file URL(s)"
+                )
+                return existing, True  # Return True to indicate it was updated
+            else:
+                logger.debug(
+                    f"Reusing existing source: {existing.source_id} (already has all file URLs)"
+                )
+                return existing, False
 
         source_type = SourceType.LEGAL_PROCEDURAL
 
@@ -446,30 +546,11 @@ class Command(BaseCommand):
                     f"Failed to parse publication date {publication_date}: {e}"
                 )
 
-        # Build URL list: file URL + press release web page URL
+        # Build URL list: web URL first, then all file URLs
         url_list = []
-        if file_url and str(file_url).strip():
-            # Properly URL-encode the file URL
-            file_url_str = str(file_url).strip()
-            parsed = urllib.parse.urlsplit(file_url_str)
-            # Encode path, query, and fragment components
-            encoded_path = urllib.parse.quote(parsed.path, safe="/")
-            encoded_query = urllib.parse.quote(parsed.query, safe="=&")
-            encoded_fragment = urllib.parse.quote(parsed.fragment, safe="")
-            # Rebuild the URL
-            encoded_url = urllib.parse.urlunsplit(
-                (
-                    parsed.scheme,
-                    parsed.netloc,
-                    encoded_path,
-                    encoded_query,
-                    encoded_fragment,
-                )
-            )
-            url_list.append(encoded_url)
 
+        # Add press release web URL first
         if press_release_url and str(press_release_url).strip():
-            # Properly URL-encode the press release URL
             pr_url_str = str(press_release_url).strip()
             parsed = urllib.parse.urlsplit(pr_url_str)
             encoded_path = urllib.parse.quote(parsed.path, safe="/")
@@ -486,20 +567,45 @@ class Command(BaseCommand):
             )
             url_list.append(encoded_url)
 
+        # Add all file URLs
+        for file_url in file_urls:
+            if file_url and str(file_url).strip():
+                file_url_str = str(file_url).strip()
+                parsed = urllib.parse.urlsplit(file_url_str)
+                encoded_path = urllib.parse.quote(parsed.path, safe="/")
+                encoded_query = urllib.parse.quote(parsed.query, safe="=&")
+                encoded_fragment = urllib.parse.quote(parsed.fragment, safe="")
+                encoded_url = urllib.parse.urlunsplit(
+                    (
+                        parsed.scheme,
+                        parsed.netloc,
+                        encoded_path,
+                        encoded_query,
+                        encoded_fragment,
+                    )
+                )
+                url_list.append(encoded_url)
+
         if not url_list:
-            logger.error(f"No valid URLs for file {file_name}")
-            raise ValueError(f"No valid URLs for file {file_name}")
+            logger.error(f"No valid URLs for press release {press_release_url}")
+            raise ValueError(f"No valid URLs for press release {press_release_url}")
+
+        # Create description with file count
+        file_count = len(file_urls)
+        description = f"CIAA Press Release with {file_count} document{'s' if file_count > 1 else ''}: {press_release_url}"
 
         # Create new source (save() will generate source_id and validate)
         source = DocumentSource.objects.create(
-            title=f"{title[:250]} - {file_name[:50]}"[:300],
-            description=f"Document from CIAA press release: {press_release_url}",
+            title=title[:300],
+            description=description[:500],
             source_type=source_type,
             url=url_list,
             publication_date=pub_date,
         )
 
-        logger.info(f"Created new source: {source.source_id} for {file_name}")
+        logger.info(
+            f"Created new source: {source.source_id} for press release with {file_count} file(s)"
+        )
         return source, True
 
     def print_summary(self, dry_run: bool):
@@ -517,6 +623,7 @@ class Command(BaseCommand):
             self.style.WARNING(f"⊘ Cases skipped:     {self.stats['cases_skipped']}")
         )
         self.stdout.write(f"Sources created:     {self.stats['sources_created']}")
+        self.stdout.write(f"Sources updated:     {self.stats['sources_updated']}")
         self.stdout.write(f"Evidence updated:    {self.stats['evidence_updated']}")
         if self.stats["errors"] > 0:
             self.stdout.write(

--- a/tests/test_map_press_release_files.py
+++ b/tests/test_map_press_release_files.py
@@ -147,12 +147,12 @@ class TestMapPressReleaseFiles:
             # Check that new source was created
             evidence_entry = case.evidence[0]
             source = DocumentSource.objects.get(source_id=evidence_entry["source_id"])
-            
+
             # Source should have both the web URL and file URLs
             assert len(source.url) == 3  # web URL + 2 file URLs
             assert any("ciaa.gov.np/pressrelease/3173" in url for url in source.url)
             assert sum("ngm-store.jawafdehi.org" in url for url in source.url) == 2
-            
+
             # Evidence description should show file count
             assert "2 documents" in evidence_entry["description"]
 

--- a/tests/test_map_press_release_files.py
+++ b/tests/test_map_press_release_files.py
@@ -141,18 +141,20 @@ class TestMapPressReleaseFiles:
             # Refresh case from database
             case.refresh_from_db()
 
-            # Evidence should be updated with file sources
-            assert len(case.evidence) == 2  # Two files from press release
+            # Evidence should be updated with ONE source per press release (not per file)
+            assert len(case.evidence) == 1  # One source containing both files
 
-            # Check that new sources were created
-            for evidence_entry in case.evidence:
-                source = DocumentSource.objects.get(
-                    source_id=evidence_entry["source_id"]
-                )
-                # Source should have file URL
-                assert any("ngm-store.jawafdehi.org" in url for url in source.url)
-                # Source should also have press release URL for reference
-                assert any("ciaa.gov.np/pressrelease/3173" in url for url in source.url)
+            # Check that new source was created
+            evidence_entry = case.evidence[0]
+            source = DocumentSource.objects.get(source_id=evidence_entry["source_id"])
+            
+            # Source should have both the web URL and file URLs
+            assert len(source.url) == 3  # web URL + 2 file URLs
+            assert any("ciaa.gov.np/pressrelease/3173" in url for url in source.url)
+            assert sum("ngm-store.jawafdehi.org" in url for url in source.url) == 2
+            
+            # Evidence description should show file count
+            assert "2 documents" in evidence_entry["description"]
 
             # Output should indicate success
             output = out.getvalue()
@@ -243,8 +245,8 @@ class TestMapPressReleaseFiles:
             case.refresh_from_db()
             other_case.refresh_from_db()
 
-            # Target case should be fixed
-            assert len(case.evidence) == 2
+            # Target case should be fixed (one source per press release)
+            assert len(case.evidence) == 1
 
             # Other case should not be changed
             assert other_case.evidence == other_original_evidence


### PR DESCRIPTION

Refactored `map_press_release_files` command to create **ONE DocumentSource per press release** containing both the web URL and all associated file URLs, instead of creating separate sources for each file.

---

## Changes

### Behavior Change

- **Before**: Created separate `DocumentSource` for each PDF/DOCX file
- **After**: Creates single `DocumentSource` per press release with web URL + all file URLs in one array

### Key Improvements

1. **Simplified data model**
   - One source per press release instead of multiple sources

2. **Better evidence descriptions**
   - Shows `"CIAA Press Release (2 documents)"` format with file count

3. **Added `sources_updated` tracking**
   - Distinguishes between newly created and updated sources

4. **Fixed dry-run statistics**
   - Properly tracks what would be created/updated in dry-run mode

5. **Renamed method**
   - `get_or_create_file_source` → `get_or_create_press_release_source`

---

## Technical Details

- Each `DocumentSource.url` now contains:

```python
[
    web_url,
    file_url_1,
    file_url_2,
    ...
]
```

- Evidence entries reference a single source instead of multiple sources per press release
- Update logic checks if existing sources need file URLs added
- Maintains backward compatibility with existing sources

---

## Testing Results

### Local Database - Dry Run

<details>
<summary>Click to expand dry-run logs (197 cases, 200 sources would be created)</summary>

```text
[DRY RUN] Starting press release mapping...
Loading root index from https://ngm-store.jawafdehi.org/index-v2.json...

Found press release index:
https://ngm-store.jawafdehi.org/indices/2026-05-08/index.ciaa-press-releases.json

Loading page 1...
Loading page 2...
...
Loading page 51...

✓ Loaded 3384 press releases from 51 page(s)

Found 197 case(s) to process

[1] Processing: case-1ca2d03092d9
- जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा...

→ Found 2 file(s) for press release 2719
→ Creating single source with web URL + 2 file URL(s)

[DRY RUN] Would create source with web URL + 2 file URL(s)

- 2719. जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा विब - 1.doc
- 2719. जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा विब - 2.pdf

[DRY RUN] Would update evidence with 2 source(s)

[2] Processing: case-3f13dfd01e3d
- जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट...

→ Found 2 file(s) for press release 2718
→ Creating single source with web URL + 2 file URL(s)

[DRY RUN] Would create source with web URL + 2 file URL(s)

- 2718. जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट्टा त - 1.doc
- 2718. जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट्टा त - 2.pdf

[DRY RUN] Would update evidence with 2 source(s)

...

[197] Processing: case-f62c5b0051a3
- जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज ख...

→ Found 2 file(s) for press release 2402
→ Creating single source with web URL + 2 file URL(s)

[DRY RUN] Would create source with web URL + 2 file URL(s)

- 2402. जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज खतिव - 1.doc
- 2402. जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज खतिव - 2.pdf

[DRY RUN] Would update evidence with 2 source(s)

============================================================

[DRY RUN] SUMMARY

Cases processed: 197
✓ Cases mapped: 197
⊘ Cases skipped: 0

Sources created: 200
Sources updated: 0
Evidence updated: 197

This was a dry run. No changes were made to the database.
Run without --dry-run to apply changes.
```

</details>

---

### Local Database - Actual Execution

<details>
<summary>Click to expand actual execution logs (197 cases, 200 sources created)</summary>

```text
Starting press release mapping...

Loading root index from https://ngm-store.jawafdehi.org/index-v2.json...

Found press release index:
https://ngm-store.jawafdehi.org/indices/2026-05-08/index.ciaa-press-releases.json

Loading page 1...
Loading page 2...
...
Loading page 51...

✓ Loaded 3384 press releases from 51 page(s)

Found 197 case(s) to process

[1] Processing: case-1ca2d03092d9
- जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा...

→ Found 2 file(s) for press release 2719
→ Creating single source with web URL + 2 file URL(s)

✓ Created/updated source source:20260508:55adf1bb with 2 file(s)
✓ Mapped: Updated evidence with 2 source(s)

[2] Processing: case-3f13dfd01e3d
- जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट...

→ Found 2 file(s) for press release 2718
→ Creating single source with web URL + 2 file URL(s)

✓ Created/updated source source:20260508:8d74fd05 with 2 file(s)
✓ Mapped: Updated evidence with 2 source(s)

...

[197] Processing: case-f62c5b0051a3
- जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज ख...

→ Found 2 file(s) for press release 2402
→ Creating single source with web URL + 2 file URL(s)

✓ Created/updated source source:20260508:9b6cd6c7 with 2 file(s)
✓ Mapped: Updated evidence with 2 source(s)

============================================================

SUMMARY

Cases processed: 197
✓ Cases mapped: 197
⊘ Cases skipped: 0

Sources created: 200
Sources updated: 0
Evidence updated: 197
```

</details>

---

### Production Database - Dry Run

<details>
<summary>Click to expand production dry-run logs (197 cases, 200 sources would be created)</summary>

```text
[DRY RUN] Starting press release mapping...

Loading root index from https://ngm-store.jawafdehi.org/index-v2.json...

Found press release index:
https://ngm-store.jawafdehi.org/indices/2026-05-08/index.ciaa-press-releases.json

Loading page 1...
Loading page 2...
...
Loading page 51...

✓ Loaded 3384 press releases from 51 page(s)

Found 197 case(s) to process

[1] Processing: case-6eb2edd1335b
- जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा...

→ Found 2 file(s) for press release 2719
→ Creating single source with web URL + 2 file URL(s)

[DRY RUN] Would create source with web URL + 2 file URL(s)

- 2719. जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा विब - 1.doc
- 2719. जिल्ला कास्की, दुर्गा आधारभूत विद्यालयका तत्कालीन शिक्षक बोधराज पौडेल उपर झुट्टा विब - 2.pdf

[DRY RUN] Would update evidence with 2 source(s)

[2] Processing: case-e734789cae4e
- जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट...

→ Found 2 file(s) for press release 2718
→ Creating single source with web URL + 2 file URL(s)

[DRY RUN] Would create source with web URL + 2 file URL(s)

- 2718. जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट्टा त - 1.doc
- 2718. जिल्ला धनुषा, श्री माध्यमिक विद्यालय बरमझियाका राहत शिक्षक ब्रहमदेव यादव उपर झुट्टा त - 2.pdf

[DRY RUN] Would update evidence with 2 source(s)

...

[197] Processing: case-6ad3a5bb1a18
- जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज ख...

→ Found 2 file(s) for press release 2402
→ Creating single source with web URL + 2 file URL(s)

[DRY RUN] Would create source with web URL + 2 file URL(s)

- 2402. जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज खतिव - 1.doc
- 2402. जिल्ला ओखलढुङ्गा, सिद्धिचरण नगरपालिकाका तत्कालीन प्रमुख प्रशासकीय अधिकत भोजराज खतिव - 2.pdf

[DRY RUN] Would update evidence with 2 source(s)

============================================================

[DRY RUN] SUMMARY

Cases processed: 197
✓ Cases mapped: 197
⊘ Cases skipped: 0

Sources created: 200
Sources updated: 0
Evidence updated: 197

This was a dry run. No changes were made to the database.
Run without --dry-run to apply changes.
```

</details>

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Press release evidence is now consolidated into a single entry per release: the entry combines the press-release web URL and all associated document files, and cases now reference one combined evidence item.

* **Chores**
  * Command metrics now track updated combined sources.

* **Behavior**
  * Dry-run simulates the combined-source creation/update without marking cases as changed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jawafdehi/JawafdehiAPI/pull/61)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jawafdehi/JawafdehiAPI/pull/61)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->