### PR TITLE
[JAWA-2353] Enforce explicit link role on DocumentSource URLs

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -14,6 +14,8 @@ from rest_framework.authtoken.models import Token
 from cases.widgets import ToastUIEditorWidget
 
 from .models import (
+    ALLOWED_UPLOAD_EXTENSIONS,
+    MAX_UPLOAD_FILE_SIZE,
     Case,
     CaseEntityRelationship,
     CaseState,
@@ -797,7 +799,13 @@ class DocumentSourceAdminForm(forms.ModelForm):
 
 
 class DocumentSourceUploadInline(admin.TabularInline):
-    """Inline form for managing multiple uploaded files on a source."""
+    """Inline form for managing multiple uploaded files on a source.
+
+    Uploaded files are always stored as RAW source links (the link-type
+    selector on the External URLs tab does not apply to uploads). Allowed
+    types and the size cap are surfaced as help text and an ``accept`` filter
+    so the constraint is clear before submit, not only on a validation error.
+    """
 
     model = DocumentSourceUpload
     extra = 1
@@ -805,6 +813,20 @@ class DocumentSourceUploadInline(admin.TabularInline):
     readonly_fields = ("filename", "content_type", "file_size", "created_at")
     verbose_name = "Uploaded file"
     verbose_name_plural = "Uploaded files"
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if db_field.name == "file" and formfield is not None:
+            max_mb = int(MAX_UPLOAD_FILE_SIZE / (1024 * 1024))
+            allowed = ", ".join(ALLOWED_UPLOAD_EXTENSIONS)
+            formfield.help_text = (
+                f"Stored as a RAW source document. Allowed types: {allowed}. "
+                f"Max size: {max_mb} MB."
+            )
+            formfield.widget.attrs["accept"] = ",".join(
+                f".{ext}" for ext in ALLOWED_UPLOAD_EXTENSIONS
+            )
+        return formfield
 
 
 @admin.register(DocumentSource)

--- a/cases/management/commands/map_press_release_files.py
+++ b/cases/management/commands/map_press_release_files.py
@@ -535,7 +535,7 @@ class Command(BaseCommand):
                 # Build complete URL list from existing link strings
                 # (existing.url has dicts, url_links gives plain strings for dedup)
                 existing_links = existing.url_links
-                url_list = [{"link": link, "role": None} for link in existing_links]
+                url_list = [{"link": link, "role": "RAW"} for link in existing_links]
 
                 # Encode and add press release web URL first (ensure it's at the beginning)
                 if press_release_url and str(press_release_url).strip():
@@ -561,7 +561,7 @@ class Command(BaseCommand):
                             break
                     if existing_idx is not None:
                         url_list.pop(existing_idx)
-                    url_list.insert(0, {"link": encoded_url, "role": None})
+                    url_list.insert(0, {"link": encoded_url, "role": "RAW"})
 
                 # Add all file URLs (skip duplicates)
                 for file_url in file_urls:
@@ -585,7 +585,7 @@ class Command(BaseCommand):
                             isinstance(u, dict) and u.get("link") == encoded_url
                             for u in url_list
                         ):
-                            url_list.append({"link": encoded_url, "role": None})
+                            url_list.append({"link": encoded_url, "role": "RAW"})
 
                 # Update existing source with complete URL list
                 existing.url = url_list
@@ -641,7 +641,7 @@ class Command(BaseCommand):
                     encoded_fragment,
                 )
             )
-            url_list.append(encoded_url)
+            url_list.append({"link": encoded_url, "role": "RAW"})
 
         # Add all file URLs
         for file_url in file_urls:
@@ -660,7 +660,7 @@ class Command(BaseCommand):
                         encoded_fragment,
                     )
                 )
-                url_list.append(encoded_url)
+                url_list.append({"link": encoded_url, "role": "RAW"})
 
         if not url_list:
             logger.error(f"No valid URLs for press release {press_release_url}")

--- a/cases/management/commands/seed_allegations.py
+++ b/cases/management/commands/seed_allegations.py
@@ -73,7 +73,9 @@ class Command(BaseCommand):
             source_id="source:20180310:ciaa001",
             title="CIAA Investigation Report - Lalita Niwas Land Grab",
             description="Comprehensive investigation report by Commission for Investigation of Abuse of Authority documenting forged land ownership certificates and illegal transfers.",
