### PR TITLE
Add primary/replica DB split: route reads to CNPG pg-r

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@ NES_API_URL=https://nes.jawafdehi.org/api
 DATABASE_URL=postgresql://user:password@localhost:5432/jawafdehi
 NGM_DATABASE_URL=postgresql://user:password@localhost:5432/ngm
 
+# Optional read-replica endpoints for the primary/replica split. Point these at
+# the CNPG `pg-r` service (primary + standbys, read-only). ORM reads and NGM
+# judicial queries are routed here; writes and migrations stay on the URLs
+# above. When unset, reads fall back to the primary, so leaving them blank
+# preserves the previous single-endpoint behavior.
+# DATABASE_READ_URL=postgresql://user:password@pg-r.db.svc.cluster.local:5432/jawafdehi
+# NGM_DATABASE_READ_URL=postgresql://user:password@pg-r.db.svc.cluster.local:5432/ngm
+
 # Optional: SSL/TLS for PostgreSQL connections (e.g. Cloud SQL).
 # These can also be supplied as URL query params:
 #   DATABASE_URL=postgresql://user:pass@host:5432/db?sslmode=verify-ca&sslrootcert=/path/to/ca.pem

--- a/cases/apps.py
+++ b/cases/apps.py
@@ -6,6 +6,11 @@ class CasesConfig(AppConfig):
     name = "cases"
 
     def ready(self):
+        # Pin management-command reads to the primary (commands aren't covered
+        # by ForcePrimaryReadsMiddleware). No-op until DATABASE_READ_URL is set.
+        from config.db_router import install_management_command_primary_reads
+
+        install_management_command_primary_reads()
 
         # Register models with auditlog
         from auditlog.registry import auditlog

--- a/config/db_router.py
+++ b/config/db_router.py
@@ -13,6 +13,7 @@ consistency run inside :func:`force_primary_reads` (the
 every unsafe-method request).
 """
 
+import functools
 import threading
 from contextlib import contextmanager
 
@@ -48,6 +49,38 @@ def force_primary_reads():
         yield
     finally:
         _state.force_primary = previous
+
+
+def install_management_command_primary_reads() -> None:
+    """Pin reads to the primary for the duration of every management command.
+
+    Management commands are not request-scoped, so ``ForcePrimaryReadsMiddleware``
+    cannot cover their read-modify-write sequences. Without this, once
+    ``DATABASE_READ_URL`` is set a command's ORM reads would hit the lagging
+    ``pg-r`` standby — e.g. a ``get_or_create`` that reads "absent" from a stale
+    replica and then creates a duplicate on the primary, or a ``select_for_update``
+    routed to a connection outside its own transaction. Wrapping
+    ``BaseCommand.execute`` keeps offline jobs (data imports, enrichment, merges)
+    reading their own writes; web GET traffic still uses the replica.
+
+    Long-running servers are unaffected: ``runserver`` serves requests in worker
+    threads (this flag is thread-local), and prod web runs through WSGI/ASGI, not
+    ``BaseCommand.execute``. Idempotent — safe to call from multiple AppConfigs.
+    """
+    from django.core.management.base import BaseCommand
+
+    if getattr(BaseCommand, "_primary_reads_patched", False):
+        return
+
+    original_execute = BaseCommand.execute
+
+    @functools.wraps(original_execute)
+    def execute(self, *args, **kwargs):
+        with force_primary_reads():
+            return original_execute(self, *args, **kwargs)
+
+    BaseCommand.execute = execute
+    BaseCommand._primary_reads_patched = True
 
 
 def _canonical(db: str) -> str:

--- a/config/db_router.py
+++ b/config/db_router.py
@@ -1,0 +1,80 @@
+"""Primary/replica database routing for the read/write split.
+
+The CloudNativePG Postgres cluster exposes a read-write endpoint (``pg-rw``,
+the primary) and a read endpoint (``pg-r``, primary + standbys). The ORM
+``default`` / ``ngm`` aliases target the write endpoints; ``replica`` /
+``ngm_replica`` target ``pg-r``. This router sends ORM reads to the replica
+aliases and writes to the primaries, and keeps migrations off the replicas.
+
+``pg-r`` load-balances across asynchronous standbys, so a read issued right
+after a write may not observe that write. Call sites needing read-your-writes
+consistency run inside :func:`force_primary_reads` (the
+:class:`ForcePrimaryReadsMiddleware` does this for the Django admin and for
+every unsafe-method request).
+"""
+
+import threading
+from contextlib import contextmanager
+
+from django.conf import settings
+
+# Primary write alias -> its read-replica alias.
+PRIMARY_TO_REPLICA = {
+    "default": "replica",
+    "ngm": "ngm_replica",
+}
+REPLICA_TO_PRIMARY = {
+    replica: primary for primary, replica in PRIMARY_TO_REPLICA.items()
+}
+READ_ALIASES = frozenset(PRIMARY_TO_REPLICA.values())
+
+_state = threading.local()
+
+
+def _force_primary() -> bool:
+    return getattr(_state, "force_primary", False)
+
+
+@contextmanager
+def force_primary_reads():
+    """Pin ORM reads to the primary for the duration of the block.
+
+    Use around read-after-write sequences that must observe their own writes
+    (the async standby behind ``pg-r`` can otherwise serve a stale snapshot).
+    """
+    previous = getattr(_state, "force_primary", False)
+    _state.force_primary = True
+    try:
+        yield
+    finally:
+        _state.force_primary = previous
+
+
+def _canonical(db: str) -> str:
+    """Collapse a replica alias onto its primary so a pair can be compared."""
+    return REPLICA_TO_PRIMARY.get(db, db)
+
+
+class PrimaryReplicaRouter:
+    """Route reads to ``replica`` and writes to ``default`` (primary)."""
+
+    def db_for_read(self, model, **hints):
+        # Fall back to the primary when no distinct replica is configured
+        # (dev/CI/single-endpoint) or when a read-your-writes block is active.
+        if _force_primary() or "replica" not in settings.DATABASES:
+            return "default"
+        return "replica"
+
+    def db_for_write(self, model, **hints):
+        return "default"
+
+    def allow_relation(self, obj1, obj2, **hints):
+        if _canonical(obj1._state.db) == _canonical(obj2._state.db):
+            return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        # Schema changes only run against the primary write aliases.
+        if db in READ_ALIASES:
+            return False
+        return None

--- a/config/db_router.py
+++ b/config/db_router.py
@@ -14,8 +14,8 @@ every unsafe-method request).
 """
 
 import functools
