### PR TITLE
Slim case LIST payload and fix entity-hydration N+1

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -65,6 +65,7 @@ from .rules.predicates import (
 from .search_serializers import SearchResponseSerializer
 from .serializers import (
     CaseDetailSerializer,
+    CaseListSerializer,
     CaseSerializer,
     DocumentSourceSerializer,
     FeedbackSerializer,
@@ -342,6 +343,10 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             return CaseCreateSerializer
         if self.action == "retrieve":
             return CaseDetailSerializer
+        if self.action == "list":
+            # Slim payload: drops detail-only body fields (description,
+            # timeline, evidence, notes, missing_details, versionInfo).
+            return CaseListSerializer
         return CaseSerializer
 
     def get_queryset(self):
@@ -470,6 +475,11 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
                     relationship_type=RelationshipType.RELATED,
                 )
 
+        # Re-fetch with the entity prefetch so CaseSerializer.get_entities()
+        # reuses the cache instead of firing one query per related entity.
+        case = Case.objects.prefetch_related("entity_relationships__entity").get(
+            pk=case.pk
+        )
         return Response(CaseSerializer(case).data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, *args, **kwargs):
@@ -669,6 +679,11 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
                         status=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     )
 
+        # Re-fetch with the entity prefetch so CaseSerializer.get_entities()
+        # reuses the cache instead of firing one query per related entity.
+        case = Case.objects.prefetch_related("entity_relationships__entity").get(
+            pk=case.pk
+        )
         return Response(CaseSerializer(case).data, status=status.HTTP_200_OK)
 
     def _build_snapshot(self, case: Case) -> dict:

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -185,7 +185,11 @@ class CaseSerializer(serializers.ModelSerializer):
     def get_entities(self, obj):
         """Get entities from unified relationship system."""
         try:
-            relationships = obj.entity_relationships.select_related("entity")
+            # Use .all() (not .select_related) so we reuse the
+            # ``entity_relationships__entity`` prefetch cache populated by the
+            # viewset. Calling .select_related() here builds a fresh queryset
+            # that bypasses the cache and fires one extra query per case (N+1).
+            relationships = obj.entity_relationships.all()
             return SimplifiedEntitySerializer(relationships, many=True).data
         except (ValueError, TypeError, AttributeError) as e:
             logger.error(
@@ -307,6 +311,44 @@ class CaseDetailSerializer(CaseSerializer):
 
     class Meta(CaseSerializer.Meta):
         pass
+
+
+class CaseListSerializer(CaseSerializer):
+    """
+    Slim serializer for the case LIST endpoint (GET /api/cases/).
+
+    The list response previously reused the full ``CaseSerializer`` and shipped
+    every detail field for every case on the page, bloating the payload (and,
+    via the MCP search tool, the LLM context that consumes it). This serializer
+    drops the heavy, detail-only body fields that no list consumer reads:
+
+      - description       (list cards render ``short_description`` instead)
+      - timeline
+      - evidence
+      - notes             (also internal-only content)
+      - missing_details
+      - versionInfo
+
+    Full fidelity is preserved on the retrieve endpoint via CaseDetailSerializer.
+    ``short_description`` is returned verbatim; when blank it is simply empty
+    (no title/description fallback).
+    """
+
+    class Meta(CaseSerializer.Meta):
+        fields = [
+            f
+            for f in CaseSerializer.Meta.fields
+            if f
+            not in {
+                "description",
+                "timeline",
+                "evidence",
+                "notes",
+                "missing_details",
+                "versionInfo",
+            }
+        ]
+        read_only_fields = fields
 
 
 class SourceLinkField(serializers.Field):

--- a/tests/api/test_api_documentation_integration.py
+++ b/tests/api/test_api_documentation_integration.py
@@ -150,9 +150,12 @@ class TestAPIDocumentationIntegration:
         assert "results" in api_data
         assert len(api_data["results"]) > 0
 
-        # Verify the response structure matches schema
+        # Verify the response structure matches schema. The list endpoint uses
+        # the slim CaseListSerializer, which drf-spectacular emits as its own
+        # "CaseList" component (distinct from the full "Case"/"CaseDetail"
+        # components). Validate the list response against that component.
         case_data = api_data["results"][0]
-        case_schema = schema["components"]["schemas"]["Case"]
+        case_schema = schema["components"]["schemas"]["CaseList"]
 
         # Check that all schema properties exist in the response
         for prop in case_schema["properties"]:

--- a/tests/api/test_case_list_slim_payload.py
+++ b/tests/api/test_case_list_slim_payload.py
@@ -1,0 +1,144 @@
+"""
+Regression tests for the slim case LIST payload.
+
+The list endpoint (GET /api/cases/) uses CaseListSerializer, which drops
+detail-only body fields to keep the payload (and the MCP search tool's LLM
+context) small. The detail endpoint (GET /api/cases/{slug}/) must still expose
+the full field set.
+
+Also guards the entity-hydration query count: the viewset prefetches
+``entity_relationships__entity`` and ``get_entities`` must reuse that cache, so
+the number of queries does not grow with the number of cases on the page.
+"""
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from cases.models import CaseState, CaseType
+from tests.conftest import create_case_with_entities
+
+# Fields intentionally removed from the list response (present only on detail).
+LIST_OMITTED_FIELDS = {
+    "description",
+    "timeline",
+    "evidence",
+    "notes",
+    "missing_details",
+    "versionInfo",
+}
+
+# A representative subset that must remain on the list response.
+LIST_REQUIRED_FIELDS = {
+    "id",
+    "case_id",
+    "slug",
+    "case_type",
+    "state",
+    "title",
+    "short_description",
+    "thumbnail_url",
+    "banner_url",
+    "case_start_date",
+    "case_end_date",
+    "entities",
+    "tags",
+    "key_allegations",
+    "court_cases",
+    "bigo",
+    "created_at",
+    "updated_at",
+}
+
+
+def _make_published_case(**overrides):
+    """Create a fully-populated PUBLISHED case so every field has content."""
+    data = {
+        "title": "Slim payload case",
+        "case_type": CaseType.CORRUPTION,
+        "state": CaseState.PUBLISHED,
+        "short_description": "A short summary.",
+        "description": "# Full markdown body that should not ship in the list.",
+        "key_allegations": ["Allegation one", "Allegation two"],
+        "timeline": [{"date": "2024-01-01", "title": "Event", "description": "x"}],
+        "evidence": [{"source_id": "DOC-1", "description": "evidence"}],
+        "notes": "Internal notes that must not leak into the list.",
+        "missing_details": "Some missing details.",
+        "alleged_entities": ["entity:person/test-a", "entity:person/test-b"],
+    }
+    data.update(overrides)
+    return create_case_with_entities(**data)
+
+
+@pytest.mark.django_db
+def test_list_response_omits_detail_only_fields():
+    """The list endpoint must not include the heavy detail-only body fields."""
+    _make_published_case()
+
+    response = APIClient().get("/api/cases/")
+    assert response.status_code == 200
+
+    results = response.data["results"]
+    assert results, "expected at least one case in the list response"
+    item = results[0]
+
+    leaked = LIST_OMITTED_FIELDS & set(item.keys())
+    assert not leaked, f"list response should not contain detail-only fields: {leaked}"
+
+    missing = LIST_REQUIRED_FIELDS - set(item.keys())
+    assert not missing, f"list response is missing expected fields: {missing}"
+
+
+@pytest.mark.django_db
+def test_list_returns_short_description_verbatim_when_blank():
+    """Blank short_description is returned as-is (empty), with no fallback."""
+    _make_published_case(short_description="")
+
+    response = APIClient().get("/api/cases/")
+    assert response.status_code == 200
+
+    item = response.data["results"][0]
+    assert item["short_description"] == ""
+    # No full description leaks in as a fallback.
+    assert "description" not in item
+
+
+@pytest.mark.django_db
+def test_detail_response_still_includes_full_fields():
+    """The detail endpoint must still expose every field the list drops."""
+    case = _make_published_case()
+
+    response = APIClient().get(f"/api/cases/{case.slug}/")
+    assert response.status_code == 200
+
+    missing = LIST_OMITTED_FIELDS - set(response.data.keys())
+    assert not missing, f"detail response is missing fields: {missing}"
+
+
+@pytest.mark.django_db
+def test_entity_hydration_is_constant_query_count():
+    """
+    Entity hydration must not be N+1: serializing 1 case and serializing 5
+    cases should issue the same number of queries (the prefetch cache is
+    reused by get_entities). Guards against reintroducing
+    ``.select_related()`` on the entity_relationships manager.
+    """
+    client = APIClient()
+
+    _make_published_case(title="Only case")
+    with CaptureQueriesContext(connection) as ctx_one:
+        assert client.get("/api/cases/").status_code == 200
+    one_case_queries = len(ctx_one.captured_queries)
+
+    for i in range(4):
+        _make_published_case(title=f"Extra case {i}")
+    with CaptureQueriesContext(connection) as ctx_many:
+        assert client.get("/api/cases/").status_code == 200
+    many_case_queries = len(ctx_many.captured_queries)
+
+    assert many_case_queries == one_case_queries, (
+        "query count grew with the number of cases — entity hydration is N+1: "
+        f"{one_case_queries} query/queries for 1 case vs "
+        f"{many_case_queries} for 5 cases"
+    )

--- a/tests/api/test_caseworker_post.py
+++ b/tests/api/test_caseworker_post.py
@@ -147,3 +147,42 @@ def test_post_rejects_array_payload():
     assert "detail" in response.data
     assert response.data["detail"] == "Request body must be a JSON object."
     assert Case.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_write_response_serializes_entities_from_prefetch():
+    """
+    The create/PATCH responses re-fetch the case with
+    ``entity_relationships__entity`` prefetched before serializing with
+    CaseSerializer. This guards that mechanism: once a case is fetched that
+    way, serializing it (which calls get_entities) issues NO further queries,
+    regardless of how many related entities it has. Without the re-fetch +
+    prefetch, get_entities fires one query per entity (N+1).
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    from cases.serializers import CaseSerializer
+
+    case = Case.objects.create(title="Many entities", case_type=CaseType.CORRUPTION)
+    for i in range(5):
+        CaseEntityRelationship.objects.create(
+            case=case,
+            entity=JawafEntity.objects.create(display_name=f"Entity {i}"),
+            relationship_type=RelationshipType.ACCUSED,
+        )
+
+    # Re-fetch exactly as the create/partial_update responses do.
+    fetched = Case.objects.prefetch_related("entity_relationships__entity").get(
+        pk=case.pk
+    )
+
+    with CaptureQueriesContext(connection) as ctx:
+        data = CaseSerializer(fetched).data
+        assert len(data["entities"]) == 5
+
+    assert len(ctx.captured_queries) == 0, (
+        "serializing a prefetched case should issue no queries, but issued "
+        f"{len(ctx.captured_queries)} — entity hydration is not reusing the "
+        "prefetch cache (N+1 on the write response)"
+    )

--- a/tests/e2e/test_public_api_e2e.py
+++ b/tests/e2e/test_public_api_e2e.py
@@ -479,7 +479,11 @@ class TestPublicAPIWorkflows:
         assert (
             returned_case["title"] == "Single Row Case - Updated Title"
         ), "Should return the current (updated) title"
-        assert returned_case["description"] == "Updated description"
+        # The list payload is slim and intentionally omits the full description;
+        # confirm the updated body via the detail endpoint, where it still lives.
+        detail = self.client.get(f"/api/cases/{returned_case['slug']}/")
+        assert detail.status_code == 200
+        assert detail.data["description"] == "Updated description"
 
     def test_pagination_workflow(self):
         """


### PR DESCRIPTION
## What

The case list endpoint (`GET /api/cases/`) reused the full `CaseSerializer`, shipping every detail field for all 20 cases per page. This introduces a slim `CaseListSerializer` for the `list` action that drops the heavy, detail-only body fields, and fixes an entity-hydration N+1 along the way.

### List payload trim
Drops from the list response (still present on the detail endpoint via `CaseDetailSerializer`):
- `description` — list cards render `short_description` instead
- `timeline`
- `evidence`
- `notes` (also internal-only content)
- `missing_details`
- `versionInfo`

Small scalars (`court_cases`, `bigo`, dates, `banner_url`, `case_id`, etc.) are kept to minimize contract churn. The MCP `search_jawafdehi_cases` tool, which dumps the list JSON into LLM context, transparently benefits.

### N+1 fix
`get_entities` called `.select_related("entity")` on the `entity_relationships` manager, which **discards** the viewset's `entity_relationships__entity` prefetch and fires one query per case (~20/page). Switched to `.all()` to reuse the prefetch cache.

Because the `create` and `partial_update` responses serialize a freshly saved (non-prefetched) case, those paths now re-fetch with the prefetch before serializing so the write responses don't regress to an N+1.

## Tests
- `tests/api/test_case_list_slim_payload.py` — slim field contract (list omits the 6, detail keeps them; blank `short_description` returned verbatim) + constant query-count guard for the list path.
- `tests/api/test_caseworker_post.py` — zero-query entity-hydration guard for the write path.
- Updated `test_api_documentation_integration.py` (validates list against the new `CaseList` OpenAPI component) and `test_public_api_e2e.py` (verifies updated `description` via the detail endpoint).

All backend tests pass (220 across `tests/api`, `tests/e2e`, `tests/cases`).

## Companion
Frontend PR adapts the `Case` type + list-card consumers: jawafdehi/jawafdehi `feat/slim-case-list-payload`.