### PR TITLE
Reusable source->markdown reprocessing + reprocess_source_markdown co…

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -730,6 +730,20 @@ SOURCE_MARKDOWN_DIR = Path(
 SOURCE_MARKDOWN_DIR.mkdir(parents=True, exist_ok=True)
 CONVERT_SOURCE_TIMEOUT = int(os.getenv("CONVERT_SOURCE_TIMEOUT", "180"))
 
+# Use LibreOffice (headless) to convert legacy Word .doc / .docx sources to a
+# clean .docx before markdown extraction. Default ON: prod is expected to have
+# LibreOffice installed (it handles files the bundled antiword crashes on or
+# rejects). An operator on a resource-constrained box may set
+# LIBREOFFICE_DOC_CONVERSION=false to fall back to the lighter likhit/antiword
+# path. When enabled but the binary is absent, the converter degrades to the
+# fallback automatically (no hard dependency).
+LIBREOFFICE_DOC_CONVERSION = (
+    os.getenv("LIBREOFFICE_DOC_CONVERSION", "true").lower() == "true"
+)
+# Optional explicit path to the soffice/libreoffice binary; otherwise PATH is
+# searched (including the versioned `libreoffice26.2` name).
+LIBREOFFICE_BINARY = os.getenv("LIBREOFFICE_BINARY", "")
+
 # Max number of case reviews allowed to run CONCURRENTLY. Additional submitted
 # reviews queue (status=pending) and start as running slots free up. Configurable
 # via env so the operator can tune the parallel review throughput.

--- a/config/settings.py
+++ b/config/settings.py
@@ -731,14 +731,15 @@ SOURCE_MARKDOWN_DIR.mkdir(parents=True, exist_ok=True)
 CONVERT_SOURCE_TIMEOUT = int(os.getenv("CONVERT_SOURCE_TIMEOUT", "180"))
 
 # Use LibreOffice (headless) to convert legacy Word .doc / .docx sources to a
-# clean .docx before markdown extraction. Default ON: prod is expected to have
-# LibreOffice installed (it handles files the bundled antiword crashes on or
-# rejects). An operator on a resource-constrained box may set
-# LIBREOFFICE_DOC_CONVERSION=false to fall back to the lighter likhit/antiword
-# path. When enabled but the binary is absent, the converter degrades to the
-# fallback automatically (no hard dependency).
+# clean .docx before markdown extraction. LibreOffice handles files the bundled
+# antiword crashes on or rejects, but it is a heavy dependency (~1GB installed)
+# that prod does NOT ship, so this defaults OFF and the converter uses the
+# lighter likhit/antiword path. An operator running the reprocess command on a
+# box that HAS LibreOffice (e.g. a one-off backfill host) can opt in with
+# LIBREOFFICE_DOC_CONVERSION=true. When enabled but the binary is absent, the
+# converter degrades to the fallback automatically (no hard dependency).
 LIBREOFFICE_DOC_CONVERSION = (
-    os.getenv("LIBREOFFICE_DOC_CONVERSION", "true").lower() == "true"
+    os.getenv("LIBREOFFICE_DOC_CONVERSION", "false").lower() == "true"
 )
 # Optional explicit path to the soffice/libreoffice binary; otherwise PATH is
 # searched (including the versioned `libreoffice26.2` name).

--- a/poetry.lock
+++ b/poetry.lock
@@ -96,6 +96,22 @@ files = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+description = "Internationalization utilities"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
+    {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
 name = "beaker"
 version = "1.13.0"
 description = "A Session and Caching library with WSGI Middleware"
@@ -535,6 +551,27 @@ humanfriendly = ">=9.1"
 cron = ["capturer (>=2.4)"]
 
 [[package]]
+name = "courlan"
+version = "1.4.0"
+description = "Clean, filter and sample URLs to optimize data collection – includes spam, content type and language filters."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "courlan-1.4.0-py3-none-any.whl", hash = "sha256:ad1dbdefd912ca7238d4607dc855df5df097f56bac175dd662c84eed3802f49e"},
+    {file = "courlan-1.4.0.tar.gz", hash = "sha256:fbbac7b7fcde2195ea08e707609503c81cf39c891e8d26cdb1fed4585782d63d"},
+]
+
+[package.dependencies]
+babel = ">=2.16.0"
+tld = ">=0.13"
+urllib3 = ">=1.26,<3"
+
+[package.extras]
+dev = ["mypy (==2.1.0)", "pytest (==9.0.3)", "pytest-cov (==7.1.0)", "pytest-httpserver (==1.1.5)", "ruff (==0.15.15)"]
+
+[[package]]
 name = "cryptography"
 version = "46.0.6"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -606,6 +643,30 @@ sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi (>=2024)", "cryptography-vectors (==46.0.6)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378"},
+    {file = "dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7.0"
+pytz = ">=2024.2"
+regex = ">=2024.9.11"
+tzlocal = ">=0.2"
+
+[package.extras]
+calendars = ["convertdate (>=2.2.1)", "hijridate"]
+fasttext = ["fasttext (>=0.9.1)", "numpy (>=1.22.0,<2)"]
+langdetect = ["langdetect (>=1.0.0)"]
 
 [[package]]
 name = "defusedxml"
@@ -1359,6 +1420,31 @@ files = [
 ]
 
 [[package]]
+name = "htmldate"
+version = "1.10.0"
+description = "Fast and robust extraction of original and updated publication dates from URLs and web pages."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "htmldate-1.10.0-py3-none-any.whl", hash = "sha256:9211dae35ab94147c8ed9e5fc2c9287a5cf31d2394cb7857e7f5dd814eb2aad6"},
+    {file = "htmldate-1.10.0.tar.gz", hash = "sha256:a38df10772ab5d7dbb11896e3f6a852a8491fb1b0965465bc174e23fc2baae58"},
+]
+
+[package.dependencies]
+charset_normalizer = ">=3.4.0"
+dateparser = ">=1.1.2"
+lxml = ">=5.3.0"
+python-dateutil = ">=2.9.0.post0"
+urllib3 = ">=1.26,<3"
+
+[package.extras]
+all = ["htmldate[dev]", "htmldate[speed]"]
+dev = ["mypy", "pytest", "pytest-cov", "ruff", "types-dateparser", "types-lxml", "types-python-dateutil", "types-urllib3"]
+speed = ["backports-datetime-fromisoformat ; python_version < \"3.11\"", "faust-cchardet (>=2.1.19)", "urllib3[brotli]"]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -1768,6 +1854,22 @@ files = [
 referencing = ">=0.31.0"
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+description = "Heuristic based boilerplate removal tool"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7"},
+    {file = "justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05"},
+]
+
+[package.dependencies]
+lxml = {version = ">=4.4.2", extras = ["html-clean"]}
+
+[[package]]
 name = "langchain"
 version = "1.2.13"
 description = "Building applications with LLMs through composability"
@@ -2017,154 +2119,173 @@ resolved_reference = "8809c174cc3eb72e20dac56143623ca597b4baa7"
 
 [[package]]
 name = "lxml"
-version = "6.1.0"
+version = "6.1.1"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"bigo-enrichment\""
 files = [
-    {file = "lxml-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41dcc4c7b10484257cbd6c37b83ddb26df2b0e5aff5ac00d095689015af868ec"},
-    {file = "lxml-6.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a31286dbb5e74c8e9a5344465b77ab4c5bd511a253b355b5ca2fae7e579fafec"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1bc4cc83fb7f66ffb16f74d6dd0162e144333fc36ebcce32246f80c8735b2551"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:20cf4d0651987c906a2f5cba4e3a8d6ba4bfdf973cfe2a96c0d6053888ea2ecd"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb34ea45a82dd637c2c97ae1bbb920850c1e59bcae79ce1c15af531d83e7215"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1d9b99e5b2597e4f5aed2484fef835256fa1b68a19e4265c97628ef4bf8bcf4"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:d43aa26dcda363f21e79afa0668f5029ed7394b3bb8c92a6927a3d34e8b610ea"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6262b87f9e5c1e5fe501d6c153247289af42eb44ad7660b9b3de17baaf92d6f6"},
-    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d1392c569c032f78a11a25d1de1c43fff13294c793b39e19d84fade3045cbbc3"},
-    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:045e387d1f4f42a418380930fa3f45c73c9b392faf67e495e58902e68e8f44a7"},
-    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:9f93d5b8b07f73e8c77e3c6556a3db269918390c804b5e5fcdd4858232cc8f16"},
-    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:de550d129f18d8ab819651ffe4f38b1b713c7e116707de3c0c6400d0ef34fbc1"},
-    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c08da09dc003c9e8c70e06b53a11db6fb3b250c21c4236b03c7d7b443c318e7a"},
-    {file = "lxml-6.1.0-cp310-cp310-win32.whl", hash = "sha256:37448bf9c7d7adfc5254763901e2bbd6bb876228dfc1fc7f66e58c06368a7544"},
-    {file = "lxml-6.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:2593a0a6621545b9095b71ad74ed4226eba438a7d9fc3712a99bdb15508cf93a"},
-    {file = "lxml-6.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80807d72f96b96ad5588cb85c75616e4f2795a7737d4630784c51497beb7776"},
-    {file = "lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9"},
-    {file = "lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289"},
-    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a"},
-    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3"},
-    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9"},
-    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11"},
-    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4"},
-    {file = "lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3"},
-    {file = "lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7"},
-    {file = "lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39"},
-    {file = "lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d"},
-    {file = "lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad"},
-    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54"},
-    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d"},
-    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69"},
-    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d"},
-    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5"},
-    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d"},
-    {file = "lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f"},
-    {file = "lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366"},
-    {file = "lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819"},
-    {file = "lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45"},
-    {file = "lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe"},
-    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88"},
-    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181"},
-    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24"},
-    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e"},
-    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495"},
-    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33"},
-    {file = "lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62"},
-    {file = "lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16"},
-    {file = "lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d"},
-    {file = "lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8"},
-    {file = "lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292"},
-    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb"},
-    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad"},
-    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb"},
-    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f"},
-    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43"},
-    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585"},
-    {file = "lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f"},
-    {file = "lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120"},
-    {file = "lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946"},
-    {file = "lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c"},
-    {file = "lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f"},
-    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773"},
-    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b"},
-    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405"},
-    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690"},
-    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd"},
-    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180"},
-    {file = "lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2"},
-    {file = "lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5"},
-    {file = "lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac"},
-    {file = "lxml-6.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b6c2f225662bc5ad416bdd06f72ca301b31b39ce4261f0e0097017fc2891b940"},
-    {file = "lxml-6.1.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a86f06f059e22a0d574990ee2df24ede03f7f3c68c1336293eee9536c4c776cd"},
-    {file = "lxml-6.1.0-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:468479e52ecf3ec23799c863336d02c05fc2f7ffd1a1424eeeb9a28d4eb69d13"},
-    {file = "lxml-6.1.0-cp38-cp38-manylinux_2_28_i686.whl", hash = "sha256:a02ca8fe48815bddcfca3248efe54451abb9dbf2f7d1c5744c8aa4142d476919"},
-    {file = "lxml-6.1.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bb40648d96157f9081886defe13eac99253e663be969ff938a9289eff6e47b72"},
-    {file = "lxml-6.1.0-cp38-cp38-win32.whl", hash = "sha256:1dd6a1c3ad4cb674f44525d9957f3e9c209bb6dd9213245195167a281fcc2bdc"},
-    {file = "lxml-6.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:4e2c54d6b47361d0f1d3bc8d4e082ad87201e56ccdcca4d3b9ee3644ff595ec8"},
-    {file = "lxml-6.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:920354904d1cb86577d4b3cfe2830c2dbe81d6f4449e57ada428f1609b5985f7"},
-    {file = "lxml-6.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c871299c595ee004d186f61840f0bfc4941aa3f17c8ba4a565ead7e4f4f820ee"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d0d799ff958655781296ec870d5e2448e75150da2b3d07f13ff5b0c2c35beefd"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ba11752e346bd804ea312ec2eea2532dfa8b8d3261d81a32ef9e6ab16256280"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26c5272c6a4bf4cf32d3f5a7890c942b0e04438691157d341616d02cca74d4bd"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c53fa3a5a52122d590e847a57ccf955557b9634a7f99ff5a35131321b0a85317"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:76b958b4ea3104483c20f74866d55aa056546e15ebe83dd7aecd63698f43b755"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:8c11b984b5ce6add4dccc7144c7be5d364d298f15b0c6a57da1991baedc750ce"},
-    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d3829a6e6fd550a219564912d4002c537f65da4c6ae4e093cc34462f4fa027ad"},
-    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:52b0ac6903cf74ebf997eb8c682d2fbac7d1ab7e4c552413eec55868a9b73f39"},
-    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:29f5c00cb7d752bce2c70ebd2d31b0a42f9499ffdd3ecb2f31a5b73ee43031ad"},
-    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:c748ebcb6877de89f48ab90ca96642ac458fff5dec291a2b9337cd4d0934e383"},
-    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:08950a23f296b3f83521577274e3d3b0f3d739bf2e68d01a752e4288bc50d286"},
-    {file = "lxml-6.1.0-cp39-cp39-win32.whl", hash = "sha256:11a873c77a181b4fef9c2e357d08ed399542c2af1390101da66720a19c7c9618"},
-    {file = "lxml-6.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:81ff55c70b67d19d52b6fd118a114c0a4c97d799cd3089ff9bd9e2ff4b414ee2"},
-    {file = "lxml-6.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:481d6e2104285d9add34f41b42b247b76b61c5b5c26c303c2e9707bbf8bd9a64"},
-    {file = "lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842"},
-    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c"},
-    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de"},
-    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635"},
-    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037"},
-    {file = "lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace"},
-    {file = "lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13"},
+    {file = "lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60"},
+    {file = "lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206"},
+    {file = "lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067"},
+    {file = "lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a"},
+    {file = "lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa"},
+    {file = "lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383"},
+    {file = "lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1"},
+    {file = "lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a"},
+    {file = "lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5"},
+    {file = "lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485"},
+    {file = "lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2"},
+    {file = "lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db1d75f6617a49c1c01bc7023713e0ff59ab32c9579ae62a7674c0e34f3b0b0a"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a12689be69a28ddaa0ab99a5a1137da2afd5f8f16df7b5680b66f616d3eda1d"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b73c339ae29b90fd2d06e58ebd555a751bde9cd6bbd36cc0281b9a2c94e9d8"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:752d3bbfe874715ccd0aec7f88d7fc623c0f1fd7aa7b3238a084e017bad2a009"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:6b1761fbf9ec984e2e9d9c589ef5f5fd684b7c19f92aadd567a26c5224958db6"},
+    {file = "lxml-6.1.1-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d680fbcb768404c601ecb43519ecd8461f6954cb11c06a78962f666832ccfca8"},
+    {file = "lxml-6.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:162af1091cd785f2f27e62d3547ae9bc58ec5c86dd314d67021fd02463708d83"},
+    {file = "lxml-6.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e9308ff8241c532df3f3e570f9a5aeed6c853f888512ba4b75638d7c11c95ef6"},
+    {file = "lxml-6.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5f6994074ebae6ffb04447268e37dc16edc304f9859cf91acb86e0af6c1b395c"},
+    {file = "lxml-6.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80c2dfadb855da477cf73373ad29a333535dedb9b12bad02c9814c8e2b43bf08"},
+    {file = "lxml-6.1.1-cp311-cp311-win32.whl", hash = "sha256:30a89d3ac8faec007453fb541f3f46807eeec88edd5826f6e3fe001752a2c621"},
+    {file = "lxml-6.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:abbefa31eee84842140f67acef1c828e28bba8bbf0c3bc6e5492a9af88152c28"},
+    {file = "lxml-6.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:dcb292aa7fe485ceff7af4f92e46c5af397daec5dff64871a528f0fc47a3cc5b"},
+    {file = "lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7"},
+    {file = "lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f"},
+    {file = "lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2"},
+    {file = "lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635"},
+    {file = "lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf"},
+    {file = "lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc"},
+    {file = "lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955"},
+    {file = "lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a"},
+    {file = "lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a"},
+    {file = "lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77"},
+    {file = "lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f"},
+    {file = "lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736"},
+    {file = "lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f"},
+    {file = "lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c"},
+    {file = "lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b"},
+    {file = "lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2"},
+    {file = "lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5"},
+    {file = "lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785"},
+    {file = "lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947"},
+    {file = "lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca"},
+    {file = "lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660"},
+    {file = "lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc"},
+    {file = "lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0"},
+    {file = "lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245"},
+    {file = "lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5"},
+    {file = "lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462"},
+    {file = "lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465"},
+    {file = "lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a"},
+    {file = "lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590"},
+    {file = "lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb"},
+    {file = "lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603"},
+    {file = "lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137"},
+    {file = "lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf"},
+    {file = "lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee"},
+    {file = "lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038"},
+    {file = "lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e"},
+    {file = "lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072"},
+    {file = "lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52"},
+    {file = "lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b"},
+    {file = "lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2"},
+    {file = "lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e"},
+    {file = "lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1"},
+    {file = "lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e"},
+    {file = "lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c"},
+    {file = "lxml-6.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6689e828a94eee4f139408c337bb198e014724bb8a8c26d3cfac49d119ed69a6"},
+    {file = "lxml-6.1.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bdebcc8a75d38c7598dfb2c9ed852d7a9eb4a10d6e2d0764b919b802bf32ac88"},
+    {file = "lxml-6.1.1-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8be8ad51249698103d24b0571df35a10990fbe93dd043b6c024172189485f5e3"},
+    {file = "lxml-6.1.1-cp38-cp38-manylinux_2_28_i686.whl", hash = "sha256:76447f65250ed2501ead1a1552f5ce8edff159a86f308348e6a9c4acb5e1f1b4"},
+    {file = "lxml-6.1.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:ffecec8eb889b58ba9be5b95fb1cc78e22ea8eedea38e8736a1568fe1979250e"},
+    {file = "lxml-6.1.1-cp38-cp38-win32.whl", hash = "sha256:c674693f055fa2495de12292cb45e9944199d8eaef5a2dec45175c7c61cb73e3"},
+    {file = "lxml-6.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:55b03549819867ea141c0202242c4816c82e52ec36e7e648db9d8da5a3dc3ed6"},
+    {file = "lxml-6.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c9f79d5325907f13e1be0b3e4dacc1049d1dffc4aeee3c995284bea5fe0fab7d"},
+    {file = "lxml-6.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:83b6b30eb131da7a75b601f28c5d6971e6ed3e887919bf6b6a1ad3c2df289080"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:441dd227fa0690eb9fc81edabc63cdcefc212bba99b906dcf6e32cc1a9d3e533"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e07c65f443c887bbcf31cc1771d932ecc192a5273943589b3c7572b749f1ffb2"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5bec7d03d78d853597d6107854c2310ce3f761fd218fe9fe91d5101fcf6c2efe"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f76acfb5f68ba982635a53fd985a8044be98a35b43232c2a1ee235ffab3e1dd"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:8d43ca737b20e106e4aebc42b2f3ae19f00ba63d7eb731698ee083d72d15646f"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:32ab449a5486f6c758e849bb86710d0e45edc24a04e250c01555f8f5653958f8"},
+    {file = "lxml-6.1.1-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53c909b62a0532183542fed00c5a7218258c56292d409bc789886fe1cb04c438"},
+    {file = "lxml-6.1.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:640f97d43d867bcb9c75b3af013b64850756b746cb6bce8ace83b70da3abba9d"},
+    {file = "lxml-6.1.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:469e3618338bd7ab5beb412d2439825479fcf0dab99e394ca563dbc4eaf6c834"},
+    {file = "lxml-6.1.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:aae97dfdb60715c164419ac2532a76d013c3918a665eb6cb7288098b5f349aaf"},
+    {file = "lxml-6.1.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c9a4b821dc7055bf9e05ff5719e18ec501f75c0f0bbfabd573b277559780833d"},
+    {file = "lxml-6.1.1-cp39-cp39-win32.whl", hash = "sha256:639f6c857d91d9be29bd7502348d6736dab168b54b5158cd899abf11684dc186"},
+    {file = "lxml-6.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:34c2d737beabfe35baada43941ed519251e9a12e779031496bcd5d539fcfd730"},
+    {file = "lxml-6.1.1-cp39-cp39-win_arm64.whl", hash = "sha256:07a4a68e286ee7a1ed7dfb8af83e615757c0ccfe9f18c6b4ea6771388d9ba8c9"},
+    {file = "lxml-6.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:31033dc34636ea6b7d5cc11b1ddbda78a14de858ba9d3e1ed4b69a3085bc521e"},
+    {file = "lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3893c14c4b6ac5b2d54ba8cf03e99fe5104e592de491f19bd6b82756c09f8004"},
+    {file = "lxml-6.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c07da4cebf6889f03ebac8d238f62318e29f495de0aa18a51ea14e61ae907e2e"},
+    {file = "lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2"},
+    {file = "lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf"},
+    {file = "lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84"},
+    {file = "lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40"},
 ]
