### PR TITLE
Drop deprecated `url` string-list from public DocumentSource API

### DIFF
--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -297,10 +297,7 @@ class CaseDetailSerializer(CaseSerializer):
             entry
             | {
                 "source": (
-                    {
-                        k: sources[sid][k]
-                        for k in ["title", "source_type", "url", "urls"]
-                    }
+                    {k: sources[sid][k] for k in ["title", "source_type", "urls"]}
                     if (sid := resolve_source_id(entry)) in sources
                     else None
                 )
@@ -374,30 +371,10 @@ class DocumentSourceSerializer(serializers.ModelSerializer):
     Used for public API access to sources associated with published cases.
     """
 
-    url = serializers.SerializerMethodField(
-        help_text="Deprecated — use 'urls'. List of URL strings for this source, "
-        "including uploaded file URL when available"
-    )
     urls = serializers.SerializerMethodField(
         help_text="List of URL dicts with 'link' and 'role' keys for this source, "
         "including uploaded file URL when available"
     )
-
-    @extend_schema_field(serializers.ListField(child=serializers.URLField()))
-    def get_url(self, obj):
-        """Backward-compat: return only link strings (deprecated).
-
-        Deduplicated by link — the same link under two roles (e.g. RAW + the
-        MARKDOWN-converted view) collapses to a single string here.
-        """
-        seen = set()
-        links = []
-        for u in self.get_urls(obj):
-            link = u["link"]
-            if link not in seen:
-                seen.add(link)
-                links.append(link)
-        return links
 
     @extend_schema_field(
         inline_serializer(
@@ -445,7 +422,6 @@ class DocumentSourceSerializer(serializers.ModelSerializer):
             "title",
             "description",
             "source_type",
-            "url",
             "urls",
             "publication_date",
             "created_at",

--- a/tests/api/test_api_documentation_integration.py
+++ b/tests/api/test_api_documentation_integration.py
@@ -124,7 +124,7 @@ class TestAPIDocumentationIntegration:
             "source_id",
             "title",
             "description",
-            "url",
+            "urls",
         ]
 
         for field in expected_fields:

--- a/tests/api/test_public_api.py
+++ b/tests/api/test_public_api.py
@@ -159,7 +159,8 @@ def test_evidence_requires_valid_source_references(case_data, source_data):
         ), "Source should not be None when it exists"
         assert evidence_item["source"]["title"] == source.title
         assert "source_type" in evidence_item["source"]
-        assert "url" in evidence_item["source"]
+        assert "urls" in evidence_item["source"]
+        assert "url" not in evidence_item["source"]
 
 
 @pytest.mark.django_db
@@ -696,8 +697,8 @@ def test_document_source_api_shows_sources_from_published_and_in_review_cases():
 
 @pytest.mark.django_db
 def test_document_source_api_returns_url_links_deduped():
-    """The API exposes the source's `url` links; the backward-compat `url`
-    string list dedupes a link that appears under more than one role."""
+    """The API exposes the source's links via `urls` (role-tagged dicts); the
+    deprecated `url` string list is no longer part of the public response."""
     source = create_document_source_with_entities(
         title="Merged Source",
         description="Source with role-tagged links",
@@ -727,12 +728,11 @@ def test_document_source_api_returns_url_links_deduped():
     response = client.get(f"/api/sources/{source.id}/")
     assert response.status_code == 200
 
-    # Backward-compat url field (list of strings), deduped by link.
-    raw_links = response.data["url"]
-    assert raw_links.count("https://example.com/reference.pdf") == 1
-    assert "https://example.com/article" in raw_links
+    # The deprecated string-list `url` field is no longer exposed.
+    assert "url" not in response.data
 
     # urls field carries the role-tagged dicts.
     role_by_link = {(u["link"], u["role"]) for u in response.data["urls"]}
     assert ("https://example.com/reference.pdf", "MARKDOWN") in role_by_link
     assert ("https://example.com/reference.pdf", "RAW") in role_by_link
+    assert ("https://example.com/article", "RAW") in role_by_link

--- a/tests/e2e/test_public_api_e2e.py
+++ b/tests/e2e/test_public_api_e2e.py
@@ -184,7 +184,8 @@ class TestPublicAPIWorkflows:
         assert evidence["source"] is not None
         assert evidence["source"]["title"] == self.corruption_source.title
         assert "source_type" in evidence["source"]
-        assert "url" in evidence["source"]
+        assert "urls" in evidence["source"]
+        assert "url" not in evidence["source"]
 
     def test_only_published_cases_accessible(self):
         """

--- a/tests/test_url_migration.py
+++ b/tests/test_url_migration.py
@@ -236,12 +236,9 @@ class TestURLFieldPostMigration:
         )
 
         serializer = DocumentSourceSerializer(source)
