### PR TITLE
[JAWA-1410] Add SSL/TLS database connection settings support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,15 @@ CSRF_TRUSTED_ORIGINS=https://*.newnepal.workers.dev
 NES_API_URL=https://nes.jawafdehi.org/api
 DATABASE_URL=postgresql://user:password@localhost:5432/jawafdehi
 NGM_DATABASE_URL=postgresql://user:password@localhost:5432/ngm
+
+# Optional: SSL/TLS for PostgreSQL connections (e.g. Cloud SQL).
+# These can also be supplied as URL query params:
+#   DATABASE_URL=postgresql://user:pass@host:5432/db?sslmode=verify-ca&sslrootcert=/path/to/ca.pem
+# DATABASE_SSL_MODE=verify-ca
+# DATABASE_SSL_CA_CERT_FILE=/path/to/server-ca.pem
+# DATABASE_SSL_CLIENT_CERT_FILE=/path/to/client-cert.pem
+# DATABASE_SSL_CLIENT_KEY_FILE=/path/to/client-key.pem
+
 NGM_QUERY_MAX_ROWS=500
 
 # NES Queue System (only needed for GitHub Actions queue processing)

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ NGM_DATABASE_URL=postgresql://user:password@localhost:5432/ngm
 # DATABASE_SSL_CA_CERT_FILE=/path/to/server-ca.pem
 # DATABASE_SSL_CLIENT_CERT_FILE=/path/to/client-cert.pem
 # DATABASE_SSL_CLIENT_KEY_FILE=/path/to/client-key.pem
+# Fallback variables (used when DATABASE_SSL_* variants are not set):
+# SSL_CA_CERT_FILE=/path/to/server-ca.pem
+# SSL_CLIENT_CERT_FILE=/path/to/client-cert.pem
+# SSL_CLIENT_KEY_FILE=/path/to/client-key.pem
 
 NGM_QUERY_MAX_ROWS=500
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -253,7 +253,6 @@ WSGI_APPLICATION = "config.wsgi.application"
 # at the top level of the config dict when they appear as URL query params
 # (e.g. ?sslmode=verify-ca&sslrootcert=/path/to/ca.pem). These need to be
 # moved into OPTIONS for Django / psycopg2 to interpret them correctly.
