### PR TITLE
Persist uploaded files as `url` links (PR1: additive)

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -835,7 +835,12 @@ class DocumentSourceAdminForm(forms.ModelForm):
                 validate_upload_file_size,
                 validate_upload_file_mimetype,
             ):
-                validator(upload_file)
+                try:
+                    validator(upload_file)
+                except ValidationError as exc:
+                    # Attach to the upload_file field so the error renders next to
+                    # the input rather than as a form-wide non-field error.
+                    self.add_error("upload_file", exc)
 
         return cleaned_data
 

--- a/cases/admin.py
+++ b/cases/admin.py
@@ -763,13 +763,39 @@ class DocumentSourceAdminForm(forms.ModelForm):
         help_text="External URLs to the source (you can add multiple)",
     )
 
+    # Ingestion-only file upload: stored to S3 and appended to `url` as a link
+    # on save (see DocumentSourceAdmin.save_model). Not a model field — a
+    # source's links live solely in `url`.
+    upload_file = forms.FileField(
+        required=False,
+        label="Upload a file",
+        help_text=(
+            "Optional. Stored to S3 and added to External URLs as a source link. "
+            f"Allowed types: {', '.join(ALLOWED_UPLOAD_EXTENSIONS)}. "
+            f"Max size: {int(MAX_UPLOAD_FILE_SIZE / (1024 * 1024))} MB."
+        ),
+    )
+    upload_role = forms.ChoiceField(
+        required=False,
+        label="Uploaded file role",
+        help_text="Role for the uploaded file's link (default RAW).",
+    )
+
     class Meta:
         model = DocumentSource
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
+        from .models import SourceLinkRole
+
         self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
+
+        # Role choices derived from the enum so new roles appear automatically.
+        self.fields["upload_role"].choices = [
+            (r.value, r.value) for r in SourceLinkRole
+        ]
+        self.fields["upload_role"].initial = SourceLinkRole.RAW.value
 
         # Restrict contributors field visibility based on user role
         if self.request:
@@ -794,6 +820,22 @@ class DocumentSourceAdminForm(forms.ModelForm):
         title = cleaned_data.get("title")
         if not title or not title.strip():
             raise ValidationError({"title": "Title is required and cannot be empty"})
+
+        # Validate an uploaded file against the same rules as model uploads.
+        upload_file = cleaned_data.get("upload_file")
+        if upload_file:
+            from .models import (
+                validate_upload_file_extension,
+                validate_upload_file_mimetype,
+                validate_upload_file_size,
+            )
+
+            for validator in (
+                validate_upload_file_extension,
+                validate_upload_file_size,
+                validate_upload_file_mimetype,
+            ):
+                validator(upload_file)
 
         return cleaned_data
 
@@ -841,7 +883,9 @@ class DocumentSourceAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
     """
 
     form = DocumentSourceAdminForm
-    inlines = [DocumentSourceUploadInline]
+    # File upload is handled by the form's `upload_file` control (stored to S3 and
+    # appended to `url`); no separate uploaded-file inline.
+    inlines = []
 
     # Disable "View on site" button since DocumentSource doesn't have a public detail page
     view_on_site = False
@@ -899,7 +943,7 @@ class DocumentSourceAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
         ),
         (
             "External URLs",
-            {"fields": ("url",)},
+            {"fields": ("url", "upload_file", "upload_role")},
         ),
     )
 
@@ -1019,9 +1063,26 @@ class DocumentSourceAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
         """
         Save the model with validation.
 
