### PR TITLE
Add role-aware API rate limits for staff and contributors

### DIFF
--- a/cases/throttles.py
+++ b/cases/throttles.py
@@ -1,0 +1,132 @@
+"""Role-aware rate throttles shared across the API.
+
+A single base, :class:`RoleBasedRateThrottle`, owns all the throttling
+machinery: choosing a per-request rate from the caller's role, parsing it, and
+bucketing requests in the cache. Subclasses only *declare* their tiers and tune
+three small hooks:
+
+- ``resolve_rate`` — turn a ``TIER_LIMITS`` value into a concrete ``N/period``
+  rate (literal passthrough by default; the global throttle resolves keys
+  against ``DEFAULT_THROTTLE_RATES`` so rates stay tunable from settings).
+- ``get_role_names`` — the set of role names to match against
+  ``GROUP_PRIORITY`` (Django group names by default).
+- ``get_authenticated_ident`` — the cache identity for an authenticated caller
+  (the user's pk by default; NGM overrides this to bucket per API token).
+"""
+
+from rest_framework.settings import api_settings
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class RoleBasedRateThrottle(SimpleRateThrottle):
+    """Base throttle whose rate is chosen by the requesting user's role.
+
+    Subclasses declare a ``scope``, a ``DEFAULT_RATE`` (for anonymous and
+    role-less users), and a ``GROUP_PRIORITY`` tuple whose entries key into
+    ``TIER_LIMITS``. The first role in ``GROUP_PRIORITY`` that the user holds
+    wins, so list roles highest-tier first.
+
+    Authenticated requests are bucketed by user identity (so a user's quota
+    follows them across addresses); anonymous requests fall back to client IP.
+    """
+
+    scope = None
+    rate = None
+    TIER_LIMITS: dict[str, str] = {}
+    DEFAULT_RATE: str | None = None
+    GROUP_PRIORITY: tuple[str, ...] = ()
+
+    # --- rate selection -----------------------------------------------------
+
+    def resolve_rate(self, value):
+        """Turn a ``TIER_LIMITS``/``DEFAULT_RATE`` entry into a concrete rate.
+
+        Default is passthrough (entries are literal ``N/period`` strings).
+        """
+        return value
+
+    def get_rate(self):
+        # SimpleRateThrottle.__init__ calls this once to seed num_requests /
+        # duration; allow_request re-parses the real per-user rate per request.
+        return self.resolve_rate(self.DEFAULT_RATE)
+
+    def get_role_names(self, user):
+        """Role names held by ``user``, matched against ``GROUP_PRIORITY``."""
+        return set(user.groups.values_list("name", flat=True))
+
+    def get_user_rate(self, user):
+        default_rate = self.get_rate()
+        if not user or not user.is_authenticated:
+            return default_rate
+
+        role_names = self.get_role_names(user)
+        for role in self.GROUP_PRIORITY:
+            if role in role_names:
+                # Fall back to the default rate if a tier's rate is unset.
+                return self.resolve_rate(self.TIER_LIMITS[role]) or default_rate
+
+        return default_rate
+
+    def allow_request(self, request, view):
+        self.rate = self.get_user_rate(getattr(request, "user", None))
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+        return super().allow_request(request, view)
+
+    # --- cache bucketing ----------------------------------------------------
+
+    def get_authenticated_ident(self, request):
+        """Cache identity for an authenticated caller. Defaults to user pk."""
+        return request.user.pk
+
+    def get_cache_key(self, request, view):
+        user = getattr(request, "user", None)
+        if user and user.is_authenticated:
+            ident = self.get_authenticated_ident(request)
+        else:
+            # Anonymous: bucket by IP so the limit still applies.
+            ident = self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class RoleBasedUserRateThrottle(RoleBasedRateThrottle):
+    """Global default throttle that raises limits for staff and contributors.
+
+    Tiers map to keys in ``DEFAULT_THROTTLE_RATES`` so rates stay tunable from
+    settings:
+
+    - ``staff``        -> Admin/Moderator group members, superusers, or any user
+                          with Django's ``is_staff`` flag set.
+    - ``contributor``  -> Contributor group members.
+    - ``user``         -> every other authenticated user (and the fallback when a
+                          tier rate is unset).
+
+    Authenticated callers are bucketed by user pk (inherited default), matching
+    DRF's stock ``UserRateThrottle`` so users sharing a NAT/proxy IP keep
+    independent quotas.
+    """
+
+    scope = "user"
+    DEFAULT_RATE = "user"
+    # Map roles to DEFAULT_THROTTLE_RATES keys; staff is the top tier.
+    TIER_LIMITS = {
+        "Admin": "staff",
+        "Moderator": "staff",
+        "Contributor": "contributor",
+    }
+    GROUP_PRIORITY = ("Admin", "Moderator", "Contributor")
+
+    def resolve_rate(self, key):
+        # TIER_LIMITS/DEFAULT_RATE hold settings keys; look them up live so the
+        # rates can be tuned without code changes.
+        if key is None:
+            return None
+        return api_settings.DEFAULT_THROTTLE_RATES.get(key)
+
+    def get_role_names(self, user):
+        roles = super().get_role_names(user)
+        # is_staff is unused in this codebase today, but honoring it (and
+        # superuser) keeps the built-in flags meaningful and future-proof.
+        # Both map onto the top "Admin" tier.
+        if user.is_superuser or user.is_staff:
+            roles = roles | {"Admin"}
+        return roles

