### PR TITLE
Add SOURCE_PAGE and ALTERNATE source-link roles

### DIFF
--- a/cases/models.py
+++ b/cases/models.py
@@ -28,6 +28,12 @@ class SourceLinkRole(enum.StrEnum):
     RAW = "RAW"
     MARKDOWN = "MARKDOWN"
     PERMALINK = "PERMALINK"
+    # The web page a document was published on / linked from (e.g. a CIAA
+    # press-release landing page), as opposed to the document file itself.
+    SOURCE_PAGE = "SOURCE_PAGE"
+    # An alternate-format rendering of the RAW document (e.g. the .doc export
+    # of a release whose .pdf is the RAW link).
+    ALTERNATE = "ALTERNATE"
 
 
 def validate_url_list(value):

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -313,8 +313,7 @@ class SourceLinkField(serializers.Field):
     """Field that accepts a ``{'link': str, 'role': str}`` source-link dict.
 
     Plain URL strings are no longer accepted — every link must be a dict with a
-    ``link`` key and an explicit ``role`` (one of the ``SourceLinkRole`` values:
-    ``RAW``/``MARKDOWN``/``PERMALINK``/``SOURCE_PAGE``/``ALTERNATE``).
+    ``link`` key and an explicit ``role`` (one of the ``SourceLinkRole`` values).
     File uploads are recorded as ``RAW`` automatically by the view; this field
     is only used for caller-supplied external URLs, which must name their role.
     """
@@ -692,9 +691,11 @@ class DocumentSourceUpdateSerializer(serializers.ModelSerializer):
     url = serializers.ListField(
         child=SourceLinkField(),
         required=False,
-        help_text="List of URLs for this source. Each item may be a plain URL "
-        "string or a dict with 'link' and 'role' keys (role can be RAW, "
-        "MARKDOWN, PERMALINK, SOURCE_PAGE or ALTERNATE).",
+        help_text=(
+            "List of URLs for this source. Each item must be a dict with "
+            "'link' and 'role' keys (role can be "
+            f"{', '.join(r.value for r in SourceLinkRole)})."
+        ),
     )
 
     class Meta:

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -313,7 +313,8 @@ class SourceLinkField(serializers.Field):
     """Field that accepts a ``{'link': str, 'role': str}`` source-link dict.
 
     Plain URL strings are no longer accepted — every link must be a dict with a
-    ``link`` key and an explicit ``role`` (``RAW``/``MARKDOWN``/``PERMALINK``).
+    ``link`` key and an explicit ``role`` (one of the ``SourceLinkRole`` values:
+    ``RAW``/``MARKDOWN``/``PERMALINK``/``SOURCE_PAGE``/``ALTERNATE``).
     File uploads are recorded as ``RAW`` automatically by the view; this field
     is only used for caller-supplied external URLs, which must name their role.
     """
@@ -693,7 +694,7 @@ class DocumentSourceUpdateSerializer(serializers.ModelSerializer):
         required=False,
         help_text="List of URLs for this source. Each item may be a plain URL "
         "string or a dict with 'link' and 'role' keys (role can be RAW, "
-        "MARKDOWN or PERMALINK).",
+        "MARKDOWN, PERMALINK, SOURCE_PAGE or ALTERNATE).",
     )
 
     class Meta:

--- a/tests/test_url_migration.py
+++ b/tests/test_url_migration.py
@@ -262,6 +262,8 @@ class TestSourceLinkDictFormat:
                 {"link": "https://example.com/doc1", "role": "RAW"},
                 {"link": "https://example.com/doc2.md", "role": "MARKDOWN"},
                 {"link": "https://example.com/permalink", "role": "PERMALINK"},
+                {"link": "https://example.com/page", "role": "SOURCE_PAGE"},
+                {"link": "https://example.com/doc1.doc", "role": "ALTERNATE"},
             ]
         )
 
@@ -386,7 +388,9 @@ class TestSourceLinkDictFormat:
         assert SourceLinkRole.RAW.value == "RAW"
         assert SourceLinkRole.MARKDOWN.value == "MARKDOWN"
         assert SourceLinkRole.PERMALINK.value == "PERMALINK"
-        assert len(list(SourceLinkRole)) == 3
+        assert SourceLinkRole.SOURCE_PAGE.value == "SOURCE_PAGE"
+        assert SourceLinkRole.ALTERNATE.value == "ALTERNATE"
+        assert len(list(SourceLinkRole)) == 5
 
     def test_create_serializer_rejects_invalid_url(self):
         """SourceLinkField should reject invalid URLs."""


### PR DESCRIPTION
Extend the SourceLinkRole enum with two roles needed to normalize DocumentSource links without losing information:

- SOURCE_PAGE: the web page a document was published on / linked from (e.g. a CIAA press-release landing page), as distinct from the file.
- ALTERNATE: an alternate-format rendering of the RAW document (e.g. the .doc export of a release whose .pdf is the canonical RAW link).

No migration is required: the url JSONField has no `choices` and role values are validated in Python against the enum, so validate_url_list, the admin widget's role_choices, and the OpenAPI ChoiceField all pick up the new values automatically.

Update SourceLinkField/serializer docstrings + help text, and extend the role-enforcement tests to cover both new values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended source link configuration with two new role types. `SOURCE_PAGE` identifies published web pages where documents are linked from, and `ALTERNATE` represents alternate-format renderings of documents. These roles can now be explicitly specified when adding or updating document sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->