### PR TITLE
Harden Casework review with source-link role rules

### DIFF
--- a/review/rule_defaults.py
+++ b/review/rule_defaults.py
@@ -204,15 +204,41 @@ DEFAULT_RULES = [
         "condition_text": "Always active.",
         "applies_to": ALL,
         "description": (
-            "Enough evidence sources, each with a resolvable URL, and a spread of "
-            "official/legal source types. The case should be verifiable from its "
-            "attached evidence."
+            "Enough evidence sources, each resolving to its primary (RAW) "
+            "document, and a spread of official/legal source types. The case "
+            "should be verifiable from its attached evidence."
         ),
         "weight": 1.5,
         "is_gate": True,
         "gate_min": 35,
         "enabled": True,
         "order": 60,
+    },
+    {
+        "key": "source_link_roles_valid",
+        "title": "Source links are well-formed (one RAW each)",
+        "category": "Sourcing",
+        "kind": "deterministic",
+        "detector": "source_link_roles_valid",
+        "condition_text": "Always active (hard gate).",
+        "applies_to": ALL,
+        "description": (
+            "Every document source **must** have exactly **one** canonical "
+            "`RAW` link, and every link must carry a recognised role "
+            "(`RAW`, `MARKDOWN`, `PERMALINK`, `SOURCE_PAGE`, `ALTERNATE`). "
+            "A source with no links, no RAW link, more than one RAW link, or an "
+            "unrecognised role **fails the review** — additional copies of the "
+            "same document (mirrors, alternate-format exports, archives, markdown "
+            "renderings) belong under `ALTERNATE` / `PERMALINK` / `MARKDOWN`, not "
+            "as a second RAW. This is the review-side enforcement of the stored "
+            "source-link convention — stricter than the model's link validator, "
+            "which only requires each link to carry a recognised role."
+        ),
+        "weight": 1.3,
+        "is_gate": True,
+        "gate_min": 50,
+        "enabled": True,
+        "order": 60.5,
     },
     {
         "key": "ciaa_press_release_attached",
@@ -306,6 +332,88 @@ DEFAULT_RULES = [
         "weight": 1.0,
         "enabled": True,
         "order": 68,
+    },
+    {
+        "key": "source_raw_link_quality",
+        "title": "RAW link is the right kind of document",
+        "category": "Sourcing",
+        "kind": "llm",
+        "detector": "",
+        "condition_text": "Always active.",
+        "applies_to": ALL,
+        "description": (
+            "Each source's single canonical **RAW** link should point at the "
+            "actual primary **document** — an uploaded / stored file or a direct "
+            "document link (e.g. a PDF or scan of the press release, charge sheet, "
+            "court order, or verdict) — rather than a generic web page.\n\n"
+            "**Exception — NEWS sources:** for a news source there is no document "
+            "to upload, so the news article's own URL is the legitimate RAW and "
+            "must NOT be penalised.\n\n"
+            "Also check that each source has **exactly one** RAW link and that any "
+            "*additional* links are filed under the correct supporting role rather "
+            "than as a second RAW: a markdown rendering as **MARKDOWN**, an "
+            "archive / web-capture as **PERMALINK**, and any other supplementary "
+            "copy (an alternate-format export, a mirror, another hosting of the "
+            "same file) as **ALTERNATE**.\n\n"
+            "Score 100 when every non-news source's RAW is a document file (news "
+            "RAW being a URL is fine), each source has a single RAW, and extra "
+            "links use the right roles. Lower the score the more sources put a "
+            "bare web page as a non-news RAW, carry multiple RAW links, or "
+            "mis-file supporting links as RAW."
+        ),
+        "good_examples": (
+            "A CIAA press-release source whose RAW is the uploaded PDF/scan, with "
+            "the ciaa.gov.np page kept as ALTERNATE and a web.archive.org capture "
+            "as PERMALINK. A NEWS source whose RAW is the article URL itself."
+        ),
+        "bad_examples": (
+            "A press-release source whose only RAW is a bare ciaa.gov.np web page "
+            "with the uploaded PDF mis-tagged (or absent); a source carrying the "
+            "ciaa.gov.np page, a .doc export and a .pdf export all three tagged "
+            "RAW (only one should be RAW, the others ALTERNATE)."
+        ),
+        "weight": 0.8,
+        "enabled": True,
+        "order": 68.5,
+    },
+    {
+        "key": "ephemeral_sources_archived",
+        "title": "Ephemeral web sources are archived",
+        "category": "Sourcing",
+        "kind": "llm",
+        "detector": "",
+        "condition_text": "Always active.",
+        "applies_to": ALL,
+        "description": (
+            "When a source's **RAW** link is an **ephemeral** external web page — "
+            "a news outlet or general website that can change or disappear — the "
+            "source should also carry a **PERMALINK** archive copy (e.g. a "
+            "`web.archive.org` capture) to guard against link rot.\n\n"
+            "This expectation applies **only** to ephemeral news/web pages. It "
+            "does **not** apply to:\n"
+            "1. Files in our own storage (`*.jawafdehi.org`), which are durable.\n"
+            "2. Official government / court / institutional records (e.g. "
+            "`*.gov.np`, UN, World Bank), which are treated as durable primary "
+            "records.\n"
+            "3. A link that is itself already a stable permalink.\n\n"
+            "Score 100 when every ephemeral news/web source has a PERMALINK "
+            "archive companion; lower the score the more such sources lack one. "
+            "Do not penalise official-record or own-storage sources for missing "
+            "an archive."
+        ),
+        "good_examples": (
+            "A NEWS source whose article URL (RAW) is paired with a "
+            "web.archive.org capture (PERMALINK). An official ciaa.gov.np / "
+            "*.gov.np source with no archive — fine, it is a durable record."
+        ),
+        "bad_examples": (
+            "A NEWS source citing only a news-outlet article URL as RAW with no "
+            "web.archive.org (or other) PERMALINK companion, leaving the citation "
+            "exposed to link rot."
+        ),
+        "weight": 0.6,
+        "enabled": True,
+        "order": 68.7,
     },
     # ---------------- Timeline ----------------
     {

--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -44,6 +44,50 @@ def _source_titles(case):
     return out
 
 
+def _valid_link_roles():
+    """The set of valid link-role values, sourced from the model enum.
+
+    Lazily imported (like ``accused_present`` does for ``requires_accused``) so
+    the model, admin, and review engine stay in sync — adding a value to
+    ``SourceLinkRole`` automatically widens what the review gate accepts.
+    """
+    from cases.models import SourceLinkRole
+
+    return {r.value for r in SourceLinkRole}
+
+
+def _sources(case):
+    """The source dicts behind a case's evidence, in order.
+
+    One entry per evidence item (NOT de-duped): a source attached to several
+    evidence rows is judged once per attachment, matching the other detectors
+    (``_source_titles`` et al.) and the original ``sourcing`` source count.
+
+    Each source dict carries the role-tagged ``urls`` ([{link, role}]) and the
+    legacy flat ``url`` string list (see review.jds_client.extract_sources).
+    """
+    return [ev.get("source") or {} for ev in (case.get("evidence") or [])]
+
+
+def _source_roles(src):
+    """Role list for a source's links. Returns ([roles], has_legacy_flat).
+
+    A missing/``None`` role is coerced to ``RAW`` to match
+    cases.models.normalize_url_list, so a legacy link without an explicit role
+    is treated as the canonical document rather than an invalid one. A source
+    still on the deprecated flat ``url`` shape (no role-tagged ``urls``) is
+    reported as has_legacy_flat=True; detectors must not penalise that shape.
+    """
+    urls = src.get("urls") or []
+    roles = [
+        (u.get("role") if u.get("role") is not None else "RAW")
+        for u in urls
+        if isinstance(u, dict)
+    ]
+    has_legacy_flat = not urls and bool(src.get("url"))
+    return roles, has_legacy_flat
+
+
 def _any(text, keywords):
     return any(k.lower() in text for k in keywords)
 
@@ -168,30 +212,72 @@ def structural_completeness(case):
 
 
 def sourcing(case):
-    evidence = case.get("evidence") or []
-    n = len(evidence)
-    with_url = 0
+    sources = _sources(case)
+    n = len(sources)
+    with_raw = 0
     types = set()
-    for ev in evidence:
-        src = ev.get("source") or {}
-        if src.get("url"):
-            with_url += 1
+    for src in sources:
+        roles, has_legacy_flat = _source_roles(src)
+        # A source is properly evidenced when it resolves to a canonical (RAW)
+        # document. Legacy flat-`url` sources count as RAW (normalize_url_list).
+        if "RAW" in roles or has_legacy_flat:
+            with_raw += 1
         if src.get("source_type"):
             types.add(src["source_type"])
     pts = 0
     pts += min(n / GOLD_SOURCES, 1.0) * 40
-    pts += (with_url / n if n else 0) * 30
+    pts += (with_raw / n if n else 0) * 30
     strong = {t for t in types if t.startswith("OFFICIAL") or t.startswith("LEGAL")}
     pts += min(len(types) / 3.0, 1.0) * 15
     pts += 15 if strong else 0
     issues = []
     if n < 2:
         issues.append(f"Only {n} sources (org min: 2).")
-    if n and with_url < n:
-        issues.append(f"{n - with_url} of {n} sources lack a resolvable URL.")
+    if n and with_raw < n:
+        issues.append(
+            f"{n - with_raw} of {n} sources have no canonical (RAW) document link."
+        )
     if not strong:
         issues.append("No OFFICIAL_GOVERNMENT or LEGAL_* source type present.")
     return _clamp(pts), issues
+
+
+def source_link_roles_valid(case):
+    """Structural validity of every source's links (gate).
+
+    Stricter than cases.models.validate_url_list: that validator only requires
+    each link to carry a recognised role, whereas this gate additionally
+    requires exactly one canonical RAW link per source and rejects link-less
+    sources. A case fails when any source has: no links, a link with an
+    unrecognised role, no RAW link, or more than one RAW link. Sources still on
+    the legacy flat-`url` shape are exempt (normalize_url_list treats those
+    links as a single RAW). Binary: 100 when every source is well-formed, else 0
+    (so the gate rejects).
+    """
+    valid_roles = _valid_link_roles()
+    issues = []
+    for src in _sources(case):
+        roles, has_legacy_flat = _source_roles(src)
+        if has_legacy_flat:
+            continue
+        title = (src.get("title") or "?")[:40]
+        if not roles:
+            issues.append(f"'{title}': source has no links.")
+            continue
+        invalid = sorted({r for r in roles if r not in valid_roles})
+        if invalid:
+            issues.append(f"'{title}': invalid link role(s) {invalid}.")
+        raw_count = roles.count("RAW")
+        if raw_count == 0:
+            issues.append(f"'{title}': no canonical (RAW) link.")
+        elif raw_count > 1:
+            issues.append(
+                f"'{title}': {raw_count} RAW links; exactly one is allowed "
+                "(extra copies should be ALTERNATE/MARKDOWN/PERMALINK)."
+            )
+    if issues:
+        return 0, issues
+    return 100, []
 
 
 def ciaa_press_release(case):
@@ -349,6 +435,7 @@ DETECTORS = {
     "additional_description": additional_description,
     "structural_completeness": structural_completeness,
     "sourcing": sourcing,
+    "source_link_roles_valid": source_link_roles_valid,
     "ciaa_press_release": ciaa_press_release,
     "charge_sheet": charge_sheet,
     "court_record": court_record,

--- a/tests/test_review_source_link_roles.py
+++ b/tests/test_review_source_link_roles.py
@@ -1,0 +1,162 @@
+"""Unit tests for the review engine's source-link role rules.
+
+Covers the new `source_link_roles_valid` gate (exactly one RAW per source,
+valid roles only) and the RAW-awareness of the existing `sourcing` detector.
+Both read the role-tagged `urls` ([{link, role}]) that jds_client attaches to
+each source, and must remain lenient toward the legacy flat-`url` shape.
+"""
+
+from review.rules_engine import source_link_roles_valid, sourcing
+
+
+def _ev(title, urls=None, url=None, source_type="OFFICIAL_GOVERNMENT", source_id=None):
+    """Build one evidence item with a nested source dict."""
+    src = {"title": title, "source_type": source_type}
+    if urls is not None:
+        src["urls"] = urls
+    if url is not None:
+        src["url"] = url
+    return {"source_id": source_id or title, "source": src}
+
+
+def _case(*evidence):
+    return {"evidence": list(evidence)}
+
+
+# ----------------------- source_link_roles_valid (gate) -----------------------
+
+
+def test_single_raw_passes():
+    case = _case(
+        _ev("Press release", [{"link": "https://x/a.pdf", "role": "RAW"}]),
+        _ev(
+            "Verdict",
+            [
+                {"link": "https://x/b.pdf", "role": "RAW"},
+                {"link": "https://web.archive.org/b", "role": "PERMALINK"},
+            ],
+        ),
+    )
+    score, issues = source_link_roles_valid(case)
+    assert score == 100
+    assert not issues
+
+
+def test_multiple_raw_fails():
+    case = _case(
+        _ev(
+            "PR",
+            [
+                {"link": "https://ciaa.gov.np/p/1", "role": "RAW"},
+                {"link": "https://x/1.doc", "role": "RAW"},
+                {"link": "https://x/1.pdf", "role": "RAW"},
+            ],
+        ),
+    )
+    score, issues = source_link_roles_valid(case)
+    assert score == 0
+    assert any("RAW links" in i for i in issues)
+
+
+def test_no_raw_fails():
+    case = _case(_ev("MD only", [{"link": "https://x/a.md", "role": "MARKDOWN"}]))
+    score, issues = source_link_roles_valid(case)
+    assert score == 0
+    assert any("no canonical (RAW)" in i for i in issues)
+
+
+def test_empty_links_fails():
+    case = _case(_ev("Empty", []))
+    score, issues = source_link_roles_valid(case)
+    assert score == 0
+    assert any("no links" in i for i in issues)
+
+
+def test_invalid_role_fails():
+    case = _case(
+        _ev(
+            "Weird",
+            [
+                {"link": "https://x/a.pdf", "role": "RAW"},
+                {"link": "https://x/b", "role": "SECONDARY"},
+            ],
+        )
+    )
+    score, issues = source_link_roles_valid(case)
+    assert score == 0
+    assert any("invalid link role" in i for i in issues)
+
+
+def test_missing_role_coerced_to_raw_passes():
+    # A link with no/None role is normalized to RAW by the model
+    # (normalize_url_list); the gate must treat it the same and not flag it as
+    # an invalid role or a missing RAW. (Also guards against a sorted() crash
+    # when a None role co-occurs with an invalid string role.)
+    case = _case(_ev("No role", [{"link": "https://x/a.pdf"}]))
+    score, issues = source_link_roles_valid(case)
+    assert score == 100
+    assert not issues
+
+
+def test_missing_role_plus_invalid_role_does_not_crash():
+    case = _case(
+        _ev(
+            "Mixed",
+            [
+                {"link": "https://x/a.pdf"},  # None role -> RAW
+                {"link": "https://x/b", "role": "SECONDARY"},  # invalid
+            ],
+        )
+    )
+    score, issues = source_link_roles_valid(case)
+    assert score == 0
+    assert any("invalid link role" in i for i in issues)
+
+
+def test_same_source_on_multiple_evidence_is_not_deduped():
+    # The same source attached to two evidence rows is judged per attachment
+    # (no dedupe), so two bad copies produce two findings.
+    bad = _ev("Dup", [], source_id="dup")
+    case = _case(bad, bad)
+    score, issues = source_link_roles_valid(case)
+    assert score == 0
+    assert sum(1 for i in issues if "no links" in i) == 2
+
+
+def test_legacy_flat_url_is_exempt():
+    # A source still on the deprecated flat `url` list (no role-tagged `urls`)
+    # is treated as a single RAW by normalize_url_list, so it must not fail.
+    case = _case(_ev("Legacy", urls=None, url=["https://x/legacy.pdf"]))
+    score, issues = source_link_roles_valid(case)
+    assert score == 100
+    assert not issues
+
+
+def test_no_sources_passes():
+    # Other rules gate on source presence; this one only judges shape.
+    score, issues = source_link_roles_valid(_case())
+    assert score == 100
+    assert not issues
+
+
+# ----------------------- sourcing detector (RAW-aware) -----------------------
+
+
+def test_sourcing_counts_raw_not_just_any_url():
+    # A markdown-only source has a link but no RAW -> flagged as lacking a
+    # canonical document, lowering the URL component of the score.
+    case = _case(
+        _ev("Has RAW", [{"link": "https://x/a.pdf", "role": "RAW"}]),
+        _ev("MD only", [{"link": "https://x/b.md", "role": "MARKDOWN"}]),
+    )
+    score, issues = sourcing(case)
+    assert any("no canonical (RAW) document link" in i for i in issues)
+
+
+def test_sourcing_legacy_flat_url_counts_as_raw():
+    case = _case(
+        _ev("L1", urls=None, url=["https://x/1.pdf"]),
+        _ev("L2", urls=None, url=["https://x/2.pdf"]),
+    )
+    _, issues = sourcing(case)
+    assert not any("RAW" in i for i in issues)


### PR DESCRIPTION
## What

Makes the Casework Review System enforce the **DocumentSource link-role convention** (`RAW` / `MARKDOWN` / `PERMALINK` / `SOURCE_PAGE` / `ALTERNATE`) that the data model already requires. The review engine was previously role-blind — the Sourcing rules only checked that a source had *some* URL.

## Rules added / changed (Sourcing category)

| Rule | Kind | Gate? | Change |
|---|---|---|---|
| `source_evidence_completeness` | det | gate | **amended** — counts sources resolving to a canonical **RAW** link, not "any URL" |
| `source_link_roles_valid` | det | **gate** | **NEW** — rejects a case if any source has no links, an unrecognised role, no RAW link, or **more than one RAW link** |
| `source_raw_link_quality` | llm | no | **NEW** — RAW should be a document file, not a bare web page (NEWS exempt); extra links use MARKDOWN/PERMALINK/ALTERNATE |
| `ephemeral_sources_archived` | llm | no | **NEW** — ephemeral news/web RAW should carry a PERMALINK archive companion |

## Notes

- The valid role set is derived from `cases.models.SourceLinkRole` via a lazy import (same pattern as `accused_present`/`requires_accused`), so it can't drift from the enum.
- A missing/`None` role is coerced to `RAW` to match `normalize_url_list`; legacy flat-`url` sources are exempt from the structural gate.
- The new gate is intentionally **stricter** than `validate_url_list` (which only requires a recognised role per link).
- Evidence is judged per attachment (no dedupe), matching the other detectors.

## ⚠️ Rollout / blast radius

The "exactly one RAW" gate will reject cases citing currently-malformed sources. Against the latest prod snapshot, **219 of 810 sources (27%)** would fail — dominated by **195 multi-RAW sources** (mostly the 2026-05-05 CIAA batch: official page + `.doc` + `.pdf` all tagged RAW), plus 17 no-RAW and 7 empty. A data-cleanup pass to fix these is tracked separately and should land before/with enabling the gate in practice.

## Tests

`tests/test_review_source_link_roles.py` — covers single/multiple/no RAW, empty links, invalid role, None-role coercion, mixed None+invalid, no-dedupe, and legacy-flat exemption. Full suite green (197 passed).