-import threading
 from contextlib import contextmanager
+from contextvars import ContextVar
 
 from django.conf import settings
 
@@ -29,11 +29,15 @@ REPLICA_TO_PRIMARY = {
 }
 READ_ALIASES = frozenset(PRIMARY_TO_REPLICA.values())
 
-_state = threading.local()
+# ContextVar (not threading.local) so the flag is isolated correctly under both
+# sync WSGI threads and async/ASGI tasks. A freshly spawned thread starts from
+# the default (False), so a management command's force-primary scope never leaks
+# into runserver's request-handling threads.
+_force_primary_var: ContextVar[bool] = ContextVar("force_primary", default=False)
 
 
 def _force_primary() -> bool:
-    return getattr(_state, "force_primary", False)
+    return _force_primary_var.get()
 
 
 @contextmanager
@@ -43,12 +47,11 @@ def force_primary_reads():
     Use around read-after-write sequences that must observe their own writes
     (the async standby behind ``pg-r`` can otherwise serve a stale snapshot).
     """
-    previous = getattr(_state, "force_primary", False)
-    _state.force_primary = True
+    token = _force_primary_var.set(True)
     try:
         yield
     finally:
-        _state.force_primary = previous
+        _force_primary_var.reset(token)
 
 
 def install_management_command_primary_reads() -> None:
@@ -64,8 +67,9 @@ def install_management_command_primary_reads() -> None:
     reading their own writes; web GET traffic still uses the replica.
 
     Long-running servers are unaffected: ``runserver`` serves requests in worker
-    threads (this flag is thread-local), and prod web runs through WSGI/ASGI, not
-    ``BaseCommand.execute``. Idempotent — safe to call from multiple AppConfigs.
+    threads that start from the ContextVar default (replica), and prod web runs
+    through WSGI/ASGI, not ``BaseCommand.execute``. Idempotent — safe to call from
+    multiple AppConfigs.
     """
     from django.core.management.base import BaseCommand
 

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -2,11 +2,46 @@ import uuid
 
 import structlog
 from auditlog.middleware import AuditlogMiddleware as _BaseAuditlogMiddleware
+from django.conf import settings
 from django.utils.functional import SimpleLazyObject