+
+[package.dependencies]
+lxml_html_clean = {version = "*", optional = true, markers = "extra == \"html-clean\""}
 
 [package.extras]
 cssselect = ["cssselect (>=0.7)"]
 html-clean = ["lxml_html_clean"]
 html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+description = "HTML cleaner from lxml project"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746"},
+    {file = "lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560"},
+]
+
+[package.dependencies]
+lxml = ">=6.1.1"
 
 [[package]]
 name = "magika"
@@ -3953,6 +4074,19 @@ files = [
 dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "twine", "wheel"]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+description = "World timezone definitions, modern and historical"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126"},
+    {file = "pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -4059,7 +4193,7 @@ description = "Alternative regular expression module, to replace re."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"llm-all\""
+markers = "extra == \"bigo-enrichment\" or extra == \"llm-all\""
 files = [
     {file = "regex-2026.3.32-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:462a041d2160090553572f6bb0be417ab9bb912a08de54cb692829c871ee88c1"},
     {file = "regex-2026.3.32-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c3c6f6b027d10f84bfe65049028892b5740878edd9eae5fea0d1710b09b1d257"},
@@ -4882,6 +5016,27 @@ requests = ">=2.26.0"
 blobfile = ["blobfile (>=2)"]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+description = "Extract the top-level domain (TLD) from the URL given."
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c"},
+    {file = "tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345"},
+]
+
+[package.extras]
+all = ["tld[build,dev,docs,lint,test]"]
+build = ["build", "pkginfo", "twine", "wheel"]
+dev = ["detect-secrets", "ipython", "uv"]
+docs = ["sphinx", "sphinx-autobuild", "sphinx-llms-txt-link", "sphinx-no-pragma", "sphinx-rtd-theme (>=1.3.0)", "sphinx-source-tree ; python_version > \"3.9\""]
+lint = ["doc8", "mypy", "pydoclint", "ruff"]
+test = ["coverage", "fake.py", "pytest", "pytest-codeblock", "pytest-cov", "pytest-ordering", "tox"]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 description = "Fast, Extensible Progress Meter"
@@ -4903,6 +5058,34 @@ discord = ["requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "trafilatura"
+version = "2.1.0"
+description = "Python & Command-line tool to gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "trafilatura-2.1.0-py3-none-any.whl", hash = "sha256:0eded5207a806445ddebbe36eae30b9035fe6a2f233c36f6fe82663fca8b9d30"},
+    {file = "trafilatura-2.1.0.tar.gz", hash = "sha256:f689e2116fc89c7bc0b9a296d01dcfe2eb0b5455f8c371a77dc0db1f06a05643"},
+]
+
+[package.dependencies]
+certifi = "*"
+charset_normalizer = ">=3.4.0"
+courlan = ">=1.4.0"
+htmldate = ">=1.10.0"
+justext = ">=3.0.2"
+lxml = ">=6.1.1"
+urllib3 = ">=1.26,<3"
+
+[package.extras]
+all = ["brotli", "faust-cchardet (>=2.1.19)", "htmldate[speed] (>=1.10.0)", "py3langid (>=0.3.0)", "pycurl (>=7.46.0)", "urllib3[socks]", "zstandard (>=0.23.0)"]
+dev = ["mypy (>=2.1.0)", "pytest (>=8.0)", "pytest-cov (>=5.0)", "ruff (>=0.15)", "types-lxml (>=2026.2.16)", "types-pycurl (>=7.46.0.20260509)", "types-urllib3 (>=1.26.25.14)"]
+docs = ["docutils (>=0.21)", "pydata-sphinx-theme (>=0.18.0)", "sphinx (>=8.1)", "sphinx-sitemap (>=2.9.0)"]
+eval = ["beautifulsoup4", "boilerpy3", "goose3", "html-text", "html2text", "inscriptis", "news-please", "newspaper3k", "pandas", "readability-lxml", "resiliparse", "tabulate", "tqdm"]
 
 [[package]]
 name = "typer"
@@ -4957,11 +5140,30 @@ description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main"]
-markers = "(sys_platform == \"win32\" or sys_platform == \"emscripten\") and (sys_platform == \"win32\" or extra == \"bigo-enrichment\")"
+markers = "(extra == \"bigo-enrichment\" or sys_platform == \"win32\") and (sys_platform == \"win32\" or sys_platform == \"emscripten\" or platform_system == \"Windows\")"
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+description = "tzinfo object for the local timezone"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"bigo-enrichment\""
+files = [
+    {file = "tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"},
+    {file = "tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "uritemplate"
@@ -5629,10 +5831,10 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b0) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-bigo-enrichment = ["likhit", "markitdown"]
+bigo-enrichment = ["likhit", "markitdown", "trafilatura"]
 llm-all = ["langchain", "langchain-google-genai", "langchain-openai", "openai"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "d27228b0dd36a7d408a260d67e5ad8f085852f2fbc444774f0e9348993fecb9e"
+content-hash = "ac3b8c49305407e2adb44f02c20ac50b9dd5bd2a0a6171d55be68b077ad340d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ anthropic = "^0.40.0"
 nepali = "^1.2.0"
 markitdown = {extras = ["docx", "pdf", "pptx", "xlsx"], version = "^0.1.5", optional = true}
 likhit = {git = "https://github.com/Jawafdehi/likhit.git", rev = "main", optional = true}
+trafilatura = {version = "^2.1.0", optional = true}
 langchain = {version = "^1.2.0", optional = true}
 langchain-openai = {version = "^0.3.0", optional = true}
 langchain-google-genai = {version = "^4.2.1", optional = true}
@@ -42,7 +43,7 @@ structlog = "^25.5.0"
 
 [tool.poetry.extras]
 llm-all = ["langchain", "langchain-openai", "langchain-google-genai", "openai"]
-bigo-enrichment = ["markitdown", "likhit"]
+bigo-enrichment = ["markitdown", "likhit", "trafilatura"]
 
 
 [tool.poetry.group.dev.dependencies]

--- a/review/converter.py
+++ b/review/converter.py
@@ -83,7 +83,11 @@ def _markitdown():
 
 
 def _pick_url(urls):
-    """Prefer a direct (non web-archive) artifact url; fall back to first."""
+    """Prefer a direct (non web-archive) artifact url; fall back to first.
+
+    Operates on a plain list of url STRINGS (the legacy ``source['url']``
+    shape). Role-aware selection lives in ``_pick_source_link``.
+    """
     if not urls:
         return None
     direct = [u for u in urls if "web.archive.org" not in u]
@@ -104,14 +108,98 @@ def _ext_from_url(url, content_type=""):
     return ".bin"
 
 
-def _with_frontmatter(body, source):
+# How cleanly a format converts to markdown — higher is better. Word docs are
+# structured text (best), HTML is extractable main-content, PDF may need OCR,
+# everything else is a guess. Used to decide whether an ALTERNATE link is a
+# better conversion target than the RAW one.
+_FORMAT_RANK = {
+    ".docx": 4,
+    ".doc": 4,
+    ".html": 3,
+    ".htm": 3,
+    ".pdf": 2,
+    ".txt": 2,
+}
+
+
+def _format_rank(url):
+    return _FORMAT_RANK.get(_ext_from_url(url), 1)
+
+
+def _pick_source_link(source):
+    """Choose which link to convert, honoring the source's link ROLES.
+
+    Returns ``(url, role)`` or ``(None, None)``. Selection priority:
+
+      1. RAW — the canonical document file — is the default target.
+      2. ALTERNATE — an alternate-format rendering of the same document — is
+         preferred over RAW only when it converts more cleanly (e.g. a ``.docx``
+         export when RAW is a scanned ``.pdf``); see ``_FORMAT_RANK``.
+      3. SOURCE_PAGE — the HTML page a document was published on — is a last
+         resort (no document file present); it is fetched and run through
+         main-content extraction to drop site chrome.
+
+    MARKDOWN (our own output) and PERMALINK (a stable pointer, not necessarily
+    fetchable) are never conversion targets. Falls back to the legacy plain
+    ``url`` string list when no role-tagged ``urls`` exist.
+    """
+    by_role = {}
+    for item in source.get("urls") or []:
+        if not isinstance(item, dict):
+            continue
+        link, role = item.get("link"), item.get("role")
+        if link and role and role not in by_role:
+            by_role[role] = link  # first link of each role wins
+
+    raw = by_role.get("RAW")
+    alt = by_role.get("ALTERNATE")
+    if raw or alt:
+        if raw and alt:
+            chosen = alt if _format_rank(alt) > _format_rank(raw) else raw
+        else:
+            chosen = raw or alt
+        return chosen, ("ALTERNATE" if chosen == alt and chosen != raw else "RAW")
+
+    page = by_role.get("SOURCE_PAGE")
+    if page:
+        return page, "SOURCE_PAGE"
+
+    # Legacy sources with only plain url strings (no roles): treat as RAW.
+    legacy = _pick_url(source.get("url", []))
+    return (legacy, "RAW") if legacy else (None, None)
+
+
+def _html_to_markdown(raw_bytes):
+    """Extract the MAIN content of an HTML page as Markdown (drops site chrome).
+
+    HTML sources (SOURCE_PAGE, or a RAW/ALTERNATE link that is itself a web
+    page) otherwise convert to markdown that includes nav/header/footer/sidebar
+    boilerplate. trafilatura isolates the article body using text-density
+    heuristics. Returns the extracted markdown, or "" when trafilatura finds no
+    main content (caller then falls back to the plain MarkItDown conversion).
+    """
+    import trafilatura
+
+    html = raw_bytes.decode("utf-8", errors="replace")
+    extracted = trafilatura.extract(
+        html,
+        output_format="markdown",
+        include_comments=False,
+        include_tables=True,
+        favor_precision=True,
+    )
+    return (extracted or "").strip()
+
+
+def _with_frontmatter(body, source, *, source_url=None):
     """Prepend a YAML frontmatter block to a converted-markdown `body`.
 
     Frontmatter carries the processing timestamp plus source metadata so each
     stored markdown file is self-describing. The timestamp is stamped fresh on
     every emit, so it is NOT part of the on-disk cache (the cache holds only the
     deterministic body); any pre-existing frontmatter on `body` is stripped first
-    so re-runs don't stack blocks.
+    so re-runs don't stack blocks. ``source_url`` is the link actually converted
+    (defaults to the role-aware pick).
     """
     from django.utils import timezone
 
@@ -121,12 +209,14 @@ def _with_frontmatter(body, source):
         # treat this source as "nothing to attach" (a frontmatter-only file is
         # not a usable conversion).
         return ""
+    if source_url is None:
+        source_url, _ = _pick_source_link(source)
     fields = {
         "processed_at": timezone.now().isoformat(),
         "source_id": source.get("source_id") or "",
         "title": source.get("title") or "",
         "source_type": source.get("source_type") or "",
-        "source_url": _pick_url(source.get("url", [])) or "",
+        "source_url": source_url or "",
     }
     lines = ["---"]
     for key, value in fields.items():
@@ -158,13 +248,15 @@ def convert_source(source, *, overwrite=False):
             "note": "Markdown already present on source.",
         }
 
-    url = _pick_url(source.get("url", []))
+    # Choose which link to convert, honoring link roles (RAW/ALTERNATE > the
+    # HTML SOURCE_PAGE; never MARKDOWN/PERMALINK).
+    url, role = _pick_source_link(source)
     if not url:
         return {
             "markdown": "",
             "status": "skipped",
             "url": None,
-            "note": "Source has no url to convert.",
+            "note": "Source has no convertible url (RAW/ALTERNATE/SOURCE_PAGE).",
         }
 
     # 2. Cache by content hash of url. The cache key is the url, NOT the
@@ -179,7 +271,7 @@ def convert_source(source, *, overwrite=False):
     if cache_path.exists() and not overwrite:
         body = cache_path.read_text(encoding="utf-8")
         return {
-            "markdown": _with_frontmatter(body, source),
+            "markdown": _with_frontmatter(body, source, source_url=url),
             "status": "converted",
             "url": url,
             "note": "From cache.",
@@ -188,20 +280,32 @@ def convert_source(source, *, overwrite=False):
     try:
         content, ctype = jds_client.download_source_file(url)
         ext = _ext_from_url(url, ctype)
-        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tf:
-            tf.write(content)
-            tmp = tf.name
-        try:
-            result = _markitdown().convert(tmp)
-            md_text = result.text_content or ""
-        finally:
-            os.unlink(tmp)
+        # HTML sources (the SOURCE_PAGE landing page, or a RAW/ALTERNATE link
+        # that is itself a web page): extract just the main content so the
+        # markdown isn't polluted with nav/header/footer chrome. Fall back to the
+        # plain MarkItDown conversion when extraction finds no article body.
+        md_text = ""
+        note = ""
+        if role == "SOURCE_PAGE" or ext in (".html", ".htm"):
+            md_text = _html_to_markdown(content)
+            if md_text:
+                note = "Converted via trafilatura (HTML main-content)."
+        if not md_text:
+            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tf:
+                tf.write(content)
+                tmp = tf.name
+            try:
+                result = _markitdown().convert(tmp)
+                md_text = result.text_content or ""
+            finally:
+                os.unlink(tmp)
+            note = note or f"Converted via likhit ({ext})."
         cache_path.write_text(md_text, encoding="utf-8")
         return {
-            "markdown": _with_frontmatter(md_text, source),
+            "markdown": _with_frontmatter(md_text, source, source_url=url),
             "status": "converted",
             "url": url,
-            "note": f"Converted via likhit ({ext}).",
+            "note": note,
         }
     except Exception as e:  # noqa: BLE001 - surface conversion failure per source
         return {
@@ -237,7 +341,7 @@ def convert_all(sources, *, overwrite=False):
         try:
             res = fut.result(timeout=timeout)
         except FutureTimeout:
-            url = _pick_url(s.get("url", []))
+            url, _ = _pick_source_link(s)
             res = {
                 "markdown": "",
                 "status": "error",
@@ -246,10 +350,11 @@ def convert_all(sources, *, overwrite=False):
             }
             fut.cancel()
         except Exception as e:  # noqa: BLE001 - never let one source kill the batch
+            url, _ = _pick_source_link(s)
             res = {
                 "markdown": "",
                 "status": "error",
-                "url": _pick_url(s.get("url", [])),
+                "url": url,
                 "note": f"Conversion failed: {e}",
             }
         finally:

--- a/review/converter.py
+++ b/review/converter.py
@@ -132,6 +132,71 @@ def _ext_from_magic(content):
     return None
 
 
+def _find_libreoffice():
+    """Return the LibreOffice/soffice executable path, or None if not installed.
+
+    Honors settings.LIBREOFFICE_BINARY, then searches PATH for the common names
+    (the Document Foundation RPMs install a versioned `libreoffice26.2`).
+    """
+    import shutil
+
+    explicit = getattr(settings, "LIBREOFFICE_BINARY", "") or ""
+    if explicit:
+        return explicit if os.path.exists(explicit) else None
+    for name in ("soffice", "libreoffice"):
+        found = shutil.which(name)
+        if found:
+            return found
+    # Versioned binaries (e.g. libreoffice26.2) installed under /usr/bin.
+    import glob
+
+    for path in sorted(glob.glob("/usr/bin/libreoffice*")):
+        if os.access(path, os.X_OK):
+            return path
+    return None
+
+
+def _libreoffice_to_docx(content, ext, soffice):
+    """Convert a legacy Word document (bytes) to .docx with LibreOffice headless.
+
+    Returns the .docx bytes, or None on failure. Each call uses a private,
+    short-lived LibreOffice user profile so concurrent conversions don't collide
+    on the shared default profile.
+    """
+    import subprocess
+
+    with tempfile.TemporaryDirectory() as work:
+        src_path = os.path.join(work, f"input{ext}")
+        with open(src_path, "wb") as f:
+            f.write(content)
+        profile = os.path.join(work, "profile")
+        timeout = getattr(settings, "CONVERT_SOURCE_TIMEOUT", 180)
+        try:
+            subprocess.run(
+                [
+                    soffice,
+                    "--headless",
+                    f"-env:UserInstallation=file://{profile}",
+                    "--convert-to",
+                    "docx",
+                    "--outdir",
+                    work,
+                    src_path,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=True,
+            )
+        except Exception:  # noqa: BLE001 - any failure -> caller falls back
+            return None
+        out_path = os.path.join(work, "input.docx")
+        if not os.path.exists(out_path):
+            return None
+        with open(out_path, "rb") as f:
+            return f.read()
+
+
 # How cleanly a format converts to markdown — higher is better. Word docs are
 # structured text (best), HTML is extractable main-content, PDF may need OCR,
 # everything else is a guess. Used to decide whether an ALTERNATE link is a
@@ -344,12 +409,25 @@ def convert_source(source, *, overwrite=False):
         # plain MarkItDown conversion when extraction finds no article body.
         md_text = ""
         note = ""
+        convert_ext = ext  # extension markitdown sees (LibreOffice may change it)
         if role == "SOURCE_PAGE" or ext in (".html", ".htm"):
             md_text = _html_to_markdown(content)
             if md_text:
                 note = "Converted via trafilatura (HTML main-content)."
+        # Legacy Word: prefer LibreOffice to produce a clean .docx (handles files
+        # the bundled antiword crashes on or rejects). Falls back to the likhit
+        # path when LibreOffice is disabled, absent, or the conversion fails.
+        if not md_text and ext in (".doc", ".docx"):
+            if getattr(settings, "LIBREOFFICE_DOC_CONVERSION", True):
+                soffice = _find_libreoffice()
+                if soffice:
+                    docx = _libreoffice_to_docx(content, ext, soffice)
+                    if docx:
+                        content = docx
+                        convert_ext = ".docx"
+                        note = f"Converted via LibreOffice + markitdown ({ext})."
         if not md_text:
-            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tf:
+            with tempfile.NamedTemporaryFile(suffix=convert_ext, delete=False) as tf:
                 tf.write(content)
                 tmp = tf.name
             try:

--- a/review/converter.py
+++ b/review/converter.py
@@ -337,6 +337,51 @@ def _pick_source_link(source):
     return (legacy, "RAW") if legacy else (None, None)
 
 
+def _pick_permalink(source):
+    """First PERMALINK link of a source (normalized), or None.
+
+    PERMALINK is an archive/stable pointer (e.g. a web.archive.org capture); it
+    is used only as a link-rot FALLBACK when the primary link is a dead
+    ephemeral web page, never as a primary conversion target.
+    """
+    for item in source.get("urls") or []:
+        if (
+            isinstance(item, dict)
+            and item.get("role") == "PERMALINK"
+            and item.get("link")
+        ):
+            return _normalize_media_url(item["link"])
+    return None
+
+
+# Hosts whose links are durable primary records — an ephemeral-web archive
+# fallback should NOT trigger for these (mirrors PR #196's archive exemptions).
+_DURABLE_HOST_SUFFIXES = (
+    "jawafdehi.org",  # our own storage
+    "gov.np",  # Nepal government / court records
+    "worldbank.org",
+    "icsid.worldbank.org",
+    "un.org",
+    "web.archive.org",  # already an archive
+)
+
+
+def _is_ephemeral_web(url):
+    """True if `url` is an ephemeral web page (news/general site) that can rot.
+
+    Used to decide whether a failed primary fetch is worth retrying against a
+    PERMALINK archive. A link is NOT ephemeral when it points at a document file
+    (has a doc extension) or a durable host (own storage, official records, an
+    existing archive) — see ``_DURABLE_HOST_SUFFIXES``.
+    """
+    if not url:
+        return False
+    if _ext_from_url(url) != ".bin":  # has a recognised file extension -> a file
+        return False
+    host = (urlparse(url).hostname or "").lower()
+    return not any(host == h or host.endswith("." + h) for h in _DURABLE_HOST_SUFFIXES)
+
+
 def _html_to_markdown(raw_bytes):
     """Extract the MAIN content of an HTML page as Markdown (drops site chrome).
 
@@ -415,6 +460,7 @@ def convert_source(source, *, overwrite=False):
             "markdown": source["markdown"],
             "status": "attached",
             "url": None,
+            "role": "MARKDOWN",
             "note": "Markdown already present on source.",
         }
 
@@ -426,6 +472,7 @@ def convert_source(source, *, overwrite=False):
             "markdown": "",
             "status": "skipped",
             "url": None,
+            "role": None,
             "note": "Source has no convertible url (RAW/ALTERNATE/SOURCE_PAGE).",
         }
 
@@ -444,16 +491,30 @@ def convert_source(source, *, overwrite=False):
     if cache_path.exists() and not overwrite:
         body = cache_path.read_text(encoding="utf-8")
         return {
-            "markdown": _with_frontmatter(
-                body, source, source_url=url, source_role=role
-            ),
+            "markdown": body,
             "status": "converted",
             "url": url,
+            "role": role,
             "note": "From cache.",
         }
 
+    from_permalink = False
     try:
-        content, ctype = jds_client.download_source_file(url)
+        try:
+            content, ctype = jds_client.download_source_file(url)
+        except Exception:  # noqa: BLE001 - try a PERMALINK archive before giving up
+            # Link-rot fallback: if the primary link is an ephemeral web page
+            # (news/general site) that failed to fetch, retry against the
+            # source's PERMALINK archive (e.g. a web.archive.org capture). Only
+            # for ephemeral web pages — never for durable doc/official links.
+            permalink = _pick_permalink(source)
+            if not (permalink and _is_ephemeral_web(url)):
+                raise
+            content, ctype = jds_client.download_source_file(permalink)
+            url, role = permalink, "SOURCE_PAGE"  # archive captures are HTML pages
+            from_permalink = True
+            cache_key = hashlib.sha256(url.encode()).hexdigest()[:24]
+            cache_path = Path(settings.SOURCE_MARKDOWN_DIR) / f"{cache_key}.md"
         ext = _ext_from_url(url, ctype)
         # Correct mislabeled Office files (e.g. a .docx saved with a .doc name)
         # by sniffing the real container, so the file is routed to the converter
@@ -498,13 +559,18 @@ def convert_source(source, *, overwrite=False):
             finally:
                 os.unlink(tmp)
             note = note or f"Converted via likhit ({ext})."
+        if from_permalink:
+            note += " (via PERMALINK archive fallback)"
         cache_path.write_text(md_text, encoding="utf-8")
         return {
-            "markdown": _with_frontmatter(
-                md_text, source, source_url=url, source_role=role
-            ),
+            # Raw converted BODY (no frontmatter): this is what the Bedrock judge
+            # reads. Frontmatter is added only at the attach boundary
+            # (convert_case_to_attach_candidates), so the stored upstream file is
+            # self-describing without polluting the judge's source-analysis input.
+            "markdown": md_text,
             "status": "converted",
             "url": url,
+            "role": role,
             "note": note,
         }
     except Exception as e:  # noqa: BLE001 - surface conversion failure per source
@@ -512,6 +578,7 @@ def convert_source(source, *, overwrite=False):
             "markdown": "",
             "status": "error",
             "url": url,
+            "role": role,
             "note": f"Conversion failed: {e}",
         }
 
@@ -541,20 +608,22 @@ def convert_all(sources, *, overwrite=False):
         try:
             res = fut.result(timeout=timeout)
         except FutureTimeout:
-            url, _ = _pick_source_link(s)
+            url, role = _pick_source_link(s)
             res = {
                 "markdown": "",
                 "status": "error",
                 "url": url,
+                "role": role,
                 "note": f"Conversion timed out after {timeout}s (artifact skipped).",
             }
             fut.cancel()
         except Exception as e:  # noqa: BLE001 - never let one source kill the batch
-            url, _ = _pick_source_link(s)
+            url, role = _pick_source_link(s)
             res = {
                 "markdown": "",
                 "status": "error",
                 "url": url,
+                "role": role,
                 "note": f"Conversion failed: {e}",
             }
         finally:
@@ -564,6 +633,8 @@ def convert_all(sources, *, overwrite=False):
         s["markdown"] = res["markdown"]
         s["conversion_status"] = res["status"]
         s["conversion_note"] = res["note"]
+        s["conversion_url"] = res.get("url")
+        s["conversion_role"] = res.get("role")
         out.append(s)
     return out
 
@@ -611,17 +682,28 @@ def convert_case_to_attach_candidates(case, *, overwrite=False):
         md = s.get("markdown") or ""
         if not (sid and md.strip()):
             continue
+        # Frontmatter is added HERE, at the attach boundary — so the markdown
+        # stored upstream is self-describing, while the raw body in s["markdown"]
+        # (what the Bedrock judge reads) stays clean.
+        attach_md = _with_frontmatter(
+            md,
+            s,
+            source_url=s.get("conversion_url"),
+            source_role=s.get("conversion_role"),
+        )
+        if not attach_md:
+            continue
         if overwrite:
             # Refresh: accept freshly converted markdown (and re-emit markdown we
             # short-circuited as "attached"); the upstream replaces existing.
             if s.get("conversion_status") in ("converted", "attached"):
-                candidates.append({"source_id": sid, "markdown": md})
+                candidates.append({"source_id": sid, "markdown": attach_md})
         else:
             # Only attach when WE produced the markdown for a source that has no
             # MARKDOWN link yet.
             if s.get(
                 "conversion_status"
             ) == "converted" and not _source_has_markdown_link(s):
-                candidates.append({"source_id": sid, "markdown": md})
+                candidates.append({"source_id": sid, "markdown": attach_md})
 
     return converted, candidates

--- a/review/converter.py
+++ b/review/converter.py
@@ -132,6 +132,34 @@ def _ext_from_magic(content):
     return None
 
 
+def _looks_like_html(content, content_type, ext):
+    """True if a downloaded source is an HTML page (so it needs main-content
+    extraction rather than plain document conversion).
+
+    Decided from the DOWNLOAD, not just the URL: a NEWS source's RAW link is the
+    article's own web page (a legitimate RAW per the source-link convention) but
+    has no file extension, so role/ext alone miss it. We look at the declared
+    extension, the Content-Type, and the leading bytes.
+
+    Guarded against false positives: a real document served with a wrong
+    ``text/html`` Content-Type (an Office file, or a PDF) must still go to the
+    document converter, so we bail out when the magic bytes say otherwise.
+    """
+    if ext in (".html", ".htm"):
+        return True
+    # A real document wins over a misleading content-type.
+    if _ext_from_magic(content) is not None or (content or b"")[:5] == b"%PDF-":
+        return False
+    if "html" in (content_type or "").lower():
+        return True
+    head = (content or b"")[:512].lstrip().lower()
+    return (
+        head.startswith((b"<!doctype html", b"<html", b"<?xml"))
+        or head[:200].find(b"<head") != -1
+        or head[:200].find(b"<body") != -1
+    )
+
+
 def _find_libreoffice():
     """Return the LibreOffice/soffice executable path, or None if not installed.
 
@@ -219,6 +247,14 @@ def _format_rank(url):
     return _FORMAT_RANK.get(_ext_from_url(url), 1)
 
 
+def _best_by_format(links):
+    """Return the link that converts most cleanly (highest _format_rank).
+
+    Tie -> first, so ordering from the source is preserved when formats match.
+    """
+    return max(links, key=_format_rank) if links else None
+
+
 # Some source links were persisted with the INTERNAL Cloudflare R2 S3-API
 # endpoint (``<account>.r2.cloudflarestorage.com/jawafdehi/case_uploads/...``)
 # instead of the PUBLIC custom-domain form (``s3.jawafdehi.org/case_uploads/...``).
@@ -257,6 +293,12 @@ def _pick_source_link(source):
          resort (no document file present); it is fetched and run through
          main-content extraction to drop site chrome.
 
+    Per the source-link convention (PR #196) there is exactly one RAW, but a
+    source may carry several ALTERNATE / PERMALINK links; for document targets we
+    pick the best-converting FORMAT among them, not just the first. For NEWS
+    sources the RAW is the article's own web page (the legitimate primary) and is
+    NEVER overridden by an ALTERNATE.
+
     MARKDOWN (our own output) and PERMALINK (a stable pointer, not necessarily
     fetchable) are never conversion targets. Falls back to the legacy plain
     ``url`` string list when no role-tagged ``urls`` exist.
@@ -269,21 +311,26 @@ def _pick_source_link(source):
         # Normalize internal R2 endpoint urls to the public host so the picked
         # link is actually fetchable (see _normalize_media_url).
         link = _normalize_media_url(link)
-        if link and role and role not in by_role:
-            by_role[role] = link  # first link of each role wins
+        if link and role:
+            by_role.setdefault(role, []).append(link)
 
-    raw = by_role.get("RAW")
-    alt = by_role.get("ALTERNATE")
+    is_news = (source.get("source_type") or "").upper() == "NEWS"
+    raw = _best_by_format(by_role.get("RAW"))
+    alt = _best_by_format(by_role.get("ALTERNATE"))
     if raw or alt:
         if raw and alt:
-            chosen = alt if _format_rank(alt) > _format_rank(raw) else raw
+            # Prefer a better-converting ALTERNATE over RAW (e.g. a .docx export
+            # of a scanned-PDF RAW) — but never override a NEWS article's RAW.
+            chosen = (
+                alt if (not is_news and _format_rank(alt) > _format_rank(raw)) else raw
+            )
         else:
             chosen = raw or alt
-        return chosen, ("ALTERNATE" if chosen == alt and chosen != raw else "RAW")
+        return chosen, ("ALTERNATE" if chosen is alt and chosen is not raw else "RAW")
 
     page = by_role.get("SOURCE_PAGE")
     if page:
-        return page, "SOURCE_PAGE"
+        return page[0], "SOURCE_PAGE"
 
     # Legacy sources with only plain url strings (no roles): treat as RAW.
     legacy = _normalize_media_url(_pick_url(source.get("url", [])))
@@ -312,15 +359,16 @@ def _html_to_markdown(raw_bytes):
     return (extracted or "").strip()
 
 
-def _with_frontmatter(body, source, *, source_url=None):
+def _with_frontmatter(body, source, *, source_url=None, source_role=None):
     """Prepend a YAML frontmatter block to a converted-markdown `body`.
 
     Frontmatter carries the processing timestamp plus source metadata so each
     stored markdown file is self-describing. The timestamp is stamped fresh on
     every emit, so it is NOT part of the on-disk cache (the cache holds only the
     deterministic body); any pre-existing frontmatter on `body` is stripped first
-    so re-runs don't stack blocks. ``source_url`` is the link actually converted
-    (defaults to the role-aware pick).
+    so re-runs don't stack blocks. ``source_url`` / ``source_role`` are the link
+    actually converted and its role (default to the role-aware pick), so the
+    stored markdown is traceable to which link produced it.
     """
     from django.utils import timezone
 
@@ -331,12 +379,13 @@ def _with_frontmatter(body, source, *, source_url=None):
         # not a usable conversion).
         return ""
     if source_url is None:
-        source_url, _ = _pick_source_link(source)
+        source_url, source_role = _pick_source_link(source)
     fields = {
         "processed_at": timezone.now().isoformat(),
         "source_id": source.get("source_id") or "",
         "title": source.get("title") or "",
         "source_type": source.get("source_type") or "",
+        "source_role": source_role or "",
         "source_url": source_url or "",
     }
     lines = ["---"]
@@ -395,7 +444,9 @@ def convert_source(source, *, overwrite=False):
     if cache_path.exists() and not overwrite:
         body = cache_path.read_text(encoding="utf-8")
         return {
-            "markdown": _with_frontmatter(body, source, source_url=url),
+            "markdown": _with_frontmatter(
+                body, source, source_url=url, source_role=role
+            ),
             "status": "converted",
             "url": url,
             "note": "From cache.",
@@ -410,14 +461,16 @@ def convert_source(source, *, overwrite=False):
         true_ext = _ext_from_magic(content)
         if true_ext and true_ext != ext:
             ext = true_ext
-        # HTML sources (the SOURCE_PAGE landing page, or a RAW/ALTERNATE link
-        # that is itself a web page): extract just the main content so the
-        # markdown isn't polluted with nav/header/footer chrome. Fall back to the
+        # HTML sources (the SOURCE_PAGE landing page, a NEWS article's own RAW
+        # url, or any RAW/ALTERNATE link that is itself a web page): extract just
+        # the main content so the markdown isn't polluted with nav/header/footer
+        # chrome. Detected from the download (content-type + bytes), not just the
+        # url extension, so extension-less news RAWs are caught. Fall back to the
         # plain MarkItDown conversion when extraction finds no article body.
         md_text = ""
         note = ""
         convert_ext = ext  # extension markitdown sees (LibreOffice may change it)
-        if role == "SOURCE_PAGE" or ext in (".html", ".htm"):
+        if role == "SOURCE_PAGE" or _looks_like_html(content, ctype, ext):
             md_text = _html_to_markdown(content)
             if md_text:
                 note = "Converted via trafilatura (HTML main-content)."
@@ -447,7 +500,9 @@ def convert_source(source, *, overwrite=False):
             note = note or f"Converted via likhit ({ext})."
         cache_path.write_text(md_text, encoding="utf-8")
         return {
-            "markdown": _with_frontmatter(md_text, source, source_url=url),
+            "markdown": _with_frontmatter(
+                md_text, source, source_url=url, source_role=role
+            ),
             "status": "converted",
             "url": url,
             "note": note,

--- a/review/converter.py
+++ b/review/converter.py
@@ -2,8 +2,14 @@
 
 `likhit` is Jawafdehi's MarkItDown plugin for Nepali PDFs / legacy docs.
 We only convert sources that do not already have markdown attached.
+
+This module is the shared conversion core: both the review pipeline
+(``review.runner``) and the ``reprocess_source_markdown`` management command go
+through ``convert_case_to_attach_candidates`` so the "convert a case's sources
+to markdown the upstream should store" logic lives in exactly one place.
 """
 
+import functools
 import hashlib
 import os
 import tempfile
@@ -92,14 +98,20 @@ def _ext_from_url(url, content_type=""):
     return ".bin"
 
 
-def convert_source(source):
+def convert_source(source, *, overwrite=False):
     """Return markdown text for a single source dict.
 
     Returns dict: {markdown, status, url, note}
     status in {attached, converted, skipped, error}
+
+    When ``overwrite`` is True the "markdown already present on source"
+    short-circuit is bypassed so the artifact is re-downloaded and re-converted
+    via likhit (the url-hash cache is still honored — same bytes in, same
+    markdown out). This is used by the reprocess command to refresh markdown
+    after a converter change (e.g. a new likhit OCR DPI).
     """
-    # 1. If markdown already attached to the source, use it.
-    if source.get("markdown"):
+    # 1. If markdown already attached to the source, use it (unless overwriting).
+    if source.get("markdown") and not overwrite:
         return {
             "markdown": source["markdown"],
             "status": "attached",
@@ -116,10 +128,14 @@ def convert_source(source):
             "note": "Source has no url to convert.",
         }
 
-    # 2. Cache by content hash of url.
+    # 2. Cache by content hash of url. The cache key is the url, NOT the
+    #    converter version, so `overwrite` must bypass the cache READ as well as
+    #    the "already attached" short-circuit — otherwise refreshing markdown
+    #    after a converter change (e.g. a new likhit OCR DPI) would just re-serve
+    #    the stale cached output. We still WRITE the fresh result below.
     cache_key = hashlib.sha256(url.encode()).hexdigest()[:24]
     cache_path = Path(settings.SOURCE_MARKDOWN_DIR) / f"{cache_key}.md"
-    if cache_path.exists():
+    if cache_path.exists() and not overwrite:
         return {
             "markdown": cache_path.read_text(encoding="utf-8"),
             "status": "converted",
@@ -154,25 +170,28 @@ def convert_source(source):
         }
 
 
-def convert_all(sources):
+def convert_all(sources, *, overwrite=False):
     """Convert a list of source dicts; attach `markdown` + `conversion`.
 
     Each source conversion is wrapped in a hard wall-clock timeout
     (settings.CONVERT_SOURCE_TIMEOUT). A single stalled artifact (e.g. a scanned
     PDF whose Bedrock OCR never returns) is marked conversion_status=error
     instead of blocking the entire review in stage `converting_sources`.
+
+    ``overwrite`` is forwarded to ``convert_source`` (see its docstring).
     """
     from concurrent.futures import ThreadPoolExecutor
     from concurrent.futures import TimeoutError as FutureTimeout
 
     timeout = getattr(settings, "CONVERT_SOURCE_TIMEOUT", 180)
+    _convert = functools.partial(convert_source, overwrite=overwrite)
     out = []
     for s in sources:
         # Run each conversion in its own short-lived executor so we can abandon
         # it on timeout. The worker thread may keep running (it's a daemon-ish
         # pool we drop the reference to), but the pipeline is no longer blocked.
         ex = ThreadPoolExecutor(max_workers=1)
-        fut = ex.submit(convert_source, s)
+        fut = ex.submit(_convert, s)
         try:
             res = fut.result(timeout=timeout)
         except FutureTimeout:
@@ -200,3 +219,62 @@ def convert_all(sources):
         s["conversion_note"] = res["note"]
         out.append(s)
     return out
+
+
+def _source_has_markdown_link(source):
+    """True if a (converted) source dict already carries a MARKDOWN-role url."""
+    if source.get("markdown_url"):
+        return True
+    for item in source.get("urls") or []:
+        if isinstance(item, dict) and item.get("role") == "MARKDOWN":
+            return True
+    return False
+
+
+def convert_case_to_attach_candidates(case, *, overwrite=False):
+    """Convert a case's document sources and return attach candidates.
+
+    Shared by ``review.runner`` (the graded review pipeline) and the
+    ``reprocess_source_markdown`` command, so the rule for "which converted
+    sources should have their markdown stored upstream" lives in one place.
+
+    Returns ``(converted, candidates)`` where:
+      - ``converted`` is the list of source dicts with ``markdown`` /
+        ``conversion_status`` / ``conversion_note`` attached (the runner feeds
+        this to its Bedrock analysis + scoring).
+      - ``candidates`` is ``[{"source_id", "markdown"}]`` — the sources whose
+        markdown should be POSTed to the upstream ``/sources/{id}/markdown/``
+        endpoint.
+
+    Default (``overwrite=False``): only sources we actually converted (status
+    ``converted``) that carry a real source_id, non-empty markdown, and do NOT
+    already have a MARKDOWN link. This is the long-standing poller behavior.
+
+    With ``overwrite=True``: also include sources whose markdown was already
+    attached (status ``attached``) and ignore any existing MARKDOWN link, so the
+    upstream replaces it (server-side ``attach_markdown(overwrite=True)`` does
+    the replace). Used to refresh markdown after a converter change.
+    """
+    sources = jds_client.extract_sources(case)
+    converted = convert_all(sources, overwrite=overwrite)
+
+    candidates = []
+    for s in converted:
+        sid = s.get("source_id")
+        md = s.get("markdown") or ""
+        if not (sid and md.strip()):
+            continue
+        if overwrite:
+            # Refresh: accept freshly converted markdown (and re-emit markdown we
+            # short-circuited as "attached"); the upstream replaces existing.
+            if s.get("conversion_status") in ("converted", "attached"):
+                candidates.append({"source_id": sid, "markdown": md})
+        else:
+            # Only attach when WE produced the markdown for a source that has no
+            # MARKDOWN link yet.
+            if s.get(
+                "conversion_status"
+            ) == "converted" and not _source_has_markdown_link(s):
+                candidates.append({"source_id": sid, "markdown": md})
+
+    return converted, candidates

--- a/review/converter.py
+++ b/review/converter.py
@@ -126,6 +126,31 @@ def _format_rank(url):
     return _FORMAT_RANK.get(_ext_from_url(url), 1)
 
 
+# Some source links were persisted with the INTERNAL Cloudflare R2 S3-API
+# endpoint (``<account>.r2.cloudflarestorage.com/jawafdehi/case_uploads/...``)
+# instead of the PUBLIC custom-domain form (``s3.jawafdehi.org/case_uploads/...``).
+# The internal endpoint returns HTTP 400 to anonymous GETs, so the file can't be
+# downloaded for conversion. Rewrite it to the public host (dropping the
+# ``jawafdehi`` bucket path segment, which the custom domain maps implicitly).
+_R2_INTERNAL_RE = re.compile(
+    r"^https?://[0-9a-f]+\.r2\.cloudflarestorage\.com/jawafdehi/(?P<path>.+)$"
+)
+_PUBLIC_MEDIA_HOST = "https://s3.jawafdehi.org/"
+
+
+def _normalize_media_url(url):
+    """Rewrite an internal R2 S3-endpoint url to the public custom-domain url.
+
+    Leaves every other url untouched. See ``_R2_INTERNAL_RE`` above.
+    """
+    if not url:
+        return url
+    m = _R2_INTERNAL_RE.match(url)
+    if m:
+        return _PUBLIC_MEDIA_HOST + m.group("path")
+    return url
+
+
 def _pick_source_link(source):
     """Choose which link to convert, honoring the source's link ROLES.
 
@@ -148,6 +173,9 @@ def _pick_source_link(source):
         if not isinstance(item, dict):
             continue
         link, role = item.get("link"), item.get("role")
+        # Normalize internal R2 endpoint urls to the public host so the picked
+        # link is actually fetchable (see _normalize_media_url).
+        link = _normalize_media_url(link)
         if link and role and role not in by_role:
             by_role[role] = link  # first link of each role wins
 
@@ -165,7 +193,7 @@ def _pick_source_link(source):
         return page, "SOURCE_PAGE"
 
     # Legacy sources with only plain url strings (no roles): treat as RAW.
-    legacy = _pick_url(source.get("url", []))
+    legacy = _normalize_media_url(_pick_url(source.get("url", [])))
     return (legacy, "RAW") if legacy else (None, None)
 
 

--- a/review/converter.py
+++ b/review/converter.py
@@ -11,7 +11,9 @@ to markdown the upstream should store" logic lives in exactly one place.
 
 import functools
 import hashlib
+import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
@@ -19,6 +21,10 @@ from urllib.parse import urlparse
 from django.conf import settings
 
 from . import jds_client
+
+# A YAML frontmatter block at the very top of a document (to strip before
+# re-emitting, so re-runs don't stack frontmatter).
+_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n+", re.DOTALL)
 
 # Lazy singleton MarkItDown instance (loading plugins is expensive).
 _md = None
@@ -98,6 +104,39 @@ def _ext_from_url(url, content_type=""):
     return ".bin"
 
 
+def _with_frontmatter(body, source):
+    """Prepend a YAML frontmatter block to a converted-markdown `body`.
+
+    Frontmatter carries the processing timestamp plus source metadata so each
+    stored markdown file is self-describing. The timestamp is stamped fresh on
+    every emit, so it is NOT part of the on-disk cache (the cache holds only the
+    deterministic body); any pre-existing frontmatter on `body` is stripped first
+    so re-runs don't stack blocks.
+    """
+    from django.utils import timezone
+
+    body = _FRONTMATTER_RE.sub("", body or "").lstrip("\n")
+    if not body.strip():
+        # No real content: stay empty so callers' `markdown.strip()` checks still
+        # treat this source as "nothing to attach" (a frontmatter-only file is
+        # not a usable conversion).
+        return ""
+    fields = {
+        "processed_at": timezone.now().isoformat(),
+        "source_id": source.get("source_id") or "",
+        "title": source.get("title") or "",
+        "source_type": source.get("source_type") or "",
+        "source_url": _pick_url(source.get("url", [])) or "",
+    }
+    lines = ["---"]
+    for key, value in fields.items():
+        # json.dumps gives safe YAML-compatible scalar quoting for arbitrary
+        # strings (colons, quotes, unicode) without a YAML dependency.
+        lines.append(f"{key}: {json.dumps(value, ensure_ascii=False)}")
+    lines.append("---")
+    return "\n".join(lines) + "\n\n" + body
+
+
 def convert_source(source, *, overwrite=False):
     """Return markdown text for a single source dict.
 
@@ -133,11 +172,14 @@ def convert_source(source, *, overwrite=False):
     #    the "already attached" short-circuit — otherwise refreshing markdown
     #    after a converter change (e.g. a new likhit OCR DPI) would just re-serve
     #    the stale cached output. We still WRITE the fresh result below.
+    # The cache holds the deterministic converted BODY — never the frontmatter,
+    # whose timestamp is stamped fresh on every emit below.
     cache_key = hashlib.sha256(url.encode()).hexdigest()[:24]
     cache_path = Path(settings.SOURCE_MARKDOWN_DIR) / f"{cache_key}.md"
     if cache_path.exists() and not overwrite:
+        body = cache_path.read_text(encoding="utf-8")
         return {
-            "markdown": cache_path.read_text(encoding="utf-8"),
+            "markdown": _with_frontmatter(body, source),
             "status": "converted",
             "url": url,
             "note": "From cache.",
@@ -156,7 +198,7 @@ def convert_source(source, *, overwrite=False):
             os.unlink(tmp)
         cache_path.write_text(md_text, encoding="utf-8")
         return {
-            "markdown": md_text,
+            "markdown": _with_frontmatter(md_text, source),
             "status": "converted",
             "url": url,
             "note": f"Converted via likhit ({ext}).",

--- a/review/converter.py
+++ b/review/converter.py
@@ -108,6 +108,30 @@ def _ext_from_url(url, content_type=""):
     return ".bin"
 
 
+def _ext_from_magic(content):
+    """Detect a file's true extension from its leading magic bytes, or None.
+
+    Source files are routed to a converter by URL extension, but uploads are
+    frequently MISLABELED — most commonly a modern ``.docx`` (a ZIP/OOXML
+    container) saved with a ``.doc`` name. antiword then rejects it ("not a Word
+    Document ... seems to be a ZIP"). Sniffing the real container lets us route
+    such files to the right converter (MarkItDown handles ``.docx`` cleanly).
+
+    Only disambiguates the Office family we actually confuse:
+      - ``PK\\x03\\x04`` (ZIP)  -> ``.docx``  (OOXML)
+      - ``\\xd0\\xcf\\x11\\xe0`` (OLE2) -> ``.doc``  (legacy binary Word)
+    Returns None for anything else (PDF/HTML/txt/etc. keep their URL ext).
+    """
+    if not content:
+        return None
+    head = content[:8]
+    if head[:4] == b"PK\x03\x04":
+        return ".docx"
+    if head[:4] == b"\xd0\xcf\x11\xe0":
+        return ".doc"
+    return None
+
+
 # How cleanly a format converts to markdown — higher is better. Word docs are
 # structured text (best), HTML is extractable main-content, PDF may need OCR,
 # everything else is a guess. Used to decide whether an ALTERNATE link is a
@@ -308,6 +332,12 @@ def convert_source(source, *, overwrite=False):
     try:
         content, ctype = jds_client.download_source_file(url)
         ext = _ext_from_url(url, ctype)
+        # Correct mislabeled Office files (e.g. a .docx saved with a .doc name)
+        # by sniffing the real container, so the file is routed to the converter
+        # that can actually read it.
+        true_ext = _ext_from_magic(content)
+        if true_ext and true_ext != ext:
+            ext = true_ext
         # HTML sources (the SOURCE_PAGE landing page, or a RAW/ALTERNATE link
         # that is itself a web page): extract just the main content so the
         # markdown isn't polluted with nav/header/footer chrome. Fall back to the

--- a/review/converter.py
+++ b/review/converter.py
@@ -414,11 +414,12 @@ def convert_source(source, *, overwrite=False):
             md_text = _html_to_markdown(content)
             if md_text:
                 note = "Converted via trafilatura (HTML main-content)."
-        # Legacy Word: prefer LibreOffice to produce a clean .docx (handles files
-        # the bundled antiword crashes on or rejects). Falls back to the likhit
-        # path when LibreOffice is disabled, absent, or the conversion fails.
+        # Legacy Word: optionally use LibreOffice to produce a clean .docx (it
+        # handles files the bundled antiword crashes on or rejects). Off by
+        # default; falls back to the likhit path when LibreOffice is disabled,
+        # absent, or the conversion fails.
         if not md_text and ext in (".doc", ".docx"):
-            if getattr(settings, "LIBREOFFICE_DOC_CONVERSION", True):
+            if getattr(settings, "LIBREOFFICE_DOC_CONVERSION", False):
                 soffice = _find_libreoffice()
                 if soffice:
                     docx = _libreoffice_to_docx(content, ext, soffice)

--- a/review/converter.py
+++ b/review/converter.py
@@ -190,10 +190,14 @@ def _libreoffice_to_docx(content, ext, soffice):
             )
         except Exception:  # noqa: BLE001 - any failure -> caller falls back
             return None
-        out_path = os.path.join(work, "input.docx")
-        if not os.path.exists(out_path):
+        # LibreOffice names the output from the input stem (input.doc -> input.docx),
+        # but glob rather than hardcode the name so an unexpected stem still works.
+        import glob
+
+        produced = glob.glob(os.path.join(work, "*.docx"))
+        if not produced:
             return None
-        with open(out_path, "rb") as f:
+        with open(produced[0], "rb") as f:
             return f.read()
 
 
@@ -377,10 +381,13 @@ def convert_source(source, *, overwrite=False):
         }
 
     # 2. Cache by content hash of url. The cache key is the url, NOT the
-    #    converter version, so `overwrite` must bypass the cache READ as well as
-    #    the "already attached" short-circuit — otherwise refreshing markdown
-    #    after a converter change (e.g. a new likhit OCR DPI) would just re-serve
-    #    the stale cached output. We still WRITE the fresh result below.
+    #    converter or its configuration, so `overwrite` must bypass the cache
+    #    READ (as well as the "already attached" short-circuit). Otherwise any
+    #    CONVERTER CHANGE re-serves stale cached output — this includes a new
+    #    likhit OCR DPI AND toggling LIBREOFFICE_DOC_CONVERSION (a .doc cached via
+    #    antiword would keep returning the antiword body even after LibreOffice is
+    #    enabled). Re-run with --overwrite after any such change. We still WRITE
+    #    the fresh result below.
     # The cache holds the deterministic converted BODY — never the frontmatter,
     # whose timestamp is stamped fresh on every emit below.
     cache_key = hashlib.sha256(url.encode()).hexdigest()[:24]
@@ -414,11 +421,12 @@ def convert_source(source, *, overwrite=False):
             md_text = _html_to_markdown(content)
             if md_text:
                 note = "Converted via trafilatura (HTML main-content)."
-        # Legacy Word: optionally use LibreOffice to produce a clean .docx (it
-        # handles files the bundled antiword crashes on or rejects). Off by
-        # default; falls back to the likhit path when LibreOffice is disabled,
-        # absent, or the conversion fails.
-        if not md_text and ext in (".doc", ".docx"):
+        # Legacy Word (.doc only): optionally use LibreOffice to produce a clean
+        # .docx (it handles files the bundled antiword crashes on or rejects).
+        # Modern .docx is left to markitdown directly — LibreOffice would be a
+        # redundant round-trip. Off by default; falls back to the likhit path when
+        # LibreOffice is disabled, absent, or the conversion fails.
+        if not md_text and ext == ".doc":
             if getattr(settings, "LIBREOFFICE_DOC_CONVERSION", False):
                 soffice = _find_libreoffice()
                 if soffice:

--- a/review/jds_client.py
+++ b/review/jds_client.py
@@ -10,6 +10,8 @@ Used in two places:
      review system runs fully offline.
 """
 
+import time
+
 import requests
 from django.conf import settings
 
@@ -17,6 +19,9 @@ UA = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/120.0 Safari/537.36 CaseworkReview/1.0"
 )
+
+# Status codes worth retrying: rate limiting + transient server errors.
+_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
 
 
 class JdsError(Exception):
@@ -40,10 +45,50 @@ def _headers(auth=True):
     return h
 
 
+def _retry_after_seconds(response, attempt, base_delay):
+    """Seconds to wait before the next attempt.
+
+    Honor the server's ``Retry-After`` header when present (the API tells us how
+    long to back off); otherwise use exponential backoff (base_delay * 2**attempt)
+    capped at 60s.
+    """
+    header = response.headers.get("Retry-After") if response is not None else None
+    if header:
+        try:
+            return min(float(header), 60.0)
+        except ValueError:
+            pass
+    return min(base_delay * (2**attempt), 60.0)
+
+
+def _get(url, *, params=None, timeout=60, auth=True):
+    """GET with retry/backoff on rate-limit (429) and transient 5xx errors.
+
+    Max attempts and base backoff are configurable via settings
+    ``JDS_MAX_RETRIES`` (default 5) and ``JDS_RETRY_BASE_DELAY`` (default 1.0s).
+    Raises ``JdsError`` if every attempt is rate-limited/5xx.
+    """
+    max_retries = int(getattr(settings, "JDS_MAX_RETRIES", 5))
+    base_delay = float(getattr(settings, "JDS_RETRY_BASE_DELAY", 1.0))
+    last = None
+    for attempt in range(max_retries + 1):
+        r = requests.get(
+            url, headers=_headers(auth=auth), params=params, timeout=timeout
+        )
+        if r.status_code not in _RETRY_STATUSES:
+            return r
+        last = r
+        if attempt < max_retries:
+            time.sleep(_retry_after_seconds(r, attempt, base_delay))
+    # Exhausted retries — return the last (still-failing) response so the caller
+    # raises its normal HTTP error with the real status code.
+    return last
+
+
 def get_case(slug, timeout=30):
     """Fetch the full case detail object for a slug from the remote JDS API."""
     url = f"{_base()}/cases/{slug}/"
-    r = requests.get(url, headers=_headers(), timeout=timeout)
+    r = _get(url, timeout=timeout)
     if r.status_code == 404:
         raise JdsError(f"Case '{slug}' not found (404).")
     if r.status_code != 200:
@@ -56,7 +101,7 @@ def iter_paginated(path, params=None, timeout=60):
     url = f"{_base()}/{path.lstrip('/')}"
     params = dict(params or {})
     while url:
-        r = requests.get(url, headers=_headers(), params=params, timeout=timeout)
+        r = _get(url, params=params, timeout=timeout)
         if r.status_code != 200:
             raise JdsError(f"JDS list fetch failed for {url}: HTTP {r.status_code}")
         data = r.json()

--- a/review/management/commands/reprocess_source_markdown.py
+++ b/review/management/commands/reprocess_source_markdown.py
@@ -72,6 +72,15 @@ class Command(BaseCommand):
             default=0.0,
             help="Seconds to pause between cases (be gentle on prod).",
         )
+        parser.add_argument(
+            "--read-sleep",
+            type=float,
+            default=0.2,
+            help=(
+                "Seconds to pause between case-read API calls (listing + each "
+                "case fetch) to avoid rate-limiting (HTTP 429). Default 0.2."
+            ),
+        )
 
     def handle(self, *args, **opts):
         slugs = opts.get("slugs")
@@ -79,6 +88,7 @@ class Command(BaseCommand):
         overwrite = opts["overwrite"]
         dry_run = opts["dry_run"]
         sleep = float(opts["sleep"])
+        self.read_sleep = float(opts["read_sleep"])
 
         # Upstream client is only needed for writes; --dry-run skips it (and
         # therefore does not require CASEWORK_POLLER_TOKEN).
@@ -139,6 +149,11 @@ class Command(BaseCommand):
         return out
 
     def _process_case(self, slug, client, overwrite, dry_run, totals):
+        # Throttle the per-case read to avoid rate-limiting (HTTP 429) when
+        # sweeping the whole published corpus. jds_client also retries 429/5xx
+        # with backoff, but a steady pace avoids tripping the limiter at all.
+        if self.read_sleep:
+            time.sleep(self.read_sleep)
         case = jds_client.get_case(slug)
         converted, candidates = converter.convert_case_to_attach_candidates(
             case, overwrite=overwrite

--- a/review/management/commands/reprocess_source_markdown.py
+++ b/review/management/commands/reprocess_source_markdown.py
@@ -165,8 +165,18 @@ class Command(BaseCommand):
                 totals["converted"] += 1
             elif status == "error":
                 totals["errored"] += 1
+                # Surface WHY a source failed (web-archive-only link, dead url,
+                # OCR timeout, ...) so errors are explainable, not just counted.
+                self.stderr.write(
+                    f"    error source {s.get('source_id')}: "
+                    f"{s.get('conversion_note') or 'unknown'}"
+                )
             else:
                 totals["skipped"] += 1
+                self.stdout.write(
+                    f"    skipped source {s.get('source_id')}: "
+                    f"{s.get('conversion_note') or 'unknown'}"
+                )
 
         self.stdout.write(
             f"  {slug}: {len(converted)} sources, {len(candidates)} to attach"

--- a/review/management/commands/reprocess_source_markdown.py
+++ b/review/management/commands/reprocess_source_markdown.py
@@ -1,0 +1,185 @@
+"""Reprocess document-source markdown for published cases.
+
+For every PUBLISHED case (or a given ``--slug`` set), pull the case, convert its
+document sources to Markdown via likhit, and attach that Markdown back to each
+source upstream (a MARKDOWN-role url on the DocumentSource). This is the on-
+demand version of the maintenance fix the review poller performs as a side
+effect of grading — useful for backfilling markdown across the whole published
+corpus or refreshing it after a converter change (e.g. a new likhit OCR DPI).
+
+This runs as a REMOTE HTTP CLIENT (no DB access), exactly like the poller:
+
+  - Cases are READ from the public Jawafdehi API (``JAWAFDEHI_API_BASE``); the
+    case list returns PUBLISHED cases for anonymous reads.
+  - Markdown is WRITTEN to the casework API (``CASEWORK_API_BASE`` +
+    ``CASEWORK_POLLER_TOKEN``) via the shared ``UpstreamClient``.
+
+The conversion + attach-candidate logic is shared with the poller through
+``review.converter.convert_case_to_attach_candidates``.
+
+Idempotent + resumable: by default a source that already has a MARKDOWN url is
+left alone (and is therefore skipped on re-runs). ``--overwrite`` forces
+re-conversion and replaces the existing markdown.
+
+Examples:
+  # Dry run over all published cases (read + convert, no upstream writes)
+  manage.py reprocess_source_markdown --dry-run
+
+  # Reprocess two specific cases
+  manage.py reprocess_source_markdown --slug case-a --slug case-b
+
+  # Refresh markdown for the first 5 cases after a converter change
+  manage.py reprocess_source_markdown --limit 5 --overwrite --sleep 1
+"""
+
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+
+from review import converter, jds_client
+from review.upstream_client import UpstreamClient, UpstreamError
+
+
+class Command(BaseCommand):
+    help = "Reprocess document-source markdown for published cases (convert via likhit, attach upstream)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--slug",
+            action="append",
+            dest="slugs",
+            help="Reprocess a specific case slug (repeatable). Default: all published cases.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Only process the first N cases.",
+        )
+        parser.add_argument(
+            "--overwrite",
+            action="store_true",
+            help="Re-convert and replace markdown even if the source already has a MARKDOWN url.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Convert and report candidates without writing anything upstream.",
+        )
+        parser.add_argument(
+            "--sleep",
+            type=float,
+            default=0.0,
+            help="Seconds to pause between cases (be gentle on prod).",
+        )
+
+    def handle(self, *args, **opts):
+        slugs = opts.get("slugs")
+        limit = opts.get("limit")
+        overwrite = opts["overwrite"]
+        dry_run = opts["dry_run"]
+        sleep = float(opts["sleep"])
+
+        # Upstream client is only needed for writes; --dry-run skips it (and
+        # therefore does not require CASEWORK_POLLER_TOKEN).
+        client = None
+        if not dry_run:
+            try:
+                client = UpstreamClient(
+                    on_log=self.stdout.write, on_err=self.stderr.write
+                )
+            except UpstreamError as e:
+                raise CommandError(str(e))
+
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                f"reprocess_source_markdown: dry_run={dry_run} overwrite={overwrite}"
+            )
+        )
+
+        slugs = self._resolve_slugs(slugs, limit)
+        self.stdout.write(f"cases to process: {len(slugs)}")
+
+        totals = {
+            "cases": 0,
+            "cases_failed": 0,
+            "converted": 0,
+            "skipped": 0,
+            "errored": 0,
+            "attached": 0,
+            "attach_skipped": 0,
+            "attach_failed": 0,
+        }
+
+        for slug in slugs:
+            try:
+                self._process_case(slug, client, overwrite, dry_run, totals)
+                totals["cases"] += 1
+            except Exception as e:  # noqa: BLE001 - isolate per-case failures
+                totals["cases_failed"] += 1
+                self.stderr.write(f"  case {slug} failed: {e}")
+            if sleep:
+                time.sleep(sleep)
+
+        self._print_summary(totals, dry_run)
+
+    # ---- helpers -----------------------------------------------------
+
+    def _resolve_slugs(self, slugs, limit):
+        """Return the list of case slugs to process (explicit, or all published)."""
+        if slugs:
+            return slugs[:limit] if limit else slugs
+        out = []
+        for case in jds_client.iter_paginated("cases/"):
+            slug = case.get("slug")
+            if slug:
+                out.append(slug)
+            if limit and len(out) >= limit:
+                break
+        return out
+
+    def _process_case(self, slug, client, overwrite, dry_run, totals):
+        case = jds_client.get_case(slug)
+        converted, candidates = converter.convert_case_to_attach_candidates(
+            case, overwrite=overwrite
+        )
+        # Per-source conversion outcome (for the summary + visibility).
+        for s in converted:
+            status = s.get("conversion_status")
+            if status in ("converted", "attached"):
+                totals["converted"] += 1
+            elif status == "error":
+                totals["errored"] += 1
+            else:
+                totals["skipped"] += 1
+
+        self.stdout.write(
+            f"  {slug}: {len(converted)} sources, {len(candidates)} to attach"
+        )
+
+        if dry_run:
+            for c in candidates:
+                self.stdout.write(f"    [dry-run] would attach source {c['source_id']}")
+            return
+
+        summary = client.attach_markdown(candidates, overwrite=overwrite)
+        totals["attached"] += summary["attached"]
+        totals["attach_skipped"] += summary["skipped"]
+        totals["attach_failed"] += summary["failed"]
+
+    def _print_summary(self, t, dry_run):
+        self.stdout.write(self.style.MIGRATE_HEADING("summary"))
+        self.stdout.write(
+            f"  cases processed: {t['cases']}  failed: {t['cases_failed']}"
+        )
+        self.stdout.write(
+            f"  sources converted: {t['converted']}  skipped: {t['skipped']}  errored: {t['errored']}"
+        )
+        if dry_run:
+            self.stdout.write("  (dry run — nothing attached upstream)")
+        else:
+            self.stdout.write(
+                f"  markdown attached: {t['attached']}  "
+                f"skipped: {t['attach_skipped']}  failed: {t['attach_failed']}"
+            )
+        self.stdout.write(self.style.SUCCESS("reprocess_source_markdown: done."))

--- a/review/management/commands/reprocess_source_markdown.py
+++ b/review/management/commands/reprocess_source_markdown.py
@@ -59,7 +59,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--overwrite",
             action="store_true",
-            help="Re-convert and replace markdown even if the source already has a MARKDOWN url.",
+            help=(
+                "Re-convert and replace markdown even if the source already has a "
+                "MARKDOWN url. Also bypasses the on-disk conversion cache, so use "
+                "this after a converter change (new likhit OCR DPI, or toggling "
+                "LIBREOFFICE_DOC_CONVERSION) to force fresh output."
+            ),
         )
         parser.add_argument(
             "--dry-run",

--- a/review/management/commands/review_poller.py
+++ b/review/management/commands/review_poller.py
@@ -33,11 +33,11 @@ poller writes anything back to the (possibly production) API.
 
 import time
 
-import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from review import runner
+from review.upstream_client import UpstreamClient, UpstreamError
 
 
 class PollerError(Exception):
@@ -69,24 +69,6 @@ class Command(BaseCommand):
             help="Seconds between polls when the queue is empty.",
         )
 
-    # ---- API helpers -------------------------------------------------
-
-    def _headers(self):
-        return {
-            "Authorization": f"Token {self.token}",
-            "Content-Type": "application/json",
-        }
-
-    def _post(self, path, payload, timeout=60):
-        url = f"{settings.CASEWORK_API_BASE.rstrip('/')}{path}"
-        return requests.post(
-            url, json=payload, headers=self._headers(), timeout=timeout
-        )
-
-    def _get(self, path, timeout=30):
-        url = f"{settings.CASEWORK_API_BASE.rstrip('/')}{path}"
-        return requests.get(url, headers=self._headers(), timeout=timeout)
-
     # ---- read-only listing ------------------------------------------
 
     def _list_pending(self):
@@ -95,7 +77,7 @@ class Command(BaseCommand):
         Does NOT claim anything (no pending->running transition), so it is safe
         to run against production just to see what is waiting.
         """
-        r = self._get("/reviews/?page_size=1000")
+        r = self.client.get("/reviews/?page_size=1000")
         if r.status_code != 200:
             raise PollerError(f"list failed: HTTP {r.status_code} {r.text[:200]}")
         data = r.json()
@@ -116,7 +98,7 @@ class Command(BaseCommand):
 
     def _claim(self):
         """Return a job payload dict, or None if the queue is empty."""
-        r = self._post("/jobs/claim/", {}, timeout=30)
+        r = self.client.post("/jobs/claim/", {}, timeout=30)
         if r.status_code == 204:
             return None
         if r.status_code != 200:
@@ -125,37 +107,16 @@ class Command(BaseCommand):
 
     def _report_stage(self, review_id, stage):
         try:
-            self._post(f"/jobs/{review_id}/stage/", {"stage": stage}, timeout=15)
+            self.client.post(f"/jobs/{review_id}/stage/", {"stage": stage}, timeout=15)
         except Exception:  # noqa: BLE001 - progress is best-effort
             pass
 
     def _submit(self, review_id, payload):
-        r = self._post(f"/jobs/{review_id}/result/", payload, timeout=60)
+        r = self.client.post(f"/jobs/{review_id}/result/", payload, timeout=60)
         if r.status_code not in (200, 201):
             raise PollerError(
                 f"result submit failed for {review_id}: HTTP {r.status_code} {r.text[:200]}"
             )
-
-    def _attach_markdown(self, items):
-        """Maintenance fix: attach locally-converted markdown back to sources."""
-        for item in items or []:
-            sid = item.get("source_id")
-            try:
-                r = self._post(
-                    f"/sources/{sid}/markdown/",
-                    {"markdown": item.get("markdown", "")},
-                    timeout=60,
-                )
-                if r.status_code == 200:
-                    body = r.json()
-                    if body.get("created"):
-                        self.stdout.write(f"    attached MARKDOWN url to source {sid}")
-                else:
-                    self.stderr.write(
-                        f"    markdown attach failed for {sid}: HTTP {r.status_code} {r.text[:150]}"
-                    )
-            except Exception as e:  # noqa: BLE001 - maintenance is best-effort
-                self.stderr.write(f"    markdown attach error for {sid}: {e}")
 
     def _process_job(self, job):
         review_id = job["review_id"]
@@ -167,7 +128,7 @@ class Command(BaseCommand):
                 on_stage=lambda s: self._report_stage(review_id, s),
             )
             # Maintenance fix: populate MARKDOWN urls on sources we converted.
-            self._attach_markdown(out.pop("markdown_to_attach", []))
+            self.client.attach_markdown(out.pop("markdown_to_attach", []))
             out["status"] = "done"
             self._submit(review_id, out)
             self.stdout.write(self.style.SUCCESS(f"  finished review {review_id}"))
@@ -187,13 +148,12 @@ class Command(BaseCommand):
         apply = opts["apply"]
         once = opts["once"]
         poll = float(opts["poll"])
-        self.token = settings.CASEWORK_POLLER_TOKEN
-        if not self.token:
-            raise PollerError(
-                "CASEWORK_POLLER_TOKEN is not set. Create a DRF token for the "
-                "poller's service account (manage.py drf_create_token <user>) "
-                "and set it in the environment."
+        try:
+            self.client = UpstreamClient(
+                on_log=self.stdout.write, on_err=self.stderr.write
             )
+        except UpstreamError as e:
+            raise PollerError(str(e))
 
         # Read-only by default: just report the pending queue and exit. Claiming
         # and submitting results (the mutating path) require an explicit --apply.

--- a/review/runner.py
+++ b/review/runner.py
@@ -15,7 +15,7 @@ import time
 
 from django.conf import settings
 
-from . import bedrock_judge, casetype, code_rules, converter, jds_client, scorer
+from . import bedrock_judge, casetype, code_rules, converter, scorer
 
 
 class _Config:
@@ -51,34 +51,18 @@ def process_case(case, config=None, on_stage=None):
 
     t0 = time.monotonic()
 
-    # 1. Sources from the case (pure; no DB).
+    # 1+2. Sources from the case + likhit conversion — LOCAL to the poller; the
+    #    markdown is not part of the scored result. The shared converter also
+    #    returns the attach candidates: sources we actually converted that do not
+    #    already carry a MARKDOWN link, which the poller attaches back to the
+    #    DocumentSource via the maintenance endpoint (populating its MARKDOWN
+    #    url). The same routine backs the `reprocess_source_markdown` command.
     stage("converting_sources")
-    sources = jds_client.extract_sources(case)
-    source_count = len(sources)
-
-    # 2. likhit conversion — LOCAL to the poller; markdown is not uploaded as
-    #    part of the result. Instead, for sources we actually converted (ran
-    #    likhit) that do not already carry a MARKDOWN link, we collect the
-    #    markdown so the poller can attach it back to the DocumentSource via the
-    #    maintenance endpoint (populating its MARKDOWN url).
-    converted = converter.convert_all(sources)
+    converted, markdown_to_attach = converter.convert_case_to_attach_candidates(case)
+    source_count = len(converted)
     sources_converted = sum(
         1 for s in converted if s.get("conversion_status") in ("converted", "attached")
     )
-
-    markdown_to_attach = []
-    for s in converted:
-        sid = s.get("source_id")
-        md = s.get("markdown") or ""
-        # Only attach when WE produced the markdown (status "converted") for a
-        # real source id that has no MARKDOWN link yet.
-        if (
-            sid
-            and s.get("conversion_status") == "converted"
-            and md.strip()
-            and not _source_has_markdown_link(s)
-        ):
-            markdown_to_attach.append({"source_id": sid, "markdown": md})
 
     # 3. Per-source analysis (Bedrock).
     stage("analyzing_sources")
@@ -106,13 +90,3 @@ def process_case(case, config=None, on_stage=None):
         # Maintenance fix: markdown the poller should attach back to sources.
         "markdown_to_attach": markdown_to_attach,
     }
-
-
-def _source_has_markdown_link(source):
-    """True if a (converted) source dict already carries a MARKDOWN-role url."""
-    if source.get("markdown_url"):
-        return True
-    for item in source.get("urls") or []:
-        if isinstance(item, dict) and item.get("role") == "MARKDOWN":
-            return True
-    return False

--- a/review/upstream_client.py
+++ b/review/upstream_client.py
@@ -1,0 +1,95 @@
+"""Token-authenticated HTTP client for the casework "upstream" API.
+
+This is the shared write-path plumbing the ``review_poller`` once owned
+privately: it authenticates to the casework API with a long-lived DRF token
+(``Authorization: Token <key>``) and posts back to it. Extracted so both the
+poller and the ``reprocess_source_markdown`` management command talk to upstream
+through one place.
+
+Auth: the token is a DRF auth token for a dedicated service account holding the
+write permission (``CanManageDocumentSources``, i.e. ReviewAssistant+). Create
+one with ``manage.py drf_create_token <service-account-username>`` and supply it
+via ``CASEWORK_POLLER_TOKEN``. The API base is ``CASEWORK_API_BASE``.
+"""
+
+import requests
+from django.conf import settings
+
+
+class UpstreamError(Exception):
+    pass
+
+
+class UpstreamClient:
+    """Thin token-auth client for the casework API.
+
+    ``on_log`` / ``on_err`` are optional callables (e.g. a command's
+    ``self.stdout.write`` / ``self.stderr.write``) used for human-facing
+    progress; they default to no-ops so the client is usable outside a command.
+    """
+
+    def __init__(self, base=None, token=None, on_log=None, on_err=None):
+        self.base = (base or settings.CASEWORK_API_BASE).rstrip("/")
+        self.token = token if token is not None else settings.CASEWORK_POLLER_TOKEN
+        if not self.token:
+            raise UpstreamError(
+                "CASEWORK_POLLER_TOKEN is not set. Create a DRF token for the "
+                "service account (manage.py drf_create_token <user>) and set it "
+                "in the environment."
+            )
+        self._log = on_log or (lambda _msg: None)
+        self._err = on_err or (lambda _msg: None)
+
+    def _headers(self):
+        return {
+            "Authorization": f"Token {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    def get(self, path, timeout=30):
+        url = f"{self.base}{path}"
+        return requests.get(url, headers=self._headers(), timeout=timeout)
+
+    def post(self, path, payload, timeout=60):
+        url = f"{self.base}{path}"
+        return requests.post(
+            url, json=payload, headers=self._headers(), timeout=timeout
+        )
+
+    def attach_markdown(self, items, *, overwrite=False):
+        """Attach locally-converted markdown back to sources upstream.
+
+        ``items`` is an iterable of ``{"source_id", "markdown"}`` dicts (the
+        candidate shape produced by ``converter.convert_case_to_attach_candidates``).
+        Each is POSTed to ``/sources/{id}/markdown/``; the server stores it as a
+        MARKDOWN-role url, idempotently (it skips a source that already has one
+        unless ``overwrite`` is set).
+
+        Returns a summary dict: ``{attached, skipped, failed}``.
+        """
+        summary = {"attached": 0, "skipped": 0, "failed": 0}
+        for item in items or []:
+            sid = item.get("source_id")
+            try:
+                r = self.post(
+                    f"/sources/{sid}/markdown/",
+                    {"markdown": item.get("markdown", ""), "overwrite": overwrite},
+                    timeout=60,
+                )
+                if r.status_code == 200:
+                    body = r.json()
+                    if body.get("created"):
+                        summary["attached"] += 1
+                        self._log(f"    attached MARKDOWN url to source {sid}")
+                    else:
+                        summary["skipped"] += 1
+                else:
+                    summary["failed"] += 1
+                    self._err(
+                        f"    markdown attach failed for {sid}: "
+                        f"HTTP {r.status_code} {r.text[:150]}"
+                    )
+            except Exception as e:  # noqa: BLE001 - attach is best-effort per source
+                summary["failed"] += 1
+                self._err(f"    markdown attach error for {sid}: {e}")
+        return summary

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -236,12 +236,14 @@ def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
 # ── Role-aware link selection ────────────────────────────────
 
 
-def _pick(urls=None, url=None):
+def _pick(urls=None, url=None, source_type=None):
     src = {}
     if urls is not None:
         src["urls"] = urls
     if url is not None:
         src["url"] = url
+    if source_type is not None:
+        src["source_type"] = source_type
     return converter._pick_source_link(src)
 
 
@@ -305,6 +307,31 @@ def test_pick_skips_markdown_and_permalink():
 
 def test_pick_falls_back_to_legacy_url_strings():
     assert _pick(url=["http://x/legacy.pdf"]) == ("http://x/legacy.pdf", "RAW")
+
+
+def test_pick_does_not_override_news_raw_with_alternate():
+    # A NEWS source's RAW is the article web page (the legitimate primary); a
+    # better-format ALTERNATE must NOT replace it as the conversion target.
+    assert _pick(
+        [
+            {"link": "https://news.example.com/article", "role": "RAW"},
+            {"link": "https://x/a.docx", "role": "ALTERNATE"},
+        ],
+        source_type="NEWS",
+    ) == ("https://news.example.com/article", "RAW")
+
+
+def test_pick_chooses_best_format_among_multiple_alternates():
+    # Two ALTERNATEs: the higher-ranked .docx wins over the first-listed .pdf.
+    url, role = _pick(
+        [
+            {"link": "https://x/raw.pdf", "role": "RAW"},
+            {"link": "https://x/alt1.pdf", "role": "ALTERNATE"},
+            {"link": "https://x/alt2.docx", "role": "ALTERNATE"},
+        ],
+        source_type="COURT_ORDER",
+    )
+    assert url == "https://x/alt2.docx" and role == "ALTERNATE"
 
 
 # ── Internal R2 endpoint → public host normalization ─────────
@@ -399,6 +426,85 @@ def test_source_page_falls_back_to_markitdown_when_extraction_empty(settings, tm
         res = converter.convert_source(src, overwrite=True)
     md.assert_called_once()
     assert res["markdown"].rstrip().endswith("fallback body")
+
+
+def test_news_raw_webpage_uses_html_extraction(settings, tmp_path):
+    """A NEWS source whose RAW is the article's own web page (no extension) is
+    detected as HTML from the download and run through main-content extraction,
+    not handed to the document converter."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "n1",
+        "title": "News article",
+        "source_type": "NEWS",
+        "urls": [{"link": "https://onlinekhabar.com/2025/12/1837107/x", "role": "RAW"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"<!DOCTYPE html><html><body>article</body></html>", "text/html"),
+    ), patch.object(
+        converter, "_html_to_markdown", return_value="article body"
+    ) as h2m, patch.object(
+        converter, "_markitdown"
+    ) as md:
+        res = converter.convert_source(src, overwrite=True)
+    h2m.assert_called_once()
+    md.assert_not_called()
+    assert "trafilatura" in res["note"]
+    assert 'source_role: "RAW"' in res["markdown"]
+
+
+def test_html_detected_by_magic_without_content_type(settings, tmp_path):
+    """HTML is recognised from leading bytes even when Content-Type is blank."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "h1",
+        "title": "Page",
+        "source_type": "NEWS",
+        "urls": [{"link": "https://example.com/story", "role": "RAW"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"   <html><head></head><body>x</body></html>", ""),
+    ), patch.object(
+        converter, "_html_to_markdown", return_value="story body"
+    ) as h2m, patch.object(
+        converter, "_markitdown"
+    ) as md:
+        res = converter.convert_source(src, overwrite=True)
+    h2m.assert_called_once()
+    md.assert_not_called()
+    assert res["markdown"].rstrip().endswith("story body")
+
+
+def test_pdf_with_html_content_type_is_not_treated_as_html(settings, tmp_path):
+    """A PDF mis-served with Content-Type text/html must still go to the document
+    converter, not trafilatura (the false-positive guard)."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "pdf1",
+        "title": "Doc",
+        "source_type": "COURT_ORDER",
+        "urls": [
+            {"link": "https://s3.jawafdehi.org/case_uploads/x.pdf", "role": "RAW"}
+        ],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"%PDF-1.7\nbinary...", "text/html"),
+    ), patch.object(converter, "_html_to_markdown") as h2m, patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="pdf body")
+        res = converter.convert_source(src, overwrite=True)
+    h2m.assert_not_called()  # not treated as HTML
+    md.assert_called_once()
+    assert res["markdown"].rstrip().endswith("pdf body")
 
 
 # ── Mislabeled-file detection (magic bytes) ──────────────────
@@ -608,6 +714,38 @@ def test_frontmatter_has_processed_at_and_source_metadata(settings, tmp_path):
     assert 'title: "My: Title"' in md
     assert 'source_type: "MEDIA_NEWS"' in md
     assert 'source_url: "http://x/a.pdf"' in md
+    # legacy url-string source resolves to RAW
+    assert 'source_role: "RAW"' in md
+
+
+def test_frontmatter_records_source_role():
+    # SOURCE_PAGE-derived markdown is tagged with its role.
+    out = converter._with_frontmatter(
+        "body",
+        {"source_id": "s", "title": "T", "source_type": "NEWS"},
+        source_url="https://x/page",
+        source_role="SOURCE_PAGE",
+    )
+    assert 'source_role: "SOURCE_PAGE"' in out
+
+
+def test_markdown_only_source_is_skipped_cleanly(settings, tmp_path):
+    """A 0-RAW source carrying only a MARKDOWN link has nothing to convert: it is
+    skipped (not errored) and produces no attach candidate."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "m1",
+        "title": "Already rendered",
+        "source_type": "NEWS",
+        "urls": [
+            {"link": "https://s3.jawafdehi.org/case_uploads/x.md", "role": "MARKDOWN"}
+        ],
+    }
+    with patch.object(converter.jds_client, "download_source_file") as dl:
+        res = converter.convert_source(src, overwrite=True)
+    dl.assert_not_called()  # nothing fetchable to convert
+    assert res["status"] == "skipped"
+    assert res["markdown"] == ""
 
 
 def test_with_frontmatter_does_not_stack_or_emit_for_empty():

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.core.management import call_command, load_command_class
 
-from review import converter
+from review import converter, jds_client
 from review.upstream_client import UpstreamClient, UpstreamError
 
 
@@ -20,7 +20,8 @@ def _stub_markitdown_if_missing(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "flag", ["--slug", "--limit", "--overwrite", "--dry-run", "--sleep"]
+    "flag",
+    ["--slug", "--limit", "--overwrite", "--dry-run", "--sleep", "--read-sleep"],
 )
 def test_cli_flags_registered(flag):
     cmd = load_command_class("review", "reprocess_source_markdown")
@@ -29,6 +30,72 @@ def test_cli_flags_registered(flag):
         if flag in action.option_strings:
             return
     pytest.fail(f"Flag {flag} not found in command arguments")
+
+
+# ── jds_client retry / backoff on rate-limit (429) ───────────
+
+
+def _resp(status, body=None, headers=None):
+    m = MagicMock()
+    m.status_code = status
+    m.headers = headers or {}
+    m.json.return_value = body or {}
+    return m
+
+
+def test_get_case_retries_on_429_then_succeeds():
+    with patch.object(
+        jds_client.requests,
+        "get",
+        side_effect=[
+            _resp(429, headers={"Retry-After": "0"}),
+            _resp(200, {"slug": "x"}),
+        ],
+    ) as get, patch.object(jds_client.time, "sleep") as slept:
+        out = jds_client.get_case("x")
+    assert out == {"slug": "x"}
+    assert get.call_count == 2
+    assert slept.called
+
+
+def test_get_case_raises_after_exhausting_retries(settings):
+    settings.JDS_MAX_RETRIES = 2
+    with patch.object(
+        jds_client.requests,
+        "get",
+        return_value=_resp(429, headers={"Retry-After": "0"}),
+    ) as get, patch.object(jds_client.time, "sleep"):
+        with pytest.raises(jds_client.JdsError) as exc:
+            jds_client.get_case("y")
+    assert "429" in str(exc.value)
+    assert get.call_count == 3  # initial + 2 retries
+
+
+def test_retry_after_header_is_honored():
+    assert (
+        jds_client._retry_after_seconds(
+            _resp(429, headers={"Retry-After": "3"}), 0, 1.0
+        )
+        == 3.0
+    )
+
+
+def test_backoff_is_exponential_without_header():
+    # base 1.0 * 2**attempt
+    assert jds_client._retry_after_seconds(_resp(429, headers={}), 0, 1.0) == 1.0
+    assert jds_client._retry_after_seconds(_resp(429, headers={}), 2, 1.0) == 4.0
+    # capped at 60s
+    assert jds_client._retry_after_seconds(_resp(429, headers={}), 10, 1.0) == 60.0
+
+
+def test_non_retryable_status_returns_immediately():
+    with patch.object(
+        jds_client.requests, "get", return_value=_resp(404)
+    ) as get, patch.object(jds_client.time, "sleep") as slept:
+        with pytest.raises(jds_client.JdsError):
+            jds_client.get_case("missing")
+    assert get.call_count == 1  # 404 is not retried
+    assert not slept.called
 
 
 # ── Shared converter: convert_case_to_attach_candidates ──────

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -118,7 +118,13 @@ def test_candidates_default_includes_freshly_converted():
         ],
     ):
         converted, candidates = converter.convert_case_to_attach_candidates(case)
-    assert converted and candidates == [{"source_id": 11, "markdown": "md"}]
+    # Candidate markdown is frontmatter-wrapped at the attach boundary; the body
+    # is present after the frontmatter block.
+    assert converted and len(candidates) == 1
+    cand = candidates[0]
+    assert cand["source_id"] == 11
+    assert cand["markdown"].startswith("---\n") and "processed_at:" in cand["markdown"]
+    assert cand["markdown"].rstrip().endswith("md")
 
 
 def test_candidates_default_excludes_source_with_markdown_link():
@@ -148,7 +154,8 @@ def test_candidates_overwrite_includes_source_with_markdown_link():
         _, candidates = converter.convert_case_to_attach_candidates(
             case, overwrite=True
         )
-    assert candidates == [{"source_id": 11, "markdown": "fresh"}]
+    assert len(candidates) == 1 and candidates[0]["source_id"] == 11
+    assert candidates[0]["markdown"].rstrip().endswith("fresh")
     # overwrite is threaded into convert_all.
     assert ca.call_args.kwargs.get("overwrite") is True
 
@@ -190,11 +197,11 @@ def test_convert_source_overwrite_bypasses_short_circuit(settings, tmp_path):
     ):
         md.return_value.convert.return_value = MagicMock(text_content="new md")
         res = converter.convert_source(src, overwrite=True)
-    # Output is frontmatter-wrapped; the converted body must be present and the
-    # short-circuit bypassed (we re-converted "new md", not re-served "old").
+    # convert_source returns the RAW body (no frontmatter — that's added at the
+    # attach boundary); the short-circuit is bypassed (re-converted, not "old").
     assert res["status"] == "converted"
-    assert res["markdown"].startswith("---\n") and "processed_at:" in res["markdown"]
-    assert res["markdown"].rstrip().endswith("new md")
+    assert res["markdown"] == "new md"
+    assert "---" not in res["markdown"]  # no frontmatter on the judge-facing body
 
 
 def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
@@ -220,17 +227,14 @@ def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
     ):
         md.return_value.convert.return_value = MagicMock(text_content="fresh")
         res = converter.convert_source(src, overwrite=True)
-    assert res["markdown"].rstrip().endswith("fresh")
-    # The cache holds the bare, frontmatter-free body (timestamp is stamped fresh
-    # on each emit, not cached).
+    assert res["markdown"] == "fresh"
+    # The cache holds the bare converted body.
     assert cache_path.read_text(encoding="utf-8") == "fresh"
 
-    # Without overwrite, the cached body is re-served (no re-download) and
-    # re-wrapped with fresh frontmatter.
+    # Without overwrite, the cached body is re-served (no re-download).
     with patch.object(converter.jds_client, "download_source_file") as dl:
         res2 = converter.convert_source(src)
-    assert res2["markdown"].rstrip().endswith("fresh") and dl.call_count == 0
-    assert "processed_at:" in res2["markdown"]
+    assert res2["markdown"] == "fresh" and dl.call_count == 0
 
 
 # ── Role-aware link selection ────────────────────────────────
@@ -452,7 +456,66 @@ def test_news_raw_webpage_uses_html_extraction(settings, tmp_path):
     h2m.assert_called_once()
     md.assert_not_called()
     assert "trafilatura" in res["note"]
-    assert 'source_role: "RAW"' in res["markdown"]
+    assert (
+        res["role"] == "RAW"
+    )  # role reported on the result (frontmatter added at attach)
+    assert res["markdown"] == "article body"  # raw body, no frontmatter
+
+
+def test_permalink_fallback_on_dead_ephemeral_raw(settings, tmp_path):
+    """When an ephemeral news RAW fails to download and the source has a
+    PERMALINK archive, conversion retries against the archive."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "n2",
+        "title": "Dead news",
+        "source_type": "NEWS",
+        "urls": [
+            {"link": "https://deadnews.example.com/article", "role": "RAW"},
+            {
+                "link": "https://web.archive.org/web/2025/https://deadnews.example.com/article",
+                "role": "PERMALINK",
+            },
+        ],
+    }
+
+    def _dl(u, *a, **k):
+        if "web.archive.org" in u:
+            return (b"<html><body>archived</body></html>", "text/html")
+        raise converter.jds_client.JdsError("HTTP 404")
+
+    with patch.object(
+        converter.jds_client, "download_source_file", side_effect=_dl
+    ), patch.object(converter, "_html_to_markdown", return_value="archived body"):
+        res = converter.convert_source(src, overwrite=True)
+    assert res["status"] == "converted"
+    assert "PERMALINK" in res["note"]
+    assert res["role"] == "SOURCE_PAGE"
+    assert "web.archive.org" in res["url"]
+    assert res["markdown"] == "archived body"
+
+
+def test_no_permalink_fallback_for_durable_doc(settings, tmp_path):
+    """A failed durable document RAW (gov.np / own storage) does NOT trigger a
+    PERMALINK fallback — only one download attempt, then error."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "d2",
+        "title": "Gov doc",
+        "source_type": "COURT_ORDER",
+        "urls": [
+            {"link": "https://ciaa.gov.np/files/order.pdf", "role": "RAW"},
+            {"link": "https://web.archive.org/x", "role": "PERMALINK"},
+        ],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        side_effect=converter.jds_client.JdsError("HTTP 500"),
+    ) as dl:
+        res = converter.convert_source(src, overwrite=True)
+    assert res["status"] == "error"
+    assert dl.call_count == 1  # no archive retry for a durable doc
 
 
 def test_html_detected_by_magic_without_content_type(settings, tmp_path):
@@ -686,28 +749,27 @@ def _convert_with_body(src, body, *, content_type="application/pdf", ext=".pdf")
 
 
 def test_converted_markdown_is_passed_through_unmodified(settings, tmp_path):
-    """MarkItDown already emits clean markdown; convert_source must add only the
-    frontmatter and leave the body verbatim (no re-escaping of * or _)."""
+    """MarkItDown already emits clean markdown; convert_source returns the body
+    verbatim (no frontmatter, no re-escaping of * or _)."""
     settings.SOURCE_MARKDOWN_DIR = tmp_path
     src = {"source_id": "s1", "title": "Verdict", "url": ["http://x/a.pdf"]}
     body = "# शीर्षक\n\n- **बुँदा** and *italic*\n\n[link](http://x)"
     md = _convert_with_body(src, body)["markdown"]
-    assert "\\*" not in md
-    # The body appears verbatim after the frontmatter block.
-    assert md.split("---\n", 2)[-1].strip().endswith(body)
+    assert md == body  # verbatim, no frontmatter wrapper
 
 
 def test_frontmatter_has_processed_at_and_source_metadata(settings, tmp_path):
-    settings.SOURCE_MARKDOWN_DIR = tmp_path
-    src = {
-        "source_id": "src:123",
-        "title": "My: Title",  # colon — must be safely quoted
-        "source_type": "MEDIA_NEWS",
-        "url": ["http://x/a.pdf"],
-    }
-    md = _convert_with_body(src, "body", content_type="application/pdf", ext=".pdf")[
-        "markdown"
-    ]
+    # Frontmatter is built at the attach boundary by _with_frontmatter.
+    md = converter._with_frontmatter(
+        "body",
+        {
+            "source_id": "src:123",
+            "title": "My: Title",  # colon — must be safely quoted
+            "source_type": "MEDIA_NEWS",
+        },
+        source_url="http://x/a.pdf",
+        source_role="RAW",
+    )
     assert md.startswith("---\n")
     assert "processed_at:" in md
     assert 'source_id: "src:123"' in md

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -443,6 +443,38 @@ def test_dry_run_does_not_attach():
     attach.assert_not_called()
 
 
+def test_per_source_errors_and_skips_are_surfaced():
+    """Errored/skipped sources are logged with their reason, not just counted."""
+    import io
+
+    case = _case_with_source()
+    converted = [
+        {
+            "source_id": "s-err",
+            "conversion_status": "error",
+            "conversion_note": "dead url",
+        },
+        {
+            "source_id": "s-skip",
+            "conversion_status": "skipped",
+            "conversion_note": "Source has no convertible url",
+        },
+        {"source_id": "s-ok", "conversion_status": "converted"},
+    ]
+    out, err = io.StringIO(), io.StringIO()
+    with patch.object(
+        jds_client_in_cmd(), "iter_paginated", return_value=[{"slug": "c1"}]
+    ), patch.object(jds_client_in_cmd(), "get_case", return_value=case), patch.object(
+        converter,
+        "convert_case_to_attach_candidates",
+        return_value=(converted, []),
+    ):
+        call_command("reprocess_source_markdown", "--dry-run", stdout=out, stderr=err)
+    err_text, out_text = err.getvalue(), out.getvalue()
+    assert "s-err" in err_text and "dead url" in err_text
+    assert "s-skip" in out_text and "no convertible url" in out_text
+
+
 def test_live_run_attaches_via_client(settings):
     settings.CASEWORK_POLLER_TOKEN = "tok"
     case = _case_with_source()

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -401,6 +401,47 @@ def test_source_page_falls_back_to_markitdown_when_extraction_empty(settings, tm
     assert res["markdown"].rstrip().endswith("fallback body")
 
 
+# ── Mislabeled-file detection (magic bytes) ──────────────────
+
+
+def test_ext_from_magic_detects_office_containers():
+    assert converter._ext_from_magic(b"PK\x03\x04rest") == ".docx"  # OOXML/ZIP
+    assert converter._ext_from_magic(b"\xd0\xcf\x11\xe0rest") == ".doc"  # OLE2
+    assert converter._ext_from_magic(b"%PDF-1.7") is None  # not disambiguated
+    assert converter._ext_from_magic(b"") is None
+    assert converter._ext_from_magic(b"<html>") is None
+
+
+def test_docx_mislabeled_as_doc_is_routed_by_magic(settings, tmp_path):
+    """A .docx saved with a .doc name (ZIP magic) must be converted as .docx,
+    not handed to the legacy .doc path that would reject it."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "d1",
+        "title": "Mislabeled",
+        "urls": [{"link": "http://x/file.doc", "role": "RAW"}],
+    }
+    captured = {}
+
+    def _fake_convert(path):
+        captured["suffix"] = path[-5:]
+        return MagicMock(text_content="docx body")
+
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        # ZIP magic but a .doc url
+        return_value=(b"PK\x03\x04 zipbytes...", "application/msword"),
+    ), patch.object(converter, "_markitdown") as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.side_effect = _fake_convert
+        res = converter.convert_source(src, overwrite=True)
+    assert res["status"] == "converted"
+    assert "(.docx)" in res["note"]  # routed as docx, not .doc
+    assert captured["suffix"] == ".docx"  # temp file given the right suffix
+
+
 # ── Frontmatter ──────────────────────────────────────────────
 
 

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -123,7 +123,11 @@ def test_convert_source_overwrite_bypasses_short_circuit(settings, tmp_path):
     ):
         md.return_value.convert.return_value = MagicMock(text_content="new md")
         res = converter.convert_source(src, overwrite=True)
