### PR TITLE
Normalize raw R2 endpoint host to public storage host on persisted links

### DIFF
--- a/cases/services/storage_links.py
+++ b/cases/services/storage_links.py
@@ -1,8 +1,46 @@
 """Shared helpers for turning stored files into source-link URLs."""
 
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from django.conf import settings
+
+# Raw Cloudflare R2 *endpoint* hosts look like
+# ``<account-id>.r2.cloudflarestorage.com`` and carry the bucket name as the
+# first path segment (``/<bucket>/<key>``). These are an internal storage
+# endpoint, never the public link host — see ``normalize_storage_host``.
+R2_ENDPOINT_HOST_SUFFIX = ".r2.cloudflarestorage.com"
+
+
+def normalize_storage_host(url: str) -> str:
+    """Rewrite a raw R2 endpoint URL to the public storage host.
+
+    File/markdown links are derived from ``default_storage.url()``, whose host
+    depends on ``AWS_S3_CUSTOM_DOMAIN``. When that env var is unset/lapsed,
+    django-storages falls back to the raw R2 *endpoint*
+    (``https://<account>.r2.cloudflarestorage.com/<bucket>/<key>``) instead of
+    the public custom-domain host. That raw URL then gets frozen into a source's
+    ``url`` JSON and is not publicly resolvable as a clean link.
+
+    Because these links are persisted at write time, a transient misconfig would
+    otherwise leave permanent bad data. We defend at the single chokepoint: any
+    R2 endpoint host is rewritten to ``JAWAFDEHI_S3_BASE`` (the public custom
+    domain), dropping the leading ``/<bucket>/`` segment so the key is preserved
+    (``.../<bucket>/case_uploads/x.pdf`` -> ``<base>/case_uploads/x.pdf``). Both
+    forms resolve to the same object. Non-R2 URLs are returned unchanged.
+    """
+    if not url:
+        return url
+    parsed = urlparse(url)
+    if not parsed.netloc.endswith(R2_ENDPOINT_HOST_SUFFIX):
+        return url
+    base = (getattr(settings, "JAWAFDEHI_S3_BASE", "") or "").rstrip("/")
+    if not base:
+        return url
+    # path is ``/<bucket>/<key...>``; drop the bucket segment, keep the key.
+    segments = parsed.path.lstrip("/").split("/", 1)
+    if len(segments) != 2 or not segments[1]:
+        return url
+    return f"{base}/{segments[1]}"
 
 
 def absolute_media_url(url: str) -> str:
@@ -12,8 +50,13 @@ def absolute_media_url(url: str) -> str:
     URLs come back absolute and this is a no-op. Locally (FileSystemStorage) URLs
     are like ``/media/...``; we prefix MEDIA_PUBLIC_BASE so the stored link
     validates against URLValidator.