+        If a file was uploaded, store it to S3 and append its URL to `obj.url`
+        as a source link (a source's links live solely in `url`). The file is
+        not persisted as a separate uploaded-file record.
+
         Note: Model's save() method calls full_clean() which handles all validation.
-        No need for explicit validation here.
         """
+        upload_file = (
+            form.cleaned_data.get("upload_file")
+            if form is not None and hasattr(form, "cleaned_data")
+            else None
+        )
+        if upload_file:
+            from cases.services.source_files import store_file_as_link
+
+            from .models import SourceLinkRole
+
+            role = form.cleaned_data.get("upload_role") or SourceLinkRole.RAW.value
+            link = store_file_as_link(upload_file, role=role)
+            obj.url = list(obj.url or []) + [link]
+
         super().save_model(request, obj, form, change)
 
     def save_related(self, request, form, formsets, change):

--- a/cases/management/commands/_enrich_utils.py
+++ b/cases/management/commands/_enrich_utils.py
@@ -19,7 +19,9 @@ from django.core.management.base import CommandError
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_HOSTS = frozenset({"ciaa.gov.np", "ngm-store.jawafdehi.org"})
+ALLOWED_HOSTS = frozenset(
+    {"ciaa.gov.np", "ngm-store.jawafdehi.org", "s3.jawafdehi.org"}
+)
 
 
 def resolve_api_key(cli_key: Optional[str]) -> Optional[str]:

--- a/cases/management/commands/backfill_upload_links_into_url.py
+++ b/cases/management/commands/backfill_upload_links_into_url.py
@@ -1,0 +1,121 @@
+"""Backfill uploaded-file URLs into each source's ``url`` list.
+
+A DocumentSource's links live solely in its ``url`` JSON list. Historically some
+files were attached via the ``uploaded_file`` FileField or ``DocumentSourceUpload``
+rows and surfaced only at read time by the serializer. Before that machinery is
+removed (a later PR), this command ensures every such file's URL is recorded in
+``url`` so nothing is lost.
+
+Idempotent: a file whose URL is already present in ``url`` (matched by storage
+path / hashed basename) is skipped. ``--dry-run`` (default) reports without
+writing; pass ``--apply`` to persist.
+
+    python manage.py backfill_upload_links_into_url            # dry run
+    python manage.py backfill_upload_links_into_url --apply    # write
+"""
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from cases.models import (
+    DocumentSource,
+    DocumentSourceUpload,
+    SourceLinkRole,
+    validate_url_list,
+)
+from cases.services.source_markdown import _absolute
+
+
+def _covered(path, links):
+    """True if some stored link contains this file's storage path / basename."""
+    if not path:
+        return True  # nothing to record
+    base = path.rsplit("/", 1)[-1]
+    return any((path in link) or (base in link) for link in links)
+
+
+def _role_for(name):
+    return (
+        SourceLinkRole.MARKDOWN.value
+        if (name or "").lower().endswith(".md")
+        else SourceLinkRole.RAW.value
+    )
+
+
+class Command(BaseCommand):
+    help = "Backfill uploaded-file URLs into DocumentSource.url (idempotent)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Persist changes (default is a dry run).",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        prefix = "" if apply else "[DRY RUN] "
+
+        # source_id -> list of {link, role} to append
+        to_append = {}
+
+        def consider(source, file_field):
+            if not file_field:
+                return
+            try:
+                name = file_field.name
+                url = _absolute(file_field.url)
+            except (ValueError, AttributeError):
+                return
+            links = [u for u in source.url_links if u]
+            pending = [d["link"] for d in to_append.get(source.source_id, [])]
+            if _covered(name, links + pending):
+                return
+            to_append.setdefault(source.source_id, []).append(
+                {"link": url, "role": _role_for(name)}
+            )
+
+        # 1) DocumentSourceUpload relation rows
+        for up in DocumentSourceUpload.objects.select_related("source").iterator():
+            consider(up.source, up.file)
+
+        # 2) legacy single uploaded_file field
+        legacy = DocumentSource.objects.exclude(uploaded_file="").exclude(
+            uploaded_file__isnull=True
+        )
+        for src in legacy.iterator():
+            consider(src, src.uploaded_file)
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"{prefix}{len(to_append)} source(s) need upload links backfilled."
+            )
+        )
+        for sid, links in list(to_append.items())[:50]:
+            for d in links:
+                self.stdout.write(f"  {sid}  +{d['role']}  {d['link']}")
+        if len(to_append) > 50:
+            self.stdout.write(f"  ... and {len(to_append) - 50} more")
+
+        if not apply or not to_append:
+            self.stdout.write(self.style.SUCCESS(f"{prefix}done (no writes)."))
+            return
+
+        updated = 0
+        for sid, new_links in to_append.items():
+            with transaction.atomic():
+                src = DocumentSource.objects.select_for_update().get(source_id=sid)
+                existing = [u for u in src.url_links if u]
+                merged = list(src.url or [])
+                for d in new_links:
+                    if not _covered(d["link"].rsplit("/", 1)[-1], existing):
+                        merged.append(d)
+                # persist only the url column (avoid full_clean on unrelated fields)
+                validate_url_list(merged)
+                DocumentSource.objects.filter(pk=src.pk).update(
+                    url=merged, updated_at=timezone.now()
+                )
+                updated += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Backfilled {updated} source(s)."))