-    assert res["status"] == "converted" and res["markdown"] == "new md"
+    # Output is frontmatter-wrapped; the converted body must be present and the
+    # short-circuit bypassed (we re-converted "new md", not re-served "old").
+    assert res["status"] == "converted"
+    assert res["markdown"].startswith("---\n") and "processed_at:" in res["markdown"]
+    assert res["markdown"].rstrip().endswith("new md")
 
 
 def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
@@ -149,14 +153,78 @@ def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
     ):
         md.return_value.convert.return_value = MagicMock(text_content="fresh")
         res = converter.convert_source(src, overwrite=True)
-    assert res["markdown"] == "fresh"
-    # And the fresh result is written back to the cache.
+    assert res["markdown"].rstrip().endswith("fresh")
+    # The cache holds the bare, frontmatter-free body (timestamp is stamped fresh
+    # on each emit, not cached).
     assert cache_path.read_text(encoding="utf-8") == "fresh"
 
-    # Without overwrite, the cache is served as-is.
+    # Without overwrite, the cached body is re-served (no re-download) and
+    # re-wrapped with fresh frontmatter.
     with patch.object(converter.jds_client, "download_source_file") as dl:
         res2 = converter.convert_source(src)
-    assert res2["markdown"] == "fresh" and dl.call_count == 0
+    assert res2["markdown"].rstrip().endswith("fresh") and dl.call_count == 0
+    assert "processed_at:" in res2["markdown"]
+
+
+# ── Frontmatter ──────────────────────────────────────────────
+
+
+def _convert_with_body(src, body, *, content_type="application/pdf", ext=".pdf"):
+    """Run convert_source for `src`, mocking the download + MarkItDown output."""
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"raw", content_type),
+    ), patch.object(converter, "_ext_from_url", return_value=ext), patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content=body)
+        return converter.convert_source(src, overwrite=True)
+
+
+def test_converted_markdown_is_passed_through_unmodified(settings, tmp_path):
+    """MarkItDown already emits clean markdown; convert_source must add only the
+    frontmatter and leave the body verbatim (no re-escaping of * or _)."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {"source_id": "s1", "title": "Verdict", "url": ["http://x/a.pdf"]}
+    body = "# शीर्षक\n\n- **बुँदा** and *italic*\n\n[link](http://x)"
+    md = _convert_with_body(src, body)["markdown"]
+    assert "\\*" not in md
+    # The body appears verbatim after the frontmatter block.
+    assert md.split("---\n", 2)[-1].strip().endswith(body)
+
+
+def test_frontmatter_has_processed_at_and_source_metadata(settings, tmp_path):
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "src:123",
+        "title": "My: Title",  # colon — must be safely quoted
+        "source_type": "MEDIA_NEWS",
+        "url": ["http://x/a.pdf"],
+    }
+    md = _convert_with_body(src, "body", content_type="application/pdf", ext=".pdf")[
+        "markdown"
+    ]
+    assert md.startswith("---\n")
+    assert "processed_at:" in md
+    assert 'source_id: "src:123"' in md
+    assert 'title: "My: Title"' in md
+    assert 'source_type: "MEDIA_NEWS"' in md
+    assert 'source_url: "http://x/a.pdf"' in md
+
+
+def test_with_frontmatter_does_not_stack_or_emit_for_empty():
+    # Empty body stays empty (so it is not treated as an attachable candidate).
+    assert converter._with_frontmatter("", {"source_id": "s"}) == ""
+    assert converter._with_frontmatter("  \n\n", {"source_id": "s"}) == ""
+    # Pre-existing frontmatter is stripped before re-adding (no stacking).
+    pre = '---\nprocessed_at: "old"\nsource_id: "s"\n---\n\nReal body'
+    out = converter._with_frontmatter(pre, {"source_id": "s9"})
+    assert out.count("processed_at:") == 1
+    assert '"old"' not in out
+    assert "Real body" in out
 
 
 # ── Command: dry-run does not write upstream ─────────────────

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -434,12 +434,131 @@ def test_docx_mislabeled_as_doc_is_routed_by_magic(settings, tmp_path):
         return_value=(b"PK\x03\x04 zipbytes...", "application/msword"),
     ), patch.object(converter, "_markitdown") as md, patch.object(
         converter, "_patch_likhit_ocr_dpi"
+    ), patch.object(
+        # Already-OOXML: LibreOffice step is unnecessary; force the direct path.
+        converter,
+        "_find_libreoffice",
+        return_value=None,
     ):
         md.return_value.convert.side_effect = _fake_convert
         res = converter.convert_source(src, overwrite=True)
     assert res["status"] == "converted"
     assert "(.docx)" in res["note"]  # routed as docx, not .doc
     assert captured["suffix"] == ".docx"  # temp file given the right suffix
+
+
+# ── LibreOffice legacy-Word conversion ───────────────────────
+
+
+def test_doc_uses_libreoffice_when_enabled(settings, tmp_path):
+    """A real .doc (OLE2 magic) is routed through LibreOffice -> .docx -> markitdown
+    when conversion is enabled and the binary is present."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    settings.LIBREOFFICE_DOC_CONVERSION = True
+    src = {
+        "source_id": "doc1",
+        "title": "Legacy doc",
+        "urls": [{"link": "http://x/order.doc", "role": "RAW"}],
+    }
+    captured = {}
+
+    def _fake_convert(path):
+        captured["suffix"] = path[-5:]
+        return MagicMock(text_content="lo body")
+
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"\xd0\xcf\x11\xe0 ole2bytes", "application/msword"),
+    ), patch.object(
+        converter, "_find_libreoffice", return_value="/usr/bin/soffice"
+    ), patch.object(
+        converter, "_libreoffice_to_docx", return_value=b"PK\x03\x04 docxbytes"
+    ) as lo, patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.side_effect = _fake_convert
+        res = converter.convert_source(src, overwrite=True)
+    lo.assert_called_once()
+    assert "LibreOffice" in res["note"]
+    assert captured["suffix"] == ".docx"  # markitdown saw the LO-produced docx
+
+
+def test_doc_falls_back_when_libreoffice_disabled(settings, tmp_path):
+    """With LIBREOFFICE_DOC_CONVERSION off, the .doc goes straight to the likhit
+    path (LibreOffice is never invoked)."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    settings.LIBREOFFICE_DOC_CONVERSION = False
+    src = {
+        "source_id": "doc2",
+        "title": "Legacy doc",
+        "urls": [{"link": "http://x/order.doc", "role": "RAW"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"\xd0\xcf\x11\xe0 ole2bytes", "application/msword"),
+    ), patch.object(converter, "_libreoffice_to_docx") as lo, patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="antiword body")
+        res = converter.convert_source(src, overwrite=True)
+    lo.assert_not_called()
+    assert "likhit (.doc)" in res["note"]
+
+
+def test_doc_falls_back_when_libreoffice_absent(settings, tmp_path):
+    """Enabled but binary not installed -> graceful fallback to the likhit path."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    settings.LIBREOFFICE_DOC_CONVERSION = True
+    src = {
+        "source_id": "doc3",
+        "title": "Legacy doc",
+        "urls": [{"link": "http://x/order.doc", "role": "RAW"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"\xd0\xcf\x11\xe0 ole2bytes", "application/msword"),
+    ), patch.object(converter, "_find_libreoffice", return_value=None), patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="antiword body")
+        res = converter.convert_source(src, overwrite=True)
+    assert "likhit (.doc)" in res["note"]
+
+
+def test_doc_falls_back_when_libreoffice_conversion_fails(settings, tmp_path):
+    """If LibreOffice runs but returns no docx, fall back to the likhit path."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    settings.LIBREOFFICE_DOC_CONVERSION = True
+    src = {
+        "source_id": "doc4",
+        "title": "Legacy doc",
+        "urls": [{"link": "http://x/order.doc", "role": "RAW"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"\xd0\xcf\x11\xe0 ole2bytes", "application/msword"),
+    ), patch.object(
+        converter, "_find_libreoffice", return_value="/usr/bin/soffice"
+    ), patch.object(
+        converter, "_libreoffice_to_docx", return_value=None  # conversion failed
+    ), patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="antiword body")
+        res = converter.convert_source(src, overwrite=True)
+    assert "likhit (.doc)" in res["note"]
 
 
 # ── Frontmatter ──────────────────────────────────────────────

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -166,6 +166,134 @@ def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
     assert "processed_at:" in res2["markdown"]
 
 
+# ── Role-aware link selection ────────────────────────────────
+
+
+def _pick(urls=None, url=None):
+    src = {}
+    if urls is not None:
+        src["urls"] = urls
+    if url is not None:
+        src["url"] = url
+    return converter._pick_source_link(src)
+
+
+def test_pick_raw_when_only_raw():
+    assert _pick([{"link": "http://x/a.pdf", "role": "RAW"}]) == (
+        "http://x/a.pdf",
+        "RAW",
+    )
+
+
+def test_pick_prefers_alternate_when_better_format():
+    # ALTERNATE .docx beats RAW .pdf (docx ranks higher).
+    assert _pick(
+        [
+            {"link": "http://x/a.pdf", "role": "RAW"},
+            {"link": "http://x/a.docx", "role": "ALTERNATE"},
+        ]
+    ) == ("http://x/a.docx", "ALTERNATE")
+
+
+def test_pick_keeps_raw_when_alternate_not_better():
+    # RAW .docx stays even though an ALTERNATE .pdf exists (pdf ranks lower).
+    assert _pick(
+        [
+            {"link": "http://x/a.docx", "role": "RAW"},
+            {"link": "http://x/a.pdf", "role": "ALTERNATE"},
+        ]
+    ) == ("http://x/a.docx", "RAW")
+    # Equal rank -> keep RAW.
+    assert _pick(
+        [
+            {"link": "http://x/raw.pdf", "role": "RAW"},
+            {"link": "http://x/alt.pdf", "role": "ALTERNATE"},
+        ]
+    ) == ("http://x/raw.pdf", "RAW")
+
+
+def test_pick_source_page_only_as_fallback():
+    # RAW present -> SOURCE_PAGE ignored.
+    assert _pick(
+        [
+            {"link": "http://x/page", "role": "SOURCE_PAGE"},
+            {"link": "http://x/a.pdf", "role": "RAW"},
+        ]
+    ) == ("http://x/a.pdf", "RAW")
+    # Only SOURCE_PAGE -> use it.
+    assert _pick([{"link": "http://x/page", "role": "SOURCE_PAGE"}]) == (
+        "http://x/page",
+        "SOURCE_PAGE",
+    )
+
+
+def test_pick_skips_markdown_and_permalink():
+    assert _pick(
+        [
+            {"link": "http://x/a.md", "role": "MARKDOWN"},
+            {"link": "http://x/p", "role": "PERMALINK"},
+        ]
+    ) == (None, None)
+
+
+def test_pick_falls_back_to_legacy_url_strings():
+    assert _pick(url=["http://x/legacy.pdf"]) == ("http://x/legacy.pdf", "RAW")
+
+
+# ── HTML main-content extraction (chrome removal) ────────────
+
+
+def test_source_page_uses_html_extraction(settings, tmp_path):
+    """A SOURCE_PAGE (HTML) link is run through main-content extraction, not the
+    plain MarkItDown PDF/doc path."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "p1",
+        "title": "Press release",
+        "urls": [{"link": "http://x/page", "role": "SOURCE_PAGE"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(
+            b"<html><body><nav>MENU</nav><article>Real body</article></body></html>",
+            "text/html",
+        ),
+    ), patch.object(
+        converter, "_html_to_markdown", return_value="Real body"
+    ) as h2m, patch.object(
+        converter, "_markitdown"
+    ) as md:
+        res = converter.convert_source(src, overwrite=True)
+    h2m.assert_called_once()
+    md.assert_not_called()  # HTML path used; MarkItDown not invoked
+    assert "trafilatura" in res["note"]
+    assert res["markdown"].rstrip().endswith("Real body")
+
+
+def test_source_page_falls_back_to_markitdown_when_extraction_empty(settings, tmp_path):
+    """If main-content extraction finds nothing, fall back to MarkItDown."""
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {
+        "source_id": "p2",
+        "title": "Empty page",
+        "urls": [{"link": "http://x/page.html", "role": "SOURCE_PAGE"}],
+    }
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"<html></html>", "text/html"),
+    ), patch.object(converter, "_html_to_markdown", return_value=""), patch.object(
+        converter, "_markitdown"
+    ) as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="fallback body")
+        res = converter.convert_source(src, overwrite=True)
+    md.assert_called_once()
+    assert res["markdown"].rstrip().endswith("fallback body")
+
+
 # ── Frontmatter ──────────────────────────────────────────────
 
 

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -307,6 +307,46 @@ def test_pick_falls_back_to_legacy_url_strings():
     assert _pick(url=["http://x/legacy.pdf"]) == ("http://x/legacy.pdf", "RAW")
 
 