-_POSTGRESQL_ENGINE = "django.db.backends.postgresql"
 _SSL_PARAMS = frozenset(
     {
         "sslmode",
@@ -282,7 +281,7 @@ def _apply_db_ssl_options(db_config):
 
     If the engine is not PostgreSQL this is a no-op.
     """
-    if db_config.get("ENGINE") != _POSTGRESQL_ENGINE:
+    if db_config.get("ENGINE") != "django.db.backends.postgresql":
         return db_config
 
     options = db_config.setdefault("OPTIONS", {})
@@ -318,11 +317,6 @@ def _apply_db_ssl_options(db_config):
 
 # Handle secret interpolation for database URLs
 def interpolate_db_url(url_env_name):
-    """Replace ${DATABASE_PASSWORD} placeholder in a URL env var with its real value.
-
-    This allows database URLs to use a template-style placeholder so the
-    password can be injected at runtime from Google Secret Manager.
-    """
     url = os.getenv(url_env_name)
     if not url:
         return
@@ -350,6 +344,7 @@ if db_password:
             "DATABASE_URL"
         )
         if db_url and "${DATABASE_PASSWORD}" in db_url:
+            DATABASES[db_key]["PASSWORD"] = db_password
             new_url = db_url.replace("${DATABASE_PASSWORD}", db_password)
             DATABASES[db_key] = dj_database_url.parse(new_url)
 
@@ -368,11 +363,14 @@ for db_key in DATABASES:
     _apply_db_ssl_options(DATABASES[db_key])
 
 # Configure connection pooling for PostgreSQL only
-if DATABASES["default"].get("ENGINE") == _POSTGRESQL_ENGINE:
+if DATABASES["default"].get("ENGINE") == "django.db.backends.postgresql":
     DATABASES["default"]["CONN_MAX_AGE"] = 60
     DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
 
-if "ngm" in DATABASES and DATABASES["ngm"].get("ENGINE") == _POSTGRESQL_ENGINE:
+if (
+    "ngm" in DATABASES
+    and DATABASES["ngm"].get("ENGINE") == "django.db.backends.postgresql"
+):
     DATABASES["ngm"]["CONN_MAX_AGE"] = 60
     DATABASES["ngm"]["CONN_HEALTH_CHECKS"] = True
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -249,6 +249,73 @@ WSGI_APPLICATION = "config.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
+# SSL-related PostgreSQL connection parameters that dj_database_url may place
+# at the top level of the config dict when they appear as URL query params
+# (e.g. ?sslmode=verify-ca&sslrootcert=/path/to/ca.pem). These need to be
+# moved into OPTIONS for Django / psycopg2 to interpret them correctly.
+_SSL_PARAMS = frozenset(
+    {
+        "sslmode",
+        "sslrootcert",
+        "sslcert",
+        "sslkey",
+        "sslcrl",
+        "sslpassword",
+        "sslcompression",
+        "sslsni",
+    }
+)
+
+
+def _apply_db_ssl_options(db_config):
+    """Apply SSL options to a PostgreSQL database config.
+
+    Sources (in priority order — first wins):
+    1. URL query parameters already in the config dict
+       (dj_database_url places them at the top level)
+    2. Environment variables:
+       - DATABASE_SSL_MODE            → sslmode
+       - DATABASE_SSL_CA_CERT_FILE    → sslrootcert
+       - DATABASE_SSL_CLIENT_CERT_FILE → sslcert
+       - DATABASE_SSL_CLIENT_KEY_FILE  → sslkey
+
+    If the engine is not PostgreSQL this is a no-op.
+    """
+    if db_config.get("ENGINE") != "django.db.backends.postgresql":
+        return db_config
+
+    options = db_config.setdefault("OPTIONS", {})
+
+    # Move SSL params that came in via URL query string into OPTIONS.
+    for param in _SSL_PARAMS:
+        if param in db_config:
+            options.setdefault(param, db_config.pop(param))
+
+    # Apply from environment variables (won't override URL-provided values).
+    ssl_mode = os.getenv("DATABASE_SSL_MODE")
+    if ssl_mode:
+        options.setdefault("sslmode", ssl_mode)
+
+    ca_cert = os.getenv("DATABASE_SSL_CA_CERT_FILE") or os.getenv(
+        "SSL_CA_CERT_FILE"
+    )
+    if ca_cert:
+        options.setdefault("sslrootcert", ca_cert)
+
+    client_cert = os.getenv("DATABASE_SSL_CLIENT_CERT_FILE") or os.getenv(
+        "SSL_CLIENT_CERT_FILE"
+    )
+    if client_cert:
+        options.setdefault("sslcert", client_cert)
+
+    client_key = os.getenv("DATABASE_SSL_CLIENT_KEY_FILE") or os.getenv(
+        "SSL_CLIENT_KEY_FILE"
+    )
+    if client_key:
+        options.setdefault("sslkey", client_key)
+
+    return db_config
+
 
 # Handle secret interpolation for database URLs
 def interpolate_db_url(url_env_name):
@@ -280,8 +347,6 @@ if db_password:
         )
         if db_url and "${DATABASE_PASSWORD}" in db_url:
             DATABASES[db_key]["PASSWORD"] = db_password
-            # Re-configure with dj_database_url if needed, but usually just setting PASSWORD works if the URL had a placeholder
-            # Better approach: replace placeholder in URL before parsing
             new_url = db_url.replace("${DATABASE_PASSWORD}", db_password)
             DATABASES[db_key] = dj_database_url.parse(new_url)
 
@@ -292,6 +357,12 @@ if os.getenv("NGM_DATABASE_URL"):
             "${DATABASE_PASSWORD}", db_password
         )
         DATABASES["ngm"] = dj_database_url.parse(new_url)
+
+# Apply SSL options to all PostgreSQL databases.
+# Must run after password interpolation so that re-parsed configs also
+# receive SSL options.
+for db_key in DATABASES:
+    _apply_db_ssl_options(DATABASES[db_key])
 
 # Configure connection pooling for PostgreSQL only
 if DATABASES["default"].get("ENGINE") == "django.db.backends.postgresql":

--- a/config/settings.py
+++ b/config/settings.py
@@ -372,10 +372,7 @@ if DATABASES["default"].get("ENGINE") == _POSTGRESQL_ENGINE:
     DATABASES["default"]["CONN_MAX_AGE"] = 60
     DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
 
-if (
-    "ngm" in DATABASES
-    and DATABASES["ngm"].get("ENGINE") == _POSTGRESQL_ENGINE
-):
+if "ngm" in DATABASES and DATABASES["ngm"].get("ENGINE") == _POSTGRESQL_ENGINE:
     DATABASES["ngm"]["CONN_MAX_AGE"] = 60
     DATABASES["ngm"]["CONN_HEALTH_CHECKS"] = True
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -253,6 +253,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 # at the top level of the config dict when they appear as URL query params
 # (e.g. ?sslmode=verify-ca&sslrootcert=/path/to/ca.pem). These need to be
 # moved into OPTIONS for Django / psycopg2 to interpret them correctly.
+_POSTGRESQL_ENGINE = "django.db.backends.postgresql"
 _SSL_PARAMS = frozenset(
     {
         "sslmode",
@@ -281,7 +282,7 @@ def _apply_db_ssl_options(db_config):
 
     If the engine is not PostgreSQL this is a no-op.
     """
-    if db_config.get("ENGINE") != "django.db.backends.postgresql":
+    if db_config.get("ENGINE") != _POSTGRESQL_ENGINE:
         return db_config
 
     options = db_config.setdefault("OPTIONS", {})
@@ -317,6 +318,11 @@ def _apply_db_ssl_options(db_config):
 
 # Handle secret interpolation for database URLs
 def interpolate_db_url(url_env_name):
+    """Replace ${DATABASE_PASSWORD} placeholder in a URL env var with its real value.
+
+    This allows database URLs to use a template-style placeholder so the
+    password can be injected at runtime from Google Secret Manager.
+    """
     url = os.getenv(url_env_name)
     if not url:
         return
@@ -344,7 +350,6 @@ if db_password:
             "DATABASE_URL"
         )
         if db_url and "${DATABASE_PASSWORD}" in db_url:
-            DATABASES[db_key]["PASSWORD"] = db_password
             new_url = db_url.replace("${DATABASE_PASSWORD}", db_password)
             DATABASES[db_key] = dj_database_url.parse(new_url)
 
@@ -363,13 +368,13 @@ for db_key in DATABASES:
     _apply_db_ssl_options(DATABASES[db_key])
 
 # Configure connection pooling for PostgreSQL only
-if DATABASES["default"].get("ENGINE") == "django.db.backends.postgresql":
+if DATABASES["default"].get("ENGINE") == _POSTGRESQL_ENGINE:
     DATABASES["default"]["CONN_MAX_AGE"] = 60
     DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
 
 if (
     "ngm" in DATABASES
-    and DATABASES["ngm"].get("ENGINE") == "django.db.backends.postgresql"
+    and DATABASES["ngm"].get("ENGINE") == _POSTGRESQL_ENGINE
 ):
     DATABASES["ngm"]["CONN_MAX_AGE"] = 60
     DATABASES["ngm"]["CONN_HEALTH_CHECKS"] = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -296,9 +296,7 @@ def _apply_db_ssl_options(db_config):
     if ssl_mode:
         options.setdefault("sslmode", ssl_mode)
 
-    ca_cert = os.getenv("DATABASE_SSL_CA_CERT_FILE") or os.getenv(
-        "SSL_CA_CERT_FILE"
-    )
+    ca_cert = os.getenv("DATABASE_SSL_CA_CERT_FILE") or os.getenv("SSL_CA_CERT_FILE")
     if ca_cert:
         options.setdefault("sslrootcert", ca_cert)
 


### PR DESCRIPTION
## Rationale
Add SSL/TLS support for PostgreSQL database connections, required for Cloud SQL connectivity. Previously, the Django database settings had no mechanism to pass SSL parameters (sslmode, certificates) to psycopg2.

## Changes
- Add `_apply_db_ssl_options()` helper that moves SSL params from URL query strings into `OPTIONS` and applies environment variable overrides
- Support `DATABASE_SSL_MODE`, `DATABASE_SSL_CA_CERT_FILE`, `DATABASE_SSL_CLIENT_CERT_FILE`, `DATABASE_SSL_CLIENT_KEY_FILE` env vars
- Apply SSL options after password interpolation to ensure re-parsed configs also receive SSL settings
- Document SSL env vars in `.env.example`

## Verification
- Verified that `dj-database-url` v3.0.1 already puts URL query params (`?sslmode=...&sslrootcert=...`) into `OPTIONS` natively
- Env var SSL settings are only applied when URL doesn't already provide them (`setdefault`)
- SSL helper is a no-op for SQLite connections
- Password interpolation preserves SSL parameters since they survive `dj_database_url.parse()`

## Paperclip Metadata
- **Issue:** [JAWA-1410](/JAWA/issues/JAWA-1410)
- **Parent:** [JAWA-1408](/JAWA/issues/JAWA-1408)
- **Paperclip-Run-Id:** 665d521a-fa6f-43ff-ba64-943775050f15

## Rollback
Revert commit `866dfa5`. No database schema changes, no migration required. SSL settings are purely additive; when no SSL env vars or URL params are present, behavior is identical to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PostgreSQL SSL/TLS guidance to the environment template, showing how to enable secure connections via URL parameters or environment variables.

* **Chores**
  * Centralized PostgreSQL SSL handling so SSL/TLS options are applied consistently across all database configurations and ensured DB URL password placeholders are resolved before finalizing connection settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jawafdehi/JawafdehiAPI/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->