-            url=["https://example.com/ciaa-lalita-niwas-report"],
+            url=[
+                {"link": "https://example.com/ciaa-lalita-niwas-report", "role": "RAW"}
+            ],
         )
         ciaa_report.related_entities.set(
             [
@@ -86,7 +88,7 @@ class Command(BaseCommand):
             source_id="source:20180310:court001",
             title="Supreme Court and District Court Case Files - Lalita Niwas",
             description="Official court documents including case filings, hearings, and rulings related to the Lalita Niwas land grab case.",
-            url=["https://example.com/court-lalita-niwas"],
+            url=[{"link": "https://example.com/court-lalita-niwas", "role": "RAW"}],
         )
         court_files.related_entities.set(
             [
@@ -98,7 +100,7 @@ class Command(BaseCommand):
             source_id="source:20230520:coop001",
             title="Police Complaint - Cooperative Fraud",
             description="Official police complaint filed by victims of Suryadarshan Cooperative alleging embezzlement of funds.",
-            url=["https://example.com/cooperative-complaint"],
+            url=[{"link": "https://example.com/cooperative-complaint", "role": "RAW"}],
         )
         coop_complaint.related_entities.set(
             [
@@ -121,7 +123,7 @@ class Command(BaseCommand):
             source_id="source:20200101:audit001",
             title="Government Audit Report - Melamchi Project Cost Escalations",
             description="Official audit reports documenting cost overruns and delays in the Melamchi Water Supply Project.",
-            url=["https://example.com/melamchi-audit"],
+            url=[{"link": "https://example.com/melamchi-audit", "role": "RAW"}],
         )
         audit_report.related_entities.set(
             [
@@ -141,7 +143,7 @@ class Command(BaseCommand):
             source_id="source:20210715:campaign001",
             title="KP Oli Election Campaign Speeches 2017",
             description="Video recordings of election campaign speeches where promises were made regarding prosperity, railways, and employment.",
-            url=["https://example.com/oli-campaign-2017"],
+            url=[{"link": "https://example.com/oli-campaign-2017", "role": "RAW"}],
         )
         campaign_videos.related_entities.set(
             [

--- a/cases/migrations/0032_backfill_source_link_role_raw.py
+++ b/cases/migrations/0032_backfill_source_link_role_raw.py
@@ -1,0 +1,66 @@
+"""Backfill a default RAW role onto existing source-link entries.
+
+Migration 0025 converted plain string URLs to ``{link, role: None}`` dicts.
+Role is now mandatory (defaults to RAW), so any stored entry whose role is
+``None`` or missing is backfilled to ``RAW`` here. Without this, re-saving a
+legacy source would fail the new ``validate_url_list`` check.
+"""
+
+from django.db import migrations
+
+RAW = "RAW"
+
+
+def backfill_roles_to_raw(apps, schema_editor):
+    DocumentSource = apps.get_model("cases", "DocumentSource")
+    db_alias = schema_editor.connection.alias
+    to_update = []
+
+    for source in DocumentSource.objects.using(db_alias).only("id", "url").iterator():
+        url_list = source.url
+        if not isinstance(url_list, list):
+            continue
+
+        changed = False
+        converted = []
+        for item in url_list:
+            if isinstance(item, dict):
+                if item.get("role") is None:
+                    item = {**item, "role": RAW}
+                    changed = True
+                converted.append(item)
+            elif isinstance(item, str):
+                # Defensive: any leftover string entry becomes a RAW dict.
+                stripped = item.strip()
+                if stripped:
+                    converted.append({"link": stripped, "role": RAW})
+                    changed = True
+            else:
+                converted.append(item)
+
+        if changed:
+            source.url = converted
+            to_update.append(source)
+
+    if to_update:
+        DocumentSource.objects.using(db_alias).bulk_update(
+            to_update, ["url"], batch_size=500
+        )
+
+
+def noop_reverse(apps, schema_editor):
+    """Irreversible in practice — RAW is indistinguishable from a backfilled
+    default once applied, so reversing is a no-op rather than re-nulling roles.
+    """
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cases", "0031_make_source_type_required"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_roles_to_raw, noop_reverse, atomic=True),
+    ]

--- a/cases/models.py
+++ b/cases/models.py
@@ -32,13 +32,16 @@ class SourceLinkRole(enum.StrEnum):
 
 def validate_url_list(value):
     """
-    Validate that the url field contains a list of valid URLs.
+    Validate that the url field contains a list of source-link dicts.
 
-    Each item may be a plain URL string or a dict with ``link`` and ``role``
-    keys where ``role`` is a valid ``SourceLinkRole`` value.
+    Each item must be a dict with a non-blank ``link`` string and an explicit
+    ``role`` that is a valid ``SourceLinkRole`` value. Plain URL strings and a
+    missing/``None`` role are no longer accepted — ``DocumentSource.clean()``
+    normalizes legacy string entries and absent roles to ``RAW`` before this
+    validator runs, so a value reaching here without a role is a real error.
 
     Args:
-        value: The value to validate (should be a list of URL strings or dicts)
+        value: The value to validate (should be a list of source-link dicts)
 
     Raises:
         ValidationError: If value is not a list or contains invalid items
@@ -47,37 +50,31 @@ def validate_url_list(value):
         return
 
     if not isinstance(value, list):
-        raise ValidationError("url must be a list of URLs.")
+        raise ValidationError("url must be a list of source-link dicts.")
 
+    valid_roles = [r.value for r in SourceLinkRole]
     validator = URLValidator()
     for item in value:
-        if isinstance(item, str):
-            stripped = item.strip()
-            if not stripped:
-                raise ValidationError("URLs cannot be blank or whitespace-only.")
-            validator(stripped)
-        elif isinstance(item, dict):
-            link = item.get("link")
-            if not link or not isinstance(link, str) or not link.strip():
-                raise ValidationError(
-                    "Each URL dict must contain a non-blank 'link' string."
-                )
-            stripped_link = link.strip()
-            validator(stripped_link)
-            item["link"] = stripped_link
-
-            role = item.get("role")
-            if role is not None:
-                try:
-                    SourceLinkRole(role)
-                except ValueError:
-                    raise ValidationError(
-                        f"Invalid role '{role}'. Must be one of "
-                        f"{[r.value for r in SourceLinkRole]}."
-                    )
-        else:
+        if not isinstance(item, dict):
             raise ValidationError(
-                "Each URL must be a string or a dict with 'link' and 'role' keys."
+                "Each URL must be a dict with a 'link' and 'role' key; "
+                "plain URL strings are no longer accepted."
+            )
+        link = item.get("link")
+        if not link or not isinstance(link, str) or not link.strip():
+            raise ValidationError(
+                "Each URL dict must contain a non-blank 'link' string."
+            )
+        validator(link.strip())
+
+        role = item.get("role")
+        if role is None:
+            raise ValidationError(
+                f"Each URL dict must contain a 'role'. Must be one of {valid_roles}."
+            )
+        if role not in valid_roles:
+            raise ValidationError(
+                f"Invalid role '{role}'. Must be one of {valid_roles}."
             )
 
 
@@ -881,38 +878,68 @@ class DocumentSource(models.Model):
                     result.append(link)
         return result
 
+    @staticmethod
+    def normalize_url_list(url):
+        """Coerce a url value to the canonical list of {link, role} dicts.
+
+        role is mandatory; a missing/None role (legacy data, programmatic
+        callers) or a plain string URL (legacy/importer input) is coerced to
+        RAW so internal saves stay valid. Anything still invalid after this
+        (e.g. a blank link, or an unknown role) is left for validate_url_list
+        to reject. A bare string / None becomes a (possibly empty) list.
+        """
+        if isinstance(url, str):
+            stripped = url.strip()
+            url = [stripped] if stripped else []
+        elif url is None:
+            return []
+
+        if not isinstance(url, list):
+            return url
+
+        normalized = []
+        for item in url:
+            if isinstance(item, str):
+                stripped = item.strip()
+                if stripped:
+                    normalized.append(
+                        {"link": stripped, "role": SourceLinkRole.RAW.value}
+                    )
+            elif isinstance(item, dict):
+                link = item.get("link", "")
+                stripped = link.strip() if isinstance(link, str) else ""
+                if stripped:
+                    role = item.get("role")
+                    normalized.append(
+                        {
+                            "link": stripped,
+                            "role": (
+                                role if role is not None else SourceLinkRole.RAW.value
+                            ),
+                        }
+                    )
+            else:
+                normalized.append(item)
+        return normalized
+
     def clean(self):
         """
         Normalize and validate DocumentSource data.
 
         - Strips whitespace from title
         - Ensures title is not empty after stripping
-        - Normalizes URL list entries (strips whitespace)
+        - Normalizes URL list entries (strips whitespace, defaults role to RAW)
         """
         # Normalize title
         self.title = (self.title or "").strip()
         if not self.title:
             raise ValidationError({"title": "Title is required and cannot be empty"})
 
-        # Normalize URL list entries (strip whitespace, normalize str→dict)
-        if isinstance(self.url, list):
-            normalized = []
-            for item in self.url:
-                if isinstance(item, str):
-                    stripped = item.strip()
-                    if stripped:
-                        normalized.append({"link": stripped, "role": None})
-                elif isinstance(item, dict):
-                    link = item.get("link", "")
-                    stripped = link.strip() if isinstance(link, str) else ""
-                    if stripped:
-                        entry = {"link": stripped}
-                        role = item.get("role")
-                        entry["role"] = role if role is not None else None
-                        normalized.append(entry)
-                else:
-                    normalized.append(item)
-            self.url = normalized
+        # Normalize URL entries to the canonical {link, role} dict form. Note
+        # save() also normalizes BEFORE full_clean() so the field validator
+        # (validate_url_list, run in clean_fields()) sees normalized data; this
+        # call covers direct clean()/full_clean() callers and is idempotent.
+        self.url = self.normalize_url_list(self.url)
 
         # Enforce publication_date for media/news sources
         if self.source_type == SourceType.NEWS and not self.publication_date:
@@ -931,16 +958,13 @@ class DocumentSource(models.Model):
             timestamp = datetime.now().strftime("%Y%m%d")
             self.source_id = f"source:{timestamp}:{uuid.uuid4().hex[:8]}"
 
-        # Normalize url to a list before validation for backward compatibility
-        # Older call sites may still pass a single string or None
-        if isinstance(self.url, str):
-            url_str = self.url.strip()
-            self.url = [url_str] if url_str else []
-        elif self.url is None:
-            self.url = []
+        # Normalize url to canonical {link, role} dicts BEFORE full_clean().
+        # Django runs field validators (validate_url_list) in clean_fields(),
+        # which executes before clean() — so legacy strings / None roles must
+        # be coerced here, or the field validator would reject them first.
+        self.url = self.normalize_url_list(self.url)
 
-        # Run full model and field validation (includes validate_url_list)
-        # This calls clean() which normalizes data, then validates
+        # Run full model and field validation (includes validate_url_list).
         self.full_clean()
 
         super().save(*args, **kwargs)

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -310,50 +310,48 @@ class CaseDetailSerializer(CaseSerializer):
 
 
 class SourceLinkField(serializers.Field):
-    """Field that accepts a plain URL string or a ``{'link': str, 'role': str}`` dict."""
+    """Field that accepts a ``{'link': str, 'role': str}`` source-link dict.
+
+    Plain URL strings are no longer accepted — every link must be a dict with a
+    ``link`` key and an explicit ``role`` (``RAW``/``MARKDOWN``/``PERMALINK``).
+    File uploads are recorded as ``RAW`` automatically by the view; this field
+    is only used for caller-supplied external URLs, which must name their role.
+    """
 
     def to_internal_value(self, data):
         from django.core.exceptions import ValidationError as DjangoValidationError
         from django.core.validators import URLValidator
 
         validator = URLValidator()
+        valid_roles = [r.value for r in SourceLinkRole]
 
-        if isinstance(data, str):
-            stripped = data.strip()
-            try:
-                validator(stripped)
-            except DjangoValidationError:
-                raise serializers.ValidationError("Enter a valid URL.")
-            return stripped
+        if not isinstance(data, dict):
+            raise serializers.ValidationError(
+                "Must be a dict with 'link' and 'role' keys; "
+                "plain URL strings are no longer accepted."
+            )
 
-        if isinstance(data, dict):
-            link = data.get("link")
-            role = data.get("role")
-            if not link or not isinstance(link, str) or not link.strip():
-                raise serializers.ValidationError(
-                    "Dict must contain a 'link' key with a non-empty string value."
-                )
-            stripped_link = link.strip()
-            try:
-                validator(stripped_link)
-            except DjangoValidationError:
-                raise serializers.ValidationError("Enter a valid URL.")
+        link = data.get("link")
+        role = data.get("role")
+        if not link or not isinstance(link, str) or not link.strip():
+            raise serializers.ValidationError(
+                "Dict must contain a 'link' key with a non-empty string value."
+            )
+        stripped_link = link.strip()
+        try:
+            validator(stripped_link)
+        except DjangoValidationError:
+            raise serializers.ValidationError("Enter a valid URL.")
 
-            cleaned = {"link": stripped_link}
-            if role is not None:
-                try:
-                    SourceLinkRole(role)
-                    cleaned["role"] = role
-                except ValueError:
-                    raise serializers.ValidationError(
-                        f"Invalid role '{role}'. Must be one of "
-                        f"{[r.value for r in SourceLinkRole]}."
-                    )
-            return cleaned
-
-        raise serializers.ValidationError(
-            "Must be a URL string or a dict with 'link' key."
-        )
+        if role is None:
+            raise serializers.ValidationError(
+                f"A 'role' is required. Must be one of {valid_roles}."
+            )
+        if role not in valid_roles:
+            raise serializers.ValidationError(
+                f"Invalid role '{role}'. Must be one of {valid_roles}."
+            )
+        return {"link": stripped_link, "role": role}
 
     def to_representation(self, value):
         if isinstance(value, str):
@@ -384,8 +382,19 @@ class DocumentSourceSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(serializers.ListField(child=serializers.URLField()))
     def get_url(self, obj):
-        """Backward-compat: return only link strings (deprecated)."""
-        return [u["link"] for u in self.get_urls(obj)]
+        """Backward-compat: return only link strings (deprecated).
+
+        Deduplicated by link — the same link under two roles (e.g. RAW + the
+        MARKDOWN-converted view) collapses to a single string here.
+        """
+        seen = set()
+        links = []
+        for u in self.get_urls(obj):
+            link = u["link"]
+            if link not in seen:
+                seen.add(link)
+                links.append(link)
+        return links
 
     @extend_schema_field(
         inline_serializer(
@@ -425,9 +434,13 @@ class DocumentSourceSerializer(serializers.ModelSerializer):
 
         if obj.uploaded_file:
             try:
-                add_url(obj.uploaded_file.url, "PERMALINK")
-            except Exception:
-                pass
+                add_url(obj.uploaded_file.url, "RAW")
+            except (ValueError, AttributeError) as exc:
+                logger.warning(
+                    "Skipping uploaded_file URL for source %s: %s",
+                    obj.source_id,
+                    exc,
+                )
 
         uploaded_files = getattr(obj, "uploaded_files", None)
         if uploaded_files is not None:
@@ -438,9 +451,14 @@ class DocumentSourceSerializer(serializers.ModelSerializer):
             )
             for uploaded_file in uploads_iterable:
                 try:
-                    add_url(uploaded_file.file.url, "PERMALINK")
-                except Exception:
-                    pass
+                    add_url(uploaded_file.file.url, "RAW")
+                except (ValueError, AttributeError) as exc:
+                    logger.warning(
+                        "Skipping uploaded file %s URL for source %s: %s",
+                        getattr(uploaded_file, "pk", "?"),
+                        obj.source_id,
+                        exc,
+                    )
 
         return merged_urls
 

--- a/cases/services/case_importer.py
+++ b/cases/services/case_importer.py
@@ -97,28 +97,31 @@ class CaseImporter:
         # Guard against None values and handle both string and list URLs
         url_raw = source_data.get("url", "")
 
-        # Handle URL as string, list, or dict
+        # Handle URL as string, list, or dict. Normalize every entry to a
+        # canonical {link, role} dict — role defaults to RAW when the input is
+        # a bare string or omits it (only external URLs reach here).
+        from cases.models import SourceLinkRole
+
+        def _make_link(raw):
+            if isinstance(raw, str):
+                stripped = raw.strip()
+                return (
+                    {"link": stripped, "role": SourceLinkRole.RAW.value}
+                    if stripped
+                    else None
+                )
+            if isinstance(raw, dict):
+                link = raw.get("link") or raw.get("url")
+                if isinstance(link, str) and link.strip():
+                    role = raw.get("role") or SourceLinkRole.RAW.value
+                    return {"link": link.strip(), "role": role}
+            return None
+
         if isinstance(url_raw, list):
-            # Filter and normalize list entries — accept str or dict
-            url_list = []
-            for item in url_raw:
-                if isinstance(item, str):
-                    stripped = item.strip()
-                    if stripped:
-                        url_list.append(stripped)
-                elif isinstance(item, dict):
-                    link = item.get("link") or item.get("url")
-                    if isinstance(link, str):
-                        stripped = link.strip()
-                        if stripped:
-                            url_list.append(stripped)
-        elif isinstance(url_raw, str):
-            stripped = url_raw.strip()
-            url_list = [stripped] if stripped else []
-        elif isinstance(url_raw, dict):
-            link = url_raw.get("link") or url_raw.get("url")
-            stripped = link.strip() if isinstance(link, str) else ""
-            url_list = [stripped] if stripped else []
+            url_list = [entry for entry in (_make_link(i) for i in url_raw) if entry]
+        elif isinstance(url_raw, (str, dict)):
+            entry = _make_link(url_raw)
+            url_list = [entry] if entry else []
         else:
             url_list = []
 
@@ -142,16 +145,20 @@ class CaseImporter:
             # Accept both str and dict lookups for backward compat during transition.
             from django.db import connection
 
+            # Match on the link only (role-agnostic) so a reused source isn't
+            # duplicated just because its stored role differs.
+            candidate_links = [entry["link"] for entry in url_list]
+
             # Use PostgreSQL JSON containment if available, otherwise fall back to Python filtering
             if connection.vendor == "postgresql":
-                for url in url_list:
+                for link in candidate_links:
                     source = (
                         DocumentSource.objects.filter(
                             is_deleted=False,
                         )
                         .filter(
                             # Match dict entry with matching link
-                            url__contains=[{"link": url}]
+                            url__contains=[{"link": link}]
                         )
                         .only("source_id", "title")
                         .first()
@@ -163,7 +170,7 @@ class CaseImporter:
                         return source
             else:
                 # SQLite fallback: fetch all non-deleted sources and check URLs in Python
-                for url in url_list:
+                for link in candidate_links:
                     for source in DocumentSource.objects.filter(is_deleted=False).only(
                         "source_id", "title", "url"
                     ):
@@ -178,7 +185,7 @@ class CaseImporter:
                                         else None
                                     )
                                 )
-                                if stored_link == url:
+                                if stored_link == link:
                                     self.stats["sources_reused"] += 1
                                     self.log(f"  Reusing source: {title}")
                                     return source

--- a/cases/services/ciaa_draft_case_service.py
+++ b/cases/services/ciaa_draft_case_service.py
@@ -407,11 +407,12 @@ class CIAADraftCaseService:
                 logger.debug(f"Reusing source: {title}")
                 return source
 
-        # Create new source
+        # Create new source. url_list holds bare link strings (used for the
+        # dedup lookups above); store them as canonical RAW source-link dicts.
         publication_date = source_data.get("publication_date")
         source = DocumentSource.objects.create(
             title=title,
-            url=url_list,
+            url=[{"link": link, "role": "RAW"} for link in url_list],
             source_type=source_type,
             publication_date=publication_date,
         )

--- a/cases/static/cases/js/widgets.js
+++ b/cases/static/cases/js/widgets.js
@@ -191,14 +191,16 @@ window.MultiWidgetConfigs = {
         inputClass: 'url-input',
         rowClass: 'input-row',
         getValues: (container) => {
-            // Emit source-link dicts {link, role}. role omitted when blank.
+            // Emit source-link dicts {link, role}. role is mandatory; the
+            // dropdown has no blank option, so it always carries a valid role.
+            // Fall back to RAW defensively if the value is somehow empty.
             return Array.from(container.querySelectorAll('.input-row')).map(row => {
                 const linkInput = row.querySelector('.url-input');
                 const roleSelect = row.querySelector('.url-role');
                 const link = linkInput ? linkInput.value.trim() : '';
                 if (!link) return null;
-                const role = roleSelect ? roleSelect.value.trim() : '';
-                return role ? { link, role } : { link, role: null };
+                const role = (roleSelect && roleSelect.value.trim()) || 'RAW';
+                return { link, role };
             }).filter(v => v);
         }
     },

--- a/cases/templates/cases/widgets/multi_url_widget.html
+++ b/cases/templates/cases/widgets/multi_url_widget.html
@@ -4,9 +4,8 @@
         <span class="drag-handle">⋮⋮</span>
         <input type="url" class="url-input" value="{{ value.link }}" placeholder="https://example.com">
         <select class="url-role" aria-label="Link type">
-            <option value="">— type —</option>
             {% for r in role_choices %}
-            <option value="{{ r }}" {% if value.role == r %}selected{% endif %}>{{ r }}</option>
+            <option value="{{ r }}" {% if value.role == r or value.role == None and r == "RAW" %}selected{% endif %}>{{ r }}</option>
             {% endfor %}
         </select>
         <button type="button" class="btn btn-sm btn-danger remove-input" aria-label="Remove URL">
@@ -31,13 +30,14 @@
     var roleChoices = JSON.parse(
         document.getElementById('{{ role_choices_id }}').textContent
     );
-    var roleOptions = '<option value="">— type —</option>' +
-        roleChoices.map(function (r) {
-            var opt = document.createElement('option');
-            opt.value = r;
-            opt.textContent = r;
-            return opt.outerHTML;
-        }).join('');
+    // No blank option — role is mandatory; new rows default to the first
+    // choice (RAW), matching the rendered existing-row selects above.
+    var roleOptions = roleChoices.map(function (r) {
+        var opt = document.createElement('option');
+        opt.value = r;
+        opt.textContent = r;
+        return opt.outerHTML;
+    }).join('');
 
     window.initMultiWidget(
         '{{ widget_id }}_container',

--- a/tests/api/test_public_api.py
+++ b/tests/api/test_public_api.py
@@ -751,9 +751,6 @@ def test_document_source_api_merges_url_with_legacy_and_multiple_uploads():
     merged_urls = response.data["urls"]
     links = [u["link"] for u in merged_urls]
     assert links.count("https://example.com/reference.pdf") == 1
-    # Uploaded files should have PERMALINK role
+    # Uploaded files are RAW source documents, as are the external URLs here.
     for u in merged_urls:
-        if u["link"] == "https://example.com/reference.pdf":
-            assert u["role"] == "RAW"
-        else:
-            assert u["role"] == "PERMALINK"
+        assert u["role"] == "RAW"

--- a/tests/test_url_migration.py
+++ b/tests/test_url_migration.py
@@ -205,16 +205,16 @@ class TestURLFieldPostMigration:
     """Test suite for URL field behavior after migration to JSONField."""
 
     def test_url_field_stores_dicts(self):
-        """Verify url field stores dict format after save normalization."""
+        """Legacy string url is normalized to a {link, role: RAW} dict on save."""
         source = DocumentSource.objects.create(
             title="Test Source", url=["https://example.com"]
         )
 
         assert isinstance(source.url, list)
-        assert source.url == [{"link": "https://example.com", "role": None}]
+        assert source.url == [{"link": "https://example.com", "role": "RAW"}]
 
     def test_multiple_urls_storage(self):
-        """Verify multiple URLs can be stored and retrieved (normalized to dicts)."""
+        """Verify multiple URLs can be stored; legacy strings default to RAW."""
         urls = [
             "https://example.com",
             {"link": "https://backup.example.com", "role": "RAW"},
@@ -223,7 +223,7 @@ class TestURLFieldPostMigration:
 
         source.refresh_from_db()
         assert source.url == [
-            {"link": "https://example.com", "role": None},
+            {"link": "https://example.com", "role": "RAW"},
             {"link": "https://backup.example.com", "role": "RAW"},
         ]
 
@@ -265,22 +265,37 @@ class TestSourceLinkDictFormat:
             ]
         )
 
-    def test_validate_url_list_accepts_mixed_list(self):
-        """validate_url_list should accept a mix of str and dict."""
+    def test_validate_url_list_rejects_plain_strings(self):
+        """validate_url_list should reject plain string items (dicts only)."""
+        from django.core.exceptions import ValidationError
+
         from cases.models import validate_url_list
 
-        validate_url_list(
-            [
-                "https://example.com/plain",
-                {"link": "https://example.com/dict", "role": "RAW"},
-            ]
-        )
+        with pytest.raises(ValidationError):
+            validate_url_list(
+                [
+                    "https://example.com/plain",
+                    {"link": "https://example.com/dict", "role": "RAW"},
+                ]
+            )
 
-    def test_validate_url_list_accepts_dict_without_role(self):
-        """role is optional in dict — defaults to None which is valid."""
+    def test_validate_url_list_rejects_dict_without_role(self):
+        """role is now mandatory — a dict missing it is rejected."""
+        from django.core.exceptions import ValidationError
+
         from cases.models import validate_url_list
 
-        validate_url_list([{"link": "https://example.com/doc"}])
+        with pytest.raises(ValidationError):
+            validate_url_list([{"link": "https://example.com/doc"}])
+
+    def test_validate_url_list_rejects_dict_with_none_role(self):
+        """An explicit None role is also rejected by validate_url_list."""
+        from django.core.exceptions import ValidationError
+
+        from cases.models import validate_url_list
+
+        with pytest.raises(ValidationError):
+            validate_url_list([{"link": "https://example.com/doc", "role": None}])
 
     def test_validate_url_list_rejects_invalid_role(self):
         """validate_url_list should reject dict with invalid role."""
@@ -307,19 +322,19 @@ class TestSourceLinkDictFormat:
         data = {
             "title": "Dict URL Test",
             "url": [
-                "https://example.com/plain",
+                {"link": "https://example.com/plain", "role": "RAW"},
                 {"link": "https://example.com/with-role", "role": "MARKDOWN"},
             ],
         }
         serializer = DocumentSourceCreateSerializer(data=data)
         assert serializer.is_valid(), f"Errors: {serializer.errors}"
         assert serializer.validated_data["url"] == [
-            "https://example.com/plain",
+            {"link": "https://example.com/plain", "role": "RAW"},
             {"link": "https://example.com/with-role", "role": "MARKDOWN"},
         ]
 
-    def test_create_serializer_accepts_plain_strings(self):
-        """DocumentSourceCreateSerializer should still accept plain strings."""
+    def test_create_serializer_rejects_plain_strings(self):
+        """Plain string URLs are no longer accepted by the create serializer."""
         from cases.serializers import DocumentSourceCreateSerializer
 
         data = {
@@ -327,8 +342,20 @@ class TestSourceLinkDictFormat:
             "url": ["https://example.com/doc"],
         }
         serializer = DocumentSourceCreateSerializer(data=data)
-        assert serializer.is_valid(), f"Errors: {serializer.errors}"
-        assert serializer.validated_data["url"] == ["https://example.com/doc"]
+        assert not serializer.is_valid()
+        assert "url" in serializer.errors
+
+    def test_create_serializer_rejects_dict_without_role(self):
+        """A dict without an explicit role is rejected (role mandatory)."""
+        from cases.serializers import DocumentSourceCreateSerializer
+
+        data = {
+            "title": "No Role Test",
+            "url": [{"link": "https://example.com/doc"}],
+        }
+        serializer = DocumentSourceCreateSerializer(data=data)
+        assert not serializer.is_valid()
+        assert "url" in serializer.errors
 
     def test_serializer_outputs_dict_format(self):
         """DocumentSourceSerializer should output {link, role} dicts."""
@@ -342,6 +369,7 @@ class TestSourceLinkDictFormat:
             ],
         )
         serializer = DocumentSourceSerializer(source)
+        # Legacy string entry is normalized to RAW on save.
         assert serializer.data["url"] == [
             "https://example.com/plain",
             "https://example.com/markdown",
@@ -383,16 +411,18 @@ class TestSourceLinkDictFormat:
         assert not serializer.is_valid()
 
     def test_create_serializer_strips_whitespace(self):
-        """SourceLinkField should strip whitespace from URLs."""
+        """SourceLinkField should strip whitespace from the link in a dict."""
         from cases.serializers import DocumentSourceCreateSerializer
 
         data = {
             "title": "Whitespace Test",
-            "url": ["  https://example.com/doc  "],
+            "url": [{"link": "  https://example.com/doc  ", "role": "RAW"}],
         }
         serializer = DocumentSourceCreateSerializer(data=data)
         assert serializer.is_valid(), f"Errors: {serializer.errors}"
-        assert serializer.validated_data["url"] == ["https://example.com/doc"]
+        assert serializer.validated_data["url"] == [
+            {"link": "https://example.com/doc", "role": "RAW"}
+        ]
 
     def test_create_serializer_sanitizes_extra_dict_keys(self):
         """SourceLinkField should strip extra keys from dict input."""
@@ -414,18 +444,57 @@ class TestSourceLinkDictFormat:
             {"link": "https://example.com/doc", "role": "RAW"}
         ]
 
-    def test_representation_defaults_none_role_to_raw(self):
-        """to_representation should default None role to RAW."""
+    def test_none_role_normalized_to_raw_on_save(self):
+        """A None role passed to the model is normalized to RAW before save."""
         from cases.serializers import DocumentSourceSerializer
 
         source = DocumentSource.objects.create(
             title="None Role Test",
             url=[{"link": "https://example.com/doc", "role": None}],
         )
+        # Stored value has a concrete RAW role, not None.
+        assert source.url == [{"link": "https://example.com/doc", "role": "RAW"}]
         serializer = DocumentSourceSerializer(source)
         assert serializer.data["url"] == ["https://example.com/doc"]
         assert serializer.data["urls"] == [
             {"link": "https://example.com/doc", "role": "RAW"}
+        ]
+
+    def test_model_rejects_invalid_role(self):
+        """An unknown role is rejected by full_clean on save."""
+        from django.core.exceptions import ValidationError
+
+        with pytest.raises(ValidationError):
+            DocumentSource.objects.create(
+                title="Bad Role",
+                url=[{"link": "https://example.com/doc", "role": "BOGUS"}],
+            )
+
+    def test_model_preserves_explicit_non_raw_role(self):
+        """A valid non-RAW role survives save unchanged."""
+        source = DocumentSource.objects.create(
+            title="Markdown Role",
+            url=[{"link": "https://example.com/md", "role": "MARKDOWN"}],
+        )
+        assert source.url == [{"link": "https://example.com/md", "role": "MARKDOWN"}]
+
+    def test_get_url_dedupes_same_link_across_roles(self):
+        """Deprecated url field collapses one link shared by two roles."""
+        from cases.serializers import DocumentSourceSerializer
+
+        source = DocumentSource.objects.create(
+            title="Dup Link Test",
+            url=[
+                {"link": "https://example.com/doc", "role": "RAW"},
+                {"link": "https://example.com/doc", "role": "MARKDOWN"},
+            ],
+        )
+        serializer = DocumentSourceSerializer(source)
+        # url (strings) is deduped; urls (dicts) keeps both role variants.
+        assert serializer.data["url"] == ["https://example.com/doc"]
+        assert serializer.data["urls"] == [
+            {"link": "https://example.com/doc", "role": "RAW"},
+            {"link": "https://example.com/doc", "role": "MARKDOWN"},
         ]
 
 
@@ -578,6 +647,93 @@ class TestDictFormatMigration(TransactionTestCase):
 
         parsed = _json.loads(url_value) if isinstance(url_value, str) else url_value
         assert parsed == ["https://example.com/1", "https://example.com/2"]
+
+    def tearDown(self):
+        call_command("migrate", verbosity=0)
+        super().tearDown()
+
+    @classmethod
+    def tearDownClass(cls):
+        call_command("migrate", verbosity=0)
+        super().tearDownClass()
+
+
+class TestRoleBackfillMigration(TransactionTestCase):
+    """Test migration 0027, which backfills None/missing roles to RAW."""
+
+    @staticmethod
+    def get_historical_model(connection, migration_tuple, app_label, model_name):
+        from django.db.migrations.executor import MigrationExecutor
+
+        executor = MigrationExecutor(connection)
+        project_state = executor.loader.project_state(migration_tuple)
+        return project_state.apps.get_model(app_label, model_name)
+
+    def setUp(self):
+        """Create data with None-role entries at the state just before 0032."""
+        from django.utils import timezone
+
+        call_command("migrate", "cases", "0031_make_source_type_required", verbosity=0)
+
+        DocumentSource = self.get_historical_model(
+            connection,
+            ("cases", "0031_make_source_type_required"),
+            "cases",
+            "DocumentSource",
+        )
+
+        now = timezone.now()
+        DocumentSource.objects.bulk_create(
+            [
+                DocumentSource(
+                    source_id="source:role:backfill:001",
+                    title="None roles",
+                    url=[
+                        {"link": "https://example.com/a", "role": None},
+                        {"link": "https://example.com/b", "role": None},
+                    ],
+                    is_deleted=False,
+                    created_at=now,
+                    updated_at=now,
+                ),
+                DocumentSource(
+                    source_id="source:role:backfill:002",
+                    title="Mixed roles",
+                    url=[
+                        {"link": "https://example.com/c", "role": "MARKDOWN"},
+                        {"link": "https://example.com/d", "role": None},
+                    ],
+                    is_deleted=False,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            ]
+        )
+
+    def test_forward_backfills_none_roles_to_raw(self):
+        """None roles become RAW; explicit non-RAW roles are preserved."""
+        call_command(
+            "migrate", "cases", "0032_backfill_source_link_role_raw", verbosity=0
+        )
+
+        DocumentSource = self.get_historical_model(
+            connection,
+            ("cases", "0032_backfill_source_link_role_raw"),
+            "cases",
+            "DocumentSource",
+        )
+
+        s1 = DocumentSource.objects.get(source_id="source:role:backfill:001")
+        assert s1.url == [
+            {"link": "https://example.com/a", "role": "RAW"},
+            {"link": "https://example.com/b", "role": "RAW"},
+        ]
+
+        s2 = DocumentSource.objects.get(source_id="source:role:backfill:002")
+        assert s2.url == [
+            {"link": "https://example.com/c", "role": "MARKDOWN"},
+            {"link": "https://example.com/d", "role": "RAW"},
+        ]
 
     def tearDown(self):
         call_command("migrate", verbosity=0)


### PR DESCRIPTION
External-URL links now require an explicit role (RAW/MARKDOWN/PERMALINK); file uploads are always recorded as RAW. Enforced at the API (SourceLinkField 400s on missing/None role or plain strings) and the admin widget (no blank option, defaults to RAW). The model normalizes legacy strings / None roles to RAW before full_clean() so internal/programmatic saves stay valid.

- models: validate_url_list requires a valid role; normalize_url_list() helper runs in save() BEFORE full_clean() (field validators run before clean()).
- serializers: SourceLinkField requires explicit role; get_url() dedups by link; narrow bare excepts in get_urls() to log skipped upload URLs.
- admin: upload inline shows RAW-only + allowed-types/size help and an accept filter on the file input.
- callers: seed_allegations, case_importer, map_press_release_files, ciaa_draft_case_service emit {link, role: RAW} dicts.
- migration 0032 backfills existing None/missing roles to RAW.
- tests updated to the strict-role contract + new coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced document upload interface in the admin panel with clearer file constraints, size limits, and allowed file types displayed before submission.
  * Standardized document source URL storage and handling across the system for improved data consistency.

* **Bug Fixes**
  * Backfilled missing role information in existing document source records to ensure data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->