+# ── Internal R2 endpoint → public host normalization ─────────
+
+_R2_BAD = (
+    "https://4c96557d73194d4f245ba23bd6063ad5.r2.cloudflarestorage.com/"
+    "jawafdehi/case_uploads/9121ea874182ef01e7eba0409168b8f60ae60c2881946c1b131d4054bb920c1c.pdf"
+)
+_R2_PUBLIC = (
+    "https://s3.jawafdehi.org/case_uploads/"
+    "9121ea874182ef01e7eba0409168b8f60ae60c2881946c1b131d4054bb920c1c.pdf"
+)
+
+
+def test_normalize_media_url_rewrites_internal_r2_endpoint():
+    assert converter._normalize_media_url(_R2_BAD) == _R2_PUBLIC
+
+
+def test_normalize_media_url_leaves_other_urls_untouched():
+    assert converter._normalize_media_url(_R2_PUBLIC) == _R2_PUBLIC
+    assert (
+        converter._normalize_media_url("https://lawcommission.gov.np/content/13421/")
+        == "https://lawcommission.gov.np/content/13421/"
+    )
+    assert converter._normalize_media_url(None) is None
+    assert converter._normalize_media_url("") == ""
+
+
+def test_pick_normalizes_internal_r2_raw_link():
+    # The real prod data shape: a broken internal-R2 RAW link listed first,
+    # with the public sibling second. The picker must return a fetchable url.
+    url, role = _pick(
+        [
+            {"link": _R2_BAD, "role": "RAW"},
+            {"link": _R2_PUBLIC, "role": "RAW"},
+        ]
+    )
+    assert url == _R2_PUBLIC and role == "RAW"
+    # Even if the internal-R2 link is the ONLY RAW link, it is normalized.
+    assert _pick([{"link": _R2_BAD, "role": "RAW"}]) == (_R2_PUBLIC, "RAW")
+
+
 # ── HTML main-content extraction (chrome removal) ────────────
 
 

