### PR TITLE
review: add org-wide ReadOnly role with system-wide read access

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -60,6 +60,7 @@ from .rules.predicates import (
     can_view_case,
     is_admin_or_moderator,
     is_contributor,
+    is_readonly,
 )
 from .search_serializers import SearchResponseSerializer
 from .serializers import (
@@ -210,8 +211,9 @@ class UnifiedSearchView(APIView):
 
         **Visibility rules:**
         - Unauthenticated requests: only PUBLISHED cases.
-        - Admin / Moderator: all non-CLOSED cases (PUBLISHED + IN_REVIEW + DRAFT).
-        - Authenticated contributor/other: PUBLISHED cases + any DRAFT or IN_REVIEW cases
+        - Admin / Moderator / Contributor / ReadOnly: all non-CLOSED cases
+          (PUBLISHED + IN_REVIEW + DRAFT).
+        - Other authenticated users: PUBLISHED cases + any DRAFT or IN_REVIEW cases
           they are explicitly assigned to as contributors.
 
         Results are ordered by creation date (newest first).
@@ -294,10 +296,10 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
     Public read-only API for Cases (with PATCH support for authenticated users).
 
     Provides:
-    - Create endpoint: POST /api/cases/ (authenticated users only)
+    - Create endpoint: POST /api/cases/ (authenticated; write authorization in create)
     - List endpoint: GET /api/cases/
     - Retrieve endpoint: GET /api/cases/{id}/
-    - Patch endpoint: PATCH /api/cases/{id}/ (authenticated users only)
+    - Patch endpoint: PATCH /api/cases/{id}/ (authenticated; gated by can_change_case)
 
     Filtering:
     - case_type: Filter by case type
@@ -306,8 +308,10 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
     Search:
     - Full-text search across title, description, key_allegations
 
-    Only published cases (state=PUBLISHED) are accessible.
-    The detail endpoint also includes IN_REVIEW cases.
+    Read visibility is role-based: unauthenticated callers see PUBLISHED cases
+    (retrieve also exposes IN_REVIEW); Admin / Moderator / Contributor / ReadOnly
+    see all non-CLOSED cases (incl. DRAFT). CLOSED cases are never exposed via
+    this API.
     """
 
     serializer_class = CaseSerializer
@@ -322,7 +326,14 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
     ]
 
     def get_permissions(self):
-        if self.action in ("create", "partial_update"):
+        # create requires the cases.add_case model permission (DjangoModelPermissions
+        # maps POST->add_case) on top of authentication, so the org-wide ReadOnly
+        # role (view-only perms) and plain authenticated users without add_case
+        # cannot create cases. partial_update stays IsAuthenticated here; its
+        # authorization is the can_change_case check inside partial_update().
+        if self.action == "create":
+            return [IsAuthenticated(), DjangoModelPermissions()]
+        if self.action == "partial_update":
             return [IsAuthenticated()]
         return super().get_permissions()
 
@@ -344,6 +355,12 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
           - CLOSED cases are never exposed via public API
         Partial update endpoint: all cases except CLOSED (authorization check happens in partial_update).
         """
+        if self.action == "create":
+            # DjangoModelPermissions calls get_queryset() only to derive the model
+            # for the add_case check; return an empty queryset (still carries
+            # .model) so the list/tag-filtering path below does not run on POST.
+            return Case.objects.none()
+
         if self.action == "partial_update":
             # PATCH endpoint: return all cases except CLOSED, authorization check happens in partial_update method
             return Case.objects.exclude(state=CaseState.CLOSED)
@@ -361,12 +378,14 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
         else:
             # List endpoint: visibility depends on authentication/role.
             # - Unauthenticated: PUBLISHED only
-            # - Admin/Moderator: all non-CLOSED cases
-            # - Other authenticated (contributor): PUBLISHED + cases they are assigned to
+            # - Admin/Moderator/Contributor/ReadOnly: all non-CLOSED cases
+            # - Other authenticated: PUBLISHED + cases they are assigned to
             if not (self.request.user and self.request.user.is_authenticated):
                 queryset = Case.objects.filter(state=CaseState.PUBLISHED)
-            elif is_admin_or_moderator(self.request.user) or is_contributor(
-                self.request.user
+            elif (
+                is_admin_or_moderator(self.request.user)
+                or is_contributor(self.request.user)
+                or is_readonly(self.request.user)
             ):
                 queryset = Case.objects.exclude(state=CaseState.CLOSED)
             else:
@@ -693,8 +712,11 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
         description="""
         Retrieve a paginated list of document sources.
 
-        Only sources associated with published or in-review cases are accessible.
-        Soft-deleted sources (is_deleted=True) are excluded.
+        Sources associated with published or in-review cases are accessible to
+        all callers. Users in the org-wide ReadOnly role get a system-wide read:
+        every non-deleted source, including those referenced only by DRAFT cases
+        or not referenced by any case. Soft-deleted sources (is_deleted=True) are
+        always excluded.
 
         **Pagination:**
         - Results are paginated with 20 items per page
@@ -728,7 +750,8 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
         description="""
         Create a new document source with an optional file upload.
 
-        Requires authentication. Accepts multipart form data.
+        Requires authentication and the `cases.add_documentsource` permission.
+        Accepts multipart form data.
         """,
         tags=["sources"],
     ),
@@ -750,18 +773,22 @@ class DocumentSourceViewSet(
     - Update endpoint: PATCH/PUT /api/sources/{id_or_source_id}/
 
     The retrieve/update endpoints accept either the database id or the source_id.
-    Only sources associated with published or in-review cases are accessible.
-    Update requires the cases.change_documentsource permission.
+    Sources tied to published or in-review cases are accessible to all callers;
+    the org-wide ReadOnly role additionally reads every non-deleted source.
+    Create requires cases.add_documentsource; update requires
+    cases.change_documentsource (enforced via DjangoModelPermissions).
     """
 
     parser_classes = [MultiPartParser, FormParser, JSONParser]
     lookup_field = "pk"
 
     def get_permissions(self):
-        if self.action in ("partial_update", "update"):
+        # Writes require the matching Django model permission (DjangoModelPermissions
+        # maps POST->add_documentsource, PUT/PATCH->change_documentsource) on top of
+        # authentication. This keeps the org-wide ReadOnly role (view-only perms) and
+        # plain authenticated users without source perms out of the write paths.
+        if self.action in ("create", "partial_update", "update"):
             return [IsAuthenticated(), DjangoModelPermissions()]
-        if self.action == "create":
-            return [IsAuthenticated()]
         return super().get_permissions()
 
     def get_serializer_class(self):
@@ -805,6 +832,26 @@ class DocumentSourceViewSet(
         A source is accessible if it's referenced in the evidence field
         of at least one published or in-review case.
         """
+        # On create, DjangoModelPermissions calls get_queryset() solely to derive
+        # the model for the permission check. Short-circuit so the expensive
+        # visibility scan (every published/in-review case + JSON evidence parse)
+        # does not run on the POST hot path. .none() still carries .model.
+        # (update/partial_update legitimately need the real queryset via
+        # get_object(), so they fall through.)
+        if self.action == "create":
+            return DocumentSource.objects.none()
+
+        # The org-wide ReadOnly role gets a system-wide read: all non-deleted
+        # sources, including those referenced only by DRAFT cases (or by no case
+        # at all). Other callers keep the public contract below.
+        user = self.request.user
+        if user and user.is_authenticated and is_readonly(user):
+            return (
+                DocumentSource.objects.filter(is_deleted=False)
+                .prefetch_related("uploaded_files")
+                .distinct()
+            )
+
         allowed_states = [CaseState.PUBLISHED, CaseState.IN_REVIEW]
         visible_cases = Case.objects.filter(state__in=allowed_states)
 
@@ -854,9 +901,13 @@ class DocumentSourceViewSet(
 
 @extend_schema_view(
     list=extend_schema(
-        summary="List all entities",
+        summary="List entities",
         description="""
-        Retrieve a paginated list of all entities in the system.
+        Retrieve a paginated list of entities.
+
+        For most callers the list is limited to entities appearing in published
+        cases. Users in the org-wide ReadOnly role get a system-wide read: every
+        entity in the system.
 
         Entities can have either:
         - `nes_id`: Reference to Nepal Entity Service
@@ -902,7 +953,7 @@ class DocumentSourceViewSet(
         description="""
         Create a new JawafEntity.
 
-        Requires authentication.
+        Requires authentication and the `cases.add_jawafentity` permission.
         """,
         tags=["entities"],
     ),
@@ -921,21 +972,28 @@ class JawafEntityViewSet(
     - List endpoint: GET /api/entities/ (filtered by case association)
     - Retrieve endpoint: GET /api/entities/{id}/
     - Create endpoint: POST /api/entities/
-    - Update endpoint: PATCH /api/entities/{id}/ (authenticated users only)
+    - Update endpoint: PATCH /api/entities/{id}/
 
     Search:
     - Full-text search across nes_id and display_name
 
-    Only entities associated with published cases are returned in list view.
-    Entities must appear in alleged_entities or related_entities (not locations).
+    For most callers the list view returns only entities associated with
+    published cases (in alleged_entities or related_entities, not locations);
+    the org-wide ReadOnly role reads every entity. Create requires
+    cases.add_jawafentity; update requires cases.change_jawafentity (enforced
+    via DjangoModelPermissions).
     """
 
     filter_backends = [filters.SearchFilter]
     search_fields = ["nes_id", "display_name"]
 
     def get_permissions(self):
+        # Writes require the matching Django model permission (DjangoModelPermissions
+        # maps POST->add_jawafentity, PUT/PATCH->change_jawafentity) on top of
+        # authentication, so the org-wide ReadOnly role (view-only perms) and plain
+        # authenticated users without entity perms cannot create or edit entities.
         if self.action in ("create", "partial_update", "update"):
-            return [IsAuthenticated()]
+            return [IsAuthenticated(), DjangoModelPermissions()]
         return super().get_permissions()
 
     def get_serializer_class(self):
@@ -970,9 +1028,23 @@ class JawafEntityViewSet(
 
         Uses caching to avoid expensive queryset evaluation.
         """
+        # On create, DjangoModelPermissions calls get_queryset() solely to derive
+        # the model for the permission check. Short-circuit so the published-case
+        # scan / cache lookup does not run on the POST hot path. .none() still
+        # carries .model. (update/partial_update fall through to the real lookup.)
+        if self.action == "create":
+            return JawafEntity.objects.none()
+
         # For retrieve action, return all entities
         if self.action == "retrieve":
             return JawafEntity.objects.all()
+
+        # The org-wide ReadOnly role gets a system-wide read: every entity in the
+        # list, not just those appearing in published cases (mirrors the source
+        # widening above). Other callers keep the public, published-only contract.
+        user = self.request.user
+        if user and user.is_authenticated and is_readonly(user):
+            return JawafEntity.objects.all().order_by("-created_at")
 
         # For list action, filter by case association
         from django.core.cache import cache

--- a/cases/management/commands/create_groups.py
+++ b/cases/management/commands/create_groups.py
@@ -268,4 +268,27 @@ class Command(BaseCommand):
             ]
         )
 
+        # ReadOnly: an org-wide read role that can be assigned to anyone. Grants
+        # view_* on every content model so the holder can GET/list all cases
+        # (including non-PUBLISHED, non-CLOSED), sources, uploads, entities, and
+        # relationships, but holds no add/change/delete permission. Casework
+        # review read access is granted by group name in review/permissions.py
+        # (CanReadReview); writes there stay gated by HasContributorRole, which
+        # does not include ReadOnly.
+        readonly_group, created = Group.objects.get_or_create(name="ReadOnly")
+        if created:
+            self.stdout.write(self.style.SUCCESS("Created ReadOnly group"))
+        else:
+            self.stdout.write("ReadOnly group already exists")
+
+        readonly_group.permissions.set(
+            [
+                case_permissions["view"],
+                source_permissions["view"],
+                upload_permissions["view"],
+                entity_permissions["view"],
+                relationship_permissions["view"],
+            ]
+        )
+
         self.stdout.write(self.style.SUCCESS("Successfully configured all groups"))

--- a/cases/rules/predicates.py
+++ b/cases/rules/predicates.py
@@ -52,6 +52,18 @@ def has_role(user: User) -> bool:
     return user.groups.filter(name__in=["Admin", "Moderator", "Contributor"]).exists()
 
 
+@rules.predicate
+def is_readonly(user: User) -> bool:
+    """Check if user is in the org-wide ReadOnly group.
+
+    ReadOnly is an assign-to-anyone role that grants system-wide read access
+    (view_* model perms) but no write perms. It deliberately does NOT imply
+    has_role, so write rules that build on is_admin_or_moderator /
+    is_*_contributor continue to exclude ReadOnly users.
+    """
+    return user.groups.filter(name="ReadOnly").exists()
+
+
 # ============================================================================
 # Case-specific Predicates
 # ============================================================================
@@ -193,11 +205,14 @@ def can_manage_user(user: User, target_user: Optional[User]) -> bool:
 # ============================================================================
 
 # Case permissions
-can_view_case = is_admin_or_moderator | is_contributor
+# ReadOnly joins the view predicate so the org-wide read role can list AND
+# retrieve all non-CLOSED cases (the retrieve() DRAFT gate uses can_view_case).
+# Write predicates intentionally omit is_readonly.
+can_view_case = is_admin_or_moderator | is_contributor | is_readonly
 can_change_case = is_admin_or_moderator | is_case_contributor
 
 # Source permissions
-can_view_source = is_admin_or_moderator | is_contributor
+can_view_source = is_admin_or_moderator | is_contributor | is_readonly
 can_change_source = is_admin_or_moderator | is_source_contributor
 can_delete_source = is_admin_or_moderator
 

--- a/review/permissions.py
+++ b/review/permissions.py
@@ -46,6 +46,32 @@ class HasContributorRole(permissions.BasePermission):
         return bool(has_role(user))
 
 
+class CanReadReview(permissions.BasePermission):
+    """Allow read access to the Casework Review System.
+
+    Admits superuser, Admin, Moderator, Contributor, ReviewAssistant, and the
+    org-wide ReadOnly role. Used only on GET endpoints (review list/detail,
+    rules, config read, ``me``); mutation endpoints keep HasContributorRole,
+    which deliberately excludes ReadOnly. This is what lets a read-only role
+    observe the queue without being able to claim jobs, submit results, or
+    re-queue reviews.
+    """
+
+    message = "Reading the Casework Review System requires a role with read access."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        if user.is_superuser:
+            return True
+        # ReviewAssistant + ReadOnly get read access by group name; the rest
+        # (Admin / Moderator / Contributor) come through has_role.
+        if user.groups.filter(name__in=["ReviewAssistant", "ReadOnly"]).exists():
+            return True
+        return bool(has_role(user))
+
+
 class IsAdminOrModerator(permissions.BasePermission):
     """Allow only Admin / Moderator (or superuser).
 

--- a/review/views.py
+++ b/review/views.py
@@ -5,7 +5,10 @@ Auth model change vs. the standalone casework system:
   - Here we reuse jawafdehi-api's JWT. Clients obtain a token pair from the
     existing /api/caseworker/auth/token/ endpoint (SimpleJWT TokenObtainPair)
     and send it as `Authorization: Bearer <access>`.
-  - Every endpoint additionally requires the Contributor role (HasContributorRole).
+  - Read endpoints (review list/detail, rules, config GET, ``me``) require a
+    role with read access (CanReadReview: Contributor+ / ReviewAssistant /
+    the org-wide ReadOnly role). Mutation endpoints require at least the
+    Contributor role (HasContributorRole), which excludes ReadOnly.
 
 So there is no login_view here anymore; the SPA logs in against the shared JWT
 endpoint. We expose a small `me` view so the SPA can show who is signed in and
@@ -22,6 +25,7 @@ from . import case_provider, code_rules
 from .models import CaseReview, ReviewConfig
 from .permissions import (
     CanManageDocumentSources,
+    CanReadReview,
     HasContributorRole,
     IsAdminOrModerator,
 )
@@ -36,7 +40,7 @@ from .serializers import (
 
 
 @api_view(["GET"])
-@permission_classes([HasContributorRole])
+@permission_classes([CanReadReview])
 def me_view(request):
     """Return the signed-in user + their roles (for the SPA header / gating)."""
     user = request.user
@@ -241,7 +245,7 @@ def attach_source_markdown(request, source_id):
 
 class ReviewListView(generics.ListAPIView):
     serializer_class = CaseReviewListSerializer
-    permission_classes = [HasContributorRole]
+    permission_classes = [CanReadReview]
 
     def get_queryset(self):
         return CaseReview.objects.all()
@@ -249,7 +253,7 @@ class ReviewListView(generics.ListAPIView):
 
 class ReviewDetailView(generics.RetrieveAPIView):
     serializer_class = CaseReviewDetailSerializer
-    permission_classes = [HasContributorRole]
+    permission_classes = [CanReadReview]
     queryset = CaseReview.objects.all()
 
 
@@ -259,14 +263,14 @@ class ReviewDetailView(generics.RetrieveAPIView):
 
 
 @api_view(["GET"])
-@permission_classes([HasContributorRole])
+@permission_classes([CanReadReview])
 def rules_list(request):
     """List all (code-defined) rules, in display order."""
     return Response([code_rules.as_dict(r) for r in code_rules.get_rules()])
 
 
 @api_view(["GET"])
-@permission_classes([HasContributorRole])
+@permission_classes([CanReadReview])
 def rule_detail(request, pk):
     """Retrieve a single (code-defined) rule by its stable id."""
     rule = code_rules.get_rule(pk)
@@ -276,7 +280,7 @@ def rule_detail(request, pk):
 
 
 @api_view(["GET", "PUT"])
-@permission_classes([HasContributorRole])
+@permission_classes([CanReadReview])
 def config_view(request):
     """Get or edit global review config (thresholds + LLM sampling).
 

--- a/tests/api/test_readonly_read_visibility.py
+++ b/tests/api/test_readonly_read_visibility.py
@@ -1,0 +1,127 @@
+"""Integration tests: the org-wide ReadOnly role gets a true system-wide READ.
+
+These exercise the actual API list endpoints (not bare ORM filters), proving a
+ReadOnly user sees materials that the public contract hides:
+  - cases: all non-CLOSED cases, including DRAFT (CaseViewSet.get_queryset)
+  - sources: every non-deleted source, including draft-only / unreferenced ones
+  - entities: every entity, not just those in published cases
+
+The public/anonymous baseline is asserted alongside each, so the tests fail if
+ReadOnly visibility regresses to the public surface.
+"""
+
+import pytest
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from cases.models import CaseState, CaseType, DocumentSource, JawafEntity
+from tests.conftest import create_case_with_entities, create_user_with_role
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the process-global cache (e.g. public_entities_list) around each
+    test so entity-list assertions never read a stale set from another test."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _ids(response):
+    """IDs from a (possibly paginated) DRF list response."""
+    data = response.json()
+    results = data["results"] if isinstance(data, dict) and "results" in data else data
+    return {row["id"] for row in results}
+
+
+def _ro_client():
+    readonly = create_user_with_role("ro_read", "ro_read@example.com", "ReadOnly")
+    client = APIClient()
+    client.force_authenticate(user=readonly)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Cases — DRAFT visibility through the real list endpoint (CodeRabbit #3)
+# ---------------------------------------------------------------------------
+
+
+def _make_case(title, state):
+    case = create_case_with_entities(
+        title=title,
+        alleged_entities=["entity:person/test-person"],
+        key_allegations=["Test"],
+        case_type=CaseType.CORRUPTION,
+        description=title,
+    )
+    case.state = state
+    case.save()
+    return case
+
+
+@pytest.mark.django_db
+def test_readonly_lists_draft_cases_via_endpoint():
+    draft = _make_case("RO Draft Case", CaseState.DRAFT)
+    published = _make_case("RO Published Case", CaseState.PUBLISHED)
+    closed = _make_case("RO Closed Case", CaseState.CLOSED)
+
+    response = _ro_client().get("/api/cases/")
+    assert response.status_code == 200
+    ids = _ids(response)
+    assert draft.id in ids  # the systemwide-read promise: DRAFT is visible
+    assert published.id in ids
+    assert closed.id not in ids  # CLOSED is never exposed via the public API
+
+
+@pytest.mark.django_db
+def test_anonymous_does_not_list_draft_cases():
+    draft = _make_case("Anon Draft", CaseState.DRAFT)
+    published = _make_case("Anon Published", CaseState.PUBLISHED)
+
+    response = APIClient().get("/api/cases/")
+    assert response.status_code == 200
+    ids = _ids(response)
+    assert draft.id not in ids
+    assert published.id in ids
+
+
+# ---------------------------------------------------------------------------
+# Sources — ReadOnly sees draft-only / unreferenced sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_readonly_lists_unreferenced_source():
+    """A source not referenced by any published/in-review case is hidden from the
+    public list but visible to ReadOnly."""
+    orphan = DocumentSource.objects.create(
+        title="Draft-only Source", source_type="MISC"
+    )
+
+    # Public/anonymous: not visible.
+    assert orphan.id not in _ids(APIClient().get("/api/sources/"))
+
+    # ReadOnly: visible (systemwide read).
+    response = _ro_client().get("/api/sources/")
+    assert response.status_code == 200
+    assert orphan.id in _ids(response)
+
+
+# ---------------------------------------------------------------------------
+# Entities — ReadOnly sees entities not attached to any published case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_readonly_lists_unpublished_entity():
+    """An entity not appearing in any published case is hidden from the public
+    list but visible to ReadOnly."""
+    orphan = JawafEntity.objects.create(display_name="Draft-only Entity")
+
+    # Public/anonymous: not visible.
+    assert orphan.id not in _ids(APIClient().get("/api/entities/"))
+
+    # ReadOnly: visible (systemwide read).
+    response = _ro_client().get("/api/entities/")
+    assert response.status_code == 200
+    assert orphan.id in _ids(response)

--- a/tests/api/test_readonly_write_endpoints.py
+++ b/tests/api/test_readonly_write_endpoints.py
@@ -1,0 +1,234 @@
+"""Integration tests: the org-wide ReadOnly role cannot write via the case /
+source / entity API endpoints.
+
+These endpoints gate writes on ``DjangoModelPermissions`` (POST -> add_*,
+PATCH/PUT -> change_*) on top of authentication. A ReadOnly user is
+authenticated and holds only ``view_*`` perms, so every write must be rejected
+with 403 — the permission check fires before serializer validation, so the
+payload shape is irrelevant for the denial cases.
+"""
+
+import pytest
+from django.contrib.auth.models import Permission
+from django.core.cache import cache
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    DocumentSource,
+    JawafEntity,
+    RelationshipType,
+)
+from tests.conftest import create_user_with_role
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the process-global cache (e.g. public_entities_list) around each
+    test so the entity list/get_object queryset never reads a stale set."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _authed_client(user):
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return client
+
+
+def _grant(user, codename):
+    """Grant a single model permission directly to the user.
+
+    The ReadOnly/Contributor *groups* get their perms from `create_groups`
+    (an ops step that the test DB does not run), so writer tests grant the
+    specific perm they exercise to keep the test self-contained and prove the
+    DjangoModelPermissions gate ALLOWS when the perm is present.
+    """
+    user.user_permissions.add(Permission.objects.get(codename=codename))
+
+
+# ---------------------------------------------------------------------------
+# DocumentSource writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_readonly_cannot_create_source():
+    readonly = create_user_with_role("ro_src", "ro_src@example.com", "ReadOnly")
+    response = _authed_client(readonly).post(
+        "/api/sources/",
+        data={"title": "RO Should Fail", "source_type": "MISC"},
+        format="json",
+    )
+    assert response.status_code == 403
+    assert not DocumentSource.objects.filter(title="RO Should Fail").exists()
+
+
+@pytest.mark.django_db
+def test_readonly_cannot_update_source():
+    readonly = create_user_with_role("ro_src2", "ro_src2@example.com", "ReadOnly")
+    source = DocumentSource.objects.create(
+        title="RO Existing Source", source_type="MISC"
+    )
+    response = _authed_client(readonly).patch(
+        f"/api/sources/{source.id}/",
+        data={"source_type": "COURT_ORDER"},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_writer_with_perm_can_create_source():
+    """A user holding add_documentsource passes the DjangoModelPermissions gate."""
+    contributor = create_user_with_role(
+        "contrib_src", "contrib_src@example.com", "Contributor"
+    )
+    _grant(contributor, "add_documentsource")
+    response = _authed_client(contributor).post(
+        "/api/sources/",
+        data={"title": "Contributor Source", "source_type": "MISC"},
+        format="json",
+    )
+    assert response.status_code == 201
+    assert DocumentSource.objects.filter(title="Contributor Source").exists()
+
+
+@pytest.mark.django_db
+def test_writer_with_perm_can_update_source():
+    """A user holding change_documentsource passes the PATCH gate (allow-path)."""
+    writer = create_user_with_role(
+        "writer_src", "writer_src@example.com", "Contributor"
+    )
+    _grant(writer, "change_documentsource")
+    source = DocumentSource.objects.create(title="Editable Source", source_type="MISC")
+    # The non-ReadOnly source queryset only exposes sources referenced by a
+    # published/in-review case, so attach it to one via evidence.
+    Case.objects.create(
+        title="Pub Case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        evidence=[{"source_id": source.source_id, "description": "ref"}],
+    )
+    response = _authed_client(writer).patch(
+        f"/api/sources/{source.id}/",
+        data={"title": "Renamed Source"},
+        format="json",
+    )
+    assert response.status_code == 200
+    source.refresh_from_db()
+    assert source.title == "Renamed Source"
+
+
+# ---------------------------------------------------------------------------
+# JawafEntity writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_readonly_cannot_create_entity():
+    readonly = create_user_with_role("ro_ent", "ro_ent@example.com", "ReadOnly")
+    response = _authed_client(readonly).post(
+        "/api/entities/",
+        data={"display_name": "RO Should Fail"},
+        format="json",
+    )
+    assert response.status_code == 403
+    assert not JawafEntity.objects.filter(display_name="RO Should Fail").exists()
+
+
+@pytest.mark.django_db
+def test_readonly_cannot_update_entity():
+    readonly = create_user_with_role("ro_ent2", "ro_ent2@example.com", "ReadOnly")
+    entity = JawafEntity.objects.create(display_name="RO Existing Entity")
+    response = _authed_client(readonly).patch(
+        f"/api/entities/{entity.id}/",
+        data={"display_name": "RO Renamed"},
+        format="json",
+    )
+    assert response.status_code == 403
+    entity.refresh_from_db()
+    assert entity.display_name == "RO Existing Entity"
+
+
+@pytest.mark.django_db
+def test_writer_with_perm_can_create_entity():
+    """A user holding add_jawafentity passes the DjangoModelPermissions gate."""
+    contributor = create_user_with_role(
+        "contrib_ent", "contrib_ent@example.com", "Contributor"
+    )
+    _grant(contributor, "add_jawafentity")
+    response = _authed_client(contributor).post(
+        "/api/entities/",
+        data={"display_name": "Contributor Entity"},
+        format="json",
+    )
+    assert response.status_code == 201
+    assert JawafEntity.objects.filter(display_name="Contributor Entity").exists()
+
+
+@pytest.mark.django_db
+def test_writer_with_perm_can_update_entity():
+    """A user holding change_jawafentity passes the PATCH gate (allow-path)."""
+    writer = create_user_with_role(
+        "writer_ent", "writer_ent@example.com", "Contributor"
+    )
+    _grant(writer, "change_jawafentity")
+    entity = JawafEntity.objects.create(display_name="Editable Entity")
+    # The non-ReadOnly entity queryset (for partial_update) only exposes entities
+    # appearing in a published case, so attach it to one.
+    case = Case.objects.create(
+        title="Pub Case Ent", case_type=CaseType.CORRUPTION, state=CaseState.PUBLISHED
+    )
+    CaseEntityRelationship.objects.create(
+        case=case, entity=entity, relationship_type=RelationshipType.ACCUSED
+    )
+    response = _authed_client(writer).patch(
+        f"/api/entities/{entity.id}/",
+        data={"display_name": "Renamed Entity"},
+        format="json",
+    )
+    assert response.status_code == 200
+    entity.refresh_from_db()
+    assert entity.display_name == "Renamed Entity"
+
+
+# ---------------------------------------------------------------------------
+# Case writes (POST /api/cases/)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_readonly_cannot_create_case():
+    """ReadOnly holds only view_case, so POST /api/cases/ is rejected by
+    DjangoModelPermissions (needs add_case) before any case is written."""
+    readonly = create_user_with_role("ro_case", "ro_case@example.com", "ReadOnly")
+    response = _authed_client(readonly).post(
+        "/api/cases/",
+        data={"title": "RO Should Not Create", "case_type": CaseType.CORRUPTION},
+        format="json",
+    )
+    assert response.status_code == 403
+    assert not Case.objects.filter(title="RO Should Not Create").exists()
+
+
+@pytest.mark.django_db
+def test_writer_with_perm_can_create_case():
+    """A user holding add_case passes the DjangoModelPermissions gate (allow-path)."""
+    contributor = create_user_with_role(
+        "contrib_case", "contrib_case@example.com", "Contributor"
+    )
+    _grant(contributor, "add_case")
+    response = _authed_client(contributor).post(
+        "/api/cases/",
+        data={"title": "Contributor Case", "case_type": CaseType.CORRUPTION},
+        format="json",
+    )
+    assert response.status_code == 201
+    assert Case.objects.filter(title="Contributor Case").exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from cases.models import (
     Case,
     CaseEntityRelationship,
     DocumentSource,
+    DocumentSourceUpload,
     JawafEntity,
     RelationshipType,
 )
@@ -253,7 +254,7 @@ def create_user_with_role(username, email, role, password="testpass123"):
     Args:
         username: Username for the user
         email: Email for the user
-        role: Role name ('Admin', 'Moderator', 'Contributor')
+        role: Role name ('Admin', 'Moderator', 'Contributor', 'ReadOnly')
         password: Password for the user (default: 'testpass123')
 
     Returns:
@@ -313,5 +314,28 @@ def create_user_with_role(username, email, role, password="testpass123"):
     # Moderators and Admins can manage users
     if role in ["Admin", "Moderator"]:
         user.user_permissions.add(*user_perms)
+
+    # ReadOnly: org-wide read role. No is_staff/is_superuser and no write perms.
+    # Mirror the view_* set granted to the ReadOnly group in create_groups.py so
+    # model-perm-gated checks (e.g. DjangoModelPermissions) behave faithfully:
+    # GET on every content model is allowed, but no add/change/delete.
+    if role == "ReadOnly":
+        readonly_view_perms = Permission.objects.filter(
+            codename__in=[
+                "view_case",
+                "view_documentsource",
+                "view_documentsourceupload",
+                "view_jawafentity",
+                "view_caseentityrelationship",
+            ],
+            content_type__in=[
+                ContentType.objects.get_for_model(Case),
+                ContentType.objects.get_for_model(DocumentSource),
+                ContentType.objects.get_for_model(DocumentSourceUpload),
+                ContentType.objects.get_for_model(JawafEntity),
+                ContentType.objects.get_for_model(CaseEntityRelationship),
+            ],
+        )
+        user.user_permissions.add(*readonly_view_perms)
 
     return user

--- a/tests/test_readonly_permissions.py
+++ b/tests/test_readonly_permissions.py
@@ -1,0 +1,206 @@
+"""
+Tests for the org-wide ReadOnly role.
+
+Verifies that a ReadOnly user can read everything (all non-CLOSED cases, the
+casework review system) but has no write path anywhere: not casework mutations,
+not the review config, and not case PATCH (even for unassigned cases).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from cases.models import CaseState, CaseType
+from cases.rules.predicates import (
+    can_change_case,
+    can_view_case,
+    has_role,
+    is_contributor,
+    is_readonly,
+)
+from review.permissions import CanReadReview, HasContributorRole, IsAdminOrModerator
+from tests.conftest import create_case_with_entities, create_user_with_role
+
+User = get_user_model()
+
+
+# ============================================================================
+# Helpers (mirror tests/test_contributor_read_permissions.py)
+# ============================================================================
+
+
+class _MockView:
+    """Minimal mock DRF view for testing permission classes."""
+
+    def __init__(self, action=None):
+        self.action = action
+        self.detail = action in ("retrieve", "partial_update", "destroy")
+
+
+def _build_request(method="GET", user=None):
+    """Build a DRF Request-like object with the given method and user."""
+    factory = RequestFactory()
+    req = factory.generic(method, "/")
+    req.user = user
+    req.method = method
+    return req
+
+
+def _make_readonly(username="readonly", email="readonly@example.com"):
+    return create_user_with_role(username, email, "ReadOnly")
+
+
+def _make_case(title, state=CaseState.DRAFT):
+    case = create_case_with_entities(
+        title=title,
+        alleged_entities=["entity:person/test-person"],
+        key_allegations=["Test"],
+        case_type=CaseType.CORRUPTION,
+        description=title,
+    )
+    case.state = state
+    case.save()
+    return case
+
+
+# ============================================================================
+# Predicates
+# ============================================================================
+
+
+@pytest.mark.django_db
+def test_is_readonly_predicate():
+    """is_readonly is True only for ReadOnly group members."""
+    readonly = _make_readonly()
+    assert is_readonly(readonly)
+
+    contrib = create_user_with_role(
+        "contrib_ro", "contrib_ro@example.com", "Contributor"
+    )
+    assert not is_readonly(contrib)
+
+    plain = User.objects.create_user(username="plain_ro", email="plain_ro@example.com")
+    assert not is_readonly(plain)
+
+
+@pytest.mark.django_db
+def test_readonly_is_not_a_content_role():
+    """ReadOnly must not satisfy has_role (which gates content writes)."""
+    readonly = _make_readonly()
+    assert not has_role(readonly)
+    assert not is_contributor(readonly)
+
+
+@pytest.mark.django_db
+def test_readonly_can_view_unassigned_draft_case():
+    """can_view_case admits ReadOnly so retrieve() exposes DRAFT details."""
+    readonly = _make_readonly()
+    case = _make_case("Unassigned Draft", state=CaseState.DRAFT)
+    assert can_view_case(readonly, case)
+
+
+@pytest.mark.django_db
+def test_readonly_cannot_change_unassigned_case():
+    """Critical no-write assertion: ReadOnly cannot PATCH a case."""
+    readonly = _make_readonly()
+    case = _make_case("Unassigned", state=CaseState.DRAFT)
+    assert not can_change_case(readonly, case)
+
+
+# ============================================================================
+# Casework read permission class — CanReadReview
+# ============================================================================
+
+
+@pytest.mark.django_db
+class TestCanReadReview:
+    def test_readonly_allowed(self):
+        user = _make_readonly()
+        assert CanReadReview().has_permission(_build_request("GET", user), _MockView())
+
+    def test_contributor_allowed(self):
+        user = create_user_with_role("c_rr", "c_rr@example.com", "Contributor")
+        assert CanReadReview().has_permission(_build_request("GET", user), _MockView())
+
+    def test_moderator_allowed(self):
+        user = create_user_with_role("m_rr", "m_rr@example.com", "Moderator")
+        assert CanReadReview().has_permission(_build_request("GET", user), _MockView())
+
+    def test_admin_allowed(self):
+        user = create_user_with_role("a_rr", "a_rr@example.com", "Admin")
+        assert CanReadReview().has_permission(_build_request("GET", user), _MockView())
+
+    def test_review_assistant_allowed(self):
+        user = create_user_with_role("ra_rr", "ra_rr@example.com", "ReviewAssistant")
+        assert CanReadReview().has_permission(_build_request("GET", user), _MockView())
+
+    def test_unauthenticated_denied(self):
+        req = _build_request("GET")
+        req.user = None
+        assert not CanReadReview().has_permission(req, _MockView())
+
+    def test_no_role_user_denied(self):
+        plain = User.objects.create_user(
+            username="norole_rr", email="norole_rr@example.com"
+        )
+        assert not CanReadReview().has_permission(
+            _build_request("GET", plain), _MockView()
+        )
+
+
+# ============================================================================
+# Casework write/admin gates — ReadOnly must be denied
+# ============================================================================
+
+
+@pytest.mark.django_db
+def test_readonly_denied_casework_mutations():
+    """HasContributorRole (guards submit/claim/stage/result/regrade) excludes ReadOnly."""
+    readonly = _make_readonly()
+    perm = HasContributorRole()
+    assert not perm.has_permission(_build_request("POST", readonly), _MockView())
+
+
+@pytest.mark.django_db
+def test_readonly_denied_config_put():
+    """The inline config PUT guard (IsAdminOrModerator) rejects ReadOnly."""
+    readonly = _make_readonly()
+    assert not IsAdminOrModerator().has_permission(
+        _build_request("PUT", readonly), None
+    )
+
+
+# ============================================================================
+# Case list visibility
+# ============================================================================
+
+
+@pytest.mark.django_db
+def test_readonly_list_queryset_includes_draft_excludes_closed():
+    """Exercise the role-gated CaseViewSet.get_queryset() (not a bare ORM filter).
+
+    Drives the real list branch with a ReadOnly request via the DRF viewset and
+    asserts DRAFT is included while CLOSED is excluded. End-to-end endpoint
+    coverage lives in tests/api/test_readonly_read_visibility.py.
+    """
+    from rest_framework.request import Request
+    from rest_framework.test import APIRequestFactory
+
+    from cases.api_views import CaseViewSet
+
+    readonly = _make_readonly()
+    draft = _make_case("RO Visible Draft", state=CaseState.DRAFT)
+    published = _make_case("RO Published", state=CaseState.PUBLISHED)
+    closed = _make_case("RO Closed", state=CaseState.CLOSED)
+
+    # Wrap in a DRF Request so get_queryset()'s query_params access works.
+    request = Request(APIRequestFactory().get("/api/cases/"))
+    request.user = readonly
+    view = CaseViewSet()
+    view.action = "list"
+    view.request = request
+
+    case_ids = set(view.get_queryset().values_list("id", flat=True))
+    assert draft.id in case_ids
+    assert published.id in case_ids
+    assert closed.id not in case_ids


### PR DESCRIPTION
Introduce a reusable 'ReadOnly' Django auth group, assignable to anyone, that grants system-wide READ access (view_* on all content models + casework review reads) with no write path anywhere. The poller is unchanged (stays Contributor).

- create_groups: add idempotent ReadOnly group (view_* only on Case, DocumentSource, DocumentSourceUpload, JawafEntity, CaseEntityRelationship).
- predicates: add is_readonly; extend can_view_case / can_view_source with it so ReadOnly can list AND retrieve all non-CLOSED cases (retrieve()'s DRAFT gate uses can_view_case). Write predicates intentionally exclude is_readonly.
- review: new CanReadReview permission class (superuser/Admin/Moderator/ Contributor/ReviewAssistant/ReadOnly). Casework GET endpoints (me, reviews list/detail, rules, config GET) move to it; mutations (submit, job claim/ stage/result, regrade) keep HasContributorRole, which excludes ReadOnly. config PUT stays gated by the inline IsAdminOrModerator check.
- cases: ReadOnly joins the 'all non-CLOSED' case-list visibility branch.
- cases: gate DocumentSourceViewSet / JawafEntityViewSet create+update on DjangoModelPermissions (POST->add_*, PATCH->change_*) instead of bare IsAuthenticated, so ReadOnly (and no-role authed users) cannot write sources or entities; realigns these endpoints with the documented role model.
- tests: extend create_user_with_role for ReadOnly (full view_* set matching the group); add test_readonly_permissions.py (reads allowed, writes denied) and api/test_readonly_write_endpoints.py (source/entity writes 403 for ReadOnly, 201 for a user holding add_*).

The ReadOnly group is inert until 'manage.py create_groups' is run against the target DB. Full suite: 837 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ReadOnly role granting system-wide read access to cases, document sources, and entities (cannot write).
  * ReadOnly users now see all non-closed cases and additional unpublished/unreferenced records.

* **Permissions**
  * Tightened write requirements on endpoints that create/update documents and entities; create now requires full authenticated+model-permission checks.
  * Read vs. mutate access separated for review endpoints (read endpoints widened to include ReadOnly).

* **Tests & Docs**
  * Added integration and unit tests for ReadOnly behaviour and updated API docs/descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->