--- a/cases/management/commands/backfill_upload_links_into_url.py
+++ b/cases/management/commands/backfill_upload_links_into_url.py
@@ -24,15 +24,21 @@ from cases.models import (
     SourceLinkRole,
     validate_url_list,
 )
-from cases.services.source_markdown import _absolute
+from cases.services.storage_links import absolute_media_url
 
 
 def _covered(path, links):
-    """True if some stored link contains this file's storage path / basename."""
+    """True if some stored link already points at this file.
+
+    Match on the file's basename (a sha256 hash + extension under the storage
+    prefix, e.g. ``case_uploads/<hash>.pdf``) as a complete final path segment of
+    a stored link, rather than a loose substring, so e.g. ``<hash>.pdf`` does not
+    spuriously match ``<hash>_copy.pdf``.
+    """
     if not path:
         return True  # nothing to record
     base = path.rsplit("/", 1)[-1]
-    return any((path in link) or (base in link) for link in links)
+    return any(link.rsplit("/", 1)[-1] == base for link in links)
 
 
 def _role_for(name):
@@ -65,7 +71,7 @@ class Command(BaseCommand):
                 return
             try:
                 name = file_field.name
-                url = _absolute(file_field.url)
+                url = absolute_media_url(file_field.url)
             except (ValueError, AttributeError):
                 return
             links = [u for u in source.url_links if u]
@@ -107,9 +113,12 @@ class Command(BaseCommand):
             with transaction.atomic():
                 src = DocumentSource.objects.select_for_update().get(source_id=sid)
                 existing = [u for u in src.url_links if u]
-                merged = list(src.url or [])
+                # Normalize first: legacy rows may hold plain string URLs, which
+                # validate_url_list rejects. normalize_url_list coerces them to
+                # {link, role: RAW} so the validate below passes.
+                merged = DocumentSource.normalize_url_list(list(src.url or []))
                 for d in new_links:
-                    if not _covered(d["link"].rsplit("/", 1)[-1], existing):
+                    if not _covered(d["link"], existing):
                         merged.append(d)
                 # persist only the url column (avoid full_clean on unrelated fields)
                 validate_url_list(merged)

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -675,17 +675,24 @@ class DocumentSourceCreateSerializer(serializers.ModelSerializer):
 
         The file is NOT persisted to the ``uploaded_file`` FileField; ``url`` is
         the single source of truth for a source's links.
+
+        The source row is created first (which runs model validation, e.g. the
+        publication_date requirement for NEWS), and the file is stored only
+        afterwards — so a validation failure never leaves an orphaned S3 object.
         """
         from cases.services.source_files import store_file_as_link
 
         uploaded_file = validated_data.pop("uploaded_file", None)
         upload_role = validated_data.pop("upload_role", SourceLinkRole.RAW.value)
 
+        instance = super().create(validated_data)
+
         if uploaded_file is not None:
             link = store_file_as_link(uploaded_file, role=upload_role)
-            validated_data["url"] = list(validated_data.get("url") or []) + [link]
+            instance.url = list(instance.url or []) + [link]
+            instance.save(update_fields=["url", "updated_at"])
 
-        return super().create(validated_data)
+        return instance
 
     def to_internal_value(self, data):
         """

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -632,7 +632,13 @@ class JawafEntityCreateSerializer(serializers.ModelSerializer):
 
 
 class DocumentSourceCreateSerializer(serializers.ModelSerializer):
-    """Serializer for creating DocumentSource records with file uploads via API."""
+    """Serializer for creating DocumentSource records with file uploads via API.
+
+    A source's links live solely in its ``url`` list. An uploaded file is an
+    ingestion convenience: we store it to S3 and append the resulting permanent
+    URL to ``url`` (role ``upload_role``, default RAW) rather than persisting a
+    separate uploaded-file record.
+    """
 
     url = serializers.ListField(
         child=SourceLinkField(),
@@ -640,6 +646,13 @@ class DocumentSourceCreateSerializer(serializers.ModelSerializer):
         default=list,
         help_text="List of external URLs for this source (e.g. original article link). "
         "Each item may be a plain URL string or a dict with 'link' and 'role' keys.",
+    )
+    upload_role = serializers.ChoiceField(
+        choices=[r.value for r in SourceLinkRole],
+        required=False,
+        default=SourceLinkRole.RAW.value,
+        write_only=True,
+        help_text="Role to assign to an uploaded_file's link in `url` (default RAW).",
     )
 
     class Meta:
@@ -653,8 +666,26 @@ class DocumentSourceCreateSerializer(serializers.ModelSerializer):
             "url",
             "publication_date",
             "uploaded_file",
+            "upload_role",
         ]
         read_only_fields = ["id", "source_id"]
+
+    def create(self, validated_data):
+        """Store any uploaded file to S3 and record its link in ``url``.
+
+        The file is NOT persisted to the ``uploaded_file`` FileField; ``url`` is
+        the single source of truth for a source's links.
+        """
+        from cases.services.source_files import store_file_as_link
+
+        uploaded_file = validated_data.pop("uploaded_file", None)
+        upload_role = validated_data.pop("upload_role", SourceLinkRole.RAW.value)
+
+        if uploaded_file is not None:
+            link = store_file_as_link(uploaded_file, role=upload_role)
+            validated_data["url"] = list(validated_data.get("url") or []) + [link]
+
+        return super().create(validated_data)
 
     def to_internal_value(self, data):
         """

--- a/cases/services/source_files.py
+++ b/cases/services/source_files.py
@@ -8,34 +8,19 @@ There is no separate uploaded-file DB row — the URL is the single source of tr
 This is shared by the create API and the admin so both ingest identically.
 """
 
-from urllib.parse import urljoin
-
-from django.conf import settings
 from django.core.files.storage import default_storage
 
 from cases.models import SourceLinkRole
-
-
-def _absolute(url: str) -> str:
-    """Make a possibly-relative media URL absolute (validators require a scheme).
-
-    In production MEDIA_URL is an absolute S3 URL (AWS_S3_CUSTOM_DOMAIN), so file
-    URLs come back absolute and this is a no-op. Locally (FileSystemStorage) URLs
-    are like ``/media/...``; we prefix MEDIA_PUBLIC_BASE so the stored link
-    validates against URLValidator.
-    """
-    if url and url.startswith(("http://", "https://")):
-        return url
-    base = getattr(settings, "MEDIA_PUBLIC_BASE", "") or ""
-    return urljoin(base + "/", url.lstrip("/")) if base else url
+from cases.services.storage_links import absolute_media_url
 
 
 def store_file_as_link(uploaded_file, role=SourceLinkRole.RAW.value) -> dict:
     """Persist ``uploaded_file`` to storage and return its ``{link, role}`` dict.
 
     The default storage backend (HashedFilenameS3Boto3Storage in prod) hashes the
-    name and prefixes it (``case_uploads/``), yielding the canonical permanent
-    URL. ``role`` defaults to RAW but the caller may pass any SourceLinkRole.
+    file name (neutralizing any path-traversal in the client-supplied name) and
+    prefixes it (``case_uploads/``), yielding the canonical permanent URL.
+    ``role`` defaults to RAW but the caller may pass any SourceLinkRole.
     """
     name = default_storage.save(uploaded_file.name, uploaded_file)
-    return {"link": _absolute(default_storage.url(name)), "role": role}
+    return {"link": absolute_media_url(default_storage.url(name)), "role": role}

--- a/cases/services/source_files.py
+++ b/cases/services/source_files.py
@@ -1,0 +1,41 @@
+"""Store an uploaded file and return it as an external source link.
+
+A DocumentSource's links live solely in its ``url`` JSON list. File upload is an
+ingestion convenience: we persist the bytes to the configured (S3) storage and
+record the resulting permanent public URL as a ``{link, role}`` entry in ``url``.
+There is no separate uploaded-file DB row — the URL is the single source of truth.
+
+This is shared by the create API and the admin so both ingest identically.
+"""
+
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+
+from cases.models import SourceLinkRole
+
+
+def _absolute(url: str) -> str:
+    """Make a possibly-relative media URL absolute (validators require a scheme).
+
+    In production MEDIA_URL is an absolute S3 URL (AWS_S3_CUSTOM_DOMAIN), so file
+    URLs come back absolute and this is a no-op. Locally (FileSystemStorage) URLs
+    are like ``/media/...``; we prefix MEDIA_PUBLIC_BASE so the stored link
+    validates against URLValidator.
+    """
+    if url and url.startswith(("http://", "https://")):
+        return url
+    base = getattr(settings, "MEDIA_PUBLIC_BASE", "") or ""
+    return urljoin(base + "/", url.lstrip("/")) if base else url
+
+
+def store_file_as_link(uploaded_file, role=SourceLinkRole.RAW.value) -> dict:
+    """Persist ``uploaded_file`` to storage and return its ``{link, role}`` dict.
+
+    The default storage backend (HashedFilenameS3Boto3Storage in prod) hashes the
+    name and prefixes it (``case_uploads/``), yielding the canonical permanent
+    URL. ``role`` defaults to RAW but the caller may pass any SourceLinkRole.
+    """
+    name = default_storage.save(uploaded_file.name, uploaded_file)
+    return {"link": _absolute(default_storage.url(name)), "role": role}