+
+from config.db_router import force_primary_reads
 
 _logger = structlog.get_logger(__name__)
 
 REQUEST_ID_HEADER = "X-Request-Id"
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+class ForcePrimaryReadsMiddleware:
+    """Pin ORM reads to the primary where stale replica reads would be wrong.
+
+    Reads are served from the ``pg-r`` replica by default, but the async
+    standby can lag. Two request classes need read-your-writes consistency and
+    are routed to the primary instead:
+
+    * Any unsafe-method request (POST/PUT/PATCH/DELETE) — so reads issued after
+      its own write (including the object echoed back in the response) are
+      current.
+    * Every Django admin request — the admin's save→redirect→list pattern reads
+      across requests, and admin traffic is low-volume, so correctness wins.
+
+    Plain GET API traffic keeps reading from the replica, which is the point of
+    the split.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.admin_prefix = getattr(settings, "ADMIN_URL_PREFIX", "/admin/")
+
+    def __call__(self, request):
+        if request.method not in _SAFE_METHODS or request.path.startswith(
+            self.admin_prefix
+        ):
+            with force_primary_reads():
+                return self.get_response(request)
+        return self.get_response(request)
 
 
 class RequestIdMiddleware:

--- a/config/settings.py
+++ b/config/settings.py
@@ -217,6 +217,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "config.middleware.RequestIdMiddleware",
+    "config.middleware.ForcePrimaryReadsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -336,6 +337,8 @@ def interpolate_db_url(url_env_name):
 
 interpolate_db_url("DATABASE_URL")
 interpolate_db_url("NGM_DATABASE_URL")
+interpolate_db_url("DATABASE_READ_URL")
+interpolate_db_url("NGM_DATABASE_READ_URL")
 
 DATABASES = {
     "default": dj_database_url.config(
@@ -364,23 +367,46 @@ if os.getenv("NGM_DATABASE_URL"):
         )
         DATABASES["ngm"] = dj_database_url.parse(new_url)
 
+
+# Read-replica aliases for the primary/replica router (config/db_router.py).
+# DATABASE_READ_URL / NGM_DATABASE_READ_URL point at the CNPG `pg-r` service
+# (primary + standbys, read-only). A replica alias is created ONLY when its
+# read URL is set; otherwise the router and the NGM read helper fall back to the
+# primary, so dev, CI, and any single-endpoint deployment behave exactly as
+# before the split (no second connection pool).
+REPLICA_OF = {"default": "replica", "ngm": "ngm_replica"}
+
+
+def _configure_replica(read_env_name, primary_alias):
+    read_url = os.getenv(read_env_name)
+    if read_url and primary_alias in DATABASES:
+        DATABASES[REPLICA_OF[primary_alias]] = dj_database_url.parse(read_url)
+
+
+_configure_replica("DATABASE_READ_URL", "default")
+_configure_replica("NGM_DATABASE_READ_URL", "ngm")
+
 # Apply SSL options to all PostgreSQL databases.
 # Must run after password interpolation so that re-parsed configs also
 # receive SSL options.
 for db_key in DATABASES:
     _apply_db_ssl_options(DATABASES[db_key])
 
-# Configure connection pooling for PostgreSQL only
-if DATABASES["default"].get("ENGINE") == "django.db.backends.postgresql":
-    DATABASES["default"]["CONN_MAX_AGE"] = 60
-    DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+# Configure connection pooling for every PostgreSQL alias (incl. replicas).
+for db_key, db_config in DATABASES.items():
+    if db_config.get("ENGINE") == "django.db.backends.postgresql":
+        db_config["CONN_MAX_AGE"] = 60
+        db_config["CONN_HEALTH_CHECKS"] = True
 
-if (
-    "ngm" in DATABASES
-    and DATABASES["ngm"].get("ENGINE") == "django.db.backends.postgresql"
-):
-    DATABASES["ngm"]["CONN_MAX_AGE"] = 60
-    DATABASES["ngm"]["CONN_HEALTH_CHECKS"] = True
+# The replica aliases are read-only mirrors of their primaries. The test runner
+# must not create/migrate a separate database for them — point each at its
+# primary's test database so the suite exercises one consistent DB per pair.
+for _primary, _replica in REPLICA_OF.items():
+    if _replica in DATABASES:
+        DATABASES[_replica].setdefault("TEST", {})["MIRROR"] = _primary
+
+# Primary/replica routing: ORM reads -> `replica`, writes -> `default`.
+DATABASE_ROUTERS = ["config.db_router.PrimaryReplicaRouter"]
 
 
 # Password validation

--- a/ngm/services.py
+++ b/ngm/services.py
@@ -137,10 +137,24 @@ def apply_row_cap(query: str, max_rows: int) -> str:
     return f"SELECT * FROM ({cleaned}) AS ngm_result LIMIT {int(max_rows)}"
 
 
+NGM_READ_ALIAS = "ngm_replica"
+
+
 def ensure_ngm_database_configured() -> None:
     database_config = settings.DATABASES.get("ngm")
     if not database_config:
         raise ValueError("NGM database is not configured")
+
+
+def ngm_read_connection():
+    """Return the connection for read-only NGM queries.
+
+    Prefers the ``ngm_replica`` alias (CNPG `pg-r`) so judicial queries hit a
+    standby, falling back to the primary ``ngm`` alias when no replica is
+    configured (dev/CI/single-endpoint deployments).
+    """
+    alias = NGM_READ_ALIAS if NGM_READ_ALIAS in settings.DATABASES else "ngm"
+    return connections[alias]
 
 
 def execute_select_query(query: str, timeout_seconds: float) -> dict:
@@ -152,9 +166,10 @@ def execute_select_query(query: str, timeout_seconds: float) -> dict:
     capped_query = apply_row_cap(query, max_rows)
 
     start_time = time.perf_counter()
+    connection = ngm_read_connection()
     try:
-        with connections["ngm"].cursor() as cursor:
-            if connections["ngm"].vendor == "postgresql":
+        with connection.cursor() as cursor:
+            if connection.vendor == "postgresql":
                 cursor.execute("SET statement_timeout = %s", [timeout_ms])
             cursor.execute(capped_query)
             rows = cursor.fetchall()
@@ -193,7 +208,7 @@ def get_court_case_details(court_identifier: str, case_number: str) -> dict | No
     ensure_ngm_database_configured()
 
     try:
-        with connections["ngm"].cursor() as cursor:
+        with ngm_read_connection().cursor() as cursor:
             # Fetch case details
             cursor.execute(
                 """