--- a/tests/commands/test_reprocess_source_markdown.py
+++ b/tests/commands/test_reprocess_source_markdown.py
@@ -1,0 +1,250 @@
+"""Tests for the reprocess_source_markdown command + shared conversion core."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command, load_command_class
+
+from review import converter
+from review.upstream_client import UpstreamClient, UpstreamError
+
+
+@pytest.fixture(autouse=True)
+def _stub_markitdown_if_missing(monkeypatch):
+    if "markitdown" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "markitdown", MagicMock())
+
+
+# ── Flag registration ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "flag", ["--slug", "--limit", "--overwrite", "--dry-run", "--sleep"]
+)
+def test_cli_flags_registered(flag):
+    cmd = load_command_class("review", "reprocess_source_markdown")
+    parser = cmd.create_parser("manage.py", "reprocess_source_markdown")
+    for action in parser._actions:
+        if flag in action.option_strings:
+            return
+    pytest.fail(f"Flag {flag} not found in command arguments")
+
+
+# ── Shared converter: convert_case_to_attach_candidates ──────
+
+
+def _case_with_source(**source_extra):
+    """A minimal case dict whose single evidence source carries source_extra."""
+    src = {"title": "S1", "source_type": "PDF", "url": ["http://x/a.pdf"]}
+    src.update(source_extra)
+    return {"evidence": [{"source_id": 11, "description": "d", "source": src}]}
+
+
+def test_candidates_default_includes_freshly_converted():
+    case = _case_with_source()
+    with patch.object(
+        converter,
+        "convert_all",
+        return_value=[
+            {"source_id": 11, "markdown": "md", "conversion_status": "converted"}
+        ],
+    ):
+        converted, candidates = converter.convert_case_to_attach_candidates(case)
+    assert converted and candidates == [{"source_id": 11, "markdown": "md"}]
+
+
+def test_candidates_default_excludes_source_with_markdown_link():
+    """A source that already has a MARKDOWN link is not a candidate by default."""
+    case = _case_with_source()
+    converted_src = {
+        "source_id": 11,
+        "markdown": "md",
+        "conversion_status": "converted",
+        "markdown_url": "http://x/11.md",
+    }
+    with patch.object(converter, "convert_all", return_value=[converted_src]):
+        _, candidates = converter.convert_case_to_attach_candidates(case)
+    assert candidates == []
+
+
+def test_candidates_overwrite_includes_source_with_markdown_link():
+    """Load-bearing: --overwrite re-emits a source that already has markdown."""
+    case = _case_with_source()
+    converted_src = {
+        "source_id": 11,
+        "markdown": "fresh",
+        "conversion_status": "attached",
+        "markdown_url": "http://x/11.md",
+    }
+    with patch.object(converter, "convert_all", return_value=[converted_src]) as ca:
+        _, candidates = converter.convert_case_to_attach_candidates(
+            case, overwrite=True
+        )
+    assert candidates == [{"source_id": 11, "markdown": "fresh"}]
+    # overwrite is threaded into convert_all.
+    assert ca.call_args.kwargs.get("overwrite") is True
+
+
+def test_candidates_skips_empty_markdown_and_missing_sid():
+    case = _case_with_source()
+    with patch.object(
+        converter,
+        "convert_all",
+        return_value=[
+            {"source_id": 11, "markdown": "   ", "conversion_status": "converted"},
+            {"source_id": None, "markdown": "x", "conversion_status": "converted"},
+        ],
+    ):
+        _, candidates = converter.convert_case_to_attach_candidates(case)
+    assert candidates == []
+
+
+# ── convert_source overwrite short-circuit ───────────────────
+
+
+def test_convert_source_attached_short_circuit():
+    res = converter.convert_source({"markdown": "x"})
+    assert res["status"] == "attached" and res["markdown"] == "x"
+
+
+def test_convert_source_overwrite_bypasses_short_circuit(settings, tmp_path):
+    """With overwrite, a source carrying markdown still goes through conversion."""
+    # Redirect the on-disk markdown cache to a tmp dir so the test never writes
+    # into the repo's review_source_markdown/.
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    src = {"markdown": "old", "url": ["http://x/a.pdf"]}
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"pdf", "application/pdf"),
+    ), patch.object(converter, "_markitdown") as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="new md")
+        res = converter.convert_source(src, overwrite=True)
+    assert res["status"] == "converted" and res["markdown"] == "new md"
+
+
+def test_convert_source_overwrite_bypasses_disk_cache(settings, tmp_path):
+    """overwrite must re-convert even when a stale cache file exists for the url.
+
+    Regression guard: the cache is keyed by url (not converter version), so
+    refreshing markdown after a converter change must NOT re-serve the cache.
+    """
+    settings.SOURCE_MARKDOWN_DIR = tmp_path
+    url = "http://x/a.pdf"
+    import hashlib
+
+    cache_path = tmp_path / f"{hashlib.sha256(url.encode()).hexdigest()[:24]}.md"
+    cache_path.write_text("stale cached", encoding="utf-8")
+
+    src = {"url": [url]}
+    with patch.object(
+        converter.jds_client,
+        "download_source_file",
+        return_value=(b"pdf", "application/pdf"),
+    ), patch.object(converter, "_markitdown") as md, patch.object(
+        converter, "_patch_likhit_ocr_dpi"
+    ):
+        md.return_value.convert.return_value = MagicMock(text_content="fresh")
+        res = converter.convert_source(src, overwrite=True)
+    assert res["markdown"] == "fresh"
+    # And the fresh result is written back to the cache.
+    assert cache_path.read_text(encoding="utf-8") == "fresh"
+
+    # Without overwrite, the cache is served as-is.
+    with patch.object(converter.jds_client, "download_source_file") as dl:
+        res2 = converter.convert_source(src)
+    assert res2["markdown"] == "fresh" and dl.call_count == 0
+
+
+# ── Command: dry-run does not write upstream ─────────────────
+
+
+def test_dry_run_does_not_attach():
+    case = _case_with_source()
+    with patch.object(
+        jds_client_in_cmd(), "iter_paginated", return_value=[{"slug": "c1"}]
+    ), patch.object(jds_client_in_cmd(), "get_case", return_value=case), patch.object(
+        converter,
+        "convert_case_to_attach_candidates",
+        return_value=(
+            [{"conversion_status": "converted"}],
+            [{"source_id": 11, "markdown": "md"}],
+        ),
+    ), patch.object(
+        UpstreamClient, "attach_markdown"
+    ) as attach:
+        call_command("reprocess_source_markdown", "--dry-run")
+    attach.assert_not_called()
+
+
+def test_live_run_attaches_via_client(settings):
+    settings.CASEWORK_POLLER_TOKEN = "tok"
+    case = _case_with_source()
+    with patch.object(
+        jds_client_in_cmd(), "iter_paginated", return_value=[{"slug": "c1"}]
+    ), patch.object(jds_client_in_cmd(), "get_case", return_value=case), patch.object(
+        converter,
+        "convert_case_to_attach_candidates",
+        return_value=(
+            [{"conversion_status": "converted"}],
+            [{"source_id": 11, "markdown": "md"}],
+        ),
+    ), patch.object(
+        UpstreamClient,
+        "attach_markdown",
+        return_value={"attached": 1, "skipped": 0, "failed": 0},
+    ) as attach:
+        call_command("reprocess_source_markdown")
+    attach.assert_called_once()
+    items, kwargs = attach.call_args.args[0], attach.call_args.kwargs
+    assert items == [{"source_id": 11, "markdown": "md"}]
+    assert kwargs.get("overwrite") is False
+
+
+def test_explicit_slugs_skip_listing(settings):
+    settings.CASEWORK_POLLER_TOKEN = "tok"
+    case = _case_with_source()
+    with patch.object(jds_client_in_cmd(), "iter_paginated") as it, patch.object(
+        jds_client_in_cmd(), "get_case", return_value=case
+    ) as gc, patch.object(
+        converter, "convert_case_to_attach_candidates", return_value=([], [])
+    ), patch.object(
+        UpstreamClient,
+        "attach_markdown",
+        return_value={"attached": 0, "skipped": 0, "failed": 0},
+    ):
+        call_command("reprocess_source_markdown", "--slug", "a", "--slug", "b")
+    it.assert_not_called()
+    assert gc.call_count == 2
+
+
+# ── UpstreamClient ───────────────────────────────────────────
+
+
+def test_upstream_client_requires_token(settings):
+    settings.CASEWORK_POLLER_TOKEN = ""
+    with pytest.raises(UpstreamError):
+        UpstreamClient()
+
+
+def test_upstream_client_attach_markdown_summary():
+    client = UpstreamClient(token="tok")
+    created = MagicMock(status_code=200)
+    created.json.return_value = {"created": True}
+    skipped = MagicMock(status_code=200)
+    skipped.json.return_value = {"created": False}
+    with patch.object(client, "post", side_effect=[created, skipped]):
+        summary = client.attach_markdown(
+            [{"source_id": 1, "markdown": "a"}, {"source_id": 2, "markdown": "b"}]
+        )
+    assert summary == {"attached": 1, "skipped": 1, "failed": 0}
+
+
+def jds_client_in_cmd():
+    """The jds_client module as imported by the command (one shared instance)."""
+    from review import jds_client
+
+    return jds_client


### PR DESCRIPTION
…mmand

Extract the poller's likhit-conversion + markdown-upload core into reusable units and expose it as a management command for reprocessing all document sources of published cases.

- review/converter.py: add convert_case_to_attach_candidates(case, overwrite) — the single home for "convert a case's sources and pick which markdown to store upstream". Move _source_has_markdown_link here from runner. Thread an overwrite flag through convert_source/convert_all that bypasses BOTH the "already attached" short-circuit AND the url-keyed disk cache, so refreshing markdown after a converter change (e.g. new likhit OCR DPI) actually re-converts instead of re-serving stale cache.
- review/upstream_client.py: new UpstreamClient wrapping the token-auth HTTP plumbing (post/attach_markdown) the poller owned privately, with on_log/on_err callbacks so any caller can reuse it. attach_markdown gains an overwrite kwarg and returns {attached, skipped, failed}.
- review/runner.py + review_poller.py: refactored onto the shared core, behavior-preserving (default non-overwrite path is byte-identical).
- review/management/commands/reprocess_source_markdown.py: new command. Runs as a remote HTTP client like the poller — reads PUBLISHED cases from the public API, writes markdown to the casework API. Flags: --slug (repeatable), --limit, --overwrite, --dry-run, --sleep. Idempotent + resumable (skips sources that already have a MARKDOWN url) with per-case error isolation and a summary.
- tests: command flags, dry-run-skips-write, the load-bearing overwrite candidate selection, cache-bypass regression guard, and UpstreamClient.

Verified end-to-end against an isolated dev server (dry-run -> live -> idempotent re-run -> overwrite-refreshes-content); 17 new + 119 existing command tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reprocess published cases to (re)convert and attach Markdown with optional overwrite and dry-run modes.
  * New CLI options to target specific cases, limit/paginate, and control pacing/throttling.

* **Improvements**
  * Improved HTML extraction (optional new extractor with fallback) and smarter source/link selection for higher-quality conversions.
  * Centralized upstream submission and poller integration; attach operations report attach/skip/fail summaries.
  * Retry/backoff added for case reads; optional LibreOffice document-conversion toggle.

* **Tests**
  * Expanded coverage for conversion, reprocessing, retry/backoff, and upstream attach behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->