--- a/cases/services/source_markdown.py
+++ b/cases/services/source_markdown.py
@@ -9,9 +9,6 @@ This is idempotent: a source that already has a MARKDOWN url is left untouched
 unless ``overwrite=True``.
 """
 
-from urllib.parse import urljoin
-
-from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.utils import timezone
@@ -21,19 +18,7 @@ from cases.models import (
     SourceLinkRole,
     validate_url_list,
 )
-
-
-def _absolute(url: str) -> str:
-    """Make a possibly-relative media URL absolute (validators require a scheme).
-
-    In production MEDIA_URL is already an absolute S3 URL, so file urls come back
-    absolute and this is a no-op. Locally (file storage) urls are like
-    ``/media/...``; we prefix MEDIA_PUBLIC_BASE so the stored link validates.
-    """
-    if url and url.startswith(("http://", "https://")):
-        return url
-    base = getattr(settings, "MEDIA_PUBLIC_BASE", "") or ""
-    return urljoin(base + "/", url.lstrip("/")) if base else url
+from cases.services.storage_links import absolute_media_url
 
 
 def source_has_markdown(source: DocumentSource) -> bool:
@@ -69,7 +54,7 @@ def attach_markdown(source: DocumentSource, markdown: str, *, overwrite: bool = 
     # live solely in `url`, so we do not persist a separate uploaded-file record.
     filename = f"{source.source_id}.md"
     stored_name = default_storage.save(filename, ContentFile(markdown.encode("utf-8")))
-    link = _absolute(default_storage.url(stored_name))
+    link = absolute_media_url(default_storage.url(stored_name))
 
     # Append (or replace) the MARKDOWN-role url on the source.
     urls = [

--- a/cases/services/source_markdown.py
+++ b/cases/services/source_markdown.py
@@ -1,10 +1,9 @@
 """Attach converted Markdown to a DocumentSource.
 
 When a source is converted to Markdown (e.g. via likhit during a casework
-review), we persist that Markdown as an uploaded file on the source and record
-a ``MARKDOWN``-role link in the source's ``url`` list, so the rendered markdown
-is a first-class, durable URL on the source rather than something recomputed
-every review.
+review), we persist that Markdown to storage (S3) and record a ``MARKDOWN``-role
+link in the source's ``url`` list, so the rendered markdown is a first-class,
+durable URL on the source rather than something recomputed every review.
 
 This is idempotent: a source that already has a MARKDOWN url is left untouched
 unless ``overwrite=True``.
@@ -14,11 +13,11 @@ from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.utils import timezone
 
 from cases.models import (
     DocumentSource,
-    DocumentSourceUpload,
     SourceLinkRole,
     validate_url_list,
 )
@@ -66,15 +65,11 @@ def attach_markdown(source: DocumentSource, markdown: str, *, overwrite: bool = 
         )
         return {"created": False, "link": existing, "skipped": True}
 
-    # Save the markdown as an uploaded file on the source.
+    # Save the markdown to storage (S3) and record its link. A source's links
+    # live solely in `url`, so we do not persist a separate uploaded-file record.
     filename = f"{source.source_id}.md"
