### PR TITLE
Rework enrich_ciaa_timeline: API-driven factual-milestone extractor (#186)

### DIFF
--- a/cases/management/commands/_enrich_utils.py
+++ b/cases/management/commands/_enrich_utils.py
@@ -143,12 +143,10 @@ def call_llm(
         raise ValueError("max_retries must be >= 1")
 
     url = f"{base_url.rstrip('/')}/chat/completions"
-
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
-
     payload = {
         "model": model,
         "messages": [
@@ -160,6 +158,24 @@ def call_llm(
         "stream": False,  # explicitly disable streaming; proxy may default to SSE
     }
 
+    data = _post_chat_completion(url, headers, payload, session, max_retries)
+    message, finish_reason = _extract_message(data)
+    return _require_text_content(message, finish_reason, data, payload["max_tokens"])
+
+
+def _post_chat_completion(
+    url: str,
+    headers: dict,
+    payload: dict,
+    session: requests.Session,
+    max_retries: int,
+) -> dict:
+    """POST a chat-completion request with retry/backoff and return parsed JSON.
+
+    Handles transient connection/timeout/5xx errors with exponential backoff,
+    fails fast on 4xx, and tolerates SSE-formatted bodies. Raises CommandError
+    on terminal failure or unparseable response.
+    """
     # Read timeouts per attempt: fail fast on attempt 1, give more time on retries.
     # This avoids burning 5 min × 3 attempts = 15 min on a slow proxy.
     read_timeouts = [60, 90, 120]
@@ -245,65 +261,373 @@ def call_llm(
 
         if not isinstance(data, dict):
             raise CommandError("LLM API returned non-dictionary JSON root")
+        return data
 
-        choices = data.get("choices")
-        if not isinstance(choices, list) or not choices:
-            raise CommandError("LLM API returned no choices")
+    # Unreachable: the loop either returns or raises on the final attempt.
+    raise CommandError("LLM API request failed")  # pragma: no cover
 
-        if not isinstance(choices[0], dict):
-            raise CommandError("LLM API returned malformed choice object")
 
-        message = choices[0].get("message")
-        if not isinstance(message, dict):
-            raise CommandError("LLM API returned message missing or invalid")
+def _extract_message(data: dict) -> tuple[dict, str]:
+    """Return (message, finish_reason) from a chat-completion response."""
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise CommandError("LLM API returned no choices")
+    if not isinstance(choices[0], dict):
+        raise CommandError("LLM API returned malformed choice object")
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise CommandError("LLM API returned message missing or invalid")
+    return message, choices[0].get("finish_reason", "")
 
-        finish_reason = choices[0].get("finish_reason", "")
 
-        content = message.get("content")
+def _require_text_content(
+    message: dict, finish_reason: str, data: dict, max_tokens: int
+) -> str:
+    """Extract the assistant text content from a message, or raise CommandError."""
+    content = message.get("content")
 
-        # DeepSeek-R1 reasoning models sometimes put the answer in
-        # reasoning_content when content is empty (proxy-dependent behaviour)
-        if not content and message.get("reasoning_content"):
-            content = message.get("reasoning_content")
+    # DeepSeek-R1 reasoning models sometimes put the answer in
+    # reasoning_content when content is empty (proxy-dependent behaviour)
+    if not content and message.get("reasoning_content"):
+        content = message.get("reasoning_content")
 
-        if content is None:
-            if "refusal" in message:
-                raise CommandError(
-                    f"LLM refused: {str(message['refusal'])[:200]}"
-                ) from None
-            if "tool_calls" in message:
-                raise CommandError(
-                    "LLM returned tool_calls instead of content"
-                ) from None
-            raise CommandError("LLM message missing required 'content' key") from None
-
-        if not isinstance(content, str):
+    if content is None:
+        if "refusal" in message:
             raise CommandError(
-                f"LLM content is not a string: {type(content).__name__}"
+                f"LLM refused: {str(message['refusal'])[:200]}"
             ) from None
+        if "tool_calls" in message:
+            raise CommandError("LLM returned tool_calls instead of content") from None
+        raise CommandError("LLM message missing required 'content' key") from None
 
-        if not content.strip():
-            usage = data.get("usage", {})
-            reasoning_tokens = usage.get("completion_tokens_details", {}).get(
-                "reasoning_tokens", 0
+    if not isinstance(content, str):
+        raise CommandError(
+            f"LLM content is not a string: {type(content).__name__}"
+        ) from None
+
+    if not content.strip():
+        usage = data.get("usage", {})
+        reasoning_tokens = usage.get("completion_tokens_details", {}).get(
+            "reasoning_tokens", 0
+        )
+        if finish_reason == "length" and reasoning_tokens >= max_tokens - 50:
+            raise CommandError(
+                f"LLM reasoning model exhausted all {max_tokens} tokens "
+                f"on internal reasoning ({reasoning_tokens} reasoning tokens) with "
+                f"no tokens left for output. Increase max_tokens or simplify prompt."
             )
-            if (
-                finish_reason == "length"
-                and reasoning_tokens >= payload["max_tokens"] - 50
-            ):
-                raise CommandError(
-                    f"LLM reasoning model exhausted all {payload['max_tokens']} tokens "
-                    f"on internal reasoning ({reasoning_tokens} reasoning tokens) with "
-                    f"no tokens left for output. Increase max_tokens or simplify prompt."
+        logger.warning(
+            "LLM API returned empty content. finish_reason=%s usage=%s",
+            finish_reason,
+            usage,
+        )
+        raise CommandError("LLM API returned empty content")
+
+    return content
+
+
+# ── date conversion tool (AD <-> Bikram Sambat) ──────────────────────────────
+
+# OpenAI function-tool definition for the LLM. Mirrors the jawafdehi-mcp
+# `convert_date` tool so the model can convert dates reliably instead of doing
+# error-prone BS<->AD arithmetic in its head.
+CONVERT_DATE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "convert_date",
+        "description": (
+            "Convert dates between AD (Gregorian) and BS (Bikram Sambat) using "
+            "Nepal's official calendar (Asia/Kathmandu). LLMs frequently get "
+            "BS<->AD conversion wrong; always use this tool instead of "
+            "converting in your head."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "dates": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Dates to convert, each in YYYY-MM-DD format "
+                        "(e.g. ['2023-01-15', '2079-10-01'])."
+                    ),
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["ad_to_bs", "bs_to_ad"],
+                    "description": "Direction of conversion.",
+                },
+            },
+            "required": ["dates", "mode"],
+        },
+    },
+}
+
+# Anthropic (Bedrock Messages API) tool schema — same tool, different envelope:
+# Anthropic uses a flat {name, description, input_schema} shape rather than
+# OpenAI's nested {type:"function", function:{...}}.
+CONVERT_DATE_TOOL_ANTHROPIC = {
+    "name": CONVERT_DATE_TOOL["function"]["name"],
+    "description": CONVERT_DATE_TOOL["function"]["description"],
+    "input_schema": CONVERT_DATE_TOOL["function"]["parameters"],
+}
+
+_DEVANAGARI_TO_ASCII_DIGITS = str.maketrans("०१२३४५६७८९", "0123456789")
+
+
+def convert_date(dates: list, mode: str) -> dict:
+    """Convert a list of dates between AD and BS using the `nepali` package.
+
+    Returns a dict mapping each input date string to its converted value, or to
+    an "Error: ..." string when that date cannot be converted. This is executed
+    in-process (no network) and is the same calendar math the jawafdehi-mcp
+    convert_date tool uses.
+    """
+    from nepali.datetime import nepalidate
+
+    if mode not in ("ad_to_bs", "bs_to_ad"):
+        raise ValueError("mode must be 'ad_to_bs' or 'bs_to_ad'")
+    if not isinstance(dates, list):
+        raise ValueError("dates must be a list of YYYY-MM-DD strings")
+
+    results: dict[str, str] = {}
+    for raw in dates:
+        if not isinstance(raw, str):
+            results[str(raw)] = "Error: date must be a YYYY-MM-DD string"
+            continue
+        normalized = (
+            raw.strip().translate(_DEVANAGARI_TO_ASCII_DIGITS).replace("/", "-")
+        )
+        parts = normalized.split("-")
+        if len(parts) != 3:
+            results[raw] = "Error: date must be in YYYY-MM-DD format"
+            continue
+        try:
+            year, month, day = (int(parts[0]), int(parts[1]), int(parts[2]))
+            if mode == "ad_to_bs":
+                import datetime as _dt
+
+                converted = nepalidate.from_date(_dt.date(year, month, day)).strftime(
+                    "%Y-%m-%d"
                 )
-            logger.warning(
-                "LLM API returned empty content. finish_reason=%s usage=%s",
-                finish_reason,
-                usage,
-            )
-            raise CommandError("LLM API returned empty content")
+            else:
+                converted = (
+                    nepalidate(year, month, day)
+                    .to_datetime()
+                    .date()
+                    .strftime("%Y-%m-%d")
+                )
+            results[raw] = converted
+        except Exception as exc:  # noqa: BLE001
+            # The `nepali` package raises its own exception types (e.g.
+            # FormatNotMatchException) that subclass neither ValueError nor
+            # TypeError; report the per-date error rather than aborting the run.
+            results[raw] = f"Error: {exc}"
+    return results
 
-        return content
+
+def call_llm_with_tools(
+    system_prompt: str,
+    user_prompt: str,
+    model: str,
+    base_url: str,
+    api_key: Optional[str],
+    session: requests.Session,
+    tools: list,
+    tool_executors: dict,
+    max_tokens: int = 4000,
+    max_tool_rounds: int = 30,
+    max_retries: int = 3,
+) -> str:
+    """Call the LLM with OpenAI function-tools, running a tool-use loop.
+
+    The model may emit tool_calls; each is dispatched to ``tool_executors[name]``
+    (a callable taking the parsed JSON arguments and returning a JSON-serialisable
+    result), the result is appended to the conversation, and the request is
+    repeated until the model returns final text content. The loop is bounded by
+    ``max_tool_rounds`` to prevent runaway tool use.
+
+    Returns the model's final text content. Raises CommandError on failure or if
+    the tool-round budget is exhausted.
+    """
+    if max_tool_rounds < 1:
+        raise ValueError("max_tool_rounds must be >= 1")
+
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    for _ in range(max_tool_rounds):
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.1,
+            "max_tokens": max_tokens,
+            "stream": False,
+            "tools": tools,
+            "tool_choice": "auto",
+        }
+        data = _post_chat_completion(url, headers, payload, session, max_retries)
+        message, finish_reason = _extract_message(data)
+
+        tool_calls = message.get("tool_calls")
+        if not tool_calls:
+            # No tool calls — this is the final answer.
+            return _require_text_content(message, finish_reason, data, max_tokens)
+
+        # Echo the assistant turn (with its tool_calls) before the tool results.
+        messages.append(
+            {
+                "role": "assistant",
+                "content": message.get("content") or "",
+                "tool_calls": tool_calls,
+            }
+        )
+        for call in tool_calls:
+            messages.append(_run_tool_call(call, tool_executors))
+
+    raise CommandError(
+        f"LLM exceeded the maximum of {max_tool_rounds} tool-use rounds "
+        "without producing a final answer."
+    )
+
+
+def _run_tool_call(call: dict, tool_executors: dict) -> dict:
+    """Execute one tool_call and return the 'tool' role message to append."""
+    call_id = call.get("id", "")
+    function = call.get("function") or {}
+    name = function.get("name", "")
+    raw_args = function.get("arguments") or "{}"
+
+    def _tool_message(content: str) -> dict:
+        return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+    executor = tool_executors.get(name)
+    if executor is None:
+        return _tool_message(f"Error: unknown tool '{name}'")
+    try:
+        args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        result = executor(**args)
+        return _tool_message(json.dumps(result, ensure_ascii=False))
+    except Exception as exc:  # noqa: BLE001
+        # Any tool failure is reported back to the model as a tool result rather
+        # than aborting the whole enrichment run; the model can then recover or
+        # proceed without that tool's output.
+        logger.warning("Tool '%s' failed: %s", name, exc)
+        return _tool_message(f"Error: {exc}")
+
+
+def call_bedrock_with_tools(
+    system_prompt: str,
+    user_prompt: str,
+    model_id: str,
+    tools: list,
+    tool_executors: dict,
+    aws_profile: str = "",
+    aws_region: str = "us-west-2",
+    max_tokens: int = 4000,
+    max_tool_rounds: int = 30,
+) -> str:
+    """Call a Claude model on AWS Bedrock (native Messages API) with a tool-use loop.
+
+    This is the Bedrock-native counterpart to ``call_llm_with_tools`` — Claude
+    (e.g. Opus 4.8) is reached through ``bedrock-runtime.invoke_model`` rather
+    than an OpenAI-compatible gateway. The model may emit ``tool_use`` content
+    blocks; each is dispatched to ``tool_executors[name]`` and returned as a
+    ``tool_result`` block in a follow-up user turn until the model stops with a
+    final text answer. Bounded by ``max_tool_rounds``.
+
+    ``tools`` must use the Anthropic schema (name/description/input_schema), e.g.
+    ``CONVERT_DATE_TOOL_ANTHROPIC``. Returns the model's final text content.
+    """
+    if max_tool_rounds < 1:
+        raise ValueError("max_tool_rounds must be >= 1")
+
+    import boto3
+    from botocore.config import Config
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    session = boto3.Session(profile_name=aws_profile or None, region_name=aws_region)
+    client = session.client(
+        "bedrock-runtime",
+        config=Config(
+            read_timeout=120, connect_timeout=15, retries={"max_attempts": 4}
+        ),
+    )
+
+    messages = [{"role": "user", "content": user_prompt}]
+
+    for _ in range(max_tool_rounds):
+        body = {
+            # Note: no "temperature" — deprecated for newer Bedrock Claude models
+            # (e.g. Opus 4.8), which reject it with a ValidationException.
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": max_tokens,
+            "system": system_prompt,
+            "tools": tools,
+            "messages": messages,
+        }
+        try:
+            resp = client.invoke_model(modelId=model_id, body=json.dumps(body))
+            payload = json.loads(resp["body"].read())
+        except (BotoCoreError, ClientError, ValueError, KeyError) as exc:
+            raise CommandError(f"Bedrock invoke_model failed: {exc}") from exc
+
+        content_blocks = payload.get("content") or []
+        stop_reason = payload.get("stop_reason")
+
+        if stop_reason != "tool_use":
+            # Final answer — concatenate any text blocks.
+            text = "".join(
+                b.get("text", "")
+                for b in content_blocks
+                if isinstance(b, dict) and b.get("type") == "text"
+            ).strip()
+            if not text:
+                raise CommandError("Bedrock returned empty content")
+            return text
+
+        # Echo the assistant turn, then answer each tool_use with a tool_result.
+        messages.append({"role": "assistant", "content": content_blocks})
+        tool_results = []
+        for block in content_blocks:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_results.append(_run_bedrock_tool_use(block, tool_executors))
+        messages.append({"role": "user", "content": tool_results})
+
+    raise CommandError(
+        f"Bedrock model exceeded the maximum of {max_tool_rounds} tool-use rounds "
+        "without producing a final answer."
+    )
+
+
+def _run_bedrock_tool_use(block: dict, tool_executors: dict) -> dict:
+    """Execute one Anthropic tool_use block; return the tool_result content block."""
+    use_id = block.get("id", "")
+    name = block.get("name", "")
+    args = block.get("input") or {}
+
+    def _result(content: str, is_error: bool = False) -> dict:
+        out = {"type": "tool_result", "tool_use_id": use_id, "content": content}
+        if is_error:
+            out["is_error"] = True
+        return out
+
+    executor = tool_executors.get(name)
+    if executor is None:
+        return _result(f"Error: unknown tool '{name}'", is_error=True)
+    try:
+        result = executor(**args) if isinstance(args, dict) else executor(args)
+        return _result(json.dumps(result, ensure_ascii=False))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Tool '%s' failed: %s", name, exc)
+        return _result(f"Error: {exc}", is_error=True)
 
 
 def convert_to_markdown(url: str, session: requests.Session) -> Optional[str]:

--- a/cases/management/commands/enrich_ciaa_timeline.py
+++ b/cases/management/commands/enrich_ciaa_timeline.py
@@ -1,15 +1,24 @@
 """
-Django management command to extract case timeline entries from CIAA source
-documents using LLM extraction.
+Django management command to extract a case's FACTUAL TIMELINE from CIAA source
+documents using LLM extraction, fully over the Jawafdehi HTTP API.
 
-Phase 1 (A.3) of CIAA FY 080/081 Case Enrichment pipeline.
-Populates ``Case.timeline`` with chronological entries covering case
-progression from investigation through verdict.
+Phase A.3 of the CIAA Case Enrichment pipeline. Populates ``Case.timeline``
+with the factual milestones of a corruption case (incident period, complaint,
+CIAA investigation, press release, chargesheet filing, interim orders, Special
+Court verdict, Supreme Court appeal/verdict) — NOT the routine hearing-by-hearing
+court progression (that is already tracked as the case's Pragati Bibaran by case
+number). See https://github.com/Jawafdehi/JawafdehiAPI/issues/186.
 
-Processes all DRAFT cases with empty ``timeline``, regardless of
-court case naming conventions.
+This command is API-driven: it reads cases, source content and NGM hearing
+records over HTTP and writes the timeline via ``PATCH /api/cases/{slug}/``. It
+never touches the ORM, so a ``--dry-run`` needs no database credentials — only
+an API token (to read DRAFT cases) and an LLM key (timeline generation requires
+the model). The LLM is given a ``convert_date`` tool so it converts dates
+between Bikram Sambat and Gregorian reliably instead of doing the arithmetic in
+its head.
 
-Idempotent: skips cases with non-empty ``timeline``.
+Idempotent: skips cases whose ``timeline`` is already populated (unless
+``--force``).
 
 Usage::
 
@@ -23,97 +32,121 @@ Usage::
 import logging
 import os
 import re
+import urllib.parse
 from typing import Optional
-from urllib.parse import urlparse
 
 import requests
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
-from django.utils import timezone
 
 from cases.management.commands._enrich_utils import (
-    ALLOWED_HOSTS,
-    call_llm,
-    convert_to_markdown,
+    CONVERT_DATE_TOOL,
+    CONVERT_DATE_TOOL_ANTHROPIC,
+    call_bedrock_with_tools,
+    call_llm_with_tools,
+    convert_date,
     is_valid_iso_date,
     parse_extraction_response,
     resolve_api_key,
 )
-from cases.models import Case, DocumentSource, SourceType
-from cases.services.priority_case_loader import filter_by_priority, load_priority_cases
-from ngm.services import get_court_case_details
+from cases.services.priority_case_loader import load_priority_cases
 
 logger = logging.getLogger(__name__)
 
+# Source types (matched as plain strings from the API payload — no model import
+# so the command stays ORM-free). Ordered by usefulness for factual milestones.
+MILESTONE_SOURCE_TYPES = (
+    "AG_ABHIYOG_PATRA",  # charge sheet — richest factual detail
+    "CIAA_PRESS_RELEASE",  # complaint / investigation / chargesheet dates
+    "COURT_ORDER",  # verdict
+    "COURT_FILING_OTHER",
+)
+
 EXTRACTION_SYSTEM_PROMPT = """\
-You are a Nepali legal analyst extracting structured timeline entries from \
-CIAA (Commission for the Investigation of Abuse of Authority) press releases, \
-court orders, charge sheets, and NGM court hearing records.
+You are a Nepali legal analyst reconstructing the FACTUAL TIMELINE of a \
+corruption case investigated by Nepal's CIAA (अख्तियार दुरुपयोग अनुसन्धान आयोग) \
+and tried at the Special Court (विशेष अदालत).
 
-Your task is to reconstruct the chronological progression of a corruption case \
-from available source documents.
+Your goal is to capture the factual milestones of the case — what happened and \
+when — NOT the routine court-procedure log. The court's hearing-by-hearing \
+progression (पेशी/sunwai) is already tracked separately as the case's Pragati \
+Bibaran by case number, so DO NOT emit one entry per hearing. Use the hearing \
+records only to anchor the dates of the milestones below.
 
-TIMELINE ENTRY FORMAT:
-Each entry must be a JSON object with:
-- "date": ISO date string (YYYY-MM-DD) in AD (Gregorian calendar)
-- "title": Brief label in Nepali (one line, 5-15 words) describing the event
-- "description": Optional 1-3 sentence explanation in Nepali
+MILESTONES TO EXTRACT (include each only when grounded in the sources):
+1. Factual incident period — the span the alleged offence covers, BEFORE the
+   complaint (the CIAA "jaanch awadhi" / जाँच अवधि, or the period the accused
+   held office or the conduct occurred). Emit as a SINGLE entry with both
+   "date" (start) and "end_date" (end).
+2. Complaint (उजुरी निवेदन) — when the complaint was registered at the CIAA.
+3. CIAA investigation (अनुसन्धान) — when the CIAA began/decided to investigate,
+   if distinct from the complaint.
+4. Press release (प्रेस विज्ञप्ति) — when the CIAA publicly announced the case.
+5. Chargesheet filed / case registered (अभियोगपत्र/आरोपपत्र दायर, मुद्दा दर्ता)
+   — when the CIAA filed the chargesheet at the Special Court.
+6. Interim court order (अन्तरिम आदेश) — any interim order dates, if issued.
+7. Special Court verdict (विशेष अदालतको फैसला) — judgment date and outcome
+   (conviction / acquittal "सफाई" / partial).
+8. Supreme Court appeal (सर्वोच्च अदालतमा पुनरावेदन) — when an appeal was filed.
+9. Supreme Court verdict (सर्वोच्च अदालतको फैसला) — final judgment.
 
-All three fields must be written in Nepali (देवनागरी लिपि).
+ENTRY FORMAT — each entry is a JSON object:
+- "date": AD date "YYYY-MM-DD" (Gregorian). REQUIRED.
+- "date_bs": the Bikram Sambat date "YYYY-MM-DD" as it appears in the source.
+  REQUIRED — every Nepali legal document states dates in BS; record it.
+- "end_date": AD "YYYY-MM-DD" — ONLY for the incident-period entry (milestone 1).
+- "end_date_bs": the BS date for end_date — only when end_date is present.
+- "title": short Nepali label (देवनागरी, 4-12 words) naming the milestone.
+- "description": 1-3 Nepali sentences with specifics (amounts, section numbers,
+  press-release number, bench, outcome). Optional but strongly encouraged.
 
-KEY EVENTS TO EXTRACT (when available in sources):
-1. CIAA investigation initiation / filing decision date
-2. Case filed to Special Court date
-3. Court hearing dates
-4. Verdict / judgment date
-5. Case registration at CIAA (if different from investigation start)
-6. Any other significant dates mentioned in the source
-
-DATE CONVERSION RULES (CRITICAL):
-- Document text sources use Bikram Sambat (BS) dates — convert to AD
-- NGM structured data contains reliable AD dates — use EXACTLY as-is
-- BS to AD offset: subtract 56 years and 8 months 17 days as baseline
-- ALWAYS output in YYYY-MM-DD format
-
-NGM DATE PRIORITY (CRITICAL):
-- NGM structured hearing data (if provided) contains ground-truth AD dates
-- For any event that exists in BOTH NGM data and document text,
-  use the NGM date exactly — do not convert or adjust it
-- Use document text to add narrative context (title, description) to
-  NGM-dated events, and to extract any additional events not in NGM
-- NGM dates are already in AD format — treat them as authoritative
+DATE CONVERSION TOOL (MANDATORY):
+You have a `convert_date` tool that converts between AD (Gregorian) and BS
+(Bikram Sambat) using Nepal's official calendar. LLMs routinely get BS<->AD
+conversion wrong by days or months — so you MUST NOT convert dates in your head.
+- For every date taken from a source document (stated in BS), call convert_date
+  with mode="bs_to_ad" to get the AD "date"; keep the original BS as "date_bs".
+- For every date taken from the NGM hearing records (in AD), call convert_date
+  with mode="ad_to_bs" to get "date_bs"; keep the AD as "date".
+- Batch dates into one tool call where possible (the tool accepts a list).
+- Use ONLY the tool's output for "date"/"date_bs"; never adjust or round it.
+- Verify every entry's "date" and "date_bs" are a matching pair the tool
+  returned before emitting it.
 
 QUALITY RULES:
-- Minimum 3 timeline entries when sufficient source material exists
-- Entries must be in chronological order (earliest first)
-- Each entry must be factually grounded in the provided sources
-- Do NOT fabricate dates or events not mentioned in the sources
-- If the source text is insufficient, return fewer entries or an empty array
+- Order entries chronologically, earliest first.
+- Every entry must be grounded in the provided sources. Do NOT fabricate dates,
+  events, amounts, or outcomes.
+- Omit a milestone entirely if the sources do not support it. Fewer, accurate
+  entries are better than padded ones.
+- Do NOT emit routine hearing/पेशी entries — synthesize them into milestone 7.
 """
 
 EXTRACTION_USER_PROMPT = """\
-Extract chronological timeline entries from the provided CIAA case source \
-documents and NGM structured hearing data.
+Reconstruct the factual timeline for the following CIAA Special Court case.
 
 Case title: {case_title}
 
 Instructions:
-- Each entry must have "date" (YYYY-MM-DD in AD) and "title" in Nepali
-- "description" is optional but encouraged when source provides details
-- For NGM dates: use them exactly as-is — they are authoritative ground-truth
-- For document-text dates: convert from BS to AD before outputting
-- Use document text for narrative context (titles, descriptions)
-- Order entries chronologically from earliest to latest
-- Only include events explicitly mentioned or clearly inferred from the sources
-- If sources are insufficient, return fewer entries
+- Extract the factual milestones defined in the system prompt that the sources
+  support.
+- Every entry needs "date" (AD YYYY-MM-DD), "date_bs" (BS YYYY-MM-DD), and a
+  Nepali "title".
+- Express the factual incident period (milestone 1) as ONE entry with "date" +
+  "end_date" (and "date_bs" + "end_date_bs").
+- Convert every date with the convert_date tool — do not convert dates yourself.
+  Source dates are BS (use bs_to_ad); NGM dates are AD (use ad_to_bs).
+- Use the NGM hearing data only to anchor milestone dates (chargesheet
+  registration, verdict). Do NOT create one entry per hearing.
+- Order entries chronologically; only include milestones the sources support.
 
-IMPORTANT: Return ONLY a valid JSON array of timeline entry objects.
-Format: [{{"date": "YYYY-MM-DD", "title": "नेपाली शीर्षक", "description": "विवरण"}}]
-No explanations, no markdown, no text outside the JSON array.
+Return ONLY a valid JSON array of entry objects. No markdown, no prose.
+Format:
+[{{"date": "YYYY-MM-DD", "date_bs": "YYYY-MM-DD", "title": "नेपाली शीर्षक", "description": "विवरण"}}]
 
 {ngm_section}
 
-DOCUMENT TEXT (use for context, narrative, and any dates not in NGM):
+DOCUMENT TEXT (chargesheet, press release, court order — use for milestones,
+narrative, amounts, and any dates not in the NGM data):
 
 {source_text}
 """
@@ -121,15 +154,15 @@ DOCUMENT TEXT (use for context, narrative, and any dates not in NGM):
 
 class Command(BaseCommand):
     help = (
-        "Extract case timeline entries from CIAA source documents via LLM. "
-        "Populates timeline for CIAA Special Court draft cases."
+        "Extract the factual timeline of CIAA Special Court cases via LLM, "
+        "reading and writing entirely over the Jawafdehi HTTP API."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="Preview without saving to database",
+            help="Preview without PATCHing the API",
         )
         parser.add_argument(
             "--case-id",
@@ -157,10 +190,35 @@ class Command(BaseCommand):
             help="Enrich only cases in the priority case list",
         )
         parser.add_argument(
+            "--api-base-url",
+            type=str,
+            default=os.environ.get("JAWAFDEHI_API_BASE_URL", "http://127.0.0.1:8000"),
+            help="Jawafdehi API base URL (root or /api).",
+        )
+        parser.add_argument(
+            "--api-token",
+            type=str,
+            default=None,
+            help="Jawafdehi API token. Defaults to JAWAFDEHI_API_TOKEN.",
+        )
+        parser.add_argument(
+            "--llm-backend",
+            type=str,
+            choices=("auto", "bedrock", "openai"),
+            default="auto",
+            help=(
+                "LLM backend. 'bedrock' uses AWS Bedrock invoke_model (Claude, "
+                "e.g. Opus 4.8); 'openai' uses an OpenAI-compatible gateway. "
+                "'auto' (default) infers bedrock for claude/anthropic model ids."
+            ),
+        )
+        parser.add_argument(
             "--llm-model",
             type=str,
-            default="claude-sonnet-4-20250514",
-            help="LLM model identifier (default: claude-sonnet-4-20250514)",
+            default=os.environ.get(
+                "BEDROCK_MODEL_ID", "global.anthropic.claude-opus-4-8"
+            ),
+            help="LLM model identifier (default: BEDROCK_MODEL_ID env / Opus 4.8).",
         )
         parser.add_argument(
             "--llm-base-url",
@@ -168,13 +226,33 @@ class Command(BaseCommand):
             default=os.environ.get(
                 "JAWAFDEHI_LLM_PROXY_URL", "https://llm-proxy.jawafdehi.org/v1"
             ),
-            help="LLM API base URL (OpenAI-compatible endpoint)",
+            help="OpenAI-backend base URL (OpenAI-compatible endpoint).",
         )
         parser.add_argument(
             "--llm-api-key",
             type=str,
             default=None,
-            help="LLM API key (defaults to JAWAFDEHI_LLM_API_KEY or ANTHROPIC_API_KEY env var)",
+            help="OpenAI-backend API key (defaults to JAWAFDEHI_LLM_API_KEY or ANTHROPIC_API_KEY env var)",
+        )
+        parser.add_argument(
+            "--aws-profile",
+            type=str,
+            default=os.environ.get(
+                "REVIEW_AWS_PROFILE", os.environ.get("AWS_PROFILE", "")
+            ),
+            help="AWS profile for the bedrock backend (defaults to REVIEW_AWS_PROFILE/AWS_PROFILE).",
+        )
+        parser.add_argument(
+            "--aws-region",
+            type=str,
+            default=os.environ.get("AWS_REGION", "us-west-2"),
+            help="AWS region for the bedrock backend (default: us-west-2).",
+        )
+        parser.add_argument(
+            "--llm-max-tokens",
+            type=int,
+            default=4000,
+            help="LLM response token budget (default: 4000).",
         )
         parser.add_argument(
             "--verbose",
@@ -200,37 +278,25 @@ class Command(BaseCommand):
             self._http_session = requests.Session()
         return self._http_session
 
+    # ── argument resolution / validation ─────────────────────────────────
+
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         case_id = options.get("case_id")
-        limit = options.get("limit")
-
-        if limit is not None:
-            try:
-                limit_int = int(limit)
-            except (ValueError, TypeError):
-                raise CommandError(
-                    f"Invalid --limit value: {limit}. Must be a positive integer."
-                )
-            if limit_int <= 0:
-                raise CommandError(
-                    f"Invalid --limit: {limit_int}. Must be a positive integer."
-                )
-            limit = limit_int
-        llm_model = options["llm_model"]
-        llm_base_url = options["llm_base_url"]
-        llm_api_key = options.get("llm_api_key")
+        limit = self._validate_limit(options.get("limit"))
         force = options.get("force")
         fiscal_year = options.get("fiscal_year")
         priority = options.get("priority")
         verbose = options.get("verbose")
+
+        api_base_url = options["api_base_url"]
+        api_token = options.get("api_token") or os.environ.get("JAWAFDEHI_API_TOKEN")
 
         if priority and case_id:
             raise CommandError("--priority and --case-id are mutually exclusive")
 
         if verbose:
             logger.setLevel(logging.DEBUG)
-
         if not logger.handlers:
             handler = logging.StreamHandler(self.stdout)
             handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
@@ -240,12 +306,16 @@ class Command(BaseCommand):
         if dry_run:
             self.stdout.write(self.style.WARNING("[DRY RUN] No changes will be saved."))
 
-        api_key = resolve_api_key(llm_api_key)
-        if not dry_run and not api_key:
+        # Reading DRAFT cases requires authentication even for a dry run.
+        if not api_token:
             raise CommandError(
-                "No LLM API key provided. Set JAWAFDEHI_LLM_API_KEY or "
-                "ANTHROPIC_API_KEY environment variable, or use --llm-api-key."
+                "Jawafdehi API token is required to read DRAFT cases. "
+                "Set --api-token or JAWAFDEHI_API_TOKEN."
             )
+
+        # Resolve + validate the LLM backend. Timeline generation always needs
+        # the LLM (even on a dry run we still call the model; we just skip PATCH).
+        llm_cfg = self._resolve_llm_config(options)
 
         if fiscal_year and not re.match(r"^\d{2,3}$", fiscal_year):
             raise CommandError(
@@ -253,7 +323,11 @@ class Command(BaseCommand):
                 "Use 2- or 3-digit format, e.g., '80' or '080'."
             )
 
+        session = self._get_session()
         cases = self._get_ciaa_cases(
+            api_base_url=api_base_url,
+            api_token=api_token,
+            session=session,
             case_id=case_id,
             limit=limit,
             force=force,
@@ -261,9 +335,9 @@ class Command(BaseCommand):
             priority=priority,
         )
         total = len(cases)
-
         self.stdout.write(
-            f"Found {total} CIAA draft cases to process. Model: {llm_model}"
+            f"Found {total} CIAA draft cases to process. "
+            f"Backend: {llm_cfg['backend']} | Model: {llm_cfg['model']}"
         )
         if force:
             self.stdout.write(
@@ -272,111 +346,246 @@ class Command(BaseCommand):
         if fiscal_year:
             self.stdout.write(f"  Fiscal year filter: {fiscal_year}")
         if priority:
-            priority_list = load_priority_cases()
-            self.stdout.write(f"  Priority mode: {len(priority_list)} cases")
+            self.stdout.write(f"  Priority mode: {len(load_priority_cases())} cases")
 
-        session = self._get_session()
         for idx, case in enumerate(cases, 1):
             self._process_case(
                 case=case,
                 idx=idx,
                 total=total,
                 dry_run=dry_run,
-                llm_model=llm_model,
-                llm_base_url=llm_base_url,
-                llm_api_key=api_key,
+                llm_cfg=llm_cfg,
+                api_base_url=api_base_url,
+                api_token=api_token,
                 session=session,
-                force=force,
             )
 
         self._print_summary(dry_run)
 
-    # ── helpers ──────────────────────────────────────────────────────────
+    def _resolve_llm_config(self, options: dict) -> dict:
+        """Resolve and validate the LLM backend + its credentials.
+
+        Backend selection: 'bedrock' or 'openai', or 'auto' which infers bedrock
+        for claude/anthropic model ids and openai otherwise. Raises CommandError
+        if the chosen backend's required credential is missing.
+        """
+        model = options["llm_model"]
+        backend = options["llm_backend"]
+        if backend == "auto":
+            lowered = model.lower()
+            backend = (
+                "bedrock"
+                if ("anthropic" in lowered or "claude" in lowered)
+                else "openai"
+            )
+
+        cfg = {
+            "backend": backend,
+            "model": model,
+            "max_tokens": options["llm_max_tokens"],
+        }
+        if backend == "bedrock":
+            # boto3 resolves credentials from the profile/instance role; we only
+            # need the profile/region here. A missing role surfaces at call time.
+            cfg["aws_profile"] = options.get("aws_profile") or ""
+            cfg["aws_region"] = options.get("aws_region") or "us-west-2"
+        else:
+            api_key = resolve_api_key(options.get("llm_api_key"))
+            if not api_key:
+                raise CommandError(
+                    "No LLM API key provided for the openai backend. Set "
+                    "JAWAFDEHI_LLM_API_KEY or ANTHROPIC_API_KEY, or use --llm-api-key."
+                )
+            cfg["base_url"] = options["llm_base_url"]
+            cfg["api_key"] = api_key
+        return cfg
+
+    @staticmethod
+    def _validate_limit(limit) -> Optional[int]:
+        if limit is None:
+            return None
+        try:
+            limit_int = int(limit)
+        except (ValueError, TypeError):
+            raise CommandError(
+                f"Invalid --limit value: {limit}. Must be a positive integer."
+            )
+        if limit_int <= 0:
+            raise CommandError(
+                f"Invalid --limit: {limit_int}. Must be a positive integer."
+            )
+        return limit_int
+
+    # ── API reads ─────────────────────────────────────────────────────────
+
+    def _api_root(self, api_base_url: str) -> str:
+        """Return the API root (".../api") for the given base URL, validated.
+
+        Memoised: the base URL is constant for a run, so we parse/validate once.
+        """
+        cached = getattr(self, "_api_root_cache", None)
+        if cached is not None and cached[0] == api_base_url:
+            return cached[1]
+        parsed = urllib.parse.urlparse((api_base_url or "").strip())
+        if not (
+            parsed.scheme == "https"
+            or (parsed.scheme == "http" and self._is_loopback_host(parsed.hostname))
+        ):
+            raise CommandError(
+                f"Invalid api_base_url '{api_base_url}': use https for non-local hosts."
+            )
+        if not parsed.netloc:
+            raise CommandError(
+                f"Invalid api_base_url '{api_base_url}': URL must include a host."
+            )
+        path = parsed.path.rstrip("/")
+        base = urllib.parse.urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+        api_root = base if base.endswith("/api") else f"{base}/api"
+        self._api_root_cache = (api_base_url, api_root)
+        return api_root
+
+    @staticmethod
+    def _is_loopback_host(hostname: Optional[str]) -> bool:
+        if not hostname:
+            return False
+        host = hostname.lower().rstrip(".")
+        if host == "localhost":
+            return True
+        import ipaddress
+
+        try:
+            return ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            return False
+
+    def _api_get(
+        self,
+        url: str,
+        api_token: str,
+        session: requests.Session,
+        params: Optional[dict] = None,
+    ) -> dict:
+        """GET a JSON document from the API with token auth."""
+        headers = {
+            "Authorization": f"Token {api_token}",
+            "Accept": "application/json",
+        }
+        try:
+            response = session.get(url, headers=headers, params=params, timeout=60)
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else "?"
+            body = exc.response.text[:300] if exc.response is not None else ""
+            raise CommandError(f"API GET {url} failed (HTTP {status}): {body}") from exc
+        except requests.RequestException as exc:
+            raise CommandError(f"API GET {url} failed: {exc}") from exc
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise CommandError(f"API GET {url} returned invalid JSON: {exc}") from exc
 
     def _get_ciaa_cases(
         self,
+        api_base_url: str,
+        api_token: str,
+        session: requests.Session,
         case_id: Optional[str] = None,
         limit: Optional[int] = None,
         force: bool = False,
         fiscal_year: Optional[str] = None,
         priority: bool = False,
-    ) -> list[Case]:
-        """Return DRAFT cases with empty timeline that are candidates for enrichment."""
-        queryset = Case.objects.filter(state="DRAFT")
-        if case_id:
-            queryset = queryset.filter(case_id=case_id)
+    ) -> list[dict]:
+        """Fetch DRAFT CIAA Special Court cases (as API dicts) to enrich."""
+        api_root = self._api_root(api_base_url)
+        priority_numbers = set(load_priority_cases()) if priority else None
 
-        if priority:
-            priority_list = load_priority_cases()
-            queryset = filter_by_priority(queryset, priority_list)
+        selected: list[dict] = []
+        next_url = f"{api_root}/cases/"
+        params = {"case_type": "CORRUPTION"}
 
-        all_cases = []
-        candidate_count = 0
-        for case in queryset.order_by("case_id"):
-            if not self._is_ciaa_special_court_case(case):
-                continue
-            if fiscal_year and not self._matches_fiscal_year(case, fiscal_year):
-                continue
-            candidate_count += 1
-            if not force and case.timeline:
-                continue
-            all_cases.append(case)
-            if limit and len(all_cases) >= limit:
-                break
+        while next_url:
+            page = self._api_get(next_url, api_token, session, params=params)
+            params = None  # the `next` link already carries query params
+            results = page.get("results", []) if isinstance(page, dict) else []
+            for summary in results:
+                if summary.get("state") != "DRAFT":
+                    continue
+                if case_id and summary.get("case_id") != case_id:
+                    continue
+                if not self._is_ciaa_special_court_case(summary):
+                    continue
+                if fiscal_year and not self._matches_fiscal_year(summary, fiscal_year):
+                    continue
+                if priority_numbers is not None and not self._matches_priority(
+                    summary, priority_numbers
+                ):
+                    continue
 
-        if not force:
-            self.stats["cases_already_populated"] = sum(
-                1
-                for c in queryset
-                if self._is_ciaa_special_court_case(c)
-                and (not fiscal_year or self._matches_fiscal_year(c, fiscal_year))
-                and c.timeline
-            )
-        return all_cases
+                if not force and summary.get("timeline"):
+                    self.stats["cases_already_populated"] += 1
+                    continue
+
+                selected.append(summary)
+                if limit and len(selected) >= limit:
+                    return selected
+
+            next_url = page.get("next") if isinstance(page, dict) else None
+
+        return selected
 
     @staticmethod
-    def _is_ciaa_special_court_case(case: Case) -> bool:
-        """Return True if the case references Special Court in court_cases."""
-        if case.court_cases and isinstance(case.court_cases, list):
-            return any(
-                isinstance(ref, str) and ref.startswith("special:")
-                for ref in case.court_cases
-            )
-        return False
+    def _is_ciaa_special_court_case(case: dict) -> bool:
+        court_cases = case.get("court_cases") or []
+        return isinstance(court_cases, list) and any(
+            isinstance(ref, str) and ref.startswith("special:") for ref in court_cases
+        )
 
-    def _matches_fiscal_year(self, case: Case, fiscal_year: str) -> bool:
-        """Check if a case's court_cases reference matches the given fiscal year."""
+    @staticmethod
+    def _matches_fiscal_year(case: dict, fiscal_year: str) -> bool:
         fy_normalized = fiscal_year.lstrip("0") or "0"
-        if case.court_cases and isinstance(case.court_cases, list):
-            for entry in case.court_cases:
-                if isinstance(entry, str):
-                    parts = entry.split(":")
-                    case_number = parts[-1] if ":" in entry else entry
-                    if "-CR-" in case_number:
-                        prefix = case_number.split("-CR-")[0].lstrip("0") or "0"
-                        if prefix == fy_normalized:
-                            return True
+        for entry in case.get("court_cases") or []:
+            if not isinstance(entry, str):
+                continue
+            case_number = entry.split(":")[-1] if ":" in entry else entry
+            if "-CR-" in case_number:
+                prefix = case_number.split("-CR-")[0].lstrip("0") or "0"
+                if prefix == fy_normalized:
+                    return True
         return False
 
-    # ── core pipeline ────────────────────────────────────────────────────
+    @staticmethod
+    def _matches_priority(case: dict, priority_numbers: set) -> bool:
+        for entry in case.get("court_cases") or []:
+            if not isinstance(entry, str):
+                continue
+            case_number = entry.split(":")[-1] if ":" in entry else entry
+            if case_number in priority_numbers:
+                return True
+        return False
+
+    # ── core pipeline ─────────────────────────────────────────────────────
 
     def _process_case(
         self,
-        case: Case,
+        case: dict,
         idx: int,
         total: int,
         dry_run: bool,
-        llm_model: str,
-        llm_base_url: str,
-        llm_api_key: Optional[str],
+        llm_cfg: dict,
+        api_base_url: str,
+        api_token: str,
         session: requests.Session,
-        force: bool = False,
     ):
         self.stats["cases_processed"] += 1
-        self.stdout.write(f"\n[{idx}/{total}] {case.case_id} — {case.title[:80]}")
+        case_id = case.get("case_id", "?")
+        title = case.get("title", "")
+        self.stdout.write(f"\n[{idx}/{total}] {case_id} — {title[:80]}")
 
-        source_text = self._get_source_content(case, session)
-        ngm_data = self._get_ngm_data(case)
+        # The case-list summary already carries court_cases/timeline, but we need
+        # the detail endpoint to get evidence enriched with source URLs.
+        detail = self._fetch_case_detail(case, api_base_url, api_token, session)
+        source_text = self._get_source_content(detail)
+        ngm_data = self._get_ngm_data(detail, api_base_url, api_token, session)
 
         if not source_text and not ngm_data:
             self.stats["cases_no_content"] += 1
@@ -387,7 +596,6 @@ class Command(BaseCommand):
 
         if source_text:
             self.stdout.write(f"  Source content: {len(source_text)} chars")
-
         if ngm_data:
             self.stats["cases_ngm_used"] += 1
             self.stdout.write(
@@ -398,170 +606,194 @@ class Command(BaseCommand):
         else:
             self.stdout.write("  NGM data: none")
 
-        if dry_run and not llm_api_key:
-            self.stdout.write(
-                self.style.WARNING("  [DRY RUN] No API key — skipping LLM extraction")
-            )
-            return
-
         try:
-            timeline_entries = self._extract_timeline(
-                source_text=source_text,
-                case_title=case.title,
-                llm_model=llm_model,
-                llm_base_url=llm_base_url,
-                llm_api_key=llm_api_key,
+            entries = self._extract_timeline(
+                source_text=source_text or "",
+                case_title=title,
+                llm_cfg=llm_cfg,
                 session=session,
                 ngm_data=ngm_data,
             )
-        except (
-            requests.RequestException,
-            CommandError,
-            ValueError,
-        ) as exc:
+        except (requests.RequestException, CommandError, ValueError) as exc:
             self.stats["cases_llm_error"] += 1
             self.stdout.write(self.style.ERROR(f"  LLM extraction failed: {exc}"))
             return
 
-        if not timeline_entries:
+        if not entries:
             self.stats["cases_skipped"] += 1
             self.stdout.write(
                 self.style.WARNING("  LLM returned no timeline entries — skipping")
             )
             return
 
-        entry_count = len(timeline_entries)
-        self.stdout.write(self.style.SUCCESS(f"  Extracted {entry_count} entry(s)"))
-        for i, entry in enumerate(timeline_entries, 1):
+        self.stdout.write(self.style.SUCCESS(f"  Extracted {len(entries)} entry(s)"))
+        for i, entry in enumerate(entries, 1):
+            span = f" → {entry['end_date']}" if entry.get("end_date") else ""
             self.stdout.write(
-                f"    {i}. {entry.get('date', '?')} — "
+                f"    {i}. {entry.get('date', '?')}{span} — "
                 f"{entry.get('title', '?')[:80]}"
             )
 
         if dry_run:
             self.stdout.write(
-                self.style.WARNING("  [DRY RUN] Would save but --dry-run is set")
+                self.style.WARNING("  [DRY RUN] Would PATCH but --dry-run is set")
             )
-        else:
-            try:
-                self._save_timeline(case, timeline_entries, force=force)
-                self.stats["cases_enriched"] += 1
-            except CommandError as exc:
-                self.stats["cases_llm_error"] += 1
-                self.stdout.write(self.style.ERROR(f"  Failed to save timeline: {exc}"))
+            return
 
-    # ── source acquisition with tiered fallback ──────────────────────────
+        try:
+            self._patch_timeline(
+                case_slug=detail.get("slug") or case.get("slug"),
+                case_id=case_id,
+                entries=entries,
+                api_base_url=api_base_url,
+                api_token=api_token,
+                session=session,
+            )
+            self.stats["cases_enriched"] += 1
+            self.stdout.write(self.style.SUCCESS(f"  [UPDATED] {case_id}"))
+        except CommandError as exc:
+            self.stats["cases_llm_error"] += 1
+            self.stdout.write(self.style.ERROR(f"  Failed to PATCH timeline: {exc}"))
 
-    def _get_source_content(
-        self, case: Case, session: requests.Session
-    ) -> Optional[str]:
-        """Acquire source document text for timeline extraction.
+    def _fetch_case_detail(
+        self,
+        case: dict,
+        api_base_url: str,
+        api_token: str,
+        session: requests.Session,
+    ) -> dict:
+        """Fetch the case-detail document (evidence enriched with source URLs)."""
+        slug = case.get("slug")
+        if not slug:
+            return case
+        api_root = self._api_root(api_base_url)
+        quoted = urllib.parse.quote(str(slug).strip(), safe="")
+        url = f"{api_root}/cases/{quoted}/"
+        try:
+            return self._api_get(url, api_token, session)
+        except CommandError as exc:
+            logger.warning("  Falling back to summary for %s: %s", slug, exc)
+            return case
 
-        Priority order:
-        1. AG_ABHIYOG_PATRA description (already extracted) — use if len > 200
-        2. AG_ABHIYOG_PATRA URLs — download + likhit/markitdown convert
-        3. COURT_ORDER URLs — supplement with court order data
-        4. CIAA_PRESS_RELEASE description/URLs — use if available
+    # ── source acquisition ─────────────────────────────────────────────────
+
+    def _get_source_content(self, case: dict) -> Optional[str]:
+        """Assemble source document text for the milestone-relevant source types.
+
+        Reads the detail endpoint's enriched evidence (each entry may carry a
+        nested ``source`` with ``source_type`` and ``urls``). Prefers the
+        already-extracted ``description`` when long enough, else downloads and
+        converts a MARKDOWN/RAW link from an allowed host.
         """
-        if not case.evidence:
-            logger.debug("  No evidence entries on case")
+        evidence = case.get("evidence") or []
+        if not evidence:
             return None
 
-        source_ids = [
-            entry["source_id"]
-            for entry in case.evidence
-            if isinstance(entry, dict) and entry.get("source_id")
-        ]
-        if not source_ids:
-            logger.debug("  No source_ids in evidence")
-            return None
+        # Group evidence by source_type so we can honour milestone priority.
+        by_type: dict[str, list[dict]] = {}
+        for entry in evidence:
+            if not isinstance(entry, dict):
+                continue
+            source = entry.get("source")
+            if not isinstance(source, dict):
+                continue
+            stype = source.get("source_type")
+            by_type.setdefault(stype, []).append(entry)
 
-        sources = list(
-            DocumentSource.objects.filter(
-                source_id__in=source_ids, is_deleted=False
-            ).only("source_id", "description", "title", "url", "source_type")
-        )
-        if not sources:
-            logger.debug("  No DocumentSource records found")
-            return None
-
-        source_by_id = {s.source_id: s for s in sources}
-
-        content_parts = []
-
-        self._append_source_content(
-            source_ids,
-            source_by_id,
-            SourceType.AG_ABHIYOG_PATRA,
-            content_parts,
-            session,
-        )
-        self._append_source_content(
-            source_ids,
-            source_by_id,
-            SourceType.COURT_ORDER,
-            content_parts,
-            session,
-        )
-        self._append_source_content(
-            source_ids,
-            source_by_id,
-            SourceType.CIAA_PRESS_RELEASE,
-            content_parts,
-            session,
-        )
+        content_parts: list[str] = []
+        for stype in MILESTONE_SOURCE_TYPES:
+            for entry in by_type.get(stype, []):
+                text = self._content_from_evidence_entry(entry)
+                if text:
+                    content_parts.append(text)
 
         if not content_parts:
-            logger.debug("  No usable content from any source type")
             return None
-
         return "\n\n---\n\n".join(content_parts)
 
-    def _append_source_content(
-        self,
-        source_ids: list[str],
-        source_by_id: dict,
-        source_type: str,
-        content_parts: list[str],
-        session: requests.Session,
-    ):
-        """Try to get content from sources of a specific type and append to parts."""
-        for sid in source_ids:
-            source = source_by_id.get(sid)
-            if source is None:
-                continue
-            if source.source_type != source_type:
-                continue
+    def _content_from_evidence_entry(self, entry: dict) -> Optional[str]:
+        """Return usable text for one evidence entry.
 
-            description = (source.description or "").strip()
-            if len(description) > 200:
-                content_parts.append(description)
-                continue
-
-            for url in source.url_links:
-                parsed = urlparse(url)
-                if parsed.hostname and parsed.hostname in ALLOWED_HOSTS:
-                    content = convert_to_markdown(url, session)
-                    if content and len(content) > 200:
-                        content_parts.append(content)
-                        break
-
-    # ── NGM structured hearing data ──────────────────────────────────────
-
-    def _get_ngm_data(self, case: Case) -> Optional[dict]:
-        """Query NGM database for structured hearing records.
-
-        Extracts the special court case number from case.court_cases
-        and fetches ground-truth dates, hearing records, and verdict info.
-        Returns None if no special court reference or NGM query fails.
+        Order of preference:
+        1. The already-extracted evidence ``description`` when long enough.
+        2. An existing MARKDOWN-role link on the source (already converted).
+        3. Otherwise, create the markdown with the shared source converter
+           (``review.converter.convert_source``) — the canonical likhit/markitdown
+           pipeline (PR #178), which disk-caches by URL so we don't re-convert.
         """
-        if not case.court_cases:
+        description = (entry.get("description") or "").strip()
+        if len(description) > 200:
+            return description
+
+        source = entry.get("source") or {}
+        urls = source.get("urls") or []
+
+        # 2. Use an existing MARKDOWN link verbatim — it is already converted.
+        md_link = next(
+            (
+                u["link"]
+                for u in urls
+                if isinstance(u, dict) and u.get("role") == "MARKDOWN" and u.get("link")
+            ),
+            None,
+        )
+        if md_link:
+            text = self._download_text(md_link)
+            if text and len(text) > 200:
+                return text
+
+        # 3. No markdown yet — create it from the convertible links.
+        convertible = [
+            u["link"]
+            for u in urls
+            if isinstance(u, dict)
+            and u.get("link")
+            and u.get("role") in ("RAW", "ALTERNATE", "SOURCE_PAGE")
+        ]
+        if not convertible:
             return None
 
+        from review import converter as source_converter
+
+        result = source_converter.convert_source({"url": convertible})
+        if result.get("status") in ("converted", "attached"):
+            text = (result.get("markdown") or "").strip()
+            if len(text) > 200:
+                return text
+        else:
+            logger.warning(
+                "  Source conversion %s: %s",
+                result.get("status"),
+                result.get("note"),
+            )
+        return None
+
+    @staticmethod
+    def _download_text(url: str) -> Optional[str]:
+        """Download an already-converted markdown link and return its text."""
+        from review import jds_client
+
+        try:
+            content, _ = jds_client.download_source_file(url)
+        except Exception as exc:  # noqa: BLE001 - one bad link must not abort
+            logger.warning("  Failed to download markdown link %s: %s", url, exc)
+            return None
+        return content.decode("utf-8", errors="replace")
+
+    # ── NGM structured hearing data (via API) ──────────────────────────────
+
+    def _get_ngm_data(
+        self,
+        case: dict,
+        api_base_url: str,
+        api_token: str,
+        session: requests.Session,
+    ) -> Optional[dict]:
+        """Fetch NGM hearing records for the case's special-court reference."""
         special_ref = next(
             (
                 ref.split(":", 1)[1]
-                for ref in case.court_cases
+                for ref in (case.get("court_cases") or [])
                 if isinstance(ref, str) and ref.startswith("special:")
             ),
             None,
@@ -569,33 +801,35 @@ class Command(BaseCommand):
         if not special_ref:
             return None
 
+        api_root = self._api_root(api_base_url)
+        quoted = urllib.parse.quote(f"special:{special_ref}", safe=":")
+        url = f"{api_root}/ngm/court_case/{quoted}"
         try:
-            ngm_data = get_court_case_details("special", special_ref)
-            if ngm_data is None:
-                logger.debug("  NGM: no case found for %s", special_ref)
-                return None
-            return ngm_data
-        except ValueError as exc:
+            data = self._api_get(url, api_token, session)
+        except CommandError as exc:
             logger.warning("  NGM query failed for %s: %s", special_ref, exc)
             return None
+        if not isinstance(data, dict) or data.get("error"):
+            return None
+        return data
 
     def _format_ngm_section(self, ngm_data: Optional[dict]) -> str:
-        """Format NGM hearing data as a structured section for the LLM prompt.
+        """Format the flat NGM API payload as a prompt section.
 
-        Returns an empty string if no NGM data available.
+        The NGM detail API returns a flat object (registration/verdict fields at
+        the top level, plus a ``hearings`` list), unlike the nested ORM shape.
         """
         if not ngm_data:
             return ""
 
         lines = [
-            "NGM STRUCTURED HEARING DATA (ground-truth dates — use these dates EXACTLY as-is):",
+            "NGM STRUCTURED HEARING DATA (ground-truth AD dates — convert to BS "
+            "with the convert_date tool; use only to anchor milestone dates):",
             "",
         ]
-
-        case_data = ngm_data.get("case") or {}
-        reg_date = case_data.get("registration_date_ad")
-        verdict_date = case_data.get("verdict_date_ad")
-        case_status = case_data.get("case_status", "")
+        reg_date = ngm_data.get("registration_date_ad")
+        verdict_date = ngm_data.get("verdict_date_ad")
+        case_status = ngm_data.get("case_status")
 
         if reg_date:
             lines.append(f"- Case registration: {reg_date}")
@@ -618,114 +852,161 @@ class Command(BaseCommand):
 
         if verdict_date:
             lines.append(f"- Verdict date: {verdict_date}")
-            verdict_judge = case_data.get("verdict_judge")
+            verdict_judge = ngm_data.get("verdict_judge")
             if verdict_judge:
                 lines.append(f"  Judge: {verdict_judge}")
 
         return "\n".join(lines) + "\n"
 
-    # ── LLM extraction ───────────────────────────────────────────────────
+    # ── LLM extraction (tool-use) ───────────────────────────────────────────
 
     def _extract_timeline(
         self,
         source_text: str,
         case_title: str,
-        llm_model: str,
-        llm_base_url: str,
-        llm_api_key: Optional[str],
+        llm_cfg: dict,
         session: requests.Session,
         ngm_data: Optional[dict] = None,
     ) -> Optional[list[dict]]:
-        """Call LLM to extract timeline entries from source text and NGM data."""
-        ngm_section = self._format_ngm_section(ngm_data)
+        """Call the LLM (with the convert_date tool) to extract timeline entries.
+
+        Dispatches to the configured backend: the OpenAI-compatible gateway
+        (``call_llm_with_tools``) or AWS Bedrock (``call_bedrock_with_tools``).
+        """
         prompt = EXTRACTION_USER_PROMPT.format(
             case_title=case_title,
-            ngm_section=ngm_section,
+            ngm_section=self._format_ngm_section(ngm_data),
             source_text=source_text[:40000],
         )
+        executors = {"convert_date": convert_date}
 
-        response_text = call_llm(
-            system_prompt=EXTRACTION_SYSTEM_PROMPT,
-            user_prompt=prompt,
-            model=llm_model,
-            base_url=llm_base_url,
-            api_key=llm_api_key,
-            session=session,
-        )
-
+        if llm_cfg["backend"] == "bedrock":
+            response_text = call_bedrock_with_tools(
+                system_prompt=EXTRACTION_SYSTEM_PROMPT,
+                user_prompt=prompt,
+                model_id=llm_cfg["model"],
+                tools=[CONVERT_DATE_TOOL_ANTHROPIC],
+                tool_executors=executors,
+                aws_profile=llm_cfg.get("aws_profile", ""),
+                aws_region=llm_cfg.get("aws_region", "us-west-2"),
+                max_tokens=llm_cfg["max_tokens"],
+            )
+        else:
+            response_text = call_llm_with_tools(
+                system_prompt=EXTRACTION_SYSTEM_PROMPT,
+                user_prompt=prompt,
+                model=llm_cfg["model"],
+                base_url=llm_cfg["base_url"],
+                api_key=llm_cfg["api_key"],
+                session=session,
+                tools=[CONVERT_DATE_TOOL],
+                tool_executors=executors,
+                max_tokens=llm_cfg["max_tokens"],
+            )
         return self._parse_timeline_response(response_text)
 
     def _parse_timeline_response(self, response_text: str) -> Optional[list[dict]]:
-        """Parse the LLM response to extract timeline entries with field mapping."""
-        entries = parse_extraction_response(
+        """Parse the LLM response into clean, validated timeline entries."""
+        raw = parse_extraction_response(
             response_text, wrapper_keys={"timeline", "entries"}
         )
-        if entries is None:
+        if raw is None:
             return None
 
         clean = []
-        for item in entries:
+        for item in raw:
             if not isinstance(item, dict):
                 continue
-            date_val = (
-                item.get("date") or item.get("date_bs") or item.get("date_ad") or ""
-            )
-            title_val = item.get("title") or item.get("event") or item.get("name") or ""
-            desc_val = (
-                item.get("description") or item.get("desc") or item.get("detail") or ""
-            )
-
-            if not date_val or not title_val:
-                continue
-
-            entry = {
-                "date": str(date_val).strip(),
-                "title": str(title_val).strip(),
-            }
-            if desc_val and str(desc_val).strip():
-                entry["description"] = str(desc_val).strip()
-
-            if not is_valid_iso_date(entry["date"]):
-                logger.warning(
-                    "  Dropping non-ISO date format: %s",
-                    entry["date"],
-                )
-                continue
-
-            clean.append(entry)
+            entry = self._clean_entry(item)
+            if entry is not None:
+                clean.append(entry)
 
         if not clean:
             return None
-
-        clean.sort(key=lambda entry: entry["date"])
+        clean.sort(key=lambda e: e["date"])
         return clean
 
-    # ── persistence ─────────────────────────────────────────────────────
+    def _clean_entry(self, item: dict) -> Optional[dict]:
+        """Validate and normalise a single LLM-produced entry, or drop it."""
+        date_val = str(item.get("date") or "").strip()
+        title_val = str(
+            item.get("title") or item.get("event") or item.get("name") or ""
+        ).strip()
+        if not date_val or not title_val:
+            return None
+        if not is_valid_iso_date(date_val):
+            logger.warning("  Dropping entry with non-ISO date: %s", date_val)
+            return None
 
-    def _save_timeline(self, case: Case, entries: list[dict], force: bool = False):
-        """Persist timeline entries to the database.
+        entry: dict = {"date": date_val, "title": title_val}
 
-        Uses select_for_update to guard against concurrent writes.
-        When force=False, skips cases whose timeline was populated
-        by another process since the initial read.
-        """
-        with transaction.atomic():
-            locked = (
-                Case.objects.select_for_update().filter(pk=case.pk).only("timeline")
-            )
-            if not force:
-                locked = locked.filter(timeline=[])
-            updated = locked.update(
-                timeline=entries,
-                updated_at=timezone.now(),
-            )
-            if not updated:
-                raise CommandError(
-                    f"Case {case.case_id} was populated concurrently; skipping save."
+        desc_val = str(
+            item.get("description") or item.get("desc") or item.get("detail") or ""
+        ).strip()
+        if desc_val:
+            entry["description"] = desc_val
+
+        date_bs = str(item.get("date_bs") or "").strip()
+        if date_bs:
+            entry["date_bs"] = date_bs
+
+        end_date = str(item.get("end_date") or "").strip()
+        if end_date:
+            if not is_valid_iso_date(end_date):
+                logger.warning(
+                    "  Dropping invalid end_date %s; keeping entry", end_date
                 )
-        logger.info("  Saved %d timeline entries to %s", len(entries), case.case_id)
+            elif end_date < date_val:
+                logger.warning(
+                    "  Dropping end_date %s before date %s; keeping entry",
+                    end_date,
+                    date_val,
+                )
+            else:
+                entry["end_date"] = end_date
+                end_date_bs = str(item.get("end_date_bs") or "").strip()
+                if end_date_bs:
+                    entry["end_date_bs"] = end_date_bs
 
-    # ── summary ──────────────────────────────────────────────────────────
+        return entry
+
+    # ── API write ───────────────────────────────────────────────────────────
+
+    def _patch_timeline(
+        self,
+        case_slug: Optional[str],
+        case_id: str,
+        entries: list[dict],
+        api_base_url: str,
+        api_token: str,
+        session: requests.Session,
+    ) -> None:
+        """PATCH the case timeline via an RFC 6902 JSON Patch replace op."""
+        if not case_slug:
+            raise CommandError(f"Case {case_id} has no slug; cannot PATCH.")
+
+        api_root = self._api_root(api_base_url)
+        quoted = urllib.parse.quote(str(case_slug).strip(), safe="")
+        url = f"{api_root}/cases/{quoted}/"
+        patch = [{"op": "replace", "path": "/timeline", "value": entries}]
+        headers = {
+            "Authorization": f"Token {api_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        try:
+            response = session.patch(url, json=patch, headers=headers, timeout=30)
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else "?"
+            body = exc.response.text[:300] if exc.response is not None else ""
+            raise CommandError(
+                f"PATCH failed for case {case_id} (status {status}): {body}"
+            ) from exc
+        except requests.RequestException as exc:
+            raise CommandError(f"PATCH failed for case {case_id}: {exc}") from exc
+
+    # ── summary ─────────────────────────────────────────────────────────────
 
     def _print_summary(self, dry_run: bool):
         self.stdout.write("\n" + "=" * 60)

--- a/cases/tests/test_enrich_ciaa_timeline.py
+++ b/cases/tests/test_enrich_ciaa_timeline.py
@@ -1,10 +1,11 @@
 """
-Tests for enrich_ciaa_timeline management command.
+Tests for the API-driven enrich_ciaa_timeline management command.
 
-Phase 1 (A.3) of CIAA FY 080/081 Case Enrichment pipeline.
-Covers: idempotency, CIAA case filtering, JSON response parsing,
-source content acquisition, dry-run safety, --force flag,
---fiscal-year filtering, and CLI flag registration.
+The command reads cases, source content and NGM hearing records over the
+Jawafdehi HTTP API and writes the timeline via PATCH — it never touches the
+ORM. These tests therefore mock the HTTP layer (the command's _api_get /
+_get_source_content / _get_ngm_data and the urllib PATCH) rather than creating
+database rows. See https://github.com/Jawafdehi/JawafdehiAPI/issues/186.
 """
 
 import json
@@ -12,897 +13,532 @@ from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
-import requests
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from cases.management.commands.enrich_ciaa_timeline import Command
-from cases.models import Case, CaseState, CaseType, DocumentSource, SourceType
+
+API_BASE = "https://portal.jawafdehi.org/api"
+COMMON = dict(
+    api_base_url=API_BASE,
+    api_token="tok",
+    llm_api_key="llmkey",
+)
 
 
-@pytest.mark.django_db
-class TestEnrichCiaaTimeline:
-    """Test suite for enrich_ciaa_timeline management command."""
+def _case(**overrides):
+    base = {
+        "case_id": "case-0001",
+        "slug": "case-0001-slug",
+        "state": "DRAFT",
+        "title": "Test CIAA case",
+        "court_cases": ["special:081-CR-0060"],
+        "timeline": [],
+        "evidence": [],
+    }
+    base.update(overrides)
+    return base
 
-    # ── helpers ──────────────────────────────────────────────────────────
 
-    def _create_case(self, **overrides):
-        defaults = {
-            "case_type": CaseType.CORRUPTION,
-            "state": CaseState.DRAFT,
-            "title": "Test CIAA Case",
-            "case_id": "case-test-001",
-            "court_cases": ["special:test-001"],
-            "timeline": [],
-            "evidence": [],
+# ── case selection / filtering ───────────────────────────────────────────────
+
+
+class TestCaseSelection:
+    def _run_select(self, pages, **kwargs):
+        cmd = Command()
+        with patch.object(cmd, "_api_get", side_effect=pages):
+            return cmd._get_ciaa_cases(
+                api_base_url=API_BASE,
+                api_token="tok",
+                session=MagicMock(),
+                **kwargs,
+            )
+
+    def test_selects_draft_special_court_cases(self):
+        page = {"results": [_case()], "next": None}
+        selected = self._run_select([page])
+        assert [c["case_id"] for c in selected] == ["case-0001"]
+
+    def test_skips_non_draft(self):
+        page = {"results": [_case(state="PUBLISHED")], "next": None}
+        assert self._run_select([page]) == []
+
+    def test_skips_non_special_court(self):
+        page = {"results": [_case(court_cases=["supreme:081-CR-0060"])], "next": None}
+        assert self._run_select([page]) == []
+
+    def test_skips_already_populated_unless_force(self):
+        page = {
+            "results": [_case(timeline=[{"date": "2025-01-01", "title": "x"}])],
+            "next": None,
         }
-        defaults.update(overrides)
-        return Case.objects.create(**defaults)
+        assert self._run_select([page]) == []
 
-    def _create_source(self, source_type=SourceType.LEGAL_PROCEDURAL, **overrides):
-        defaults = {
-            "title": "CIAA Press Release",
-            "description": "Source document content with timeline information. " * 30,
-            "url": ["https://ciaa.gov.np/pressrelease/3173"],
-            "source_type": source_type,
+    def test_force_includes_populated(self):
+        page = {
+            "results": [_case(timeline=[{"date": "2025-01-01", "title": "x"}])],
+            "next": None,
         }
-        defaults.update(overrides)
-        return DocumentSource.objects.create(**defaults)
+        selected = self._run_select([page], force=True)
+        assert len(selected) == 1
 
-    def _session(self):
-        """Create a mock requests.Session for direct method tests."""
-        session = MagicMock(spec=requests.Session)
-        return session
+    def test_fiscal_year_filter(self):
+        page = {
+            "results": [
+                _case(case_id="a", court_cases=["special:081-CR-0060"]),
+                _case(case_id="b", court_cases=["special:080-CR-0010"]),
+            ],
+            "next": None,
+        }
+        selected = self._run_select([page], fiscal_year="081")
+        assert [c["case_id"] for c in selected] == ["a"]
 
-    def _mock_llm_response(self, entries=None):
-        if entries is None:
-            entries = [
+    def test_case_id_filter(self):
+        page = {
+            "results": [_case(case_id="a"), _case(case_id="b")],
+            "next": None,
+        }
+        selected = self._run_select([page], case_id="b")
+        assert [c["case_id"] for c in selected] == ["b"]
+
+    def test_limit(self):
+        page = {
+            "results": [_case(case_id=f"c{i}") for i in range(5)],
+            "next": None,
+        }
+        selected = self._run_select([page], limit=2)
+        assert len(selected) == 2
+
+    def test_follows_pagination(self):
+        page1 = {"results": [_case(case_id="a")], "next": f"{API_BASE}/cases/?page=2"}
+        page2 = {"results": [_case(case_id="b")], "next": None}
+        selected = self._run_select([page1, page2])
+        assert [c["case_id"] for c in selected] == ["a", "b"]
+
+
+# ── response parsing ───────────────────────────────────────────────────────
+
+
+class TestParseTimelineResponse:
+    def setup_method(self):
+        self.cmd = Command()
+
+    def test_parses_clean_array_with_bs_and_span(self):
+        text = json.dumps(
+            [
                 {
-                    "date": "2023-08-15",
-                    "title": "अख्तियारले अनुसन्धान शुरु",
-                    "description": "विशेष अदालतमा मुद्दा दायर गर्ने निर्णय",
+                    "date": "1989-07-14",
+                    "date_bs": "2046-03-30",
+                    "end_date": "2020-07-15",
+                    "end_date_bs": "2077-03-31",
+                    "title": "जाँच अवधि",
+                    "description": "Investigation span.",
                 },
                 {
-                    "date": "2023-09-20",
-                    "title": "विशेष अदालतमा मुद्दा दायर",
-                    "description": "विशेष अदालतमा मुद्दा दर्ता भएको",
+                    "date": "2025-02-09",
+                    "date_bs": "2081-10-27",
+                    "title": "मुद्दा दर्ता",
                 },
-                {"date": "2024-03-10", "title": "फैसला सुनाइएको", "description": ""},
             ]
-        return json.dumps(entries)
-
-    def _mock_call_llm(self, entries=None):
-        """Patch call_llm in the enrich_ciaa_timeline namespace."""
-        return patch(
-            "cases.management.commands.enrich_ciaa_timeline.call_llm",
-            return_value=self._mock_llm_response(entries),
         )
+        entries = self.cmd._parse_timeline_response(text)
+        assert len(entries) == 2
+        # sorted chronologically
+        assert entries[0]["date"] == "1989-07-14"
+        assert entries[0]["date_bs"] == "2046-03-30"
+        assert entries[0]["end_date"] == "2020-07-15"
+        assert entries[0]["end_date_bs"] == "2077-03-31"
+        assert entries[1]["date_bs"] == "2081-10-27"
 
-    def _mock_call_llm_error(self, exc=None):
-        """Patch call_llm to raise an error."""
-        if exc is None:
-            exc = requests.ConnectionError("Connection refused")
-        return patch(
-            "cases.management.commands.enrich_ciaa_timeline.call_llm",
-            side_effect=exc,
+    def test_strips_markdown_fences(self):
+        text = '```json\n[{"date": "2025-02-09", "title": "x"}]\n```'
+        entries = self.cmd._parse_timeline_response(text)
+        assert entries and entries[0]["date"] == "2025-02-09"
+
+    def test_invalid_json_returns_none(self):
+        assert self.cmd._parse_timeline_response("not json") is None
+
+    def test_empty_array_returns_none(self):
+        assert self.cmd._parse_timeline_response("[]") is None
+
+    def test_drops_entries_missing_required_fields(self):
+        text = json.dumps(
+            [
+                {"date": "2025-02-09"},  # no title
+                {"title": "no date"},  # no date
+                {"date": "2025-02-09", "title": "ok"},
+            ]
         )
+        entries = self.cmd._parse_timeline_response(text)
+        assert len(entries) == 1
+        assert entries[0]["title"] == "ok"
 
-    def _mock_call_llm_missing_content(
-        self,
-        message: str = "LLM refused: I cannot help",
-    ):
-        """Patch call_llm to raise CommandError simulating a missing-content LLM response.
+    def test_drops_non_iso_date(self):
+        text = json.dumps([{"date": "2081-10-27 BS", "title": "x"}])
+        assert self.cmd._parse_timeline_response(text) is None
 
-        When the LLM returns a response where choices[0].message lacks a 'content'
-        key (e.g. 'refusal' or 'tool_calls' instead), call_llm raises CommandError
-        with a descriptive message. This helper simulates that production failure
-        mode so the test exercises the caller's error-handling path.
-        """
-        return patch(
-            "cases.management.commands.enrich_ciaa_timeline.call_llm",
-            side_effect=CommandError(message),
+    def test_drops_end_date_before_start_but_keeps_entry(self):
+        text = json.dumps(
+            [{"date": "2020-07-15", "end_date": "1989-07-14", "title": "x"}]
         )
+        entries = self.cmd._parse_timeline_response(text)
+        assert len(entries) == 1
+        assert "end_date" not in entries[0]
 
-    def _mock_ngm_data(self, hearings=None, case_overrides=None):
-        """Create mock NGM data dict."""
-        data = {
-            "case": {
-                "registration_date_ad": "2023-09-20",
-                "verdict_date_ad": "2024-03-10",
+    def test_nested_timeline_key(self):
+        text = json.dumps({"timeline": [{"date": "2025-02-09", "title": "x"}]})
+        entries = self.cmd._parse_timeline_response(text)
+        assert entries and entries[0]["title"] == "x"
+
+
+# ── NGM section formatting ─────────────────────────────────────────────────
+
+
+class TestFormatNgmSection:
+    def test_flat_api_payload(self):
+        cmd = Command()
+        section = cmd._format_ngm_section(
+            {
+                "registration_date_ad": "2025-02-09",
                 "case_status": "फैसला भएको",
-                "verdict_judge": "Hon. Judge Name",
-                **(case_overrides or {}),
-            },
-            "hearings": hearings
-            or [
+                "verdict_date_ad": "2025-06-20",
+                "verdict_judge": "Judge X",
+                "hearings": [
+                    {"hearing_date_ad": "2025-03-01", "decision_type": "पेशी"},
+                ],
+            }
+        )
+        assert "Case registration: 2025-02-09" in section
+        assert "Hearings (1 records)" in section
+        assert "Verdict date: 2025-06-20" in section
+        assert "Judge X" in section
+
+    def test_empty(self):
+        assert Command()._format_ngm_section(None) == ""
+
+
+# ── source content acquisition ─────────────────────────────────────────────
+
+
+class TestSourceContent:
+    def test_uses_long_description(self):
+        cmd = Command()
+        case = {
+            "evidence": [
                 {
-                    "hearing_date_ad": "2023-11-15",
-                    "decision_type": "पेशी",
-                    "remarks": "सुनुवाइ भएको",
-                },
-                {
-                    "hearing_date_ad": "2024-01-20",
-                    "decision_type": "पेशी",
-                    "remarks": "अन्तिम सुनुवाइ",
-                },
-            ],
-        }
-        return data
-
-    # ── 1. Idempotency ──────────────────────────────────────────────────
-
-    def test_skips_cases_with_populated_timeline(self):
-        """Idempotency: cases with non-empty timeline are skipped."""
-        self._create_case(
-            case_id="populated-test",
-            timeline=[{"date": "2023-08-15", "title": "Test event"}],
-        )
-
-        out = StringIO()
-        call_command("enrich_ciaa_timeline", "--dry-run", stdout=out)
-
-        output = out.getvalue()
-        assert "Already populated:      1" in output
-        assert "Cases processed:        0" in output
-
-    def test_processes_cases_with_empty_timeline(self):
-        """Cases with empty timeline are processed."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            timeline=[],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with self._mock_call_llm():
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                f"--case-id={case.case_id}",
-                "--dry-run",
-                stdout=out,
-            )
-
-        output = out.getvalue()
-        assert "Cases processed:        1" in output
-        assert "Cases enriched:         0" in output
-        assert "Already populated:      0" in output
-        assert "DRY RUN" in output
-
-    # ── 2. --force flag ─────────────────────────────────────────────────
-
-    def test_force_reprocesses_populated_cases(self):
-        """--force flag re-generates timeline even when already populated."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            timeline=[{"date": "2022-01-01", "title": "Old event"}],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with self._mock_call_llm():
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                f"--case-id={case.case_id}",
-                "--force",
-                "--dry-run",
-                stdout=out,
-            )
-
-        output = out.getvalue()
-        assert "force" in output.lower()
-        assert "Cases processed:        1" in output
-        assert "Already populated:      0" in output
-
-    # ── 3. --fiscal-year filtering ───────────────────────────────────────
-
-    def test_fiscal_year_filter_matches_court_cases(self):
-        """--fiscal-year 080 filters cases with 080-CR court cases."""
-        self._create_case(
-            case_id="fy-080-case",
-            court_cases=["special:080-CR-0007"],
-            timeline=[],
-        )
-        self._create_case(
-            case_id="fy-081-case",
-            court_cases=["special:081-CR-0123"],
-            timeline=[],
-        )
-
-        cmd = Command()
-        cmd.stats = {
-            "cases_processed": 0,
-            "cases_enriched": 0,
-            "cases_skipped": 0,
-            "cases_no_content": 0,
-            "cases_llm_error": 0,
-            "cases_already_populated": 0,
-            "cases_ngm_used": 0,
-        }
-
-        cases = cmd._get_ciaa_cases(fiscal_year="080")
-        case_ids = [c.case_id for c in cases]
-        assert "fy-080-case" in case_ids
-        assert "fy-081-case" not in case_ids
-
-    def test_fiscal_year_filter_normalized(self):
-        """--fiscal-year handles leading zeros (e.g., '080' and '80' both work)."""
-        self._create_case(
-            case_id="fy-080-case",
-            court_cases=["special:080-CR-0007"],
-            timeline=[],
-        )
-
-        cmd = Command()
-        cmd.stats = dict.fromkeys(
-            [
-                "cases_processed",
-                "cases_enriched",
-                "cases_skipped",
-                "cases_no_content",
-                "cases_llm_error",
-                "cases_already_populated",
-                "cases_ngm_used",
-            ],
-            0,
-        )
-
-        cases = cmd._get_ciaa_cases(fiscal_year="80")
-        case_ids = [c.case_id for c in cases]
-        assert "fy-080-case" in case_ids
-
-    def test_fiscal_year_rejects_invalid_format(self):
-        """Invalid fiscal year format raises CommandError."""
-        with pytest.raises(CommandError) as exc_info:
-            call_command(
-                "enrich_ciaa_timeline",
-                "--fiscal-year=not-a-year",
-                "--dry-run",
-            )
-        assert "Invalid fiscal year" in str(exc_info.value)
-
-    # ── 4. CIAA case filtering ───────────────────────────────────────────
-
-    def test_skips_non_draft_cases(self):
-        """Only DRAFT cases are considered for enrichment."""
-        self._create_case(
-            case_id="draft-case",
-            state=CaseState.DRAFT,
-            timeline=[],
-        )
-        self._create_case(
-            case_id="published-case",
-            state=CaseState.PUBLISHED,
-            timeline=[],
-        )
-
-        cmd = Command()
-        cmd.stats = dict.fromkeys(
-            [
-                "cases_processed",
-                "cases_enriched",
-                "cases_skipped",
-                "cases_no_content",
-                "cases_llm_error",
-                "cases_already_populated",
-                "cases_ngm_used",
-            ],
-            0,
-        )
-
-        cases = cmd._get_ciaa_cases()
-        case_ids = [c.case_id for c in cases]
-        assert "draft-case" in case_ids
-        assert "published-case" not in case_ids
-
-    # ── 5. JSON response parsing ────────────────────────────────────────
-
-    def test_parse_clean_json_array(self):
-        """Clean JSON array of timeline entries parses correctly."""
-        cmd = Command()
-        entries = [
-            {"date": "2023-08-15", "title": "घटना १"},
-            {"date": "2023-09-20", "title": "घटना २", "description": "विवरण"},
-        ]
-        result = cmd._parse_timeline_response(json.dumps(entries))
-        assert len(result) == 2
-        assert result[0]["date"] == "2023-08-15"
-        assert result[0]["title"] == "घटना १"
-
-    def test_parse_json_with_markdown_wrappers(self):
-        """Timeline wrapped in markdown code fences is extracted."""
-        cmd = Command()
-        response = (
-            "Here is the timeline:\n```json\n"
-            + json.dumps([{"date": "2023-08-15", "title": "Test"}])
-            + "\n```\nDone."
-        )
-        result = cmd._parse_timeline_response(response)
-        assert len(result) == 1
-        assert result[0]["date"] == "2023-08-15"
-
-    def test_parse_invalid_json_returns_none(self):
-        """Invalid JSON returns None."""
-        cmd = Command()
-        result = cmd._parse_timeline_response("This is not JSON at all.")
-        assert result is None
-
-    def test_parse_empty_array_returns_none(self):
-        """Empty JSON array returns None (no timeline entries)."""
-        cmd = Command()
-        result = cmd._parse_timeline_response("[]")
-        assert result is None
-
-    def test_parse_missing_required_fields(self):
-        """Entries missing date or title are filtered out."""
-        cmd = Command()
-        entries = [
-            {"title": "No date entry"},
-            {"date": "2023-08-15"},
-            {"date": "2023-09-20", "title": "Valid entry"},
-        ]
-        result = cmd._parse_timeline_response(json.dumps(entries))
-        assert len(result) == 1
-        assert result[0]["date"] == "2023-09-20"
-
-    def test_parse_accepts_alternate_field_names(self):
-        """Fallback field names (date_bs, event, desc) are accepted."""
-        cmd = Command()
-        entries = [
-            {"date_bs": "2023-08-15", "event": "Alt field test", "desc": "Alt desc"},
-        ]
-        result = cmd._parse_timeline_response(json.dumps(entries))
-        assert len(result) == 1
-        assert result[0]["date"] == "2023-08-15"
-        assert result[0]["title"] == "Alt field test"
-        assert result[0]["description"] == "Alt desc"
-
-    def test_parse_rejects_non_iso_dates_in_alternate_fields(self):
-        """Entries with non-ISO dates in fallback fields are dropped."""
-        cmd = Command()
-        entries = [
-            {"date": "2023-08-15", "title": "Valid entry"},
-            {"date_bs": "15-08-2023", "event": "Bad date format"},
-            {"date_bs": "2080-04-32", "event": "Invalid calendar date"},
-        ]
-        result = cmd._parse_timeline_response(json.dumps(entries))
-        assert len(result) == 1
-        assert result[0]["date"] == "2023-08-15"
-
-    def test_parse_nested_timeline_key(self):
-        """Response with 'timeline' wrapper key is extracted."""
-        cmd = Command()
-        entries = [
-            {"date": "2023-08-15", "title": "Wrapped"},
-        ]
-        result = cmd._parse_timeline_response(json.dumps({"timeline": entries}))
-        assert len(result) == 1
-
-    # ── 6. Source content acquisition ───────────────────────────────────
-
-    def test_extract_source_from_description(self):
-        """Source content extracted from DocumentSource.description when >200 chars."""
-        source = self._create_source(
-            source_type=SourceType.LEGAL_PROCEDURAL,
-            description="Detailed case information with timeline data. " * 20,
-        )
-        case = self._create_case(
-            evidence=[{"source_id": source.source_id, "description": "test"}],
-        )
-
-        cmd = Command()
-        session = self._session()
-        content = cmd._get_source_content(case, session)
-
-        assert content is not None
-        assert "Detailed case information" in content
-
-    def test_skips_case_without_evidence(self):
-        """Cases with no evidence return None."""
-        case = self._create_case(evidence=[])
-
-        cmd = Command()
-        session = self._session()
-        content = cmd._get_source_content(case, session)
-
-        assert content is None
-
-    def test_source_from_url_when_description_short(self):
-        """When description is short, download from URL via _convert_to_markdown."""
-        source = DocumentSource.objects.create(
-            title="CIAA Press Release",
-            description="Short.",
-            url=["https://ciaa.gov.np/pressrelease/3173"],
-            source_type=SourceType.LEGAL_PROCEDURAL,
-        )
-        case = self._create_case(
-            evidence=[{"source_id": source.source_id, "description": "test"}],
-        )
-
-        cmd = Command()
-        session = self._session()
-        with patch(
-            "cases.management.commands.enrich_ciaa_timeline.convert_to_markdown",
-            return_value="Extracted text. " * 50,
-        ):
-            content = cmd._get_source_content(case, session)
-
-        assert content is not None
-        assert "Extracted text" in content
-
-    def test_combines_multiple_source_types(self):
-        """Content from LEGAL_PROCEDURAL + LEGAL_COURT_ORDER are combined."""
-        legal_proc = DocumentSource.objects.create(
-            title="CIAA Press Release",
-            description="Press release content with dates. " * 30,
-            url=["https://ciaa.gov.np/pressrelease/3173"],
-            source_type=SourceType.LEGAL_PROCEDURAL,
-        )
-        court_order = DocumentSource.objects.create(
-            title="Court Order",
-            description="Court order with hearing and verdict dates. " * 30,
-            url=["https://ngm-store.jawafdehi.org/court/123"],
-            source_type=SourceType.LEGAL_COURT_ORDER,
-        )
-        case = self._create_case(
-            evidence=[
-                {"source_id": legal_proc.source_id, "description": "press release"},
-                {"source_id": court_order.source_id, "description": "court order"},
-            ],
-        )
-
-        cmd = Command()
-        session = self._session()
-        content = cmd._get_source_content(case, session)
-
-        assert content is not None
-        assert "Press release content" in content
-        assert "Court order" in content
-        assert "---" in content
-
-    # ── 7. Dry-run safety ───────────────────────────────────────────────
-
-    def test_dry_run_no_db_writes(self):
-        """Dry-run does not modify the database."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            timeline=[],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with self._mock_call_llm():
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                f"--case-id={case.case_id}",
-                "--dry-run",
-                stdout=out,
-            )
-
-        case.refresh_from_db()
-        assert case.timeline == []
-
-    def test_production_mode_saves_timeline(self):
-        """Without --dry-run, timeline entries are saved to the database."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            timeline=[],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with self._mock_call_llm(
-            entries=[
-                {"date": "2023-08-15", "title": "Saved event"},
+                    "description": "x" * 250,
+                    "source": {"source_type": "CIAA_PRESS_RELEASE", "urls": []},
+                }
             ]
-        ):
+        }
+        text = cmd._get_source_content(case)
+        assert text and len(text) >= 250
 
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                f"--case-id={case.case_id}",
-                "--llm-api-key=test-key",
-                stdout=out,
-            )
-
-        case.refresh_from_db()
-        assert len(case.timeline) == 1
-        assert case.timeline[0]["date"] == "2023-08-15"
-        assert case.timeline[0]["title"] == "Saved event"
-
-    # ── 8. CLI flag registration ────────────────────────────────────────
-
-    def test_cli_dry_run_flag_registered(self):
-        """--dry-run flag is properly registered."""
-        parser = MagicMock()
+    def test_uses_existing_markdown_link_when_description_short(self):
         cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--dry-run",
-            action="store_true",
-            help="Preview without saving to database",
-        )
+        case = {
+            "evidence": [
+                {
+                    "description": "short",
+                    "source": {
+                        "source_type": "AG_ABHIYOG_PATRA",
+                        "urls": [
+                            {
+                                "role": "MARKDOWN",
+                                "link": "https://s3.jawafdehi.org/x.md",
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        with patch.object(Command, "_download_text", return_value="m" * 300) as mock_dl:
+            text = cmd._get_source_content(case)
+        assert text and len(text) >= 300
+        mock_dl.assert_called_once_with("https://s3.jawafdehi.org/x.md")
 
-    def test_cli_force_flag_registered(self):
-        """--force flag is properly registered."""
-        parser = MagicMock()
+    def test_creates_markdown_via_shared_converter_when_none_exists(self):
         cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--force",
-            action="store_true",
-            help="Re-generate timeline even if timeline already exists",
-        )
-
-    def test_cli_fiscal_year_flag_registered(self):
-        """--fiscal-year flag is properly registered."""
-        parser = MagicMock()
-        cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--fiscal-year",
-            type=str,
-            help="Filter by fiscal year (e.g., '080' or '081')",
-        )
-
-    def test_cli_case_id_flag_registered(self):
-        """--case-id flag is properly registered."""
-        parser = MagicMock()
-        cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--case-id",
-            type=str,
-            help="Process a specific case by case_id",
-        )
-
-    def test_cli_limit_flag_registered(self):
-        """--limit flag is properly registered."""
-        parser = MagicMock()
-        cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--limit",
-            type=int,
-            help="Maximum number of cases to process",
-        )
-
-    def test_cli_limit_enforced(self):
-        """--limit option caps the number of cases processed."""
-        for i in range(5):
-            self._create_case(
-                case_id=f"limit-test-{i:03d}",
-                timeline=[],
-            )
-
-        with self._mock_call_llm():
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                "--limit=1",
-                "--dry-run",
-                stdout=out,
-            )
-
-        output = out.getvalue()
-        assert "Cases processed:        1" in output
-
-    def test_cli_verbose_flag_registered(self):
-        """--verbose flag is properly registered."""
-        parser = MagicMock()
-        cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--verbose",
-            action="store_true",
-            help="Enable verbose debug logging",
-        )
-
-    # ── edge cases ──────────────────────────────────────────────────────
-
-    def test_llm_error_increments_counter(self):
-        """LLM API failures are tracked in stats without crashing."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with self._mock_call_llm_error():
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                f"--case-id={case.case_id}",
-                "--llm-api-key=test-key",
-                "--dry-run",
-                stdout=out,
-            )
-
-        output = out.getvalue()
-        assert "LLM errors:             1" in output
-
-    def test_llm_malformed_response_increments_counter(self):
-        """LLM response without 'content' key is counted as LLM error and
-        command continues processing remaining cases."""
-        pr_source = self._create_source()
-        self._create_case(
-            case_id="missing-content-1",
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-            timeline=[],
-        )
-        self._create_case(
-            case_id="missing-content-2",
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-            timeline=[],
-        )
-
-        side_effects = [
-            CommandError("LLM refused: I cannot help"),
-            self._mock_llm_response(
-                [{"date": "2023-08-15", "title": "Recovered", "description": ""}]
-            ),
-        ]
+        case = {
+            "evidence": [
+                {
+                    "description": "short",
+                    "source": {
+                        "source_type": "AG_ABHIYOG_PATRA",
+                        "urls": [
+                            {"role": "RAW", "link": "https://s3.jawafdehi.org/x.pdf"}
+                        ],
+                    },
+                }
+            ]
+        }
         with patch(
-            "cases.management.commands.enrich_ciaa_timeline.call_llm",
-            side_effect=side_effects,
-        ):
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                "--dry-run",
-                "--llm-api-key=test-key",
-                stdout=out,
+            "review.converter.convert_source",
+            return_value={"status": "converted", "markdown": "m" * 300, "note": ""},
+        ) as mock_conv:
+            text = cmd._get_source_content(case)
+        assert text and len(text) >= 300
+        # The shared converter was handed the convertible (RAW) link.
+        _, kwargs = mock_conv.call_args
+        passed = mock_conv.call_args.args[0]
+        assert passed == {"url": ["https://s3.jawafdehi.org/x.pdf"]}
+
+    def test_no_evidence_returns_none(self):
+        assert Command()._get_source_content({"evidence": []}) is None
+
+    def test_orders_by_milestone_source_type(self):
+        cmd = Command()
+        case = {
+            "evidence": [
+                {
+                    "description": "B" * 250,
+                    "source": {"source_type": "COURT_ORDER", "urls": []},
+                },
+                {
+                    "description": "A" * 250,
+                    "source": {"source_type": "AG_ABHIYOG_PATRA", "urls": []},
+                },
+            ]
+        }
+        text = cmd._get_source_content(case)
+        # AG_ABHIYOG_PATRA is higher priority, so its content comes first.
+        assert text.index("A" * 250) < text.index("B" * 250)
+
+
+# ── end-to-end process_case (mocked HTTP + LLM) ─────────────────────────────
+
+
+class TestProcessCase:
+    def _cmd(self):
+        cmd = Command()
+        cmd.stdout = MagicMock()
+        return cmd
+
+    def test_dry_run_does_not_patch(self):
+        cmd = self._cmd()
+        case = _case()
+        entries = [{"date": "2025-02-09", "date_bs": "2081-10-27", "title": "x"}]
+        with patch.object(cmd, "_fetch_case_detail", return_value=case), patch.object(
+            cmd, "_get_source_content", return_value="src"
+        ), patch.object(cmd, "_get_ngm_data", return_value=None), patch.object(
+            cmd, "_extract_timeline", return_value=entries
+        ), patch.object(
+            cmd, "_patch_timeline"
+        ) as mock_patch:
+            cmd._process_case(
+                case=case,
+                idx=1,
+                total=1,
+                dry_run=True,
+                llm_cfg={
+                    "backend": "openai",
+                    "model": "m",
+                    "base_url": "http://x/v1",
+                    "api_key": "k",
+                    "max_tokens": 4000,
+                },
+                api_base_url=API_BASE,
+                api_token="tok",
+                session=MagicMock(),
             )
