### PR TITLE
Fix stray comment text on Document Source admin External URLs widget

### DIFF
--- a/cases/templates/cases/widgets/multi_url_widget.html
+++ b/cases/templates/cases/widgets/multi_url_widget.html
@@ -21,8 +21,8 @@
 </div>
 <input type="hidden" name="{{ name }}" id="{{ widget_id }}" value="{{ values_json }}">
 
-{# Role choices as JSON (json_script safely escapes for embedding) so the new-row
-   template builds the <select> in JS without interpolating values into JS source. #}
+{% comment %}Role choices as JSON (json_script safely escapes for embedding) so the new-row
+template builds the <select> in JS without interpolating values into JS source.{% endcomment %}
 {{ role_choices|json_script:role_choices_id }}
 
 <script>


### PR DESCRIPTION
## Problem

On the **Document Source** Django admin page, the literal text *"Role choices as JSON (json_script safely escapes for embedding) so the new-row template builds the `<select>` in JS without interpolating values into JS source."* was rendering as visible text above the **External URLs** widget.

## Root cause

The `multi_url_widget.html` template used a **multi-line `{# … #}` comment**. Django's `{# #}` comment syntax only works on a single line — the template lexer regex (`tag_re`) does not use the `DOTALL` flag, so a `{# #}` comment spanning a newline is **not** recognized as a comment token and renders verbatim (markers included).

Verified empirically against the project's Django 5.2.9:
- single-line `{# … #}` → stripped
- multi-line `{# … #}` → emitted as literal text (the bug)

## Fix

Switch to `{% comment %}…{% endcomment %}`, the correct construct for multi-line comments. A render test confirms the stray text is gone and the `{{ role_choices|json_script:role_choices_id }}` element the JS depends on for building new-row role `<select>`s is unaffected.

## Note

The same bug exists in two other feature branches that carry their own copy of this template (`feat/enrich-ciaa-timeline-api-factual`, `JAWA-reprocess-source-markdown`). Since the file is identical across all three, fixing it here and letting it merge through `main` is cleanest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal template documentation for clarity in the widget configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->