-        # Backward-compat url field returns strings
-        assert serializer.data["url"] == [
-            "https://example.com",
-            "https://backup.com",
-        ]
-        # New urls field returns dicts
+        # The deprecated string-list `url` field is no longer exposed.
+        assert "url" not in serializer.data
+        # urls field returns role-tagged dicts
         assert serializer.data["urls"] == [
             {"link": "https://example.com", "role": "RAW"},
             {"link": "https://backup.com", "role": "RAW"},
@@ -371,11 +368,9 @@ class TestSourceLinkDictFormat:
             ],
         )
         serializer = DocumentSourceSerializer(source)
+        # The deprecated string-list `url` field is no longer exposed.
+        assert "url" not in serializer.data
         # Legacy string entry is normalized to RAW on save.
-        assert serializer.data["url"] == [
-            "https://example.com/plain",
-            "https://example.com/markdown",
-        ]
         assert serializer.data["urls"] == [
             {"link": "https://example.com/plain", "role": "RAW"},
             {"link": "https://example.com/markdown", "role": "MARKDOWN"},
@@ -459,7 +454,7 @@ class TestSourceLinkDictFormat:
         # Stored value has a concrete RAW role, not None.
         assert source.url == [{"link": "https://example.com/doc", "role": "RAW"}]
         serializer = DocumentSourceSerializer(source)
-        assert serializer.data["url"] == ["https://example.com/doc"]
+        assert "url" not in serializer.data
         assert serializer.data["urls"] == [
             {"link": "https://example.com/doc", "role": "RAW"}
         ]
@@ -482,8 +477,9 @@ class TestSourceLinkDictFormat:
         )
         assert source.url == [{"link": "https://example.com/md", "role": "MARKDOWN"}]
 
-    def test_get_url_dedupes_same_link_across_roles(self):
-        """Deprecated url field collapses one link shared by two roles."""
+    def test_urls_keeps_same_link_across_roles(self):
+        """urls (dicts) keeps both role variants of one shared link; the
+        deprecated string-list url field is no longer exposed."""
         from cases.serializers import DocumentSourceSerializer
 
         source = DocumentSource.objects.create(
@@ -494,8 +490,7 @@ class TestSourceLinkDictFormat:
             ],
         )
         serializer = DocumentSourceSerializer(source)
-        # url (strings) is deduped; urls (dicts) keeps both role variants.
-        assert serializer.data["url"] == ["https://example.com/doc"]
+        assert "url" not in serializer.data
         assert serializer.data["urls"] == [
             {"link": "https://example.com/doc", "role": "RAW"},
             {"link": "https://example.com/doc", "role": "MARKDOWN"},


### PR DESCRIPTION
## What

Removes the deprecated `url: list[str]` field from the **public read** surface of the document-source endpoints. The canonical `urls` field (a list of `{link, role}` dicts) stays and remains the single source of links.

### Changes (`cases/serializers.py`)
- **`DocumentSourceSerializer`** (`/api/sources/…`): drop the `url` `SerializerMethodField`, its `get_url()` method, and `"url"` from `Meta.fields`.
- **`CaseDetailSerializer.get_evidence`**: stop embedding `"url"` in each evidence entry's nested `source` object (keeps `"urls"`).

### Out of scope (unchanged)
- The **write** serializers (`DocumentSourceCreate`/`UpdateSerializer`) keep their `url` *input* field — that's the model write-input (list of `{link, role}` dicts), not the deprecated string-list output.
- The `DocumentSource.url` model field and all internal callers are untouched.

## Why

`url` was kept only for backward compatibility (it deduped the role-tagged links down to bare strings). The frontend already consumes `urls` exclusively (`DocumentSourceCard.tsx`, `guest-chat-adapter.ts`; the public `DocumentSource` TS type only declares `urls`), so the deprecated field can be dropped from the public response. No frontend change is required.

## Tests
Updated assertions in `tests/api/test_public_api.py`, `tests/test_url_migration.py`, and `tests/api/test_api_documentation_integration.py` to assert `url` is **absent** and that `urls` carries the links (including across multiple roles).

```
52 passed
```
(ran `test_url_migration.py`, `test_public_api.py`, `test_api_documentation_integration.py`)