+        mock_patch.assert_not_called()
+        assert cmd.stats["cases_enriched"] == 0
 
-        output = out.getvalue()
-        assert "LLM errors:             1" in output
-        assert "Cases processed:        2" in output
-        assert "Cases enriched:         0" in output
+    def test_production_patches_timeline(self):
+        cmd = self._cmd()
+        case = _case()
+        entries = [{"date": "2025-02-09", "date_bs": "2081-10-27", "title": "x"}]
+        with patch.object(cmd, "_fetch_case_detail", return_value=case), patch.object(
+            cmd, "_get_source_content", return_value="src"
+        ), patch.object(cmd, "_get_ngm_data", return_value=None), patch.object(
+            cmd, "_extract_timeline", return_value=entries
+        ), patch.object(
+            cmd, "_patch_timeline"
+        ) as mock_patch:
+            cmd._process_case(
+                case=case,
+                idx=1,
+                total=1,
+                dry_run=False,
+                llm_cfg={
+                    "backend": "openai",
+                    "model": "m",
+                    "base_url": "http://x/v1",
+                    "api_key": "k",
+                    "max_tokens": 4000,
+                },
+                api_base_url=API_BASE,
+                api_token="tok",
+                session=MagicMock(),
+            )
+        mock_patch.assert_called_once()
+        _, kwargs = mock_patch.call_args
+        assert kwargs["entries"] == entries
+        assert kwargs["case_slug"] == "case-0001-slug"
+        assert cmd.stats["cases_enriched"] == 1
 
