### PR TITLE
Feat/search

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -22,7 +22,7 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 from django.db.models import Q
-from rest_framework import filters, mixins, status, viewsets
+from rest_framework import filters, mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
@@ -59,8 +59,130 @@ from .serializers import (
     FeedbackSerializer,
     JawafEntitySerializer,
 )
+from .search_serializers import SearchResponseSerializer
+from .services.search import UnifiedSearchService
 
 logger = logging.getLogger(__name__)
+
+
+class UnifiedSearchQuerySerializer(serializers.Serializer):
+    q = serializers.CharField(required=False, allow_blank=True, default="")
+    type = serializers.ChoiceField(
+        choices=[
+            "all",
+            "case",
+            "entity",
+            "document",
+            "person",
+            "organization",
+            "location",
+        ],
+        required=False,
+        default="all",
+    )
+    status = serializers.ChoiceField(
+        choices=[CaseState.PUBLISHED, CaseState.IN_REVIEW, CaseState.DRAFT],
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    role = serializers.ChoiceField(
+        choices=RelationshipType.values,
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    case_type = serializers.ChoiceField(
+        choices=["CORRUPTION"], required=False, allow_null=True, default=None
+    )
+    tags = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=None
+    )
+    sort = serializers.ChoiceField(
+        choices=["relevance", "newest", "oldest", "title"],
+        required=False,
+        default="relevance",
+    )
+    page = serializers.IntegerField(required=False, min_value=1, default=1)
+    page_size = serializers.IntegerField(required=False, min_value=1, default=10)
+
+
+@extend_schema(
+    summary="Search the accountability archive",
+    description="""
+    Search visible accountability cases, entities, and evidence documents in one
+    deterministic relevance-ranked result list. Anonymous case search exposes
+    published records only. Entity types are derived locally from NES IDs; this
+    endpoint does not call external services.
+    """,
+    parameters=[
+        OpenApiParameter("q", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False),
+        OpenApiParameter(
+            "type",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            enum=[
+                "all",
+                "case",
+                "entity",
+                "document",
+                "person",
+                "organization",
+                "location",
+            ],
+        ),
+        OpenApiParameter(
+            "status",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            enum=["PUBLISHED", "IN_REVIEW", "DRAFT"],
+        ),
+        OpenApiParameter(
+            "role",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            enum=RelationshipType.values,
+        ),
+        OpenApiParameter(
+            "case_type",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            enum=["CORRUPTION"],
+        ),
+        OpenApiParameter(
+            "tags", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False
+        ),
+        OpenApiParameter(
+            "sort",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            enum=["relevance", "newest", "oldest", "title"],
+        ),
+        OpenApiParameter(
+            "page", OpenApiTypes.INT, OpenApiParameter.QUERY, required=False
+        ),
+        OpenApiParameter(
+            "page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, required=False
+        ),
+    ],
+    responses={200: SearchResponseSerializer},
+    tags=["search"],
+)
+class UnifiedSearchView(APIView):
+    """Expose backend-owned mixed archive discovery."""
+
+    def get(self, request):
+        serializer = UnifiedSearchQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        response = UnifiedSearchService().search(
+            request=request, **serializer.validated_data
+        )
+        return Response(response)
 
 
 @extend_schema_view(

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -42,6 +42,7 @@ from .models import (
     Case,
     CaseEntityRelationship,
     CaseState,
+    CaseType,
     DocumentSource,
     JawafEntity,
     RelationshipType,
@@ -85,7 +86,7 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
         default=list,
     )
     case_type = serializers.ListField(
-        child=serializers.ChoiceField(choices=["CORRUPTION"]),
+        child=serializers.ChoiceField(choices=CaseType.values),
         required=False,
         default=list,
     )
@@ -142,7 +143,7 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
             OpenApiTypes.STR,
             OpenApiParameter.QUERY,
             required=False,
-            enum=["CORRUPTION"],
+            enum=CaseType.values,
             many=True,
         ),
         OpenApiParameter(

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -68,35 +68,31 @@ logger = logging.getLogger(__name__)
 class UnifiedSearchQuerySerializer(serializers.Serializer):
     q = serializers.CharField(required=False, allow_blank=True, default="")
     type = serializers.ChoiceField(
-        choices=[
-            "all",
-            "case",
-            "entity",
-            "document",
-            "person",
-            "organization",
-            "location",
-        ],
+        choices=["all", "case", "entity", "document"],
         required=False,
         default="all",
     )
-    status = serializers.ChoiceField(
-        choices=[CaseState.PUBLISHED, CaseState.IN_REVIEW, CaseState.DRAFT],
+    entity_type = serializers.ListField(
+        child=serializers.ChoiceField(
+            choices=["person", "organization", "location", "unknown"]
+        ),
         required=False,
-        allow_null=True,
-        default=None,
+        default=list,
     )
-    role = serializers.ChoiceField(
-        choices=RelationshipType.values,
+    role = serializers.ListField(
+        child=serializers.ChoiceField(choices=RelationshipType.values),
         required=False,
-        allow_null=True,
-        default=None,
+        default=list,
     )
-    case_type = serializers.ChoiceField(
-        choices=["CORRUPTION"], required=False, allow_null=True, default=None
+    case_type = serializers.ListField(
+        child=serializers.ChoiceField(choices=["CORRUPTION"]),
+        required=False,
+        default=list,
     )
-    tags = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True, default=None
+    tags = serializers.ListField(
+        child=serializers.CharField(allow_blank=False),
+        required=False,
+        default=list,
     )
     sort = serializers.ChoiceField(
         choices=["relevance", "newest", "oldest", "title"],
@@ -110,10 +106,10 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
 @extend_schema(
     summary="Search the accountability archive",
     description="""
-    Search visible accountability cases, entities, and evidence documents in one
-    deterministic relevance-ranked result list. Anonymous case search exposes
-    published records only. Entity types are derived locally from NES IDs; this
-    endpoint does not call external services.
+    Search published accountability cases, entities, and evidence documents in
+    one deterministic relevance-ranked result list. Detailed sidebar filters
+    accept repeated query parameters. Entity types are derived locally from NES
+    IDs; this endpoint does not call external services.
     """,
     parameters=[
         OpenApiParameter("q", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False),
@@ -122,22 +118,15 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
             OpenApiTypes.STR,
             OpenApiParameter.QUERY,
             required=False,
-            enum=[
-                "all",
-                "case",
-                "entity",
-                "document",
-                "person",
-                "organization",
-                "location",
-            ],
+            enum=["all", "case", "entity", "document"],
         ),
         OpenApiParameter(
-            "status",
+            "entity_type",
             OpenApiTypes.STR,
             OpenApiParameter.QUERY,
             required=False,
-            enum=["PUBLISHED", "IN_REVIEW", "DRAFT"],
+            enum=["person", "organization", "location", "unknown"],
+            many=True,
         ),
         OpenApiParameter(
             "role",
@@ -145,6 +134,7 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
             OpenApiParameter.QUERY,
             required=False,
             enum=RelationshipType.values,
+            many=True,
         ),
         OpenApiParameter(
             "case_type",
@@ -152,9 +142,14 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
             OpenApiParameter.QUERY,
             required=False,
             enum=["CORRUPTION"],
+            many=True,
         ),
         OpenApiParameter(
-            "tags", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False
+            "tags",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            many=True,
         ),
         OpenApiParameter(
             "sort",

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -67,10 +67,10 @@ logger = logging.getLogger(__name__)
 
 class UnifiedSearchQuerySerializer(serializers.Serializer):
     q = serializers.CharField(required=False, allow_blank=True, default="")
-    type = serializers.ChoiceField(
-        choices=["all", "case", "entity", "document"],
+    type = serializers.ListField(
+        child=serializers.ChoiceField(choices=["case", "entity", "document"]),
         required=False,
-        default="all",
+        default=list,
     )
     entity_type = serializers.ListField(
         child=serializers.ChoiceField(
@@ -107,9 +107,9 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
     summary="Search the accountability archive",
     description="""
     Search published accountability cases, entities, and evidence documents in
-    one deterministic relevance-ranked result list. Detailed sidebar filters
-    accept repeated query parameters. Entity types are derived locally from NES
-    IDs; this endpoint does not call external services.
+    one deterministic relevance-ranked result list. Sidebar filters accept
+    repeated query parameters, including record type. Entity types are derived
+    locally from NES IDs; this endpoint does not call external services.
     """,
     parameters=[
         OpenApiParameter("q", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False),
@@ -118,7 +118,8 @@ class UnifiedSearchQuerySerializer(serializers.Serializer):
             OpenApiTypes.STR,
             OpenApiParameter.QUERY,
             required=False,
-            enum=["all", "case", "entity", "document"],
+            enum=["case", "entity", "document"],
+            many=True,
         ),
         OpenApiParameter(
             "entity_type",

--- a/cases/search_serializers.py
+++ b/cases/search_serializers.py
@@ -61,10 +61,10 @@ class SearchDocumentResultSerializer(SearchResultSerializer):
 
 
 class SearchFacetsSerializer(serializers.Serializer):
-    type = SearchFacetItemSerializer(many=True)
-    status = SearchFacetItemSerializer(many=True)
+    entity_type = SearchFacetItemSerializer(many=True)
     role = SearchFacetItemSerializer(many=True)
     case_type = SearchFacetItemSerializer(many=True)
+    tags = SearchFacetItemSerializer(many=True)
 
 
 class SearchResponseSerializer(serializers.Serializer):

--- a/cases/search_serializers.py
+++ b/cases/search_serializers.py
@@ -1,0 +1,92 @@
+"""OpenAPI serializers for unified archive search."""
+
+from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema_field
+from rest_framework import serializers
+
+
+class SearchFacetItemSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    display_name = serializers.CharField()
+    count = serializers.IntegerField(min_value=0)
+
+
+class SearchCountsSerializer(serializers.Serializer):
+    all = serializers.IntegerField(min_value=0)
+    cases = serializers.IntegerField(min_value=0)
+    entities = serializers.IntegerField(min_value=0)
+    documents = serializers.IntegerField(min_value=0)
+
+
+class SearchResultEntityPreviewSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    display_name = serializers.CharField(allow_null=True)
+    nes_id = serializers.CharField(allow_null=True)
+    relationship_type = serializers.CharField(required=False)
+
+
+class SearchResultSerializer(serializers.Serializer):
+    result_type = serializers.CharField()
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    description = serializers.CharField()
+    url = serializers.CharField()
+    api_url = serializers.CharField()
+    matched_fields = serializers.ListField(child=serializers.CharField())
+    score = serializers.IntegerField()
+
+
+class SearchCaseResultSerializer(SearchResultSerializer):
+    result_type = serializers.ChoiceField(choices=["case"])
+    slug = serializers.CharField()
+    state = serializers.CharField()
+    case_type = serializers.CharField()
+    date = serializers.DateField(allow_null=True)
+    tags = serializers.ListField(child=serializers.CharField())
+    entities = SearchResultEntityPreviewSerializer(many=True)
+
+
+class SearchEntityResultSerializer(SearchResultSerializer):
+    result_type = serializers.ChoiceField(choices=["entity"])
+    entity_type = serializers.CharField()
+    nes_id = serializers.CharField(allow_null=True)
+    role_counts = serializers.DictField(child=serializers.IntegerField(min_value=0))
+    related_case_count = serializers.IntegerField(min_value=0)
+
+
+class SearchDocumentResultSerializer(SearchResultSerializer):
+    result_type = serializers.ChoiceField(choices=["document"])
+    source_id = serializers.CharField()
+    source_type = serializers.CharField(allow_null=True)
+    related_entities = SearchResultEntityPreviewSerializer(many=True)
+
+
+class SearchFacetsSerializer(serializers.Serializer):
+    type = SearchFacetItemSerializer(many=True)
+    status = SearchFacetItemSerializer(many=True)
+    role = SearchFacetItemSerializer(many=True)
+    case_type = SearchFacetItemSerializer(many=True)
+
+
+class SearchResponseSerializer(serializers.Serializer):
+    query = serializers.CharField()
+    page = serializers.IntegerField(min_value=1)
+    page_size = serializers.IntegerField(min_value=1, max_value=50)
+    count = serializers.IntegerField(min_value=0)
+    counts = SearchCountsSerializer()
+    facets = SearchFacetsSerializer()
+    results = serializers.SerializerMethodField()
+
+    @extend_schema_field(
+        PolymorphicProxySerializer(
+            component_name="ArchiveSearchResult",
+            serializers=[
+                SearchCaseResultSerializer,
+                SearchEntityResultSerializer,
+                SearchDocumentResultSerializer,
+            ],
+            resource_type_field_name="result_type",
+            many=True,
+        )
+    )
+    def get_results(self, obj):
+        return obj["results"]

--- a/cases/search_serializers.py
+++ b/cases/search_serializers.py
@@ -61,6 +61,7 @@ class SearchDocumentResultSerializer(SearchResultSerializer):
 
 
 class SearchFacetsSerializer(serializers.Serializer):
+    type = SearchFacetItemSerializer(many=True)
     entity_type = SearchFacetItemSerializer(many=True)
     role = SearchFacetItemSerializer(many=True)
     case_type = SearchFacetItemSerializer(many=True)

--- a/cases/services/search.py
+++ b/cases/services/search.py
@@ -28,6 +28,11 @@ ENTITY_TYPE_DISPLAY_NAMES = {
     "location": "Locations",
     "unknown": "Unknown",
 }
+TYPE_DISPLAY_NAMES = {
+    "case": "Cases",
+    "entity": "Entities",
+    "document": "Documents",
+}
 
 
 def extract_entity_type(nes_id: str | None) -> str:
@@ -99,7 +104,7 @@ class UnifiedSearchService:
         *,
         request,
         q: str,
-        type: str,
+        type: list[str],
         entity_type: list[str],
         role: list[str],
         case_type: list[str],
@@ -497,6 +502,7 @@ class UnifiedSearchService:
         }
 
     def _facets(self, records, cases_by_id):
+        type_counts = Counter(record["kind"] for record in records)
         entity_type_counts = Counter(
             record["entity_type"] for record in records if record["kind"] == "entity"
         )
@@ -519,6 +525,10 @@ class UnifiedSearchService:
             relationship.relationship_type for relationship in relationships.values()
         )
         return {
+            "type": [
+                self._facet_item(name, TYPE_DISPLAY_NAMES[name], type_counts[name])
+                for name in ("case", "entity", "document")
+            ],
             "entity_type": [
                 self._facet_item(
                     name, ENTITY_TYPE_DISPLAY_NAMES[name], entity_type_counts[name]
@@ -540,11 +550,9 @@ class UnifiedSearchService:
         }
 
     def _matches_type(self, record, search_type):
-        if search_type == "all":
+        if not search_type:
             return True
-        if search_type == "entity":
-            return record["kind"] == "entity"
-        return record["kind"] == search_type
+        return record["kind"] in search_type
 
     def _sort(self, records, sort):
         if sort == "newest":

--- a/cases/services/search.py
+++ b/cases/services/search.py
@@ -7,7 +7,8 @@ from collections import Counter
 from datetime import datetime
 from typing import Any
 
-from django.db.models import Prefetch, Q
+from django.db.models import Prefetch, Q, TextField
+from django.db.models.functions import Cast
 from django.utils import timezone
 
 from cases.models import (
@@ -117,23 +118,24 @@ class UnifiedSearchService:
         page_size = min(page_size, 50)
 
         del request  # Public archive search is intentionally published-only.
-        cases = list(self._visible_cases(entity_type, role, case_type))
-        documents = list(self._visible_documents(cases, query))
-        source_case_ids = self._source_case_ids(cases, documents)
+        visible_cases = list(self._visible_cases(entity_type, role, case_type))
+        cases = (
+            list(self._visible_cases(entity_type, role, case_type, query))
+            if query
+            else visible_cases
+        )
+        documents = list(self._visible_documents(visible_cases, query))
+        source_case_ids = self._source_case_ids(visible_cases, documents)
         case_entity_ids = {
             relationship.entity_id
-            for case in cases
+            for case in visible_cases
             for relationship in case.entity_relationships.all()
         }
+        visible_case_ids = {case.id for case in visible_cases}
         entities = list(
-            JawafEntity.objects.filter(id__in=case_entity_ids).prefetch_related(
-                Prefetch(
-                    "case_relationships",
-                    queryset=CaseEntityRelationship.objects.select_related("case"),
-                )
-            )
+            self._visible_entities(case_entity_ids, visible_case_ids, query)
         )
-        cases_by_id = {case.id: case for case in cases}
+        cases_by_id = {case.id: case for case in visible_cases}
 
         records = []
         for case in cases:
@@ -187,7 +189,7 @@ class UnifiedSearchService:
             "results": results,
         }
 
-    def _visible_cases(self, entity_types, roles, case_types):
+    def _visible_cases(self, entity_types, roles, case_types, query=""):
         queryset = Case.objects.filter(state=CaseState.PUBLISHED)
         if case_types:
             queryset = queryset.filter(case_type__in=case_types)
@@ -204,7 +206,55 @@ class UnifiedSearchService:
                     )
                 )
             queryset = queryset.filter(entity_filter)
+        queryset = self._filter_cases_by_query(queryset, query)
         return queryset.prefetch_related("entity_relationships__entity").distinct()
+
+    def _filter_cases_by_query(self, queryset, query):
+        if not query:
+            return queryset
+
+        queryset = queryset.annotate(
+            tags_text=Cast("tags", output_field=TextField()),
+            key_allegations_text=Cast("key_allegations", output_field=TextField()),
+            court_cases_text=Cast("court_cases", output_field=TextField()),
+        )
+        for term in query.split():
+            queryset = queryset.filter(
+                Q(title__icontains=term)
+                | Q(short_description__icontains=term)
+                | Q(description__icontains=term)
+                | Q(case_id__icontains=term)
+                | Q(tags_text__icontains=term)
+                | Q(key_allegations_text__icontains=term)
+                | Q(court_cases_text__icontains=term)
+                | Q(entity_relationships__entity__display_name__icontains=term)
+                | Q(entity_relationships__entity__nes_id__icontains=term)
+                | Q(entity_relationships__notes__icontains=term)
+                | Q(entity_relationships__relationship_type__icontains=term)
+            )
+        return queryset
+
+    def _visible_entities(self, entity_ids, visible_case_ids, query):
+        relationships = CaseEntityRelationship.objects.filter(
+            case_id__in=visible_case_ids
+        ).select_related("case")
+        queryset = JawafEntity.objects.filter(id__in=entity_ids)
+        for term in query.split():
+            queryset = queryset.filter(
+                Q(display_name__icontains=term)
+                | Q(nes_id__icontains=term)
+                | (
+                    Q(case_relationships__case_id__in=visible_case_ids)
+                    & (
+                        Q(case_relationships__case__title__icontains=term)
+                        | Q(case_relationships__relationship_type__icontains=term)
+                        | Q(case_relationships__notes__icontains=term)
+                    )
+                )
+            )
+        return queryset.prefetch_related(
+            Prefetch("case_relationships", queryset=relationships)
+        ).distinct()
 
     def _visible_documents(self, cases, query):
         source_ids = {

--- a/cases/services/search.py
+++ b/cases/services/search.py
@@ -7,7 +7,7 @@ from collections import Counter
 from datetime import datetime
 from typing import Any
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.utils import timezone
 
 from cases.models import (
@@ -117,8 +117,8 @@ class UnifiedSearchService:
         page_size = min(page_size, 50)
 
         del request  # Public archive search is intentionally published-only.
-        cases = list(self._visible_cases())
-        documents = list(self._visible_documents())
+        cases = list(self._visible_cases(entity_type, role, case_type))
+        documents = list(self._visible_documents(cases, query))
         source_case_ids = self._source_case_ids(cases, documents)
         case_entity_ids = {
             relationship.entity_id
@@ -153,13 +153,14 @@ class UnifiedSearchService:
                 source,
                 cases_by_id,
                 source_case_ids,
+                case_entity_ids,
                 entity_type,
                 role,
                 case_type,
                 tags,
             ):
                 record = self._document_record(
-                    source, query, cases_by_id, source_case_ids
+                    source, query, cases_by_id, source_case_ids, case_entity_ids
                 )
                 if record:
                     records.append(record)
@@ -186,22 +187,45 @@ class UnifiedSearchService:
             "results": results,
         }
 
-    def _visible_cases(self):
-        return Case.objects.filter(state=CaseState.PUBLISHED).prefetch_related(
-            "entity_relationships__entity"
-        )
+    def _visible_cases(self, entity_types, roles, case_types):
+        queryset = Case.objects.filter(state=CaseState.PUBLISHED)
+        if case_types:
+            queryset = queryset.filter(case_type__in=case_types)
+        if roles:
+            queryset = queryset.filter(
+                entity_relationships__relationship_type__in=roles
+            )
+        if entity_types and "unknown" not in entity_types:
+            entity_filter = Q()
+            for entity_type in entity_types:
+                entity_filter |= Q(
+                    entity_relationships__entity__nes_id__startswith=(
+                        f"entity:{entity_type}/"
+                    )
+                )
+            queryset = queryset.filter(entity_filter)
+        return queryset.prefetch_related("entity_relationships__entity").distinct()
 
-    def _visible_documents(self):
-        visible_cases = Case.objects.filter(state=CaseState.PUBLISHED)
+    def _visible_documents(self, cases, query):
         source_ids = {
             item["source_id"]
-            for case in visible_cases
+            for case in cases
             for item in (case.evidence or [])
             if isinstance(item, dict) and item.get("source_id")
         }
-        return DocumentSource.objects.filter(
+        queryset = DocumentSource.objects.filter(
             source_id__in=source_ids, is_deleted=False
-        ).prefetch_related("related_entities")
+        )
+        for term in query.split():
+            queryset = queryset.filter(
+                Q(title__icontains=term)
+                | Q(description__icontains=term)
+                | Q(source_id__icontains=term)
+                | Q(source_type__icontains=term)
+                | Q(related_entities__display_name__icontains=term)
+                | Q(related_entities__nes_id__icontains=term)
+            )
+        return queryset.prefetch_related("related_entities").distinct()
 
     def _source_case_ids(self, cases, documents):
         source_ids = {source.source_id for source in documents}
@@ -249,6 +273,7 @@ class UnifiedSearchService:
         source,
         cases_by_id,
         source_case_ids,
+        visible_entity_ids,
         entity_types,
         roles,
         case_types,
@@ -264,7 +289,7 @@ class UnifiedSearchService:
             for case in related_cases
         ):
             return False
-        related_entities = self._visible_document_entities(source, cases_by_id)
+        related_entities = self._visible_document_entities(source, visible_entity_ids)
         if entity_types and not any(
             extract_entity_type(entity.nes_id) in entity_types
             for entity in related_entities
@@ -390,8 +415,11 @@ class UnifiedSearchService:
             },
         }
 
-    def _document_record(self, source, query, cases_by_id, source_case_ids):
-        related_entities = self._visible_document_entities(source, cases_by_id)
+    def _document_record(
+        self, source, query, cases_by_id, source_case_ids, visible_entity_ids
+    ):
+        del cases_by_id
+        related_entities = self._visible_document_entities(source, visible_entity_ids)
         searchable = {
             "title": source.title,
             "description": source.description,
@@ -592,12 +620,7 @@ class UnifiedSearchService:
     def _facet_item(self, name, display_name, count):
         return {"name": name, "display_name": display_name, "count": count}
 
-    def _visible_document_entities(self, source, cases_by_id):
-        visible_entity_ids = {
-            relationship.entity_id
-            for case in cases_by_id.values()
-            for relationship in case.entity_relationships.all()
-        }
+    def _visible_document_entities(self, source, visible_entity_ids):
         return [
             entity
             for entity in source.related_entities.all()

--- a/cases/services/search.py
+++ b/cases/services/search.py
@@ -193,10 +193,18 @@ class UnifiedSearchService:
         queryset = Case.objects.filter(state=CaseState.PUBLISHED)
         if case_types:
             queryset = queryset.filter(case_type__in=case_types)
+        relationship_filter = self._case_relationship_queryset_filter(
+            entity_types, roles
+        )
+        if relationship_filter:
+            queryset = queryset.filter(relationship_filter)
+        queryset = self._filter_cases_by_query(queryset, query)
+        return queryset.prefetch_related("entity_relationships__entity").distinct()
+
+    def _case_relationship_queryset_filter(self, entity_types, roles):
+        relationship_filter = Q()
         if roles:
-            queryset = queryset.filter(
-                entity_relationships__relationship_type__in=roles
-            )
+            relationship_filter &= Q(entity_relationships__relationship_type__in=roles)
         if entity_types and "unknown" not in entity_types:
             entity_filter = Q()
             for entity_type in entity_types:
@@ -205,9 +213,8 @@ class UnifiedSearchService:
                         f"entity:{entity_type}/"
                     )
                 )
-            queryset = queryset.filter(entity_filter)
-        queryset = self._filter_cases_by_query(queryset, query)
-        return queryset.prefetch_related("entity_relationships__entity").distinct()
+            relationship_filter &= entity_filter
+        return relationship_filter
 
     def _filter_cases_by_query(self, queryset, query):
         if not query:
@@ -292,16 +299,18 @@ class UnifiedSearchService:
             return False
         if tags and not any(tag in (case.tags or []) for tag in tags):
             return False
-        if roles and not any(
-            relationship.relationship_type in roles for relationship in relationships
-        ):
-            return False
-        if entity_types and not any(
-            extract_entity_type(relationship.entity.nes_id) in entity_types
+        if any((roles, entity_types)) and not any(
+            self._relationship_passes_filters(relationship, entity_types, roles)
             for relationship in relationships
         ):
             return False
         return True
+
+    def _relationship_passes_filters(self, relationship, entity_types, roles):
+        return (not roles or relationship.relationship_type in roles) and (
+            not entity_types
+            or extract_entity_type(relationship.entity.nes_id) in entity_types
+        )
 
     def _entity_passes_filters(
         self, entity, cases_by_id, entity_types, roles, case_types, tags
@@ -340,19 +349,16 @@ class UnifiedSearchService:
         ):
             return False
         related_entities = self._visible_document_entities(source, visible_entity_ids)
-        if entity_types and not any(
-            extract_entity_type(entity.nes_id) in entity_types
-            for entity in related_entities
+        if not any((entity_types, roles)):
+            return True
+        related_entity_ids = {entity.id for entity in related_entities}
+        if not any(
+            relationship.entity_id in related_entity_ids
+            and self._relationship_passes_filters(relationship, entity_types, roles)
+            for case in related_cases
+            for relationship in case.entity_relationships.all()
         ):
             return False
-        if roles:
-            related_entity_ids = {entity.id for entity in related_entities}
-            return any(
-                relationship.relationship_type in roles
-                and relationship.entity_id in related_entity_ids
-                for case in related_cases
-                for relationship in case.entity_relationships.all()
-            )
         return True
 
     def _case_record(self, case, query):

--- a/cases/services/search.py
+++ b/cases/services/search.py
@@ -7,7 +7,7 @@ from collections import Counter
 from datetime import datetime
 from typing import Any
 
-from django.db.models import Prefetch, Q
+from django.db.models import Prefetch
 from django.utils import timezone
 
 from cases.models import (
@@ -19,22 +19,14 @@ from cases.models import (
     JawafEntity,
     RelationshipType,
 )
-from cases.rules.predicates import is_admin_or_moderator
 
 ENTITY_TYPE_PATTERN = re.compile(r"^entity:([^/]+)/")
 ENTITY_TYPES = ("person", "organization", "location")
-TYPE_DISPLAY_NAMES = {
-    "case": "Cases",
+ENTITY_TYPE_DISPLAY_NAMES = {
     "person": "People",
     "organization": "Organizations",
     "location": "Locations",
-    "document": "Documents",
-    "unknown": "Unknown entities",
-}
-STATUS_DISPLAY_NAMES = {
-    CaseState.PUBLISHED: "Published",
-    CaseState.IN_REVIEW: "In Review",
-    CaseState.DRAFT: "Draft",
+    "unknown": "Unknown",
 }
 
 
@@ -108,10 +100,10 @@ class UnifiedSearchService:
         request,
         q: str,
         type: str,
-        status: str | None,
-        role: str | None,
-        case_type: str | None,
-        tags: str | None,
+        entity_type: list[str],
+        role: list[str],
+        case_type: list[str],
+        tags: list[str],
         sort: str,
         page: int,
         page_size: int,
@@ -119,7 +111,8 @@ class UnifiedSearchService:
         query = _normalize(q)
         page_size = min(page_size, 50)
 
-        cases = list(self._visible_cases(request))
+        del request  # Public archive search is intentionally published-only.
+        cases = list(self._visible_cases())
         documents = list(self._visible_documents())
         source_case_ids = self._source_case_ids(cases, documents)
         case_entity_ids = {
@@ -139,20 +132,26 @@ class UnifiedSearchService:
 
         records = []
         for case in cases:
-            if self._case_passes_filters(case, status, role, case_type, tags):
+            if self._case_passes_filters(case, entity_type, role, case_type, tags):
                 record = self._case_record(case, query)
                 if record:
                     records.append(record)
         for entity in entities:
             if self._entity_passes_filters(
-                entity, cases_by_id, status, role, case_type, tags
+                entity, cases_by_id, entity_type, role, case_type, tags
             ):
                 record = self._entity_record(entity, query, cases_by_id)
                 if record:
                     records.append(record)
         for source in documents:
             if self._document_passes_filters(
-                source, cases_by_id, source_case_ids, status, role, case_type, tags
+                source,
+                cases_by_id,
+                source_case_ids,
+                entity_type,
+                role,
+                case_type,
+                tags,
             ):
                 record = self._document_record(
                     source, query, cases_by_id, source_case_ids
@@ -182,24 +181,13 @@ class UnifiedSearchService:
             "results": results,
         }
 
-    def _visible_cases(self, request):
-        user = request.user
-        if not (user and user.is_authenticated):
-            queryset = Case.objects.filter(state=CaseState.PUBLISHED)
-        elif is_admin_or_moderator(user):
-            queryset = Case.objects.exclude(state=CaseState.CLOSED)
-        else:
-            queryset = (
-                Case.objects.exclude(state=CaseState.CLOSED)
-                .filter(Q(state=CaseState.PUBLISHED) | Q(contributors=user))
-                .distinct()
-            )
-        return queryset.prefetch_related("entity_relationships__entity")
+    def _visible_cases(self):
+        return Case.objects.filter(state=CaseState.PUBLISHED).prefetch_related(
+            "entity_relationships__entity"
+        )
 
     def _visible_documents(self):
-        visible_cases = Case.objects.filter(
-            state__in=[CaseState.PUBLISHED, CaseState.IN_REVIEW]
-        )
+        visible_cases = Case.objects.filter(state=CaseState.PUBLISHED)
         source_ids = {
             item["source_id"]
             for case in visible_cases
@@ -219,52 +207,68 @@ class UnifiedSearchService:
                     mapping[item["source_id"]].add(case.id)
         return mapping
 
-    def _case_passes_filters(self, case, status, role, case_type, tags):
-        if status and case.state != status:
+    def _case_passes_filters(self, case, entity_types, roles, case_types, tags):
+        relationships = list(case.entity_relationships.all())
+        if case_types and case.case_type not in case_types:
             return False
-        if case_type and case.case_type != case_type:
+        if tags and not any(tag in (case.tags or []) for tag in tags):
             return False
-        if tags and tags not in (case.tags or []):
+        if roles and not any(
+            relationship.relationship_type in roles for relationship in relationships
+        ):
             return False
-        if role and not any(
-            relationship.relationship_type == role
-            for relationship in case.entity_relationships.all()
+        if entity_types and not any(
+            extract_entity_type(relationship.entity.nes_id) in entity_types
+            for relationship in relationships
         ):
             return False
         return True
 
     def _entity_passes_filters(
-        self, entity, cases_by_id, status, role, case_type, tags
+        self, entity, cases_by_id, entity_types, roles, case_types, tags
     ):
-        has_case_filter = any((status, role, case_type, tags))
+        if entity_types and extract_entity_type(entity.nes_id) not in entity_types:
+            return False
+        has_case_filter = any((roles, case_types, tags))
         if not has_case_filter:
             return True
         return any(
             relationship.case_id in cases_by_id
-            and (not role or relationship.relationship_type == role)
-            and self._case_passes_filters(
-                relationship.case, status, None, case_type, tags
-            )
+            and (not roles or relationship.relationship_type in roles)
+            and self._case_passes_filters(relationship.case, [], [], case_types, tags)
             for relationship in entity.case_relationships.all()
         )
 
     def _document_passes_filters(
-        self, source, cases_by_id, source_case_ids, status, role, case_type, tags
+        self,
+        source,
+        cases_by_id,
+        source_case_ids,
+        entity_types,
+        roles,
+        case_types,
+        tags,
     ):
         related_cases = [
             cases_by_id[case_id]
             for case_id in source_case_ids.get(source.source_id, set())
             if case_id in cases_by_id
         ]
-        if any((status, case_type, tags)) and not any(
-            self._case_passes_filters(case, status, None, case_type, tags)
+        if any((case_types, tags)) and not any(
+            self._case_passes_filters(case, [], [], case_types, tags)
             for case in related_cases
         ):
             return False
-        if role:
-            related_entity_ids = {entity.id for entity in source.related_entities.all()}
+        related_entities = self._visible_document_entities(source, cases_by_id)
+        if entity_types and not any(
+            extract_entity_type(entity.nes_id) in entity_types
+            for entity in related_entities
+        ):
+            return False
+        if roles:
+            related_entity_ids = {entity.id for entity in related_entities}
             return any(
-                relationship.relationship_type == role
+                relationship.relationship_type in roles
                 and relationship.entity_id in related_entity_ids
                 for case in related_cases
                 for relationship in case.entity_relationships.all()
@@ -382,16 +386,7 @@ class UnifiedSearchService:
         }
 
     def _document_record(self, source, query, cases_by_id, source_case_ids):
-        visible_entity_ids = {
-            relationship.entity_id
-            for case in cases_by_id.values()
-            for relationship in case.entity_relationships.all()
-        }
-        related_entities = [
-            entity
-            for entity in source.related_entities.all()
-            if entity.id in visible_entity_ids
-        ]
+        related_entities = self._visible_document_entities(source, cases_by_id)
         searchable = {
             "title": source.title,
             "description": source.description,
@@ -502,8 +497,8 @@ class UnifiedSearchService:
         }
 
     def _facets(self, records, cases_by_id):
-        type_counts = Counter(
-            record.get("entity_type", record["kind"]) for record in records
+        entity_type_counts = Counter(
+            record["entity_type"] for record in records if record["kind"] == "entity"
         )
         related_case_ids = set().union(
             *(record["case_ids"] for record in records), set()
@@ -513,8 +508,8 @@ class UnifiedSearchService:
             for case_id in related_case_ids
             if case_id in cases_by_id
         ]
-        status_counts = Counter(case.state for case in related_cases)
         case_type_counts = Counter(case.case_type for case in related_cases)
+        tag_counts = Counter(tag for case in related_cases for tag in (case.tags or []))
         relationships = {
             relationship.id: relationship
             for case in related_cases
@@ -524,24 +519,11 @@ class UnifiedSearchService:
             relationship.relationship_type for relationship in relationships.values()
         )
         return {
-            "type": [
-                self._facet_item(name, TYPE_DISPLAY_NAMES[name], type_counts[name])
-                for name in (
-                    "case",
-                    "person",
-                    "organization",
-                    "location",
-                    "document",
-                    "unknown",
+            "entity_type": [
+                self._facet_item(
+                    name, ENTITY_TYPE_DISPLAY_NAMES[name], entity_type_counts[name]
                 )
-            ],
-            "status": [
-                self._facet_item(name, STATUS_DISPLAY_NAMES[name], status_counts[name])
-                for name in (
-                    CaseState.PUBLISHED,
-                    CaseState.IN_REVIEW,
-                    CaseState.DRAFT,
-                )
+                for name in ("person", "organization", "location", "unknown")
             ],
             "role": [
                 self._facet_item(name, label, role_counts[name])
@@ -551,6 +533,10 @@ class UnifiedSearchService:
                 self._facet_item(name, label, case_type_counts[name])
                 for name, label in CaseType.choices
             ],
+            "tags": [
+                self._facet_item(name, self._display_tag(name), count)
+                for name, count in sorted(tag_counts.items())
+            ],
         }
 
     def _matches_type(self, record, search_type):
@@ -558,10 +544,6 @@ class UnifiedSearchService:
             return True
         if search_type == "entity":
             return record["kind"] == "entity"
-        if search_type in ENTITY_TYPES:
-            return (
-                record["kind"] == "entity" and record.get("entity_type") == search_type
-            )
         return record["kind"] == search_type
 
     def _sort(self, records, sort):
@@ -601,6 +583,21 @@ class UnifiedSearchService:
 
     def _facet_item(self, name, display_name, count):
         return {"name": name, "display_name": display_name, "count": count}
+
+    def _visible_document_entities(self, source, cases_by_id):
+        visible_entity_ids = {
+            relationship.entity_id
+            for case in cases_by_id.values()
+            for relationship in case.entity_relationships.all()
+        }
+        return [
+            entity
+            for entity in source.related_entities.all()
+            if entity.id in visible_entity_ids
+        ]
+
+    def _display_tag(self, tag):
+        return tag.replace("-", " ").capitalize()
 
     def _public_result(self, record):
         return record["result"]

--- a/cases/services/search.py
+++ b/cases/services/search.py
@@ -1,0 +1,606 @@
+"""Local, deterministic discovery across cases, entities, and documents."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from datetime import datetime
+from typing import Any
+
+from django.db.models import Prefetch, Q
+from django.utils import timezone
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    DocumentSource,
+    JawafEntity,
+    RelationshipType,
+)
+from cases.rules.predicates import is_admin_or_moderator
+
+ENTITY_TYPE_PATTERN = re.compile(r"^entity:([^/]+)/")
+ENTITY_TYPES = ("person", "organization", "location")
+TYPE_DISPLAY_NAMES = {
+    "case": "Cases",
+    "person": "People",
+    "organization": "Organizations",
+    "location": "Locations",
+    "document": "Documents",
+    "unknown": "Unknown entities",
+}
+STATUS_DISPLAY_NAMES = {
+    CaseState.PUBLISHED: "Published",
+    CaseState.IN_REVIEW: "In Review",
+    CaseState.DRAFT: "Draft",
+}
+
+
+def extract_entity_type(nes_id: str | None) -> str:
+    """Derive a local entity type without contacting NES."""
+    match = ENTITY_TYPE_PATTERN.match(nes_id or "")
+    if not match:
+        return "unknown"
+    entity_type = match.group(1)
+    return entity_type if entity_type in ENTITY_TYPES else "unknown"
+
+
+def _flatten_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        return " ".join(
+            f"{_flatten_text(key)} {_flatten_text(item)}" for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set)):
+        return " ".join(_flatten_text(item) for item in value)
+    return str(value)
+
+
+def _normalize(value: Any) -> str:
+    return " ".join(_flatten_text(value).casefold().split())
+
+
+def _matched_fields(query: str, searchable: dict[str, Any]) -> list[str]:
+    if not query:
+        return []
+    terms = query.split()
+    normalized_fields = {name: _normalize(value) for name, value in searchable.items()}
+    haystack = " ".join(normalized_fields.values())
+    if not all(term in haystack for term in terms):
+        return []
+    return [
+        name
+        for name, value in normalized_fields.items()
+        if any(term in value for term in terms)
+    ]
+
+
+def _field_matches(query: str, value: Any) -> bool:
+    normalized = _normalize(value)
+    return bool(
+        query
+        and (query in normalized or any(term in normalized for term in query.split()))
+    )
+
+
+def _recent_boost(updated_at: datetime) -> int:
+    days_old = max(0, (timezone.now() - updated_at).days)
+    return max(0, 10 - min(10, days_old // 30))
+
+
+def _excerpt(value: str | None, fallback: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", value or "")
+    normalized = " ".join(text.split())
+    if not normalized:
+        return fallback
+    return normalized[:237] + ("..." if len(normalized) > 237 else "")
+
+
+class UnifiedSearchService:
+    """Build one normalized archive search response for API consumers."""
+
+    def search(
+        self,
+        *,
+        request,
+        q: str,
+        type: str,
+        status: str | None,
+        role: str | None,
+        case_type: str | None,
+        tags: str | None,
+        sort: str,
+        page: int,
+        page_size: int,
+    ) -> dict[str, Any]:
+        query = _normalize(q)
+        page_size = min(page_size, 50)
+
+        cases = list(self._visible_cases(request))
+        documents = list(self._visible_documents())
+        source_case_ids = self._source_case_ids(cases, documents)
+        case_entity_ids = {
+            relationship.entity_id
+            for case in cases
+            for relationship in case.entity_relationships.all()
+        }
+        entities = list(
+            JawafEntity.objects.filter(id__in=case_entity_ids).prefetch_related(
+                Prefetch(
+                    "case_relationships",
+                    queryset=CaseEntityRelationship.objects.select_related("case"),
+                )
+            )
+        )
+        cases_by_id = {case.id: case for case in cases}
+
+        records = []
+        for case in cases:
+            if self._case_passes_filters(case, status, role, case_type, tags):
+                record = self._case_record(case, query)
+                if record:
+                    records.append(record)
+        for entity in entities:
+            if self._entity_passes_filters(
+                entity, cases_by_id, status, role, case_type, tags
+            ):
+                record = self._entity_record(entity, query, cases_by_id)
+                if record:
+                    records.append(record)
+        for source in documents:
+            if self._document_passes_filters(
+                source, cases_by_id, source_case_ids, status, role, case_type, tags
+            ):
+                record = self._document_record(
+                    source, query, cases_by_id, source_case_ids
+                )
+                if record:
+                    records.append(record)
+        counts = self._counts(records)
+        facets = self._facets(records, cases_by_id)
+        selected_records = [
+            record for record in records if self._matches_type(record, type)
+        ]
+        self._sort(selected_records, sort)
+
+        count = len(selected_records)
+        start = (page - 1) * page_size
+        results = [
+            self._public_result(record)
+            for record in selected_records[start : start + page_size]
+        ]
+        return {
+            "query": q.strip(),
+            "page": page,
+            "page_size": page_size,
+            "count": count,
+            "counts": counts,
+            "facets": facets,
+            "results": results,
+        }
+
+    def _visible_cases(self, request):
+        user = request.user
+        if not (user and user.is_authenticated):
+            queryset = Case.objects.filter(state=CaseState.PUBLISHED)
+        elif is_admin_or_moderator(user):
+            queryset = Case.objects.exclude(state=CaseState.CLOSED)
+        else:
+            queryset = (
+                Case.objects.exclude(state=CaseState.CLOSED)
+                .filter(Q(state=CaseState.PUBLISHED) | Q(contributors=user))
+                .distinct()
+            )
+        return queryset.prefetch_related("entity_relationships__entity")
+
+    def _visible_documents(self):
+        visible_cases = Case.objects.filter(
+            state__in=[CaseState.PUBLISHED, CaseState.IN_REVIEW]
+        )
+        source_ids = {
+            item["source_id"]
+            for case in visible_cases
+            for item in (case.evidence or [])
+            if isinstance(item, dict) and item.get("source_id")
+        }
+        return DocumentSource.objects.filter(
+            source_id__in=source_ids, is_deleted=False
+        ).prefetch_related("related_entities")
+
+    def _source_case_ids(self, cases, documents):
+        source_ids = {source.source_id for source in documents}
+        mapping = {source_id: set() for source_id in source_ids}
+        for case in cases:
+            for item in case.evidence or []:
+                if isinstance(item, dict) and item.get("source_id") in mapping:
+                    mapping[item["source_id"]].add(case.id)
+        return mapping
+
+    def _case_passes_filters(self, case, status, role, case_type, tags):
+        if status and case.state != status:
+            return False
+        if case_type and case.case_type != case_type:
+            return False
+        if tags and tags not in (case.tags or []):
+            return False
+        if role and not any(
+            relationship.relationship_type == role
+            for relationship in case.entity_relationships.all()
+        ):
+            return False
+        return True
+
+    def _entity_passes_filters(
+        self, entity, cases_by_id, status, role, case_type, tags
+    ):
+        has_case_filter = any((status, role, case_type, tags))
+        if not has_case_filter:
+            return True
+        return any(
+            relationship.case_id in cases_by_id
+            and (not role or relationship.relationship_type == role)
+            and self._case_passes_filters(
+                relationship.case, status, None, case_type, tags
+            )
+            for relationship in entity.case_relationships.all()
+        )
+
+    def _document_passes_filters(
+        self, source, cases_by_id, source_case_ids, status, role, case_type, tags
+    ):
+        related_cases = [
+            cases_by_id[case_id]
+            for case_id in source_case_ids.get(source.source_id, set())
+            if case_id in cases_by_id
+        ]
+        if any((status, case_type, tags)) and not any(
+            self._case_passes_filters(case, status, None, case_type, tags)
+            for case in related_cases
+        ):
+            return False
+        if role:
+            related_entity_ids = {entity.id for entity in source.related_entities.all()}
+            return any(
+                relationship.relationship_type == role
+                and relationship.entity_id in related_entity_ids
+                for case in related_cases
+                for relationship in case.entity_relationships.all()
+            )
+        return True
+
+    def _case_record(self, case, query):
+        relationships = list(case.entity_relationships.all())
+        searchable = {
+            "title": case.title,
+            "short_description": case.short_description,
+            "description": case.description,
+            "key_allegations": case.key_allegations,
+            "tags": case.tags,
+            "case_id": case.case_id,
+            "court_cases": case.court_cases,
+            "entities": [
+                (relationship.entity.display_name, relationship.entity.nes_id)
+                for relationship in relationships
+            ],
+            "relationship_notes": [
+                relationship.notes for relationship in relationships
+            ],
+        }
+        matched_fields = _matched_fields(query, searchable)
+        if query and not matched_fields:
+            return None
+        score = self._score_case(case, query, searchable)
+        return {
+            "kind": "case",
+            "case_ids": {case.id},
+            "created_at": case.created_at,
+            "updated_at": case.updated_at,
+            "result": {
+                "result_type": "case",
+                "id": case.id,
+                "title": case.title,
+                "description": _excerpt(
+                    case.short_description or case.description,
+                    "Published accountability case.",
+                ),
+                "url": f"/case/{case.slug}",
+                "api_url": f"/api/cases/{case.slug}/",
+                "slug": case.slug,
+                "state": case.state,
+                "case_type": case.case_type,
+                "date": (
+                    case.case_start_date.isoformat()
+                    if case.case_start_date
+                    else case.created_at.date().isoformat()
+                ),
+                "tags": list(case.tags or []),
+                "entities": [
+                    {
+                        "id": relationship.entity_id,
+                        "display_name": relationship.entity.display_name,
+                        "nes_id": relationship.entity.nes_id,
+                        "relationship_type": relationship.relationship_type,
+                    }
+                    for relationship in relationships
+                ],
+                "matched_fields": matched_fields,
+                "score": score,
+            },
+        }
+
+    def _entity_record(self, entity, query, cases_by_id):
+        relationships = [
+            relationship
+            for relationship in entity.case_relationships.all()
+            if relationship.case_id in cases_by_id
+        ]
+        searchable = {
+            "display_name": entity.display_name,
+            "nes_id": entity.nes_id,
+            "related_case_titles": [
+                relationship.case.title for relationship in relationships
+            ],
+            "relationship_type": [
+                relationship.relationship_type for relationship in relationships
+            ],
+            "relationship_notes": [
+                relationship.notes for relationship in relationships
+            ],
+        }
+        matched_fields = _matched_fields(query, searchable)
+        if query and not matched_fields:
+            return None
+        role_counts = Counter(
+            relationship.relationship_type for relationship in relationships
+        )
+        score = self._score_entity(entity, query, searchable)
+        return {
+            "kind": "entity",
+            "case_ids": {relationship.case_id for relationship in relationships},
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "entity_type": extract_entity_type(entity.nes_id),
+            "result": {
+                "result_type": "entity",
+                "id": entity.id,
+                "title": entity.display_name or entity.nes_id or "Unknown entity",
+                "description": "Tracked public entity connected to accountability records.",
+                "url": f"/entity/{entity.id}",
+                "api_url": f"/api/entities/{entity.id}/",
+                "entity_type": extract_entity_type(entity.nes_id),
+                "nes_id": entity.nes_id,
+                "role_counts": dict(role_counts),
+                "related_case_count": len(
+                    {relationship.case_id for relationship in relationships}
+                ),
+                "matched_fields": matched_fields,
+                "score": score,
+            },
+        }
+
+    def _document_record(self, source, query, cases_by_id, source_case_ids):
+        visible_entity_ids = {
+            relationship.entity_id
+            for case in cases_by_id.values()
+            for relationship in case.entity_relationships.all()
+        }
+        related_entities = [
+            entity
+            for entity in source.related_entities.all()
+            if entity.id in visible_entity_ids
+        ]
+        searchable = {
+            "title": source.title,
+            "description": source.description,
+            "source_id": source.source_id,
+            "source_type": source.source_type,
+            "related_entities": [
+                (entity.display_name, entity.nes_id) for entity in related_entities
+            ],
+        }
+        matched_fields = _matched_fields(query, searchable)
+        if query and not matched_fields:
+            return None
+        score = self._score_document(source, query, searchable)
+        return {
+            "kind": "document",
+            "case_ids": set(source_case_ids.get(source.source_id, set())),
+            "created_at": source.created_at,
+            "updated_at": source.updated_at,
+            "result": {
+                "result_type": "document",
+                "id": source.id,
+                "title": source.title,
+                "description": _excerpt(
+                    source.description, "Evidence document linked to an archive case."
+                ),
+                "url": f"/api/sources/{source.source_id}/",
+                "api_url": f"/api/sources/{source.source_id}/",
+                "source_id": source.source_id,
+                "source_type": source.source_type,
+                "related_entities": [
+                    {
+                        "id": entity.id,
+                        "display_name": entity.display_name,
+                        "nes_id": entity.nes_id,
+                    }
+                    for entity in related_entities
+                ],
+                "matched_fields": matched_fields,
+                "score": score,
+            },
+        }
+
+    def _score_case(self, case, query, searchable):
+        score = _recent_boost(case.updated_at)
+        if query == _normalize(case.title):
+            score += 100
+        elif _field_matches(query, case.title):
+            score += 70
+        weights = {
+            "entities": 50,
+            "key_allegations": 45,
+            "tags": 40,
+            "case_id": 35,
+            "court_cases": 35,
+            "short_description": 20,
+            "description": 20,
+            "relationship_notes": 15,
+        }
+        return score + sum(
+            weight
+            for field, weight in weights.items()
+            if _field_matches(query, searchable[field])
+        )
+
+    def _score_entity(self, entity, query, searchable):
+        score = _recent_boost(entity.updated_at)
+        if query == _normalize(entity.display_name):
+            score += 100
+        elif _field_matches(query, entity.display_name):
+            score += 70
+        weights = {
+            "nes_id": 50,
+            "related_case_titles": 35,
+            "relationship_type": 20,
+            "relationship_notes": 15,
+        }
+        return score + sum(
+            weight
+            for field, weight in weights.items()
+            if _field_matches(query, searchable[field])
+        )
+
+    def _score_document(self, source, query, searchable):
+        score = _recent_boost(source.updated_at)
+        if query == _normalize(source.title):
+            score += 100
+        elif _field_matches(query, source.title):
+            score += 70
+        weights = {
+            "related_entities": 50,
+            "source_id": 35,
+            "source_type": 35,
+            "description": 20,
+        }
+        return score + sum(
+            weight
+            for field, weight in weights.items()
+            if _field_matches(query, searchable[field])
+        )
+
+    def _counts(self, records):
+        counter = Counter(record["kind"] for record in records)
+        return {
+            "all": len(records),
+            "cases": counter["case"],
+            "entities": counter["entity"],
+            "documents": counter["document"],
+        }
+
+    def _facets(self, records, cases_by_id):
+        type_counts = Counter(
+            record.get("entity_type", record["kind"]) for record in records
+        )
+        related_case_ids = set().union(
+            *(record["case_ids"] for record in records), set()
+        )
+        related_cases = [
+            cases_by_id[case_id]
+            for case_id in related_case_ids
+            if case_id in cases_by_id
+        ]
+        status_counts = Counter(case.state for case in related_cases)
+        case_type_counts = Counter(case.case_type for case in related_cases)
+        relationships = {
+            relationship.id: relationship
+            for case in related_cases
+            for relationship in case.entity_relationships.all()
+        }
+        role_counts = Counter(
+            relationship.relationship_type for relationship in relationships.values()
+        )
+        return {
+            "type": [
+                self._facet_item(name, TYPE_DISPLAY_NAMES[name], type_counts[name])
+                for name in (
+                    "case",
+                    "person",
+                    "organization",
+                    "location",
+                    "document",
+                    "unknown",
+                )
+            ],
+            "status": [
+                self._facet_item(name, STATUS_DISPLAY_NAMES[name], status_counts[name])
+                for name in (
+                    CaseState.PUBLISHED,
+                    CaseState.IN_REVIEW,
+                    CaseState.DRAFT,
+                )
+            ],
+            "role": [
+                self._facet_item(name, label, role_counts[name])
+                for name, label in RelationshipType.choices
+            ],
+            "case_type": [
+                self._facet_item(name, label, case_type_counts[name])
+                for name, label in CaseType.choices
+            ],
+        }
+
+    def _matches_type(self, record, search_type):
+        if search_type == "all":
+            return True
+        if search_type == "entity":
+            return record["kind"] == "entity"
+        if search_type in ENTITY_TYPES:
+            return (
+                record["kind"] == "entity" and record.get("entity_type") == search_type
+            )
+        return record["kind"] == search_type
+
+    def _sort(self, records, sort):
+        if sort == "newest":
+            records.sort(
+                key=lambda record: (
+                    -record["created_at"].timestamp(),
+                    record["kind"],
+                    record["result"]["id"],
+                )
+            )
+        elif sort == "oldest":
+            records.sort(
+                key=lambda record: (
+                    record["created_at"].timestamp(),
+                    record["kind"],
+                    record["result"]["id"],
+                )
+            )
+        elif sort == "title":
+            records.sort(
+                key=lambda record: (
+                    record["result"]["title"].casefold(),
+                    record["kind"],
+                    record["result"]["id"],
+                )
+            )
+        else:
+            records.sort(
+                key=lambda record: (
+                    -record["result"]["score"],
+                    -record["updated_at"].timestamp(),
+                    record["kind"],
+                    record["result"]["id"],
+                )
+            )
+
+    def _facet_item(self, name, display_name, count):
+        return {"name": name, "display_name": display_name, "count": count}
+
+    def _public_result(self, record):
+        return record["result"]

--- a/cases/urls.py
+++ b/cases/urls.py
@@ -13,6 +13,7 @@ from .api_views import (
     OEmbedView,
     StatisticsView,
     FeedbackView,
+    UnifiedSearchView,
 )
 
 # Create a router and register our viewsets
@@ -22,6 +23,7 @@ router.register(r"sources", DocumentSourceViewSet, basename="documentsource")
 router.register(r"entities", JawafEntityViewSet, basename="jawafentity")
 
 urlpatterns = [
+    path("search/", UnifiedSearchView.as_view(), name="unified-search"),
     path("statistics/", StatisticsView.as_view(), name="statistics"),
     path("feedback/", FeedbackView.as_view(), name="feedback"),
     path("oembed/", OEmbedView.as_view(), name="oembed"),

--- a/tests/api/test_openapi_documentation.py
+++ b/tests/api/test_openapi_documentation.py
@@ -106,7 +106,7 @@ class TestOpenAPIDocumentation:
         assert set(parameter_names) == {
             "q",
             "type",
-            "status",
+            "entity_type",
             "role",
             "case_type",
             "tags",

--- a/tests/api/test_openapi_documentation.py
+++ b/tests/api/test_openapi_documentation.py
@@ -89,6 +89,32 @@ class TestOpenAPIDocumentation:
         assert "/api/sources/" in schema["paths"]
         assert "/api/sources/{id}/" in schema["paths"]
 
+    def test_schema_contains_unified_search_endpoint(self):
+        """Test that the schema documents unified archive search."""
+        client = Client()
+        response = client.get(reverse("schema"))
+
+        import yaml
+
+        schema = yaml.safe_load(response.content)
+
+        assert "/api/search/" in schema["paths"]
+        search = schema["paths"]["/api/search/"]["get"]
+        assert search["summary"] == "Search the accountability archive"
+        assert "search" in search["tags"]
+        parameter_names = [parameter["name"] for parameter in search["parameters"]]
+        assert set(parameter_names) == {
+            "q",
+            "type",
+            "status",
+            "role",
+            "case_type",
+            "tags",
+            "sort",
+            "page",
+            "page_size",
+        }
+
     def test_schema_contains_component_schemas(self):
         """Test that the schema contains component definitions."""
         client = Client()

--- a/tests/api/test_unified_search_api.py
+++ b/tests/api/test_unified_search_api.py
@@ -165,6 +165,19 @@ def test_search_supports_repeatable_refinement_filters(archive_records):
 
 
 @pytest.mark.django_db
+def test_role_and_entity_type_filters_match_same_relationship(archive_records):
+    archive_records["source"].related_entities.add(archive_records["organization"])
+
+    response = APIClient().get(
+        "/api/search/", {"role": "accused", "entity_type": "organization"}
+    )
+
+    assert response.status_code == 200
+    assert response.data["results"] == []
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
 def test_entity_type_refines_mixed_results(archive_records):
     response = APIClient().get("/api/search/", {"entity_type": "organization"})
 

--- a/tests/api/test_unified_search_api.py
+++ b/tests/api/test_unified_search_api.py
@@ -116,7 +116,6 @@ def test_search_returns_one_mixed_normalized_result_list(archive_records):
     [
         ({"type": "case"}, {"case"}),
         ({"type": "entity"}, {"entity"}),
-        ({"type": "person"}, {"entity"}),
         ({"type": "document"}, {"document"}),
         ({"role": "accused"}, {"case", "entity", "document"}),
         ({"case_type": "CORRUPTION"}, {"case", "entity", "document"}),
@@ -131,6 +130,56 @@ def test_search_supports_type_and_relationship_filters(
     assert {result["result_type"] for result in response.data["results"]} == (
         expected_types
     )
+
+
+@pytest.mark.django_db
+def test_search_supports_repeatable_refinement_filters(archive_records):
+    response = APIClient().get(
+        "/api/search/",
+        [
+            ("entity_type", "person"),
+            ("entity_type", "organization"),
+            ("role", "accused"),
+            ("role", "related"),
+            ("case_type", "CORRUPTION"),
+            ("tags", "procurement"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert {result["result_type"] for result in response.data["results"]} == {
+        "case",
+        "entity",
+        "document",
+    }
+    entity_ids = {
+        result["id"]
+        for result in response.data["results"]
+        if result["result_type"] == "entity"
+    }
+    assert entity_ids == {
+        archive_records["person"].id,
+        archive_records["organization"].id,
+    }
+
+
+@pytest.mark.django_db
+def test_entity_type_refines_mixed_results(archive_records):
+    response = APIClient().get("/api/search/", {"entity_type": "organization"})
+
+    assert response.status_code == 200
+    assert {result["result_type"] for result in response.data["results"]} == {
+        "case",
+        "entity",
+    }
+    entity_results = [
+        result
+        for result in response.data["results"]
+        if result["result_type"] == "entity"
+    ]
+    assert [result["id"] for result in entity_results] == [
+        archive_records["organization"].id
+    ]
 
 
 @pytest.mark.django_db
@@ -184,10 +233,7 @@ def test_public_search_does_not_expose_in_review_only_entities(archive_records):
     response = APIClient().get("/api/search/", {"q": "In-review source"})
 
     assert response.status_code == 200
-    assert [result["result_type"] for result in response.data["results"]] == [
-        "document"
-    ]
-    assert response.data["results"][0]["related_entities"] == []
+    assert response.data["results"] == []
 
 
 @pytest.mark.django_db
@@ -197,15 +243,13 @@ def test_facets_are_calculated_before_pagination(archive_records):
     assert response.status_code == 200
     assert response.data["count"] == 5
     assert len(response.data["results"]) == 2
-    type_facets = {
-        item["name"]: item["count"] for item in response.data["facets"]["type"]
+    entity_type_facets = {
+        item["name"]: item["count"] for item in response.data["facets"]["entity_type"]
     }
-    assert type_facets == {
-        "case": 1,
+    assert entity_type_facets == {
         "person": 1,
         "organization": 1,
         "location": 1,
-        "document": 1,
         "unknown": 0,
     }
     role_facets = {
@@ -214,6 +258,9 @@ def test_facets_are_calculated_before_pagination(archive_records):
     assert role_facets["accused"] == 1
     assert role_facets["related"] == 1
     assert role_facets["location"] == 1
+    assert response.data["facets"]["tags"] == [
+        {"name": "procurement", "display_name": "Procurement", "count": 1}
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/api/test_unified_search_api.py
+++ b/tests/api/test_unified_search_api.py
@@ -1,0 +1,244 @@
+"""Contract tests for the unified archive search endpoint."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    DocumentSource,
+    JawafEntity,
+    RelationshipType,
+    SourceType,
+)
+
+
+@pytest.fixture
+def archive_records():
+    person = JawafEntity.objects.create(
+        nes_id="entity:person/kp-sharma-oli",
+        display_name="K.P. Sharma Oli",
+    )
+    organization = JawafEntity.objects.create(
+        nes_id="entity:organization/nepal-government",
+        display_name="नेपाल सरकार",
+    )
+    location = JawafEntity.objects.create(
+        nes_id="entity:location/kathmandu",
+        display_name="काठमाडौं",
+    )
+    source = DocumentSource.objects.create(
+        source_id="source:ciaa:procurement",
+        title="CIAA procurement filing",
+        description="Official procurement investigation filing.",
+        source_type=SourceType.OFFICIAL_GOVERNMENT,
+    )
+    published_case = Case.objects.create(
+        case_id="case-procurement",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        title="KP Sharma Oli procurement case",
+        short_description="Procurement accountability record.",
+        description="A public procurement investigation.",
+        key_allegations=["Irregular procurement decision"],
+        tags=["procurement"],
+        evidence=[{"source_id": source.source_id, "description": "Official filing"}],
+        court_cases=["special:081-CR-0001"],
+    )
+    CaseEntityRelationship.objects.create(
+        case=published_case,
+        entity=person,
+        relationship_type=RelationshipType.ACCUSED,
+        notes="Named in irregular procurement allegation.",
+    )
+    CaseEntityRelationship.objects.create(
+        case=published_case,
+        entity=organization,
+        relationship_type=RelationshipType.RELATED,
+    )
+    CaseEntityRelationship.objects.create(
+        case=published_case,
+        entity=location,
+        relationship_type=RelationshipType.LOCATION,
+    )
+    source.related_entities.add(person)
+
+    draft_case = Case.objects.create(
+        case_id="case-private-draft",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        title="Private draft procurement note",
+        description="Not ready for publication.",
+    )
+    return {
+        "person": person,
+        "organization": organization,
+        "location": location,
+        "source": source,
+        "published_case": published_case,
+        "draft_case": draft_case,
+    }
+
+
+@pytest.mark.django_db
+def test_search_returns_one_mixed_normalized_result_list(archive_records):
+    response = APIClient().get("/api/search/", {"q": "K.P. Sharma Oli"})
+
+    assert response.status_code == 200
+    assert response.data["query"] == "K.P. Sharma Oli"
+    assert response.data["count"] == 3
+    assert response.data["counts"] == {
+        "all": 3,
+        "cases": 1,
+        "entities": 1,
+        "documents": 1,
+    }
+    results_by_type = {
+        result["result_type"]: result for result in response.data["results"]
+    }
+    assert set(results_by_type) == {"case", "entity", "document"}
+    assert results_by_type["case"]["url"] == (
+        f"/case/{archive_records['published_case'].slug}"
+    )
+    assert results_by_type["entity"]["url"] == (
+        f"/entity/{archive_records['person'].id}"
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("params", "expected_types"),
+    [
+        ({"type": "case"}, {"case"}),
+        ({"type": "entity"}, {"entity"}),
+        ({"type": "person"}, {"entity"}),
+        ({"type": "document"}, {"document"}),
+        ({"role": "accused"}, {"case", "entity", "document"}),
+        ({"case_type": "CORRUPTION"}, {"case", "entity", "document"}),
+    ],
+)
+def test_search_supports_type_and_relationship_filters(
+    archive_records, params, expected_types
+):
+    response = APIClient().get("/api/search/", params)
+
+    assert response.status_code == 200
+    assert {result["result_type"] for result in response.data["results"]} == (
+        expected_types
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "query",
+    [
+        "KP Sharma",
+        "Irregular procurement",
+        "procurement",
+        "entity:person/kp-sharma-oli",
+    ],
+)
+def test_search_matches_case_and_entity_fields(archive_records, query):
+    response = APIClient().get("/api/search/", {"q": query})
+
+    assert response.status_code == 200
+    result_types = {result["result_type"] for result in response.data["results"]}
+    assert "case" in result_types
+    assert "entity" in result_types
+
+
+@pytest.mark.django_db
+def test_public_search_does_not_expose_draft_cases(archive_records):
+    response = APIClient().get("/api/search/", {"q": "Private draft"})
+
+    assert response.status_code == 200
+    assert response.data["results"] == []
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_public_search_does_not_expose_in_review_only_entities(archive_records):
+    private_entity = JawafEntity.objects.create(
+        nes_id="entity:person/private-review-only",
+        display_name="Private Review Only",
+    )
+    private_source = DocumentSource.objects.create(
+        source_id="source:ciaa:private-review",
+        title="In-review source",
+        description="Visible source without a published entity association.",
+    )
+    private_source.related_entities.add(private_entity)
+    Case.objects.create(
+        case_id="case-private-review",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.IN_REVIEW,
+        title="Private review case",
+        evidence=[{"source_id": private_source.source_id, "description": "Review"}],
+    )
+
+    response = APIClient().get("/api/search/", {"q": "In-review source"})
+
+    assert response.status_code == 200
+    assert [result["result_type"] for result in response.data["results"]] == [
+        "document"
+    ]
+    assert response.data["results"][0]["related_entities"] == []
+
+
+@pytest.mark.django_db
+def test_facets_are_calculated_before_pagination(archive_records):
+    response = APIClient().get("/api/search/", {"page": 1, "page_size": 2})
+
+    assert response.status_code == 200
+    assert response.data["count"] == 5
+    assert len(response.data["results"]) == 2
+    type_facets = {
+        item["name"]: item["count"] for item in response.data["facets"]["type"]
+    }
+    assert type_facets == {
+        "case": 1,
+        "person": 1,
+        "organization": 1,
+        "location": 1,
+        "document": 1,
+        "unknown": 0,
+    }
+    role_facets = {
+        item["name"]: item["count"] for item in response.data["facets"]["role"]
+    }
+    assert role_facets["accused"] == 1
+    assert role_facets["related"] == 1
+    assert role_facets["location"] == 1
+
+
+@pytest.mark.django_db
+def test_newest_sort_is_deterministic(archive_records):
+    other_case = Case.objects.create(
+        case_id="case-newer",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        title="Newest published record",
+    )
+    Case.objects.filter(pk=other_case.pk).update(
+        created_at=timezone.now() + timedelta(days=1)
+    )
+
+    response = APIClient().get("/api/search/", {"type": "case", "sort": "newest"})
+
+    assert response.status_code == 200
+    assert response.data["results"][0]["id"] == other_case.id
+
+
+@pytest.mark.django_db
+def test_page_size_is_capped_and_invalid_params_are_rejected(archive_records):
+    capped_response = APIClient().get("/api/search/", {"page_size": 500})
+    invalid_response = APIClient().get("/api/search/", {"type": "invalid"})
+
+    assert capped_response.status_code == 200
+    assert capped_response.data["page_size"] == 50
+    assert invalid_response.status_code == 400

--- a/tests/api/test_unified_search_api.py
+++ b/tests/api/test_unified_search_api.py
@@ -203,6 +203,17 @@ def test_search_matches_case_and_entity_fields(archive_records, query):
 
 
 @pytest.mark.django_db
+def test_search_matches_document_fields_without_case_text_match(archive_records):
+    response = APIClient().get("/api/search/", {"q": "CIAA filing"})
+
+    assert response.status_code == 200
+    assert [result["result_type"] for result in response.data["results"]] == [
+        "document"
+    ]
+    assert response.data["results"][0]["id"] == archive_records["source"].id
+
+
+@pytest.mark.django_db
 def test_public_search_does_not_expose_draft_cases(archive_records):
     response = APIClient().get("/api/search/", {"q": "Private draft"})
 

--- a/tests/api/test_unified_search_api.py
+++ b/tests/api/test_unified_search_api.py
@@ -137,6 +137,8 @@ def test_search_supports_repeatable_refinement_filters(archive_records):
     response = APIClient().get(
         "/api/search/",
         [
+            ("type", "case"),
+            ("type", "entity"),
             ("entity_type", "person"),
             ("entity_type", "organization"),
             ("role", "accused"),
@@ -150,7 +152,6 @@ def test_search_supports_repeatable_refinement_filters(archive_records):
     assert {result["result_type"] for result in response.data["results"]} == {
         "case",
         "entity",
-        "document",
     }
     entity_ids = {
         result["id"]
@@ -243,6 +244,14 @@ def test_facets_are_calculated_before_pagination(archive_records):
     assert response.status_code == 200
     assert response.data["count"] == 5
     assert len(response.data["results"]) == 2
+    type_facets = {
+        item["name"]: item["count"] for item in response.data["facets"]["type"]
+    }
+    assert type_facets == {
+        "case": 1,
+        "entity": 3,
+        "document": 1,
+    }
     entity_type_facets = {
         item["name"]: item["count"] for item in response.data["facets"]["entity_type"]
     }


### PR DESCRIPTION
## Summary
- Unified search feature for Jawafdehi accountability platform
- Adds search API endpoints, search UI components, and i18n support
- 15 commits adding 74 files (8,517 insertions, 1,319 deletions)

## Conflicts Resolved (JAWA-2423)
- `cases/api_views.py`: Import lines — kept feat/search additions (`serializers` import)
- `cases/urls.py`: Import lines — kept feat/search additions (`UnifiedSearchView`)

## Test Plan
- [ ] Search API returns correct results
- [ ] Search UI renders with filters
- [ ] i18n translations work for search components
- [ ] No regressions in existing API endpoints

## Metadata
- **Issue:** [JAWA-2423](https://github.com/Jawafdehi/JawafdehiAPI/issues?q=JAWA-2423)
- **Paperclip-Run-Id:** a018bc6f-6e51-4889-8bd2-74ade3d7bf74
- **Rationale:** Resolves trivial import conflicts from two PRs landing on main after feat/search branched

## Rollback
Revert commit or close without merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
