### PR TITLE
admin: MultiURL widget supports {link, role} source-link dicts

### DIFF
--- a/cases/static/cases/js/widgets.js
+++ b/cases/static/cases/js/widgets.js
@@ -64,6 +64,12 @@ class MultiWidgetManager {
             });
         }
 
+        // Also update the hidden value when any <select> in the row changes
+        // (e.g. the URL link-role dropdown, which isn't an `.inputClass` input).
+        row.querySelectorAll('select').forEach(sel => {
+            sel.addEventListener('change', () => this.updateHidden());
+        });
+
         // Setup widget-specific handlers
         if (this.config.setupRowCallback) {
             this.config.setupRowCallback(row, this);
@@ -185,8 +191,15 @@ window.MultiWidgetConfigs = {
         inputClass: 'url-input',
         rowClass: 'input-row',
         getValues: (container) => {
-            const inputs = container.querySelectorAll('.url-input');
-            return Array.from(inputs).map(i => i.value.trim()).filter(v => v);
+            // Emit source-link dicts {link, role}. role omitted when blank.
+            return Array.from(container.querySelectorAll('.input-row')).map(row => {
+                const linkInput = row.querySelector('.url-input');
+                const roleSelect = row.querySelector('.url-role');
+                const link = linkInput ? linkInput.value.trim() : '';
+                if (!link) return null;
+                const role = roleSelect ? roleSelect.value.trim() : '';
+                return role ? { link, role } : { link, role: null };
+            }).filter(v => v);
         }
     },
 

--- a/cases/templates/cases/widgets/multi_url_widget.html
+++ b/cases/templates/cases/widgets/multi_url_widget.html
@@ -2,7 +2,13 @@
     {% for value in values %}
     <div class="input-row" draggable="true">
         <span class="drag-handle">⋮⋮</span>
-        <input type="url" class="url-input" value="{{ value }}" placeholder="https://example.com">
+        <input type="url" class="url-input" value="{{ value.link }}" placeholder="https://example.com">
+        <select class="url-role" aria-label="Link type">
+            <option value="">— type —</option>
+            {% for r in role_choices %}
+            <option value="{{ r }}" {% if value.role == r %}selected{% endif %}>{{ r }}</option>
+            {% endfor %}
+        </select>
         <button type="button" class="btn btn-sm btn-danger remove-input" aria-label="Remove URL">
             <i class="fas fa-times" aria-hidden="true"></i>
         </button>
@@ -16,19 +22,37 @@
 </div>
 <input type="hidden" name="{{ name }}" id="{{ widget_id }}" value="{{ values_json }}">
 
+{# Role choices as JSON (json_script safely escapes for embedding) so the new-row
+   template builds the <select> in JS without interpolating values into JS source. #}
+{{ role_choices|json_script:role_choices_id }}
+
 <script>
-window.initMultiWidget(
-    '{{ widget_id }}_container',
-    '{{ widget_id }}',
-    'url',
-    {
-        rowTemplate: [
-            '<span class="drag-handle">⋮⋮</span>',
-            '<input type="url" class="url-input" placeholder="https://example.com">',
-            '<button type="button" class="btn btn-sm btn-danger remove-input" aria-label="Remove URL">',
-            '<i class="fas fa-times" aria-hidden="true"></i>',
-            '</button>'
-        ].join(' ')
-    }
-);
+(function () {
+    var roleChoices = JSON.parse(
+        document.getElementById('{{ role_choices_id }}').textContent
+    );
+    var roleOptions = '<option value="">— type —</option>' +
+        roleChoices.map(function (r) {
+            var opt = document.createElement('option');
+            opt.value = r;
+            opt.textContent = r;
+            return opt.outerHTML;
+        }).join('');
+
+    window.initMultiWidget(
+        '{{ widget_id }}_container',
+        '{{ widget_id }}',
+        'url',
+        {
+            rowTemplate: [
+                '<span class="drag-handle">⋮⋮</span>',
+                '<input type="url" class="url-input" placeholder="https://example.com">',
+                '<select class="url-role" aria-label="Link type">' + roleOptions + '</select>',
+                '<button type="button" class="btn btn-sm btn-danger remove-input" aria-label="Remove URL">',
+                '<i class="fas fa-times" aria-hidden="true"></i>',
+                '</button>'
+            ].join(' ')
+        }
+    );
+})();
 </script>

--- a/cases/widgets.py
+++ b/cases/widgets.py
@@ -2,7 +2,6 @@ import json
 from json import JSONDecodeError
 
 from django.core.exceptions import ValidationError
-from django.core.validators import URLValidator
 from django.forms.fields import Field
 from django.forms.widgets import Textarea, Widget
 from django.template.loader import render_to_string
@@ -319,12 +318,31 @@ class MultiURLWidget(BaseMultiWidget):
         final_attrs = self.build_attrs(self.attrs, attrs)
         widget_id = final_attrs.get("id", name)
 
+        from cases.models import SourceLinkRole
+
+        # Normalize every value to a {link, role} dict so the template can render
+        # value.link / value.role unconditionally. Without this, a legacy plain
+        # string vs a dict need different handling, and a dict with an empty link
+        # would render its repr into the input via the `default` filter.
+        normalized = []
+        for item in value or []:
+            if isinstance(item, dict):
+                normalized.append(
+                    {"link": item.get("link") or "", "role": item.get("role") or ""}
+                )
+            else:
+                normalized.append({"link": item or "", "role": ""})
+
         context = {
             "widget_id": widget_id,
             "name": name,
-            "values": value,
+            "values": normalized,
             "values_json": json.dumps(value),
             "button_label": self.button_label,
+            "role_choices": [r.value for r in SourceLinkRole],
+            # Unique id for the json_script block (avoids collisions when several
+            # MultiURL widgets render on one page, e.g. an inline formset).
+            "role_choices_id": f"{widget_id}_role_choices",
         }
         return context
 
@@ -359,28 +377,15 @@ class MultiURLField(Field):
 
     def validate(self, value):
         super().validate(value)
-        # Validate each URL
+        # Each item may be a plain URL string OR a {"link": str, "role": ...}
+        # dict (source-link format). Delegate to the model validator so the
+        # admin form stays in sync with DocumentSource.url's own rules — a
+        # string-only check here wrongly rejected dict items, which broke
+        # selecting a link type/role in the admin.
         if value:
-            validator = URLValidator()
-            for url in value:
-                # Check type before calling .strip()
-                if not isinstance(url, str):
-                    raise ValidationError(
-                        f"Invalid URL type: expected string, got {type(url).__name__} ({url!r})"
-                    )
+            from cases.models import validate_url_list
 
-                # Normalize and check if empty
-                normalized = url.strip()
-                if not normalized:
-                    # Reject whitespace-only or empty URLs at form validation time
-                    raise ValidationError(
-                        f"URL cannot be blank or whitespace-only: {url!r}"
-                    )
-
-                try:
-                    validator(normalized)
-                except ValidationError as err:
-                    raise ValidationError(f"Invalid URL: {url}") from err
+            validate_url_list(value)
 
 
 class MultiCourtCaseWidget(BaseMultiWidget):


### PR DESCRIPTION
The Django admin url widget now accepts the {link, role} source-link dict format (matching DocumentSource.url and the public API), so the link type/role (RAW / MARKDOWN / PERMALINK) can be selected in the admin. Delegates validation to validate_url_list so the form stays in sync with the model validator.