### PR TITLE
Add auto-deploy to Dokploy via GH Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,3 +42,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Trigger Dokploy redeploy
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: |
+          curl -s -X POST \
+            -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            "https://infra.jawafdehi.org/api/compose.deploy" \
+            -d '{"composeId":"92hysPKOvbk0Z3lfJqD6M","title":"Auto-deploy: ${{ github.sha }}"}'


### PR DESCRIPTION
After a successful Docker push to main, trigger `compose.deploy` via the Dokploy REST API to redeploy jawafdehi-api with the latest image.

The `DOKPLOY_API_KEY` secret is already set at the organization level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation to improve release pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->