### PR TITLE
Use admin URLs in case evidence widget to prevent navigation errors

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -170,15 +170,21 @@ class CaseAdminForm(forms.ModelForm):
                     # No role - see nothing
                     sources_queryset = DocumentSource.objects.none()
 
-            sources = sources_queryset.values_list("source_id", "title", "url")
+            # Build sources list with admin URLs for viewing
+            # Format: (source_id, title, admin_url)
+            sources = []
+            for source in sources_queryset:
+                admin_url = f"/admin/cases/documentsource/{source.pk}/change/"
+                sources.append((source.source_id, source.title, admin_url))
         else:
             # Fallback if no request (shouldn't happen in normal admin usage)
-            sources = DocumentSource.objects.filter(is_deleted=False).values_list(
-                "source_id", "title", "url"
-            )
+            sources = []
+            for source in DocumentSource.objects.filter(is_deleted=False):
+                admin_url = f"/admin/cases/documentsource/{source.pk}/change/"
+                sources.append((source.source_id, source.title, admin_url))
 
-        self.fields["evidence"].sources = list(sources)
-        self.fields["evidence"].widget.sources = list(sources)
+        self.fields["evidence"].sources = sources
+        self.fields["evidence"].widget.sources = sources
 
         # Disable PUBLISHED and CLOSED states for Contributors
         if self.request:
@@ -773,6 +779,9 @@ class DocumentSourceAdmin(admin.ModelAdmin):
 
     form = DocumentSourceAdminForm
     inlines = [DocumentSourceUploadInline]
+
+    # Disable "View on site" button since DocumentSource doesn't have a public detail page
+    view_on_site = False
 
     list_display = [
         "source_id",

--- a/tests/test_document_source_admin.py
+++ b/tests/test_document_source_admin.py
@@ -117,6 +117,15 @@ class TestDocumentSourceAdmin:
         inline_models = [inline.model.__name__ for inline in admin_instance.inlines]
         assert "DocumentSourceUpload" in inline_models
 
+    def test_view_on_site_is_disabled(self, db):
+        """Test that 'View on site' button is disabled for DocumentSource.
+
+        DocumentSource doesn't have a public detail page, so the 'View on site'
+        button should be disabled to prevent errors when users click it.
+        """
+        admin_instance = admin.site._registry[DocumentSource]
+        assert admin_instance.view_on_site is False
+
     def test_list_display_configured(self, db):
         """Test that list display is properly configured."""
         admin_instance = admin.site._registry[DocumentSource]
@@ -328,3 +337,66 @@ class TestDocumentSourceAdminForm:
         )
 
         assert form.is_valid(), f"Form errors: {form.errors}"
+
+
+class TestCaseEvidenceWidget:
+    """Test Case admin evidence widget configuration."""
+
+    def test_evidence_widget_uses_admin_urls_not_source_urls(self, db, admin_user):
+        """Test that evidence widget uses admin URLs instead of DocumentSource.url field.
+
+        The evidence widget's "View" button should link to the DocumentSource admin page,
+        not to the DocumentSource.url field (which is a JSON array and causes errors).
+
+        Regression test for: "Case with ID '691/change/[...]' doesn't exist" error.
+        """
+        from cases.admin import CaseAdminForm
+        from cases.models import CaseType
+
+        # Create a document source with URL array
+        source = create_document_source_with_entities(
+            title="Test Source", description="Test", related_entity_ids=[]
+        )
+        source.url = ["https://example.com/file.pdf", "https://example.com/page"]
+        source.save()
+
+        # Create a case
+        case = create_case_with_entities(
+            title="Test Case",
+            alleged_entities=["entity:person/test"],
+            case_type=CaseType.CORRUPTION,
+        )
+
+        # Create a mock request with admin user
+        request = create_mock_request(admin_user)
+
+        # Initialize the form with request
+        form = CaseAdminForm(instance=case, request=request)
+
+        # Check that sources are populated with admin URLs, not the url field
+        sources = form.fields["evidence"].widget.sources
+
+        # Find our test source in the sources list
+        test_source_entry = None
+        for source_id, title, url in sources:
+            if source_id == source.source_id:
+                test_source_entry = (source_id, title, url)
+                break
+
+        assert test_source_entry is not None, "Test source should be in sources list"
+
+        source_id, title, admin_url = test_source_entry
+
+        # Verify the URL is an admin URL, not the source.url array
+        assert admin_url.startswith(
+            "/admin/cases/documentsource/"
+        ), f"Expected admin URL, got: {admin_url}"
+        assert admin_url.endswith(
+            "/change/"
+        ), f"Expected admin change URL, got: {admin_url}"
+
+        # Verify it's NOT the JSON array from source.url
+        assert not isinstance(admin_url, list), "URL should be a string, not a list"
+        assert (
+            "https://example.com" not in admin_url
+        ), "URL should not contain the source's external URLs"


### PR DESCRIPTION
## Problem
The case admin evidence widget was using `DocumentSource.url` field values for the "View" button links. Since `DocumentSource.url` is a JSON array (e.g., `["https://ciaa.gov.np/pressrelease/2672"]`), clicking "View" caused navigation errors like:

`Case with ID "401/change/['https://ciaa.gov.np/pressrelease/2672']" doesn't exist. Perhaps it was deleted?`


Additionally, the DocumentSource admin had a "View on site" button that would fail since DocumentSource doesn't have a public detail page.

## Solution
- **Evidence widget**: Changed to use admin change URLs instead of `source.url` values
- **DocumentSource admin**: Disabled "View on site" button by setting `view_on_site = False`

## Changes
- Modified `CaseAdminForm.__init__()` to build sources list with admin URLs
- Set `DocumentSourceAdmin.view_on_site = False`
- Added comprehensive test coverage for widget URL behavior

## Before & After
**Before**: Clicking "View" tried to navigate to the JSON array value
❌ /admin/cases/case/401/change/['https://ciaa.gov.np/pressrelease/2672']

**After**: Clicking "View" navigates to the DocumentSource admin page
✅ /admin/cases/documentsource/5681/change/


## Testing
-  All existing tests pass
-  New test: `test_view_on_site_is_disabled()`
- New test: `test_evidence_widget_uses_admin_urls_not_source_urls()`
  - Verifies widget uses admin URLs, not source.url arrays
  - Tests with sources containing URL arrays
  - Ensures no navigation errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed evidence link display in case administration to properly route through the internal admin interface for document sources
  * Disabled external "View on site" functionality for document source entries in the administration panel

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jawafdehi/JawafdehiAPI/pull/71)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->