-    def test_no_content_counted(self):
-        """Cases without usable source content count as 'No source content'."""
-        self._create_case(
-            case_id="no-source-case",
-            evidence=[],
-            timeline=[],
+    def test_no_content_skips(self):
+        cmd = self._cmd()
+        case = _case()
+        with patch.object(cmd, "_fetch_case_detail", return_value=case), patch.object(
+            cmd, "_get_source_content", return_value=None
+        ), patch.object(cmd, "_get_ngm_data", return_value=None), patch.object(
+            cmd, "_patch_timeline"
+        ) as mock_patch:
+            cmd._process_case(
+                case=case,
+                idx=1,
+                total=1,
+                dry_run=False,
+                llm_cfg={
+                    "backend": "openai",
+                    "model": "m",
+                    "base_url": "http://x/v1",
+                    "api_key": "k",
+                    "max_tokens": 4000,
+                },
+                api_base_url=API_BASE,
+                api_token="tok",
+                session=MagicMock(),
+            )
+        mock_patch.assert_not_called()
+        assert cmd.stats["cases_no_content"] == 1
+
+
+# ── PATCH payload ───────────────────────────────────────────────────────────
+
+
+class TestPatchTimeline:
+    def test_sends_json_patch_replace(self):
+        cmd = Command()
+        entries = [{"date": "2025-02-09", "date_bs": "2081-10-27", "title": "x"}]
+        captured = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                return None
+
+        def fake_patch(url, json=None, headers=None, timeout=None):
+            captured["url"] = url
+            captured["body"] = json
+            captured["auth"] = (headers or {}).get("Authorization")
+            return _Resp()
+
+        session = MagicMock()
+        session.patch.side_effect = fake_patch
+        cmd._patch_timeline(
+            case_slug="case-0001-slug",
+            case_id="case-0001",
+            entries=entries,
+            api_base_url=API_BASE,
+            api_token="tok",
+            session=session,
         )
+        assert captured["url"] == f"{API_BASE}/cases/case-0001-slug/"
+        assert captured["auth"] == "Token tok"
+        assert captured["body"] == [
+            {"op": "replace", "path": "/timeline", "value": entries}
+        ]
+
+    def test_patch_http_error_raises_command_error(self):
+        import requests
 
         cmd = Command()
-        cmd.stats = dict.fromkeys(
-            [
-                "cases_processed",
-                "cases_enriched",
-                "cases_skipped",
-                "cases_no_content",
-                "cases_llm_error",
-                "cases_already_populated",
-                "cases_ngm_used",
-            ],
-            0,
-        )
-
-        out = StringIO()
-        call_command(
-            "enrich_ciaa_timeline",
-            "--case-id=no-source-case",
-            "--dry-run",
-            stdout=out,
-        )
-
-        output = out.getvalue()
-        assert "No source content" in output
-
-    def test_summary_printed_correctly(self):
-        """The summary section displays all stat counters."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with self._mock_call_llm():
-            out = StringIO()
-            call_command(
-                "enrich_ciaa_timeline",
-                f"--case-id={case.case_id}",
-                "--dry-run",
-                stdout=out,
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 422
+        resp.text = "bad timeline"
+        err = requests.HTTPError(response=resp)
+        resp.raise_for_status.side_effect = err
+        session.patch.return_value = resp
+        with pytest.raises(CommandError, match="422"):
+            cmd._patch_timeline(
+                case_slug="case-0001-slug",
+                case_id="case-0001",
+                entries=[{"date": "2025-02-09", "title": "x"}],
+                api_base_url=API_BASE,
+                api_token="tok",
+                session=session,
             )
 
-        output = out.getvalue()
-        assert "Cases processed:" in output
-        assert "Cases enriched:" in output
-        assert "Cases skipped:" in output
-        assert "No source content:" in output
-        assert "LLM errors:" in output
-        assert "Already populated:" in output
-        assert "NGM data used:" in output
+    def test_missing_slug_raises(self):
+        with pytest.raises(CommandError, match="no slug"):
+            Command()._patch_timeline(
+                case_slug=None,
+                case_id="case-0001",
+                entries=[],
+                api_base_url=API_BASE,
+                api_token="tok",
+                session=MagicMock(),
+            )
+
+
+# ── CLI argument handling ───────────────────────────────────────────────────
+
+
+class TestCliArguments:
+    def _run(self, **kwargs):
+        out = StringIO()
+        call_command("enrich_ciaa_timeline", stdout=out, **kwargs)
+        return out.getvalue()
+
+    def test_requires_api_token(self):
+        with pytest.raises(CommandError, match="API token is required"):
+            self._run(dry_run=True, llm_api_key="k")
+
+    def test_openai_backend_requires_llm_key(self):
+        with pytest.raises(CommandError, match="LLM API key"):
+            self._run(dry_run=True, api_token="tok", llm_backend="openai")
+
+    def test_bedrock_backend_does_not_require_llm_key(self):
+        # Default model is Opus (bedrock) — no LLM key needed; runs with 0 cases.
+        with patch.object(Command, "_get_ciaa_cases", return_value=[]):
+            output = self._run(dry_run=True, api_token="tok", llm_backend="bedrock")
+        assert "Backend: bedrock" in output
         assert "Timeline extraction complete" in output
 
-    def test_responds_to_missing_api_key_in_production(self):
-        """Production mode without API key raises appropriate error."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with patch.dict("os.environ", {}, clear=True):
-            with pytest.raises(CommandError) as exc_info:
-                call_command(
-                    "enrich_ciaa_timeline",
-                    f"--case-id={case.case_id}",
-                )
-        assert "No LLM API key" in str(exc_info.value)
-
-    # ── NGM structured hearing data ─────────────────────────────────────
-
-    def test_get_ngm_data_returns_data_for_special_ref(self):
-        """_get_ngm_data queries NGM when special: ref exists in court_cases."""
-        case = self._create_case(
-            court_cases=["special:080-CR-0111"],
-        )
-        mock_data = self._mock_ngm_data()
-
-        cmd = Command()
-        with patch(
-            "cases.management.commands.enrich_ciaa_timeline.get_court_case_details",
-            return_value=mock_data,
-        ):
-            result = cmd._get_ngm_data(case)
-
-        assert result is not None
-        assert result["case"]["registration_date_ad"] == "2023-09-20"
-        assert len(result["hearings"]) == 2
-
-    def test_get_ngm_data_returns_none_without_special_ref(self):
-        """_get_ngm_data returns None when no special: ref in court_cases."""
-        case = self._create_case(
-            court_cases=["supreme:123"],
-        )
-
-        cmd = Command()
-        result = cmd._get_ngm_data(case)
-
-        assert result is None
-
-    def test_get_ngm_data_returns_none_empty_court_cases(self):
-        """_get_ngm_data returns None when court_cases is empty."""
-        case = self._create_case(court_cases=[])
-
-        cmd = Command()
-        result = cmd._get_ngm_data(case)
-
-        assert result is None
-
-    def test_get_ngm_data_queries_database(self):
-        """_get_ngm_data fetches real data from NGM when available."""
-        case = self._create_case(
-            court_cases=["special:080-CR-0111"],
-        )
-        mock_data = self._mock_ngm_data()
-
-        cmd = Command()
-        with patch(
-            "cases.management.commands.enrich_ciaa_timeline.get_court_case_details",
-            return_value=mock_data,
-        ):
-            result = cmd._get_ngm_data(case)
-
-        assert result is not None
-        assert result["case"]["registration_date_ad"] == "2023-09-20"
-        assert len(result["hearings"]) == 2
-
-    def test_format_ngm_section_with_data(self):
-        """_format_ngm_section produces structured text from NGM data."""
-        mock_data = self._mock_ngm_data()
-
-        cmd = Command()
-        section = cmd._format_ngm_section(mock_data)
-
-        assert "NGM STRUCTURED HEARING DATA" in section
-        assert "2023-09-20" in section
-        assert "2024-03-10" in section
-        assert "2023-11-15" in section
-        assert "सुनुवाइ भएको" in section
-
-    def test_format_ngm_section_empty(self):
-        """_format_ngm_section returns empty string for None/empty data."""
-        cmd = Command()
-        assert cmd._format_ngm_section(None) == ""
-        assert cmd._format_ngm_section({}) == ""
-
-    def test_ngm_data_passed_to_extract_timeline(self):
-        """NGM data is used in the extraction prompt."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            court_cases=["special:080-CR-0111"],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-        mock_ngm = self._mock_ngm_data()
-
-        with patch(
-            "cases.management.commands.enrich_ciaa_timeline.get_court_case_details",
-            return_value=mock_ngm,
-        ):
-            with self._mock_call_llm():
-                out = StringIO()
-                call_command(
-                    "enrich_ciaa_timeline",
-                    f"--case-id={case.case_id}",
-                    "--dry-run",
-                    stdout=out,
-                )
-
-        output = out.getvalue()
-        assert "NGM data: 2 hearing(s)" in output
-
-    def test_ngm_counter_incremented(self):
-        """cases_ngm_used stat is incremented when NGM data is available."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            court_cases=["special:080-CR-0111"],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-        mock_ngm = self._mock_ngm_data()
-
-        with patch(
-            "cases.management.commands.enrich_ciaa_timeline.get_court_case_details",
-            return_value=mock_ngm,
-        ):
-            with self._mock_call_llm():
-                out = StringIO()
-                call_command(
-                    "enrich_ciaa_timeline",
-                    f"--case-id={case.case_id}",
-                    "--dry-run",
-                    stdout=out,
-                )
-
-        output = out.getvalue()
-        assert "NGM data used:          1" in output
-
-    def test_ngm_query_failure_handled_gracefully(self):
-        """NGM query failures are caught and logged without crashing."""
-        pr_source = self._create_source()
-        case = self._create_case(
-            court_cases=["special:080-CR-0111"],
-            evidence=[{"source_id": pr_source.source_id, "description": "test"}],
-        )
-
-        with patch(
-            "cases.management.commands.enrich_ciaa_timeline.get_court_case_details",
-            side_effect=ValueError("Database error"),
-        ):
-            with self._mock_call_llm():
-                out = StringIO()
-                call_command(
-                    "enrich_ciaa_timeline",
-                    f"--case-id={case.case_id}",
-                    "--dry-run",
-                    stdout=out,
-                )
-
-        output = out.getvalue()
-        assert "NGM data: none" in output
-
-    # ── --priority flag ──────────────────────────────────────────────────
-
-    def test_cli_priority_flag_registered(self):
-        """--priority flag is properly registered."""
-        parser = MagicMock()
-        cmd = Command()
-        cmd.add_arguments(parser)
-        parser.add_argument.assert_any_call(
-            "--priority",
-            action="store_true",
-            help="Enrich only cases in the priority case list",
-        )
-
     def test_priority_and_case_id_mutually_exclusive(self):
-        """--priority and --case-id cannot be used together."""
-        out = StringIO()
-        with pytest.raises(CommandError) as exc_info:
-            call_command(
-                "enrich_ciaa_timeline",
-                "--priority",
-                "--case-id=case-001",
-                "--dry-run",
-                stdout=out,
-            )
-        assert "mutually exclusive" in str(exc_info.value)
+        with pytest.raises(CommandError, match="mutually exclusive"):
+            self._run(priority=True, case_id="x", **COMMON)
+
+    def test_invalid_fiscal_year(self):
+        with pytest.raises(CommandError, match="Invalid fiscal year"):
+            self._run(fiscal_year="20810", **COMMON)
+
+    def test_invalid_limit(self):
+        with pytest.raises(CommandError, match="Must be a positive integer"):
+            self._run(limit=-1, **COMMON)
+
+    def test_dry_run_runs_with_no_cases(self):
+        # No DB access at all: mock the case fetch to return an empty list.
+        with patch.object(Command, "_get_ciaa_cases", return_value=[]):
+            output = self._run(dry_run=True, **COMMON)
+        assert "Timeline extraction complete" in output
+
+    def test_backend_auto_detects_bedrock_for_claude_model(self):
+        cmd = Command()
+        cfg = cmd._resolve_llm_config(
+            {
+                "llm_backend": "auto",
+                "llm_model": "global.anthropic.claude-opus-4-8",
+                "llm_max_tokens": 4000,
+                "aws_profile": "",
+                "aws_region": "us-west-2",
+            }
+        )
+        assert cfg["backend"] == "bedrock"
+        assert cfg["model"] == "global.anthropic.claude-opus-4-8"
+
+    def test_backend_auto_detects_openai_for_other_model(self):
+        cmd = Command()
+        cfg = cmd._resolve_llm_config(
+            {
+                "llm_backend": "auto",
+                "llm_model": "qwen.qwen3-235b-a22b-2507",
+                "llm_max_tokens": 4000,
+                "llm_base_url": "http://x/v1",
+                "llm_api_key": "k",
+            }
+        )
+        assert cfg["backend"] == "openai"
+        assert cfg["api_key"] == "k"

--- a/tests/commands/test_enrich_utils.py
+++ b/tests/commands/test_enrich_utils.py
@@ -1,0 +1,372 @@
+"""Unit tests for shared enrichment utilities (_enrich_utils).
+
+Focus on the date-conversion tool and the tool-use LLM loop added for the
+API-driven timeline enrichment command. These tests do not touch the database.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from cases.management.commands._enrich_utils import (
+    CONVERT_DATE_TOOL,
+    CONVERT_DATE_TOOL_ANTHROPIC,
+    call_bedrock_with_tools,
+    call_llm_with_tools,
+    convert_date,
+)
+
+# ── convert_date ─────────────────────────────────────────────────────────────
+
+
+class TestConvertDate:
+    def test_bs_to_ad(self):
+        result = convert_date(["2081-10-27"], "bs_to_ad")
+        assert result == {"2081-10-27": "2025-02-09"}
+
+    def test_ad_to_bs(self):
+        result = convert_date(["2025-02-09"], "ad_to_bs")
+        assert result == {"2025-02-09": "2081-10-27"}
+
+    def test_batch_conversion(self):
+        result = convert_date(["2046-03-30", "2077-03-31"], "bs_to_ad")
+        assert result["2046-03-30"] == "1989-07-14"
+        assert result["2077-03-31"] == "2020-07-15"
+
+    def test_normalizes_slashes_and_devanagari_digits(self):
+        result = convert_date(["२०८१/१०/२७"], "bs_to_ad")
+        assert result["२०८१/१०/२७"] == "2025-02-09"
+
+    def test_malformed_date_reports_error_per_entry(self):
+        result = convert_date(["not-a-date", "2081-10-27"], "bs_to_ad")
+        assert result["not-a-date"].startswith("Error")
+        assert result["2081-10-27"] == "2025-02-09"
+
+    def test_out_of_range_date_reports_error_not_crash(self):
+        # nepali raises its own exception types (not ValueError/TypeError) for
+        # out-of-range dates; convert_date must report per-entry, not crash.
+        result = convert_date(["9999-13-40", "2081-10-27"], "bs_to_ad")
+        assert result["9999-13-40"].startswith("Error")
+        assert result["2081-10-27"] == "2025-02-09"
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            convert_date(["2081-10-27"], "sideways")
+
+    def test_non_list_raises(self):
+        with pytest.raises(ValueError):
+            convert_date("2081-10-27", "bs_to_ad")
+
+
+# ── call_llm_with_tools ──────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Returns a queued sequence of chat-completion responses, one per POST."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.requests = []
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        self.requests.append(json)
+        return _FakeResponse(self._responses.pop(0))
+
+
+def _assistant_text(text):
+    return {"choices": [{"message": {"content": text}, "finish_reason": "stop"}]}
+
+
+def _assistant_tool_call(call_id, name, arguments):
+    return {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+
+def test_returns_text_when_no_tool_calls():
+    session = _FakeSession([_assistant_text("final answer")])
+    out = call_llm_with_tools(
+        system_prompt="sys",
+        user_prompt="usr",
+        model="m",
+        base_url="http://x/v1",
+        api_key="k",
+        session=session,
+        tools=[CONVERT_DATE_TOOL],
+        tool_executors={"convert_date": convert_date},
+    )
+    assert out == "final answer"
+    assert len(session.requests) == 1
+
+
+def test_executes_tool_call_then_returns_final_text():
+    session = _FakeSession(
+        [
+            _assistant_tool_call(
+                "c1",
+                "convert_date",
+                {
+                    "dates": ["2081-10-27"],
+                    "mode": "bs_to_ad",
+                },
+            ),
+            _assistant_text('[{"date": "2025-02-09", "title": "x"}]'),
+        ]
+    )
+    out = call_llm_with_tools(
+        system_prompt="sys",
+        user_prompt="usr",
+        model="m",
+        base_url="http://x/v1",
+        api_key="k",
+        session=session,
+        tools=[CONVERT_DATE_TOOL],
+        tool_executors={"convert_date": convert_date},
+    )
+    assert "2025-02-09" in out
+    # Two round-trips: tool call, then final answer.
+    assert len(session.requests) == 2
+    # The second request must include the tool result message.
+    second_msgs = session.requests[1]["messages"]
+    tool_msgs = [m for m in second_msgs if m.get("role") == "tool"]
+    assert tool_msgs and "2025-02-09" in tool_msgs[0]["content"]
+
+
+def test_unknown_tool_is_reported_to_model_not_fatal():
+    session = _FakeSession(
+        [
+            _assistant_tool_call("c1", "no_such_tool", {}),
+            _assistant_text("recovered"),
+        ]
+    )
+    out = call_llm_with_tools(
+        system_prompt="sys",
+        user_prompt="usr",
+        model="m",
+        base_url="http://x/v1",
+        api_key="k",
+        session=session,
+        tools=[CONVERT_DATE_TOOL],
+        tool_executors={"convert_date": convert_date},
+    )
+    assert out == "recovered"
+    tool_msg = [m for m in session.requests[1]["messages"] if m.get("role") == "tool"][
+        0
+    ]
+    assert "unknown tool" in tool_msg["content"]
+
+
+def test_tool_executor_exception_is_reported_not_fatal():
+    """A tool executor that raises any exception is reported to the model."""
+
+    def _boom(**kwargs):
+        raise RuntimeError("executor blew up")
+
+    session = _FakeSession(
+        [
+            _assistant_tool_call("c1", "boom", {"x": 1}),
+            _assistant_text("recovered after tool error"),
+        ]
+    )
+    out = call_llm_with_tools(
+        system_prompt="sys",
+        user_prompt="usr",
+        model="m",
+        base_url="http://x/v1",
+        api_key="k",
+        session=session,
+        tools=[CONVERT_DATE_TOOL],
+        tool_executors={"boom": _boom},
+    )
+    assert out == "recovered after tool error"
+    tool_msg = [m for m in session.requests[1]["messages"] if m.get("role") == "tool"][
+        0
+    ]
+    assert "executor blew up" in tool_msg["content"]
+
+
+def test_exceeding_tool_round_budget_raises():
+    # Always returns a tool call, never a final answer.
+    responses = [
+        _assistant_tool_call(
+            f"c{i}", "convert_date", {"dates": ["2081-10-27"], "mode": "bs_to_ad"}
+        )
+        for i in range(5)
+    ]
+    session = _FakeSession(responses)
+    with pytest.raises(CommandError, match="tool-use rounds"):
+        call_llm_with_tools(
+            system_prompt="sys",
+            user_prompt="usr",
+            model="m",
+            base_url="http://x/v1",
+            api_key="k",
+            session=session,
+            tools=[CONVERT_DATE_TOOL],
+            tool_executors={"convert_date": convert_date},
+            max_tool_rounds=3,
+        )
+
+
+# ── call_bedrock_with_tools ──────────────────────────────────────────────────
+
+
+def _bedrock_body(payload):
+    """Wrap a payload dict as a Bedrock invoke_model response (body has .read())."""
+    resp_body = MagicMock()
+    resp_body.read.return_value = json.dumps(payload).encode("utf-8")
+    return {"body": resp_body}
+
+
+def _fake_bedrock_client(payloads):
+    """A bedrock-runtime client whose invoke_model returns queued payloads."""
+    client = MagicMock()
+    client.invoke_model.side_effect = [_bedrock_body(p) for p in payloads]
+    return client
+
+
+def _patch_boto3(client):
+    """Patch boto3.Session(...).client(...) to return the given fake client."""
+    session = MagicMock()
+    session.client.return_value = client
+    return patch("boto3.Session", return_value=session)
+
+
+def test_bedrock_returns_text_when_no_tool_use():
+    client = _fake_bedrock_client(
+        [{"stop_reason": "end_turn", "content": [{"type": "text", "text": "final"}]}]
+    )
+    with _patch_boto3(client):
+        out = call_bedrock_with_tools(
+            system_prompt="sys",
+            user_prompt="usr",
+            model_id="global.anthropic.claude-opus-4-8",
+            tools=[CONVERT_DATE_TOOL_ANTHROPIC],
+            tool_executors={"convert_date": convert_date},
+        )
+    assert out == "final"
+    assert client.invoke_model.call_count == 1
+
+
+def test_bedrock_executes_tool_use_then_returns_text():
+    client = _fake_bedrock_client(
+        [
+            {
+                "stop_reason": "tool_use",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu1",
+                        "name": "convert_date",
+                        "input": {"dates": ["2081-10-27"], "mode": "bs_to_ad"},
+                    }
+                ],
+            },
+            {
+                "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "done 2025-02-09"}],
+            },
+        ]
+    )
+    with _patch_boto3(client):
+        out = call_bedrock_with_tools(
+            system_prompt="sys",
+            user_prompt="usr",
+            model_id="global.anthropic.claude-opus-4-8",
+            tools=[CONVERT_DATE_TOOL_ANTHROPIC],
+            tool_executors={"convert_date": convert_date},
+        )
+    assert "2025-02-09" in out
+    assert client.invoke_model.call_count == 2
+    # 2nd call must carry a tool_result block with the conversion output.
+    second_body = json.loads(client.invoke_model.call_args_list[1].kwargs["body"])
+    user_turns = [m for m in second_body["messages"] if m["role"] == "user"]
+    tool_result = user_turns[-1]["content"][0]
+    assert tool_result["type"] == "tool_result"
+    assert tool_result["tool_use_id"] == "tu1"
+    assert "2025-02-09" in tool_result["content"]
+
+
+def test_bedrock_unknown_tool_reported_not_fatal():
+    client = _fake_bedrock_client(
+        [
+            {
+                "stop_reason": "tool_use",
+                "content": [
+                    {"type": "tool_use", "id": "t", "name": "nope", "input": {}}
+                ],
+            },
+            {"stop_reason": "end_turn", "content": [{"type": "text", "text": "ok"}]},
+        ]
+    )
+    with _patch_boto3(client):
+        out = call_bedrock_with_tools(
+            system_prompt="sys",
+            user_prompt="usr",
+            model_id="m",
+            tools=[CONVERT_DATE_TOOL_ANTHROPIC],
+            tool_executors={"convert_date": convert_date},
+        )
+    assert out == "ok"
+    second_body = json.loads(client.invoke_model.call_args_list[1].kwargs["body"])
+    tr = [m for m in second_body["messages"] if m["role"] == "user"][-1]["content"][0]
+    assert tr.get("is_error") and "unknown tool" in tr["content"]
+
+
+def test_bedrock_exceeding_tool_rounds_raises():
+    payloads = [
+        {
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": f"t{i}",
+                    "name": "convert_date",
+                    "input": {"dates": ["2081-10-27"], "mode": "bs_to_ad"},
+                }
+            ],
+        }
+        for i in range(5)
+    ]
+    client = _fake_bedrock_client(payloads)
+    with _patch_boto3(client):
+        with pytest.raises(CommandError, match="tool-use rounds"):
+            call_bedrock_with_tools(
+                system_prompt="sys",
+                user_prompt="usr",
+                model_id="m",
+                tools=[CONVERT_DATE_TOOL_ANTHROPIC],
+                tool_executors={"convert_date": convert_date},
+                max_tool_rounds=3,
+            )


### PR DESCRIPTION
## Summary

PR 2 of 2 for the CIAA factual-timeline work (#186). **Stacked on #189** (the schema PR) — review/merge that first; this PR's base is `feat/timeline-entry-bs-and-span`, so the diff here is only the command rework.

Reworks `enrich_ciaa_timeline` from a generic chronological extractor into the **factual-milestone** timeline described in #186, and makes it run **entirely over the HTTP API**.

### Factual milestones (not court procedure)
- New prompts target the incident period (as a `date`/`end_date` span), complaint (उजुरी), CIAA investigation, press release, chargesheet filing (आरोपपत्र दायर), interim orders, Special Court verdict, and Supreme Court appeal/verdict.
- The NGM hearings table is still fed to the LLM so it can anchor dates — but the model is told **not** to emit per-hearing entries, since that progression is already the case's Pragati Bibaran by case number.
- Every entry carries `date_bs` (and `end_date`/`end_date_bs` for spans), matching published cases. Fixes the prior `date`/`date_bs` aliasing bug.

### Reliable date conversion via tool use
- New `call_llm_with_tools()` runs an OpenAI function-tool loop (bounded at 30 rounds). The LLM is given a `convert_date` tool and instructed to use it for all BS↔AD conversion instead of doing the arithmetic in its head.
- `convert_date()` runs in-process via the `nepali` package (same calendar math as the jawafdehi-mcp tool) — no network, no new dependency.
- `call_llm`'s POST/retry/parse core was refactored into shared helpers; its behavior is unchanged (existing bigo/allegations tests pass).

### API-driven (no ORM)
- Reads DRAFT special-court cases, source content (evidence + source URLs from the detail endpoint) and NGM hearings over HTTP; writes via `PATCH /api/cases/{slug}/`.
- Drops the `SourceType` model import — the old tests referenced enum members (`LEGAL_PROCEDURAL`, `LEGAL_COURT_ORDER`) removed in the source-type revamp (#175/#184), so the old test file no longer collected on main. Source types are now matched as plain strings from the API payload.
- **A `--dry-run` needs no `DATABASE_URL`** — only an API token (to read drafts) and an LLM key (timeline generation requires the model). Verified by running the command with no DB env set.

### Review fixes (from code-review pass)
- Tool executor failures are now reported back to the model rather than aborting the whole run.
- `_api_root` is memoised (parsed once per run, not per case).

## Test plan
- `cases/tests/test_enrich_ciaa_timeline.py` — rewritten against mocked HTTP (no `django_db`): case filtering, milestone parsing incl. `date_bs`/`end_date`, NGM section, source acquisition, dry-run vs PATCH, PATCH payload shape, CLI guards.
- `tests/commands/test_enrich_utils.py` — new: `convert_date` both directions + error handling, tool-use loop (tool dispatch, unknown tool, executor exception, round-budget).
- Full enrichment + patch suite: 202 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CIAA case timeline enrichment now operates through API endpoints with new authentication and configuration options (`--api-base-url`, `--api-token`).
  * Enhanced timeline validation with mandatory AD and BS date conversions for improved data consistency.

* **Improvements**
  * Strengthened timeline entry validation with ISO date format checks and ordering verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->