-    upload = DocumentSourceUpload(source=source)
-    upload.file.save(filename, ContentFile(markdown.encode("utf-8")), save=False)
-    upload.filename = filename
-    upload.content_type = "text/markdown"
-    upload.save()
-
-    link = _absolute(upload.file.url)
+    stored_name = default_storage.save(filename, ContentFile(markdown.encode("utf-8")))
+    link = _absolute(default_storage.url(stored_name))
 
     # Append (or replace) the MARKDOWN-role url on the source.
     urls = [

--- a/cases/services/storage_links.py
+++ b/cases/services/storage_links.py
@@ -1,0 +1,19 @@
+"""Shared helpers for turning stored files into source-link URLs."""
+
+from urllib.parse import urljoin
+
+from django.conf import settings
+
+
+def absolute_media_url(url: str) -> str:
+    """Make a possibly-relative media URL absolute (validators require a scheme).
+
+    In production MEDIA_URL is an absolute S3 URL (AWS_S3_CUSTOM_DOMAIN), so file
+    URLs come back absolute and this is a no-op. Locally (FileSystemStorage) URLs
+    are like ``/media/...``; we prefix MEDIA_PUBLIC_BASE so the stored link
+    validates against URLValidator.
+    """
+    if url and url.startswith(("http://", "https://")):
+        return url
+    base = getattr(settings, "MEDIA_PUBLIC_BASE", "") or ""
+    return urljoin(base + "/", url.lstrip("/")) if base else url

--- a/scripts/verify_uploads_in_url.py
+++ b/scripts/verify_uploads_in_url.py
@@ -1,0 +1,74 @@
+"""READ-ONLY: verify every uploaded file's URL is already present in its source's
+stored `url` column, so dropping the DocumentSourceUpload table / uploaded_file
+fields loses nothing referenced by `url`.
+
+Run against the target DB (e.g. prod), read-only — issues only SELECTs:
+
+    python manage.py shell < scripts/verify_uploads_in_url.py
+
+Comparison is by storage PATH (e.g. ``case_uploads/<hash>.pdf``), not full URL,
+so it is robust to domain/scheme differences between the FileField's
+``.url`` and the absolute link stored in ``url``.
+"""
+
+from cases.models import DocumentSource, DocumentSourceUpload
+
+
+def stored_links(src):
+    return [u for u in src.url_links if u]
+
+
+def file_path(file_field):
+    """The storage key/path of a FileField, or None if empty/broken."""
+    try:
+        return file_field.name or None
+    except Exception:  # noqa: BLE001 - defensive: never let a bad row crash the scan
+        return None
+
+
+def covered(path, links):
+    """True if some stored link contains this storage path (the hashed name)."""
+    if not path:
+        return False
+    # match on the path or just its basename (hash+ext), whichever is present
+    base = path.rsplit("/", 1)[-1]
+    return any((path in link) or (base in link) for link in links)
+
+
+missing = []  # (source_id, which, path) where the file URL is NOT in stored url
+total_uploads = 0
+
+# 1) DocumentSourceUpload relation rows
+for up in DocumentSourceUpload.objects.select_related("source").iterator():
+    total_uploads += 1
+    path = file_path(up.file)
+    links = stored_links(up.source)
+    if not covered(path, links):
+        missing.append((up.source.source_id, f"upload#{up.pk}", path))
+
+# 2) legacy single uploaded_file field
+legacy_qs = DocumentSource.objects.exclude(uploaded_file="").exclude(
+    uploaded_file__isnull=True
+)
+total_legacy = 0
+for src in legacy_qs.iterator():
+    total_legacy += 1
+    path = file_path(src.uploaded_file)
+    if not covered(path, stored_links(src)):
+        missing.append((src.source_id, "uploaded_file", path))
+
+print("=" * 70)
+print("UPLOAD-COVERAGE CHECK (read-only)")
+print("=" * 70)
+print(f"DocumentSourceUpload rows scanned : {total_uploads}")
+print(f"legacy uploaded_file sources      : {total_legacy}")
+print(f"file URLs NOT found in stored url  : {len(missing)}")
+if missing:
+    print("\n-- NOT covered (would be lost if table dropped) --")
+    for sid, which, path in missing[:100]:
+        print(f"  {sid}  {which}  {path}")
+    if len(missing) > 100:
+        print(f"  ... and {len(missing) - 100} more")
+    print("\n=> DO NOT drop yet: backfill these into `url` first.")
+else:
+    print("\n=> SAFE: every uploaded file's URL is already in stored `url`.")

--- a/scripts/verify_uploads_in_url.py
+++ b/scripts/verify_uploads_in_url.py
@@ -22,7 +22,8 @@ def file_path(file_field):
     """The storage key/path of a FileField, or None if empty/broken."""
     try:
         return file_field.name or None
-    except Exception:  # noqa: BLE001 - defensive: never let a bad row crash the scan
+    except (ValueError, AttributeError):
+        # No file associated / broken descriptor — treat as nothing to record.
         return None
 
 

--- a/tests/test_backfill_upload_links.py
+++ b/tests/test_backfill_upload_links.py
@@ -1,0 +1,72 @@
+"""Tests for the backfill_upload_links_into_url management command."""
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
+
+from cases.models import DocumentSource, DocumentSourceUpload
+from tests.conftest import create_document_source_with_entities
+
+
+@pytest.mark.django_db
+def test_backfill_adds_upload_link_and_tolerates_legacy_string_urls():
+    """A DocumentSourceUpload whose URL isn't in `url` gets backfilled, even when
+    the source's existing `url` holds legacy plain-string entries."""
+    source = create_document_source_with_entities(
+        title="Legacy source", related_entity_ids=[]
+    )
+    # Simulate legacy stored data: a plain string URL (pre-normalization).
+    DocumentSource.objects.filter(pk=source.pk).update(
+        url=["https://example.com/legacy-article"]
+    )
+    upload = DocumentSourceUpload.objects.create(
+        source=source,
+        file=SimpleUploadedFile(
+            "eviden.pdf", b"%PDF-1.4", content_type="application/pdf"
+        ),
+    )
+
+    call_command("backfill_upload_links_into_url", "--apply")
+
+    source.refresh_from_db()
+    # Legacy string was normalized, not dropped, and the upload link was added.
+    links = {u["link"]: u["role"] for u in source.url}
+    assert any("legacy-article" in link for link in links)
+    base = upload.file.name.rsplit("/", 1)[-1]
+    assert any(link.rsplit("/", 1)[-1] == base for link in links)
+
+
+@pytest.mark.django_db
+def test_backfill_is_idempotent():
+    """Running the backfill twice does not duplicate links."""
+    source = create_document_source_with_entities(
+        title="Idempotent source", related_entity_ids=[]
+    )
+    DocumentSourceUpload.objects.create(
+        source=source,
+        file=SimpleUploadedFile("a.pdf", b"%PDF-1.4", content_type="application/pdf"),
+    )
+
+    call_command("backfill_upload_links_into_url", "--apply")
+    source.refresh_from_db()
+    first = list(source.url)
+
+    call_command("backfill_upload_links_into_url", "--apply")
+    source.refresh_from_db()
+    assert source.url == first  # no change on the second run
+
+
+@pytest.mark.django_db
+def test_backfill_dry_run_writes_nothing():
+    source = create_document_source_with_entities(
+        title="Dry source", related_entity_ids=[]
+    )
+    DocumentSourceUpload.objects.create(
+        source=source,
+        file=SimpleUploadedFile("b.pdf", b"%PDF-1.4", content_type="application/pdf"),
+    )
+
+    call_command("backfill_upload_links_into_url")  # no --apply
+
+    source.refresh_from_db()
+    assert source.url == []  # dry run made no writes

--- a/tests/test_document_source_admin.py
+++ b/tests/test_document_source_admin.py
@@ -110,11 +110,14 @@ class TestDocumentSourceAdmin:
 
         assert "publication_date" in basic_fieldset_fields
 
-    def test_upload_inline_is_configured(self, db):
-        """DocumentSource admin should expose inline uploads for multi-file support."""
+    def test_upload_control_is_on_form(self, db):
+        """File upload is a form control (stored to S3 + appended to `url`),
+        not a persisted-row inline."""
         admin_instance = admin.site._registry[DocumentSource]
-        inline_models = [inline.model.__name__ for inline in admin_instance.inlines]
-        assert "DocumentSourceUpload" in inline_models
+        assert admin_instance.inlines == []
+        form_fields = admin_instance.form.base_fields
+        assert "upload_file" in form_fields
+        assert "upload_role" in form_fields
 
     def test_view_on_site_is_disabled(self, db):
         """Test that 'View on site' button is disabled for DocumentSource.

--- a/tests/test_source_upload_to_url.py
+++ b/tests/test_source_upload_to_url.py
@@ -1,0 +1,87 @@
+"""Uploads become `url` links (single source of truth), not separate records.
+
+Covers the WS0.5 behavior: the create API and the admin both store an uploaded
+file to storage and append its URL to `DocumentSource.url`, without persisting a
+`DocumentSourceUpload` row or the legacy `uploaded_file` FileField.
+"""
+
+import pytest
+from django.contrib import admin
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from cases.admin import DocumentSourceAdmin
+from cases.models import DocumentSource, DocumentSourceUpload, SourceLinkRole
+from cases.serializers import DocumentSourceCreateSerializer
+from tests.conftest import (
+    create_document_source_with_entities,
+    create_mock_request,
+    create_user_with_role,
+)
+
+
+@pytest.fixture
+def admin_user(db):
+    return create_user_with_role("upload_admin", "upload_admin@test.com", "Admin")
+
+
+@pytest.mark.django_db
+def test_create_serializer_stores_upload_as_url_link():
+    """Creating a source with uploaded_file appends a RAW link to `url`."""
+    pdf = SimpleUploadedFile(
+        "evidence.pdf", b"%PDF-1.4 data", content_type="application/pdf"
+    )
+    serializer = DocumentSourceCreateSerializer(
+        data={"title": "Uploaded source", "source_type": "MISC", "uploaded_file": pdf}
+    )
+    assert serializer.is_valid(), serializer.errors
+    source = serializer.save()
+
+    raw_links = [u for u in source.url if u.get("role") == SourceLinkRole.RAW.value]
+    assert len(raw_links) == 1
+    assert raw_links[0]["link"].endswith(".pdf")
+    # No separate upload record, and the legacy FileField is untouched.
+    assert source.uploaded_files.count() == 0
+    assert not source.uploaded_file
+
+
+@pytest.mark.django_db
+def test_create_serializer_honors_upload_role():
+    """A caller-supplied upload_role is applied to the stored link."""
+    md = SimpleUploadedFile("notes.md", b"# hi", content_type="text/markdown")
+    serializer = DocumentSourceCreateSerializer(
+        data={
+            "title": "Markdown upload",
+            "source_type": "MISC",
+            "uploaded_file": md,
+            "upload_role": SourceLinkRole.MARKDOWN.value,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    source = serializer.save()
+    roles = {u["role"] for u in source.url}
+    assert roles == {SourceLinkRole.MARKDOWN.value}
+
+
+@pytest.mark.django_db
+def test_admin_upload_appends_url_link(admin_user):
+    """Admin save_model stores the uploaded file and appends its link to `url`."""
+    admin_instance = DocumentSourceAdmin(DocumentSource, admin.site)
+    request = create_mock_request(admin_user, method="post")
+
+    source = create_document_source_with_entities(
+        title="Admin upload", description="x", related_entity_ids=[]
+    )
+    before = len(source.url or [])
+
+    pdf = SimpleUploadedFile("a.pdf", b"%PDF-1.4", content_type="application/pdf")
+
+    class _Form:
+        cleaned_data = {"upload_file": pdf, "upload_role": SourceLinkRole.RAW.value}
+
+    admin_instance.save_model(request, source, _Form(), change=True)
+    source.refresh_from_db()
+
+    assert len(source.url) == before + 1
+    assert source.url[-1]["role"] == SourceLinkRole.RAW.value
+    assert source.url[-1]["link"].endswith(".pdf")
+    assert DocumentSourceUpload.objects.filter(source=source).count() == 0


### PR DESCRIPTION
A DocumentSource's links should live solely in its `url` JSON list. File upload becomes an ingestion convenience: store the file to S3 and append the resulting permanent URL to `url` (role defaults RAW, caller may override), rather than relying on the `uploaded_file`/`DocumentSourceUpload` machinery that surfaces only at read time.

This PR is additive and non-destructive — the model fields, DocumentSourceUpload model, and get_urls' read-time merge are all kept so existing data still renders. A follow-up PR removes the dead machinery once prod is verified.

- New `store_file_as_link()` helper (cases/services/source_files.py), used by both the create API and the admin so ingestion is identical.
- DocumentSourceCreateSerializer: custom create() stores uploaded_file to S3 and appends its link to `url`; adds write-only `upload_role` (default RAW).
- Admin: replace the row-persisting DocumentSourceUploadInline with an `upload_file` + `upload_role` form control whose save_model stores to S3 and appends to `url`.
- attach_markdown: save markdown via default_storage instead of creating a DocumentSourceUpload row.
- enrich: add s3.jawafdehi.org to ALLOWED_HOSTS so URL-based conversion can fetch files now recorded in `url`.
- backfill_upload_links_into_url management command (--dry-run default) + scripts/verify_uploads_in_url.py to confirm every existing uploaded file's URL is in `url` before the PR2 removal.
- Tests for the new upload-to-url behavior (API + admin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File uploads now integrate directly as document source links, simplifying storage and retrieval.
  * Admin interface includes streamlined file upload controls with configurable link roles.
  * API supports upload role specification for better content organization.

* **Improvements**
  * Enhanced file storage and URL handling across upload workflows.
  * Expanded trusted download hosts for content conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->