--- a/cases/throttles.py
+++ b/cases/throttles.py
@@ -62,8 +62,10 @@ class RoleBasedRateThrottle(SimpleRateThrottle):
         role_names = self.get_role_names(user)
         for role in self.GROUP_PRIORITY:
             if role in role_names:
-                # Fall back to the default rate if a tier's rate is unset.
-                return self.resolve_rate(self.TIER_LIMITS[role]) or default_rate
+                # .get() (not []) so a role listed in GROUP_PRIORITY but missing
+                # from TIER_LIMITS degrades to the default rate instead of
+                # raising KeyError. Also covers an unset tier rate.
+                return self.resolve_rate(self.TIER_LIMITS.get(role)) or default_rate
 
         return default_rate
 
@@ -123,10 +125,10 @@ class RoleBasedUserRateThrottle(RoleBasedRateThrottle):
         return api_settings.DEFAULT_THROTTLE_RATES.get(key)
 
     def get_role_names(self, user):
-        roles = super().get_role_names(user)
         # is_staff is unused in this codebase today, but honoring it (and
         # superuser) keeps the built-in flags meaningful and future-proof.
-        # Both map onto the top "Admin" tier.
+        # Both map onto the top "Admin" tier, so short-circuit and skip the
+        # groups query on this per-request hot path.
         if user.is_superuser or user.is_staff:
-            roles = roles | {"Admin"}
-        return roles
+            return {"Admin"}
+        return super().get_role_names(user)

--- a/config/settings.py
+++ b/config/settings.py
@@ -512,11 +512,15 @@ REST_FRAMEWORK = {
 if not TESTING:
     REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
         "rest_framework.throttling.AnonRateThrottle",
-        "rest_framework.throttling.UserRateThrottle",
+        "cases.throttles.RoleBasedUserRateThrottle",
     ]
+    # RoleBasedUserRateThrottle picks the highest tier the user qualifies for:
+    # staff (Admin/Moderator/superuser/is_staff) > contributor > user.
     REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
         "anon": "100/hour",
         "user": "1000/hour",
+        "contributor": "2500/hour",
+        "staff": "5000/hour",
     }
 
 # JWT Configuration

--- a/ngm/api_views.py
+++ b/ngm/api_views.py
@@ -5,9 +5,9 @@ from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.throttling import SimpleRateThrottle
 from rest_framework.views import APIView
 