--- a/review/views.py
+++ b/review/views.py
@@ -22,6 +22,8 @@ from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 
+from config.db_router import force_primary_reads
+
 from . import case_provider, code_rules
 from .models import CaseReview, ReviewConfig
 from .permissions import (
@@ -92,7 +94,10 @@ def claim_job(request):
     poller needs to run the review without any DB access: the review id, slug,
     the resolved case dict, and the active review config.
     """
-    with transaction.atomic():
+    # force_primary_reads keeps the SELECT ... FOR UPDATE on the primary
+    # connection enrolled in this transaction; otherwise the router would send
+    # the read to the replica (a connection outside the atomic block).
+    with force_primary_reads(), transaction.atomic():
         review = (
             CaseReview.objects.select_for_update(skip_locked=True)
             .filter(status=CaseReview.STATUS_PENDING)

--- a/tests/test_db_router.py
+++ b/tests/test_db_router.py
@@ -6,7 +6,9 @@ from django.conf import settings
 
 from config.db_router import (
     PrimaryReplicaRouter,
+    _force_primary,
     force_primary_reads,
+    install_management_command_primary_reads,
 )
 from config.middleware import ForcePrimaryReadsMiddleware
 from ngm import services
@@ -122,6 +124,33 @@ class TestForcePrimaryReadsMiddleware:
         middleware, _ = self._middleware()
         middleware(SimpleNamespace(method="POST", path="/admin/"))
         assert _force_primary() is False
+
+
+class TestManagementCommandPrimaryReads:
+    def test_command_handle_runs_with_primary_reads(self):
+        from django.core.management.base import BaseCommand
+
+        # ready() already installed the patch; this is idempotent.
+        install_management_command_primary_reads()
+
+        captured = {}
+
+        class _Cmd(BaseCommand):
+            def handle(self, *args, **options):
+                captured["force_primary"] = _force_primary()
+
+        _Cmd().run_from_argv(["manage.py", "_cmd"])
+        assert captured["force_primary"] is True
+        # Flag is released once the command finishes.
+        assert _force_primary() is False
+
+    def test_install_is_idempotent(self):
+        from django.core.management.base import BaseCommand
+
+        install_management_command_primary_reads()
+        first = BaseCommand.execute
+        install_management_command_primary_reads()
+        assert BaseCommand.execute is first
 
 
 class TestNgmReadConnection:

--- a/tests/test_db_router.py
+++ b/tests/test_db_router.py
@@ -1,0 +1,143 @@
+"""Tests for the primary/replica database split (config/db_router.py)."""
+
+from types import SimpleNamespace
+
+from django.conf import settings
+
+from config.db_router import (
+    PrimaryReplicaRouter,
+    force_primary_reads,
+)
+from config.middleware import ForcePrimaryReadsMiddleware
+from ngm import services
+
+
+def _obj(db):
+    """Minimal stand-in for a model instance bound to a database alias."""
+    return SimpleNamespace(_state=SimpleNamespace(db=db))
+
+
+def _register_replica(monkeypatch, alias="replica"):
+    """Pretend a distinct read replica is configured for this test."""
+    monkeypatch.setitem(
+        settings.DATABASES, alias, {"ENGINE": "django.db.backends.postgresql"}
+    )
+
+
+class TestPrimaryReplicaRouter:
+    def test_reads_go_to_replica_when_configured(self, monkeypatch):
+        _register_replica(monkeypatch)
+        router = PrimaryReplicaRouter()
+        assert router.db_for_read(object) == "replica"
+
+    def test_reads_fall_back_to_primary_without_replica(self, monkeypatch):
+        monkeypatch.delitem(settings.DATABASES, "replica", raising=False)
+        router = PrimaryReplicaRouter()
+        assert router.db_for_read(object) == "default"
+
+    def test_writes_go_to_primary(self):
+        router = PrimaryReplicaRouter()
+        assert router.db_for_write(object) == "default"
+
+    def test_force_primary_reads_pins_reads_to_primary(self, monkeypatch):
+        _register_replica(monkeypatch)
+        router = PrimaryReplicaRouter()
+        with force_primary_reads():
+            assert router.db_for_read(object) == "default"
+        # Flag is restored on exit.
+        assert router.db_for_read(object) == "replica"
+
+    def test_force_primary_reads_nests(self, monkeypatch):
+        _register_replica(monkeypatch)
+        router = PrimaryReplicaRouter()
+        with force_primary_reads():
+            with force_primary_reads():
+                assert router.db_for_read(object) == "default"
+            assert router.db_for_read(object) == "default"
+        assert router.db_for_read(object) == "replica"
+
+    def test_migrations_blocked_on_replicas(self):
+        router = PrimaryReplicaRouter()
+        assert router.allow_migrate("replica", "cases") is False
+        assert router.allow_migrate("ngm_replica", "ngm") is False
+
+    def test_migrations_allowed_on_primaries(self):
+        router = PrimaryReplicaRouter()
+        assert router.allow_migrate("default", "cases") is None
+        assert router.allow_migrate("ngm", "ngm") is None
+
+    def test_relations_within_a_pair_allowed(self):
+        router = PrimaryReplicaRouter()
+        assert router.allow_relation(_obj("default"), _obj("replica")) is True
+        assert router.allow_relation(_obj("ngm"), _obj("ngm_replica")) is True
+
+    def test_relations_across_pairs_not_decided(self):
+        router = PrimaryReplicaRouter()
+        assert router.allow_relation(_obj("default"), _obj("ngm")) is None
+
+
+class TestReplicaSettings:
+    def test_no_replica_alias_without_read_url(self):
+        # The test suite runs without DATABASE_READ_URL, so reads stay on the
+        # primary and no phantom replica connection is created.
+        assert "replica" not in settings.DATABASES
+
+    def test_router_is_registered(self):
+        assert "config.db_router.PrimaryReplicaRouter" in settings.DATABASE_ROUTERS
+
+
+class TestForcePrimaryReadsMiddleware:
+    def _middleware(self):
+        captured = {}
+
+        def get_response(request):
+            from config.db_router import _force_primary
+
+            captured["force_primary"] = _force_primary()
+            return "ok"
+
+        return ForcePrimaryReadsMiddleware(get_response), captured
+
+    def test_safe_get_reads_from_replica(self):
+        middleware, captured = self._middleware()
+        request = SimpleNamespace(method="GET", path="/api/cases/")
+        assert middleware(request) == "ok"
+        assert captured["force_primary"] is False
+
+    def test_unsafe_method_forces_primary(self):
+        middleware, captured = self._middleware()
+        request = SimpleNamespace(method="POST", path="/api/cases/")
+        middleware(request)
+        assert captured["force_primary"] is True
+
+    def test_admin_request_forces_primary(self):
+        middleware, captured = self._middleware()
+        request = SimpleNamespace(method="GET", path="/admin/cases/case/")
+        middleware(request)
+        assert captured["force_primary"] is True
+
+    def test_flag_cleared_after_request(self):
+        from config.db_router import _force_primary
+
+        middleware, _ = self._middleware()
+        middleware(SimpleNamespace(method="POST", path="/admin/"))
+        assert _force_primary() is False
+
+
+class TestNgmReadConnection:
+    def test_prefers_replica_when_configured(self, monkeypatch):
+        monkeypatch.setitem(
+            settings.DATABASES,
+            "ngm_replica",
+            {"ENGINE": "django.db.backends.postgresql"},
+        )
+        monkeypatch.setattr(
+            services, "connections", {"ngm": "primary", "ngm_replica": "replica"}
+        )
+        assert services.ngm_read_connection() == "replica"
+
+    def test_falls_back_to_primary_without_replica(self, monkeypatch):
+        # Ensure no replica alias is registered.
+        monkeypatch.delitem(settings.DATABASES, "ngm_replica", raising=False)
+        monkeypatch.setattr(services, "connections", {"ngm": "primary"})
+        assert services.ngm_read_connection() == "primary"


### PR DESCRIPTION
## Summary
Routes read traffic onto the CloudNativePG read endpoint (`pg-r`) while keeping writes and migrations on the primary (`pg-rw`), implementing the read/write distribution in the Django app layer.

- **`PrimaryReplicaRouter`** (`config/db_router.py`): ORM reads → `replica`, writes → `default`; migrations blocked on replica aliases; relations allowed within a primary/replica pair.
- **`ForcePrimaryReadsMiddleware`** (`config/middleware.py`): pins reads to the primary for unsafe-method requests (read-your-writes within a request, incl. the object echoed in the response) and for **all** Django admin traffic (admin's save→redirect→list reads across requests). `force_primary_reads()` is the reusable escape hatch for management commands / scripts that do read-modify-write.
- **Replica aliases** (`replica`, `ngm_replica`) are created **only** when `DATABASE_READ_URL` / `NGM_DATABASE_READ_URL` are set. When unset, the router and the NGM read helper fall back to the primary — so dev, CI, and any single-endpoint deployment behave exactly as before (no second connection pool).
- **NGM judicial queries** (`execute_select_query`, `get_court_case_details`) read via `ngm_replica` when configured.

## Consistency note
`pg-r` load-balances across the **async** standby, so a read right after a write can be stale. The middleware covers the common web read-after-write cases; **data-mutating management commands are not request-scoped** and will read from the replica when a read URL is configured — wrap those in `force_primary_reads()` as a follow-up if/when we point them at the replica.

## Deploy / infra follow-up (not in this PR)
App code is inert until the env vars exist (safe fallback to primary). To enable the split in prod, add to GCP Secret Manager + the `jawafdehi-api-env` ExternalSecret and restart:
- `DATABASE_READ_URL` → `pg-r…/nes_db`
- `NGM_DATABASE_READ_URL` → `pg-r…/ngm_v1`

(Or point them at a pgdog read pool if we'd rather keep reads behind the pooler.)

## Test plan
- [x] `tests/test_db_router.py` — router routing, force-primary (incl. nesting), migrate/relation rules, middleware behavior (safe GET vs unsafe vs admin), NGM replica selection + fallback.
- [x] Existing ORM suite (`test_case_model`, admin/role/review/api slices, ngm) passes unchanged — reads fall back to `default` with no `DATABASE_READ_URL`.
- [ ] Verify against a real `pg-r` endpoint in staging once the secrets are wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional primary/replica database routing so read-only queries can use replica endpoints while writes stay on primary.
  * Added automatic “primary pinning” for sensitive requests (non-read methods and admin paths) and for management commands that must run against primary.
* **Bug Fixes**
  * Ensured the `claim_job` endpoint’s locking SELECT runs on the primary to avoid replica-routing issues.
* **Documentation**
  * Updated environment configuration guidance for optional read-replica URL settings.
* **Tests**
  * Added coverage for routing, primary pinning behavior (including nested cases), and NGM read connection selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->