### PR TITLE
Fix empty admin lists for ReadOnly role and duplicate Tokens entry

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -634,7 +634,7 @@ class CaseAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
         """
         Filter queryset based on user role.
 
-        - Contributors: See all non-CLOSED cases (global read access)
+        - Contributors and ReadOnly: See all non-CLOSED cases (global read access)
         - Moderators/Admins: See all cases
         """
         qs = super().get_queryset(request)
@@ -982,7 +982,7 @@ class DocumentSourceAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
 
         - Admins: See all sources (including deleted)
         - Moderators: Only see active sources (exclude deleted)
-        - Contributors: See active sources they're assigned to OR sources referenced in their assigned cases
+        - Contributors and ReadOnly: See all active sources (global read access)
         """
         qs = super().get_queryset(request)
 

--- a/cases/admin.py
+++ b/cases/admin.py
@@ -9,7 +9,7 @@ from django.forms.models import BaseInlineFormSet
 from django.template.response import TemplateResponse
 from django.utils.html import format_html
 from rest_framework.authtoken.admin import TokenAdmin as BaseTokenAdmin
-from rest_framework.authtoken.models import Token
+from rest_framework.authtoken.models import TokenProxy
 
 from cases.widgets import ToastUIEditorWidget
 
@@ -37,6 +37,7 @@ from .rules.predicates import (
     is_admin_or_moderator,
     is_contributor,
     is_moderator,
+    is_readonly,
 )
 from .services import EntityMergeError, analyze_merge_impact, merge_entities_by_ids
 from .validators import COURT_CHOICES
@@ -642,8 +643,8 @@ class CaseAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
         if is_admin_or_moderator(request.user):
             return qs
 
-        # Contributors see all non-CLOSED cases (global read-only access)
-        if is_contributor(request.user):
+        # Contributors and ReadOnly users see all non-CLOSED cases (global read access)
+        if is_contributor(request.user) or is_readonly(request.user):
             return qs.exclude(state=CaseState.CLOSED)
 
         # No role - see nothing
@@ -993,8 +994,8 @@ class DocumentSourceAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
         if is_moderator(request.user):
             return qs.filter(is_deleted=False)
 
-        # Contributors see all active sources (global read access)
-        if is_contributor(request.user):
+        # Contributors and ReadOnly users see all active sources (global read access)
+        if is_contributor(request.user) or is_readonly(request.user):
             return qs.filter(is_deleted=False)
 
         # No role - see nothing
@@ -1474,13 +1475,16 @@ class FeedbackAdmin(admin.ModelAdmin):
 # Token Admin (DRF authtoken) — show full name for user
 # ============================================================================
 
+# DRF's authtoken app auto-registers TokenProxy (not Token) with its TokenAdmin.
+# Unregister that proxy and re-register it with our custom admin, otherwise both
+# Token and TokenProxy end up registered and the admin shows "Tokens" twice.
 try:
-    admin.site.unregister(Token)
+    admin.site.unregister(TokenProxy)
 except admin.sites.NotRegistered:
     pass
 
 
-@admin.register(Token)
+@admin.register(TokenProxy)
 class CustomTokenAdmin(UserFullNameAdminMixin, BaseTokenAdmin):
     raw_id_fields = ()
 


### PR DESCRIPTION
## Summary
- **ReadOnly admin lists were always empty.** ReadOnly users hold `view_*` perms and `can_view_*` includes `is_readonly`, so the Cases/Sources admin tabs and individual case URLs were reachable — but `CaseAdmin.get_queryset()` and `DocumentSourceAdmin.get_queryset()` never checked `is_readonly` and fell through to `qs.none()`, filtering every row out. They now get the same read scope as contributors (non-CLOSED cases / active sources).
- **Admin showed "Tokens" twice (for admins).** DRF's authtoken app auto-registers `TokenProxy` with its `TokenAdmin`. The old code unregistered `Token` (a silent no-op — it was never registered) and registered a custom admin against `Token`, leaving both `Token` and `TokenProxy` registered, each labeled "Tokens". Switched to unregister/register `TokenProxy` so there's a single entry.

## Changes
- `cases/admin.py`: import `is_readonly`; add `is_readonly` branch to both admin `get_queryset()` methods; register `CustomTokenAdmin` against `TokenProxy` instead of `Token`.

## Test plan
- [ ] As a ReadOnly user, open `/admin/cases/case/` and `/admin/cases/documentsource/` — lists populate (non-CLOSED cases / active sources) instead of being empty.
- [ ] As a ReadOnly user, confirm no add/change/delete controls (write perms unchanged).
- [ ] As an admin, confirm the admin index shows a single "Tokens" entry under Auth Token, and the token changelist still maps by user id.
- [ ] Run `tests/test_readonly_permissions.py` and `tests/test_document_source_admin.py` (needs DB access; not runnable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved duplicate "Tokens" entries in Django admin interface

* **Admin & Access Control**
  * Extended admin visibility for read-only users to access case and document items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->