+
+    As a final safety net we normalize any raw R2 endpoint host to the public
+    storage host (see ``normalize_storage_host``), so a missing
+    ``AWS_S3_CUSTOM_DOMAIN`` can never bake an internal endpoint URL into a
+    source's persisted links.
     """
     if url and url.startswith(("http://", "https://")):
-        return url
+        return normalize_storage_host(url)
     base = getattr(settings, "MEDIA_PUBLIC_BASE", "") or ""
     return urljoin(base + "/", url.lstrip("/")) if base else url

--- a/tests/test_storage_links.py
+++ b/tests/test_storage_links.py
@@ -1,0 +1,76 @@
+"""Tests for cases.services.storage_links host normalization.
+
+Links are frozen into a source's ``url`` JSON at write time, so a missing
+``AWS_S3_CUSTOM_DOMAIN`` must never let a raw Cloudflare R2 *endpoint* host
+(``<account>.r2.cloudflarestorage.com/<bucket>/<key>``) be persisted. The
+helpers rewrite any such URL to the public ``JAWAFDEHI_S3_BASE`` host.
+"""
+
+import pytest
+from django.test import override_settings
+
+from cases.services.storage_links import (
+    absolute_media_url,
+    normalize_storage_host,
+)
+
+R2 = (
+    "https://4c96557d73194d4f245ba23bd6063ad5.r2.cloudflarestorage.com"
+    "/jawafdehi/case_uploads/abc123.pdf"
+)
+S3 = "https://s3.jawafdehi.org/case_uploads/abc123.pdf"
+
+
+@override_settings(JAWAFDEHI_S3_BASE="https://s3.jawafdehi.org")
+def test_r2_endpoint_host_rewritten_to_public_host():
+    assert normalize_storage_host(R2) == S3
+
+
+@override_settings(JAWAFDEHI_S3_BASE="https://s3.jawafdehi.org")
+def test_absolute_media_url_normalizes_r2_endpoint():
+    # Already-absolute R2 URL: passes the scheme check, then gets normalized.
+    assert absolute_media_url(R2) == S3
+
+
+@override_settings(JAWAFDEHI_S3_BASE="https://s3.jawafdehi.org")
+def test_bucket_segment_is_dropped_but_nested_key_preserved():
+    src = "https://acct.r2.cloudflarestorage.com/mybucket/case_uploads/sub/dir/file.md"
+    assert (
+        normalize_storage_host(src)
+        == "https://s3.jawafdehi.org/case_uploads/sub/dir/file.md"
+    )
+
+
+@override_settings(JAWAFDEHI_S3_BASE="https://s3.jawafdehi.org/")
+def test_trailing_slash_on_base_does_not_double_up():
+    assert normalize_storage_host(R2) == S3
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://s3.jawafdehi.org/case_uploads/abc.pdf",  # already public
+        "https://web.archive.org/web/x/https://example.com",  # external
+        "https://ciaa.gov.np/report.pdf",
+        "",
+        None,
+    ],
+)
+@override_settings(JAWAFDEHI_S3_BASE="https://s3.jawafdehi.org")
+def test_non_r2_urls_unchanged(url):
+    assert normalize_storage_host(url) == url
+
+
+@override_settings(JAWAFDEHI_S3_BASE="")
+def test_no_public_base_leaves_url_untouched():
+    # Without a configured base we cannot rewrite; return as-is rather than
+    # producing a broken host.
+    assert normalize_storage_host(R2) == R2
+
+
+@override_settings(JAWAFDEHI_S3_BASE="https://s3.jawafdehi.org")
+def test_bare_r2_host_without_key_unchanged():
+    # No ``/<bucket>/<key>`` to rewrite — leave it alone rather than emit a base
+    # that points nowhere useful.
+    bare = "https://acct.r2.cloudflarestorage.com/onlybucket"
+    assert normalize_storage_host(bare) == bare


### PR DESCRIPTION
## Problem

Some production DocumentSources have their `url` links pointing at the **raw Cloudflare R2 endpoint** host:

```
https://4c96557d73194d4f245ba23bd6063ad5.r2.cloudflarestorage.com/jawafdehi/case_uploads/<hash>.pdf
```

instead of the public custom-domain host:

```
https://s3.jawafdehi.org/case_uploads/<hash>.pdf
```

(146 such links across ~134 sources observed in prod.) The raw endpoint form carries the bucket name as the first path segment and is not the intended public link.

## Root cause

File/markdown links are derived from `default_storage.url()`, whose host is driven by `AWS_S3_CUSTOM_DOMAIN`. When that env var is unset/lapsed, django-storages falls back to the raw R2 *endpoint* URL.

Since #188 ("Persist uploaded files as `url` links"), these URLs are **frozen into `DocumentSource.url` at write time** (previously they were computed at read time and always reflected current settings). So any link minted during a config gap is now permanently baked into the data — and the upload backfill, reading `uploaded_file.url`, captured many historical ones the same way.

## Fix

Defend at the single chokepoint that all writers (`store_file_as_link`, `attach_markdown`) and the upload backfill route through — `absolute_media_url()`:

- New `normalize_storage_host()` rewrites any `*.r2.cloudflarestorage.com` host to `JAWAFDEHI_S3_BASE` (the public custom domain), dropping the leading `/<bucket>/` path segment so the key is preserved.
- Both URL forms resolve to the same object (verified via HEAD -> 200 on `s3.jawafdehi.org`).
- Non-R2 URLs are returned unchanged; safe no-op when no base is configured or there's no key to rewrite.

After this, a transient `AWS_S3_CUSTOM_DOMAIN` misconfig can no longer persist an internal endpoint URL.

## Tests

New `tests/test_storage_links.py`: rewrite correctness, nested-key preservation, trailing-slash handling, idempotence on already-public/external URLs, and safe no-ops. All storage/source suites pass.

## Note - not in this PR

This fixes the **forward** path only. The ~145 already-bad links in prod still need a one-time data rewrite (a dry-run-verified one-off script exists separately); that remediation requires a token/credential with `cases.change_documentsource`.