### PR TITLE
Add optional date_bs and end_date to timeline entries

### DIFF
--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -5,6 +5,7 @@ CasePatchSerializer validates the post-patch result dict (not the patch document
 itself) before the changes are persisted.
 """
 
+import re
 from datetime import datetime
 
 from rest_framework import serializers
@@ -35,9 +36,16 @@ BLOCKED_PATH_PREFIXES = frozenset(
 
 
 class TimelineItemSerializer(serializers.Serializer):
+    # Bikram Sambat dates are not Gregorian-parseable, so they are validated by
+    # shape only (mirrors cases.fields.TimelineListField._BS_DATE_RE).
+    _BS_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
     date = serializers.CharField()
     title = serializers.CharField()
     description = serializers.CharField(required=False, allow_blank=True)
+    date_bs = serializers.CharField(required=False)
+    end_date = serializers.CharField(required=False)
+    end_date_bs = serializers.CharField(required=False)
 
     def validate_date(self, value):
         try:
@@ -52,6 +60,39 @@ class TimelineItemSerializer(serializers.Serializer):
         if not value or not value.strip():
             raise serializers.ValidationError("Title must be a non-empty string")
         return value
+
+    def validate_end_date(self, value):
+        try:
+            datetime.fromisoformat(value)
+        except (ValueError, TypeError):
+            raise serializers.ValidationError(
+                "Invalid end_date format (expected ISO format YYYY-MM-DD)"
+            )
+        return value
+
+    def validate_date_bs(self, value):
+        return self._validate_bs("date_bs", value)
+
+    def validate_end_date_bs(self, value):
+        return self._validate_bs("end_date_bs", value)
+
+    def _validate_bs(self, field_name, value):
+        if not self._BS_DATE_RE.match(value):
+            raise serializers.ValidationError(
+                f"{field_name} must be a Bikram Sambat date string in YYYY-MM-DD "
+                "format"
+            )
+        return value
+
+    def validate(self, attrs):
+        end_date = attrs.get("end_date")
+        if end_date is not None:
+            # date already validated to ISO format by validate_date
+            if datetime.fromisoformat(end_date) < datetime.fromisoformat(attrs["date"]):
+                raise serializers.ValidationError(
+                    {"end_date": "end_date must be on or after date"}
+                )
+        return attrs
 
 
 class EvidenceItemSerializer(serializers.Serializer):

--- a/cases/fields.py
+++ b/cases/fields.py
@@ -4,6 +4,9 @@ Custom field types for the Case model.
 These fields provide structured validation and storage for list-based data.
 """
 
+import re
+from datetime import datetime
+
 from django.core.exceptions import ValidationError
 from django.db import models
 
@@ -79,8 +82,16 @@ class TimelineListField(models.JSONField):
     """
     Stores a list of timeline entry objects.
 
-    Each entry must have: date (ISO format), title, description
+    Each entry must have: date (AD ISO format), title.
+    Optional: description, date_bs (Bikram Sambat YYYY-MM-DD), end_date
+    (AD ISO format, for events that span a period — must be >= date),
+    end_date_bs (Bikram Sambat YYYY-MM-DD for the span's end).
     """
+
+    # Bikram Sambat dates are not Gregorian-parseable, so they are validated
+    # by shape only (YYYY-MM-DD with a 4-digit year). AD<->BS conversion is
+    # done on the fly elsewhere (frontend display, enrichment commands).
+    _BS_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
     def __init__(self, *args, **kwargs):
         kwargs["default"] = list
@@ -106,15 +117,13 @@ class TimelineListField(models.JSONField):
                         f"Timeline entry missing required field '{field}': {entry}"
                     )
 
-            # Validate date format (ISO format: YYYY-MM-DD)
+            # Validate date format (AD ISO format: YYYY-MM-DD)
             date_str = entry["date"]
             if not isinstance(date_str, str):
                 raise ValidationError(f"Timeline date must be a string: {date_str}")
 
             try:
-                from datetime import datetime
-
-                datetime.fromisoformat(date_str)
+                date_obj = datetime.fromisoformat(date_str)
             except (ValueError, TypeError):
                 raise ValidationError(
                     f"Invalid date format (expected ISO format YYYY-MM-DD): {date_str}"
@@ -131,6 +140,39 @@ class TimelineListField(models.JSONField):
                 if not isinstance(entry["description"], str):
                     raise ValidationError(
                         f"Timeline description must be a string: {entry}"
+                    )
+
+            # Validate Bikram Sambat dates if present (optional, shape-checked
+            # only — see _BS_DATE_RE)
+            for bs_field in ("date_bs", "end_date_bs"):
+                if bs_field in entry:
+                    bs_value = entry[bs_field]
+                    if not isinstance(bs_value, str) or not self._BS_DATE_RE.match(
+                        bs_value
+                    ):
+                        raise ValidationError(
+                            f"Timeline {bs_field} must be a Bikram Sambat date "
+                            f"string in YYYY-MM-DD format: {entry}"
+                        )
+
+            # Validate end_date if present (optional AD ISO date for spans;
+            # must parse and be on or after the start date)
+            if "end_date" in entry:
+                end_date_str = entry["end_date"]
+                if not isinstance(end_date_str, str):
+                    raise ValidationError(
+                        f"Timeline end_date must be a string: {end_date_str}"
+                    )
+                try:
+                    end_date_obj = datetime.fromisoformat(end_date_str)
+                except (ValueError, TypeError):
+                    raise ValidationError(
+                        "Invalid end_date format (expected ISO format YYYY-MM-DD): "
+                        f"{end_date_str}"
+                    )
+                if end_date_obj < date_obj:
+                    raise ValidationError(
+                        f"Timeline end_date must be on or after date: {entry}"
                     )
 
 

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -129,6 +129,71 @@ def test_patch_replace_timeline_item_title():
 
 
 @pytest.mark.django_db
+def test_patch_timeline_preserves_date_bs_and_span_fields():
+    """PATCH must not strip the optional date_bs/end_date/end_date_bs fields."""
+    user = _contributor("kamala")
+    case = _make_case()
+    case.contributors.add(user)
+
+    new_timeline = [
+        {
+            "date": "1989-07-14",
+            "date_bs": "2046-03-30",
+            "end_date": "2020-07-15",
+            "end_date_bs": "2077-03-31",
+            "title": "जाँच अवधि",
+            "description": "Investigation period span.",
+        },
+        {
+            "date": "2025-02-09",
+            "date_bs": "2081-10-27",
+            "title": "मुद्दा दर्ता",
+        },
+    ]
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/timeline", "value": new_timeline}],
+        format="json",
+    )
+    assert response.status_code == 200
+    timeline = response.data["timeline"]
+    assert timeline[0]["date_bs"] == "2046-03-30"
+    assert timeline[0]["end_date"] == "2020-07-15"
+    assert timeline[0]["end_date_bs"] == "2077-03-31"
+    assert timeline[1]["date_bs"] == "2081-10-27"
+
+    case.refresh_from_db()
+    assert case.timeline[0]["end_date"] == "2020-07-15"
+    assert case.timeline[0]["end_date_bs"] == "2077-03-31"
+    assert case.timeline[1]["date_bs"] == "2081-10-27"
+
+
+@pytest.mark.django_db
+def test_patch_timeline_rejects_malformed_date_bs():
+    """A malformed date_bs in a PATCHed timeline is rejected (422)."""
+    user = _contributor("nabin")
+    case = _make_case()
+    case.contributors.add(user)
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[
+            {
+                "op": "replace",
+                "path": "/timeline",
+                "value": [
+                    {"date": "2025-02-09", "date_bs": "2081/10/27", "title": "X"}
+                ],
+            }
+        ],
+        format="json",
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
 def test_patch_add_appends_timeline_item():
     user = _contributor("ram")
     case = _make_case(timeline=[{"date": "2024-01-01", "title": "First"}])

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -150,6 +150,124 @@ def test_timeline_list_field_accepts_empty_description():
         )
 
 