+from cases.throttles import RoleBasedRateThrottle
 from ngm.serializers import CourtCaseDetailSerializer, NGMQuerySerializer
 from ngm.services import (
     execute_select_query,
@@ -19,9 +19,8 @@ from ngm.services import (
 logger = logging.getLogger(__name__)
 
 
-class NGMQueryRateThrottle(SimpleRateThrottle):
+class NGMQueryRateThrottle(RoleBasedRateThrottle):
     scope = "ngm_token"
-    rate = None
     TIER_LIMITS = {
         "Admin": "500/hour",
         "Moderator": "500/hour",
@@ -38,35 +37,12 @@ class NGMQueryRateThrottle(SimpleRateThrottle):
         "NGM_SilverTier",
     )
 
-    def get_rate(self):
-        return self.DEFAULT_RATE
-
-    def get_user_rate(self, user):
-        if not user or not user.is_authenticated:
-            return self.DEFAULT_RATE
-
-        group_names = set(user.groups.values_list("name", flat=True))
-        for group_name in self.GROUP_PRIORITY:
-            if group_name in group_names:
-                return self.TIER_LIMITS[group_name]
-
-        return self.DEFAULT_RATE
-
-    def allow_request(self, request, view):
-        self.rate = self.get_user_rate(getattr(request, "user", None))
-        self.num_requests, self.duration = self.parse_rate(self.rate)
-        return super().allow_request(request, view)
-
-    def get_cache_key(self, request, view):
-        # For authenticated requests, use token key
+    def get_authenticated_ident(self, request):
+        # NGM uses DRF TokenAuthentication; bucket per API token so each token
+        # gets its own tier quota. Fall back to user pk if the token is absent.
         token = getattr(request, "auth", None)
         token_key = getattr(token, "key", None)
-        if token_key:
-            return self.cache_format % {"scope": self.scope, "ident": token_key}
-
-        # For anonymous requests, use IP address to enforce rate limiting
-        ident = self.get_ident(request)
-        return self.cache_format % {"scope": self.scope, "ident": ident}
+        return token_key or request.user.pk
 
 
 @extend_schema(

--- a/tests/cases/test_role_based_throttle.py
+++ b/tests/cases/test_role_based_throttle.py
@@ -1,0 +1,116 @@
+"""Tests for the role-aware global default throttle.
+
+The ``TESTING`` guard in settings strips ``DEFAULT_THROTTLE_RATES`` during the
+suite, so each test supplies its own rates via ``override_settings`` (DRF's
+``api_settings`` reloads on the ``setting_changed`` signal).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser, Group
+from django.test import override_settings
+from rest_framework.test import APIRequestFactory
+
+from cases.throttles import RoleBasedUserRateThrottle
+
+User = get_user_model()
+
+RATES = {
+    "anon": "100/hour",
+    "user": "1000/hour",
+    "contributor": "2500/hour",
+    "staff": "5000/hour",
+}
+
+
+def add_user_to_groups(user, *group_names):
+    for group_name in group_names:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+
+
+@override_settings(REST_FRAMEWORK={"DEFAULT_THROTTLE_RATES": RATES})
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("groups", "is_staff", "is_superuser", "expected_rate"),
+    [
+        ([], False, False, "1000/hour"),
+        (["Admin"], False, False, "5000/hour"),
+        (["Moderator"], False, False, "5000/hour"),
+        (["Contributor"], False, False, "2500/hour"),
+        ([], True, False, "5000/hour"),
+        ([], False, True, "5000/hour"),
+        # Staff group wins over contributor regardless of group set order.
+        (["Contributor", "Admin"], False, False, "5000/hour"),
+        # ReadOnly is not a staff/contributor tier -> stays at the user default.
+        (["ReadOnly"], False, False, "1000/hour"),
+    ],
+)
+def test_get_user_rate_by_role(groups, is_staff, is_superuser, expected_rate):
+    user = User.objects.create_user(
+        username="rate_user",
+        password="testpass123",
+        is_staff=is_staff,
+        is_superuser=is_superuser,
+    )
+    add_user_to_groups(user, *groups)
+
+    throttle = RoleBasedUserRateThrottle()
+
+    assert throttle.get_user_rate(user) == expected_rate
+
+
+@override_settings(REST_FRAMEWORK={"DEFAULT_THROTTLE_RATES": RATES})
+def test_anonymous_user_gets_default_rate():
+    throttle = RoleBasedUserRateThrottle()
+
+    assert throttle.get_user_rate(AnonymousUser()) == "1000/hour"
+    assert throttle.get_user_rate(None) == "1000/hour"
+
+
+@pytest.mark.django_db
+def test_authenticated_users_bucket_by_identity_not_ip():
+    """Two users sharing one IP must get independent cache buckets.
+
+    Regression guard: the global throttle must key authenticated callers by
+    user identity (like DRF's UserRateThrottle), not by client IP. JWT/Session
+    auth leave request.auth without a token key, so an IP fallback would make
+    users behind a shared NAT/proxy share a quota.
+    """
+    factory = APIRequestFactory()
+    throttle = RoleBasedUserRateThrottle()
+    throttle.scope = "user"
+
+    user_a = User.objects.create_user(username="user_a", password="testpass123")
+    user_b = User.objects.create_user(username="user_b", password="testpass123")
+
+    # Same client IP, different authenticated users.
+    req_a = factory.get("/api/anything/", REMOTE_ADDR="10.0.0.1")
+    req_a.user = user_a
+    req_a.auth = None  # JWT/Session: no DRF token key on request.auth
+    req_b = factory.get("/api/anything/", REMOTE_ADDR="10.0.0.1")
+    req_b.user = user_b
+    req_b.auth = None
+
+    key_a = throttle.get_cache_key(req_a, view=None)
+    key_b = throttle.get_cache_key(req_b, view=None)
+
+    assert key_a != key_b
+    assert str(user_a.pk) in key_a
+    assert str(user_b.pk) in key_b
+
+
+@pytest.mark.django_db
+def test_anonymous_requests_bucket_by_ip():
+    factory = APIRequestFactory()
+    throttle = RoleBasedUserRateThrottle()
+    throttle.scope = "user"
+
+    request = factory.get("/api/anything/", REMOTE_ADDR="10.0.0.9")
+    request.user = AnonymousUser()
+    request.auth = None
+
+    assert throttle.get_cache_key(request, view=None) == throttle.cache_format % {
+        "scope": "user",
+        "ident": "10.0.0.9",
+    }

--- a/tests/cases/test_role_based_throttle.py
+++ b/tests/cases/test_role_based_throttle.py
@@ -22,6 +22,11 @@ RATES = {
     "staff": "5000/hour",
 }
 
+# Arbitrary client addresses for cache-key assertions (documentation-range IPs
+# per RFC 5737, so they can never collide with a real host).
+SHARED_IP = "192.0.2.1"
+ANON_IP = "192.0.2.9"
+
 
 def add_user_to_groups(user, *group_names):
     for group_name in group_names:
@@ -49,7 +54,6 @@ def add_user_to_groups(user, *group_names):
 def test_get_user_rate_by_role(groups, is_staff, is_superuser, expected_rate):
     user = User.objects.create_user(
         username="rate_user",
-        password="testpass123",
         is_staff=is_staff,
         is_superuser=is_superuser,
     )
@@ -81,14 +85,14 @@ def test_authenticated_users_bucket_by_identity_not_ip():
     throttle = RoleBasedUserRateThrottle()
     throttle.scope = "user"
 
-    user_a = User.objects.create_user(username="user_a", password="testpass123")
-    user_b = User.objects.create_user(username="user_b", password="testpass123")
+    user_a = User.objects.create_user(username="user_a")
+    user_b = User.objects.create_user(username="user_b")
 
     # Same client IP, different authenticated users.
-    req_a = factory.get("/api/anything/", REMOTE_ADDR="10.0.0.1")
+    req_a = factory.get("/api/anything/", REMOTE_ADDR=SHARED_IP)
     req_a.user = user_a
     req_a.auth = None  # JWT/Session: no DRF token key on request.auth
-    req_b = factory.get("/api/anything/", REMOTE_ADDR="10.0.0.1")
+    req_b = factory.get("/api/anything/", REMOTE_ADDR=SHARED_IP)
     req_b.user = user_b
     req_b.auth = None
 
@@ -106,11 +110,11 @@ def test_anonymous_requests_bucket_by_ip():
     throttle = RoleBasedUserRateThrottle()
     throttle.scope = "user"
 
-    request = factory.get("/api/anything/", REMOTE_ADDR="10.0.0.9")
+    request = factory.get("/api/anything/", REMOTE_ADDR=ANON_IP)
     request.user = AnonymousUser()
     request.auth = None
 
     assert throttle.get_cache_key(request, view=None) == throttle.cache_format % {
         "scope": "user",
-        "ident": "10.0.0.9",
+        "ident": ANON_IP,
     }

--- a/tests/ngm/test_api.py
+++ b/tests/ngm/test_api.py
@@ -189,6 +189,27 @@ def test_query_rate_uses_highest_priority_group(
 
 
 @pytest.mark.django_db
+def test_ngm_throttle_buckets_per_token(authenticated_user):
+    """NGM keeps per-token bucketing so each API token gets its own quota."""
+    from rest_framework.test import APIRequestFactory
+
+    token = Token.objects.create(user=authenticated_user)
+    throttle = api_views.NGMQueryRateThrottle()
+
+    request = APIRequestFactory().post(QUERY_URL)
+    request.user = authenticated_user
+    request.auth = token
+
+    cache_key = throttle.get_cache_key(request, view=None)
+
+    assert token.key in cache_key
+    assert cache_key == throttle.cache_format % {
+        "scope": "ngm_token",
+        "ident": token.key,
+    }
+
+
+@pytest.mark.django_db
 def test_query_endpoint_rate_limited_per_token(authenticated_client, monkeypatch):
     monkeypatch.setattr(api_views.NGMQueryRateThrottle, "DEFAULT_RATE", "2/min")
 


### PR DESCRIPTION
## Summary

Authenticated users previously shared a flat **1000/hour** `UserRateThrottle` regardless of role. This introduces a single role-aware throttling layer that raises limits for staff and contributors:

| Audience | Rate |
|---|---|
| Staff — Admin/Moderator group, superuser, or `is_staff` | **5000/hour** |
| Contributor group | **2500/hour** |
| Other authenticated users | 1000/hour (unchanged) |
| Anonymous | 100/hour (unchanged) |

Rates live in `DEFAULT_THROTTLE_RATES`, so any tier is tunable from settings without code changes.

## Design — one throttling layer

`RoleBasedRateThrottle` (new, `cases/throttles.py`) owns all the machinery: role→rate selection via `GROUP_PRIORITY`/`TIER_LIMITS`, per-request rate parsing, and cache bucketing. Subclasses only declare their tiers and tune three small hooks:

| Hook | Default | NGM | Global |
|---|---|---|---|
| `resolve_rate` | literal passthrough | literal (`"500/hour"`) | looks up `DEFAULT_THROTTLE_RATES` keys |
| `get_role_names` | Django groups | groups | groups + `is_staff`/superuser → Admin tier |
| `get_authenticated_ident` | `user.pk` | API token key | `user.pk` |

- `NGMQueryRateThrottle` now extends this base — **behavior unchanged** (literal tier rates, per-token bucketing); ~30 lines of duplicated logic removed.
- `RoleBasedUserRateThrottle` is wired in as the global `DEFAULT_THROTTLE_CLASSES` default.

## Correctness fix — bucket by identity, not IP

Authenticated callers are bucketed by **`user.pk`** (matching DRF's stock `UserRateThrottle`), not client IP. The app's interactive traffic authenticates via JWT/Session, where `request.auth` has no token key — so an IP fallback would make distinct users behind a shared NAT/proxy/office IP share one quota (premature 429s) and give a non-deterministic ceiling. NGM keeps per-token bucketing via the `get_authenticated_ident` hook (it uses `TokenAuthentication`).

## Tests

- `tests/cases/test_role_based_throttle.py` (new): per-role rate resolution (incl. `is_staff`/superuser, group priority, ReadOnly stays default), anonymous fallback, and regression guards that authenticated users bucket by **identity not IP** and anon by IP.
- `tests/ngm/test_api.py`: added a test locking in NGM's **per-token** bucketing.

All 37 throttle tests pass; `ruff` and `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented role-based API rate limiting that assigns different request thresholds to users based on their assigned role (anonymous user, contributor, staff, or administrator), enabling more granular control over API access patterns.

* **Tests**
  * Added comprehensive test coverage for the new role-aware rate throttling system, including role assignment, rate resolution, and request bucketing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->