+def test_timeline_list_field_accepts_date_bs():
+    """
+    Feature: accountability-platform-core, Property 2: Draft validation is lenient
+
+    TimelineListField should accept an optional date_bs (Bikram Sambat) field
+    when shaped as YYYY-MM-DD.
+    """
+    field = TimelineListField()
+
+    try:
+        field.validate(
+            [{"date": "2025-02-09", "date_bs": "2081-10-27", "title": "मुद्दा दर्ता"}],
+            None,
+        )
+    except ValidationError as e:
+        pytest.fail(f"TimelineListField should accept valid date_bs, but raised: {e}")
+
+
+def test_timeline_list_field_rejects_malformed_date_bs():
+    """
+    Feature: accountability-platform-core, Property 2: Draft validation is lenient
+
+    TimelineListField should reject a date_bs that is not a YYYY-MM-DD string.
+    """
+    field = TimelineListField()
+
+    with pytest.raises(ValidationError):
+        field.validate(
+            [{"date": "2025-02-09", "date_bs": "2081/10/27", "title": "Event"}],
+            None,
+        )
+
+    with pytest.raises(ValidationError):
+        field.validate(
+            [{"date": "2025-02-09", "date_bs": 20811027, "title": "Event"}],
+            None,
+        )
+
+
+def test_timeline_list_field_accepts_end_date_span():
+    """
+    Feature: accountability-platform-core, Property 2: Draft validation is lenient
+
+    TimelineListField should accept an optional end_date for events that span a
+    period, as long as it is on or after the start date.
+    """
+    field = TimelineListField()
+
+    try:
+        field.validate(
+            [
+                {
+                    "date": "1989-07-14",
+                    "date_bs": "2046-03-30",
+                    "end_date": "2020-07-15",
+                    "end_date_bs": "2077-03-31",
+                    "title": "जाँच अवधि",
+                }
+            ],
+            None,
+        )
+    except ValidationError as e:
+        pytest.fail(f"TimelineListField should accept valid end_date, but raised: {e}")
+
+
+def test_timeline_list_field_rejects_malformed_end_date_bs():
+    """
+    Feature: accountability-platform-core, Property 2: Draft validation is lenient
+
+    TimelineListField should reject an end_date_bs that is not a YYYY-MM-DD
+    Bikram Sambat string.
+    """
+    field = TimelineListField()
+
+    with pytest.raises(ValidationError):
+        field.validate(
+            [
+                {
+                    "date": "1989-07-14",
+                    "end_date": "2020-07-15",
+                    "end_date_bs": "2077/03/31",
+                    "title": "Event",
+                }
+            ],
+            None,
+        )
+
+
+def test_timeline_list_field_rejects_end_date_before_date():
+    """
+    Feature: accountability-platform-core, Property 2: Draft validation is lenient
+
+    TimelineListField should reject an end_date that is before the start date.
+    """
+    field = TimelineListField()
+
+    with pytest.raises(ValidationError):
+        field.validate(
+            [{"date": "2020-07-15", "end_date": "1989-07-14", "title": "Event"}],
+            None,
+        )
+
+
+def test_timeline_list_field_rejects_malformed_end_date():
+    """
+    Feature: accountability-platform-core, Property 2: Draft validation is lenient
+
+    TimelineListField should reject an end_date that is not an ISO date string.
+    """
+    field = TimelineListField()
+
+    with pytest.raises(ValidationError):
+        field.validate(
+            [{"date": "2020-07-15", "end_date": "not-a-date", "title": "Event"}],
+            None,
+        )
+
+
 # ============================================================================
 # EvidenceListField Tests
 # ============================================================================


### PR DESCRIPTION
## Summary

PR 1 of 2 for the CIAA factual-timeline work (#186). This is the **schema** PR; the reworked \`enrich_ciaa_timeline\` command lands in PR 2.

Surveying currently published cases showed that every curated timeline entry carries a **Bikram Sambat date (\`date_bs\`)** alongside the AD \`date\`, and factual-incident periods are expressed as **date ranges** — neither of which the \`TimelineListField\` schema knew about.

This PR extends \`TimelineListField.validate()\` to accept four optional, additive fields:

- \`date_bs\` — a Bikram Sambat \`YYYY-MM-DD\` string (shape-checked only; BS is not Gregorian-parseable, and AD↔BS conversion is done on the fly elsewhere)
- \`end_date\` — an AD ISO date for events that span a period (must be ≥ \`date\`)
- \`end_date_bs\` — the BS date for the span's end (shape-checked like \`date_bs\`)

\`date\`/\`title\` remain required; \`description\` stays optional.

## Notes

- **No migration required** — validation is Python-side only, not a schema change (\`makemigrations --check\` confirms no changes). Existing rows stay valid.
- No new dependency — the codebase already ships \`nepali ^1.2.0\` for BS↔AD conversion.

## Companion PR

Frontend rendering of \`date_bs\` / \`end_date\` spans: Jawafdehi/Jawafdehi#feat/timeline-entry-bs-and-span

## Test plan

- \`pytest tests/test_custom_fields.py\` — 17 passed (6 new: date_bs accept/reject, end_date span/order/format, end_date_bs accept/reject)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline entries now support optional alternative calendar format dates
  * Added validation to ensure end dates occur on or after start dates

* **Tests**
  * Comprehensive new tests added for date format validation and date range constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->