### PR TITLE
Cut review-judge cost: prompt-cache shared prefix + tier model by gate

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -758,6 +758,21 @@ AWS_PROFILE = os.getenv("REVIEW_AWS_PROFILE", os.getenv("AWS_PROFILE", ""))
 AWS_REGION = os.getenv("AWS_REGION", "us-west-2")
 BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "global.anthropic.claude-opus-4-8")
 BEDROCK_MAX_WORKERS = int(os.getenv("BEDROCK_MAX_WORKERS", "8"))
+# Prompt-cache the shared rule-grading prefix (case data + source excerpts) so it
+# is billed once per case instead of once per (rule x sample) call. Kill switch
+# for regions/models where Bedrock prompt caching is unavailable.
+BEDROCK_PROMPT_CACHE = os.getenv("BEDROCK_PROMPT_CACHE", "1") not in (
+    "0",
+    "false",
+    "False",
+    "",
+)
+# Tiered model routing: high-stakes GATE rules (a low score can REJECT the case)
+# are graded by the premium model above; routine non-gate rules and the narrative
+# use this cheaper SKU. Defaults to the premium model id, so routing is a no-op
+# until a real cheaper model id is configured for this deployment's region/account
+# (the operator picks the SKU — we never guess one that may not exist).
+BEDROCK_MODEL_ID_CHEAP = os.getenv("BEDROCK_MODEL_ID_CHEAP", BEDROCK_MODEL_ID)
 
 # Converted source markdown cache + per-source conversion timeout.
 SOURCE_MARKDOWN_DIR = Path(

--- a/config/settings.py
+++ b/config/settings.py
@@ -761,12 +761,7 @@ BEDROCK_MAX_WORKERS = int(os.getenv("BEDROCK_MAX_WORKERS", "8"))
 # Prompt-cache the shared rule-grading prefix (case data + source excerpts) so it
 # is billed once per case instead of once per (rule x sample) call. Kill switch
 # for regions/models where Bedrock prompt caching is unavailable.
-BEDROCK_PROMPT_CACHE = os.getenv("BEDROCK_PROMPT_CACHE", "1") not in (
-    "0",
-    "false",
-    "False",
-    "",
-)
+BEDROCK_PROMPT_CACHE = env_flag("BEDROCK_PROMPT_CACHE", default=True)
 # Tiered model routing: high-stakes GATE rules (a low score can REJECT the case)
 # are graded by the premium model above; routine non-gate rules and the narrative
 # use this cheaper SKU. Defaults to the premium model id, so routing is a no-op

--- a/review/bedrock_judge.py
+++ b/review/bedrock_judge.py
@@ -66,6 +66,13 @@ MAX_WORKERS = int(getattr(settings, "BEDROCK_MAX_WORKERS", 8))
 # budget; raise it so figures deep in a source are actually visible.
 _SOURCE_EXCERPTS_CAP = int(getattr(settings, "JUDGE_SOURCE_EXCERPTS_CAP", 120000))
 
+# Whether to prompt-cache the shared rule-grading prefix. The same case data +
+# source-excerpt block is re-sent for every (rule x sample) call; with hundreds
+# of rules that block dominates input cost. Marking it with `cache_control` makes
+# Bedrock bill it once per case (cache write) and ~free on every later call
+# (cache read) for the cache TTL, which the back-to-back fan-out keeps warm.
+PROMPT_CACHE = bool(getattr(settings, "BEDROCK_PROMPT_CACHE", True))
+
 
 def _bedrock():
     global _client
@@ -94,21 +101,30 @@ SYSTEM = (
 )
 
 
-def _build_single_rule_prompt(case_summary, source_excerpts, case_type_label, rule):
-    block = f"### Rule `{rule['key']}` — {rule['title']}\n{rule.get('description','')}"
-    if rule.get("good_examples"):
-        block += f"\nGOOD: {rule['good_examples']}"
-    if rule.get("bad_examples"):
-        block += f"\nBAD: {rule['bad_examples']}"
-    return f"""Grade this Jawafdehi case against the ONE rule below. Reply with JSON only.
+def _rule_context_block(case_summary, source_excerpts, case_type_label):
+    """The case data + source excerpts shared verbatim by every rule call.
 
-CASE TYPE: {case_type_label or "unknown"}
+    Kept as a standalone leading block so it can be marked `cache_control` and
+    billed once per case instead of once per (rule x sample) invocation.
+    """
+    return f"""CASE TYPE: {case_type_label or "unknown"}
 
 CASE DATA:
 {json.dumps(case_summary, ensure_ascii=False, indent=2)[:30000]}
 
 SOURCE DOCUMENT EXCERPTS (converted to markdown):
-{source_excerpts[:_SOURCE_EXCERPTS_CAP]}
+{source_excerpts[:_SOURCE_EXCERPTS_CAP]}"""
+
+
+def _rule_instruction_block(rule):
+    """The per-rule grading instruction (varies per call; never cached)."""
+    block = f"### Rule `{rule['key']}` — {rule['title']}\n{rule.get('description','')}"
+    if rule.get("good_examples"):
+        block += f"\nGOOD: {rule['good_examples']}"
+    if rule.get("bad_examples"):
+        block += f"\nBAD: {rule['bad_examples']}"
+    return f"""Grade the Jawafdehi case above (CASE DATA + SOURCE DOCUMENT EXCERPTS)
+against the ONE rule below. Reply with JSON only.
 
 RULE TO GRADE:
 {block}
@@ -120,6 +136,27 @@ the case against THIS rule (each suggestion an imperative one-liner, e.g.
 satisfied, return an empty suggestions list. Judge ONLY against this rule.
 Reply EXACTLY in this JSON shape:
 {{"score": <int 0-100>, "rationale": "<str>", "issues": ["<str>"], "suggestions": ["<str>"]}}"""
+
+
+def _build_single_rule_content(context_block, rule):
+    """User-message content for grading one rule against the shared context.
+
+    When prompt caching is on, return two content blocks — the shared context
+    (marked `cache_control`) followed by the per-rule instruction — so Bedrock
+    reuses the cached prefix across every rule. Otherwise fall back to a single
+    concatenated string (identical text, no cache markers).
+    """
+    instruction = _rule_instruction_block(rule)
+    if PROMPT_CACHE:
+        return [
+            {
+                "type": "text",
+                "text": context_block,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": instruction},
+        ]
+    return f"{context_block}\n\n{instruction}"
 
 
 def _build_narrative_prompt(case_summary, source_excerpts, case_type_label):
@@ -137,20 +174,23 @@ SOURCE DOCUMENT EXCERPTS:
 Reply EXACTLY: {{"narrative": "<str>"}}"""
 
 
-def _invoke_text(prompt, max_tokens, usage=None):
-    """Invoke the judge once and return its raw text reply (code-fence stripped).
+def _invoke_text(content, max_tokens, model_id=None, usage=None):
+    """Invoke the judge and return the raw assistant text (code-fence stripped).
 
-    When a `usage` accumulator is supplied, the response's token counts are
-    recorded into it for cost tracking.
+    `content` is the user message content: either a plain string, or a list of
+    Anthropic content blocks (used to attach `cache_control` to the shared prefix).
+    `model_id` selects the Bedrock model (tiered routing); defaults to the premium
+    BEDROCK_MODEL_ID. When a `usage` accumulator is supplied, the response's token
+    counts are recorded into it for cost tracking.
     """
     body = {
         "anthropic_version": "bedrock-2023-05-31",
         "max_tokens": max_tokens,
         "system": SYSTEM,
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": [{"role": "user", "content": content}],
     }
     resp = _bedrock().invoke_model(
-        modelId=settings.BEDROCK_MODEL_ID,
+        modelId=model_id or settings.BEDROCK_MODEL_ID,
         body=json.dumps(body),
     )
     payload = json.loads(resp["body"].read())
@@ -165,13 +205,21 @@ def _invoke_text(prompt, max_tokens, usage=None):
     return text
 
 
-def _invoke_once(prompt, max_tokens=900, usage=None):
-    return json.loads(_invoke_text(prompt, max_tokens, usage))
+def _invoke_once(content, max_tokens=900, model_id=None, usage=None):
+    return json.loads(_invoke_text(content, max_tokens, model_id, usage))
 
 
-def _invoke_once_salvaged(prompt, max_tokens=900, usage=None):
+def _invoke_once_salvaged(content, max_tokens=900, model_id=None, usage=None):
     """Like _invoke_once but tolerant of truncated/dirty JSON (source analysis)."""
-    return _salvage_json(_invoke_text(prompt, max_tokens, usage))
+    return _salvage_json(_invoke_text(content, max_tokens, model_id, usage))
+
+
+def _model_for_rule(rule):
+    """Pick the Bedrock model for a rule: premium for hard gates (a low score can
+    REJECT the case, so accuracy matters most), the cheaper SKU for the rest."""
+    if rule.get("is_gate"):
+        return settings.BEDROCK_MODEL_ID
+    return getattr(settings, "BEDROCK_MODEL_ID_CHEAP", settings.BEDROCK_MODEL_ID)
 
 
 def _salvage_json(text):
@@ -318,6 +366,12 @@ def judge_rules(
     keys = [r["key"] for r in llm_rules]
     by_key = {r["key"]: r for r in llm_rules}
 
+    # Build the case data + source-excerpt block once. It is identical for every
+    # rule, so we cache it (see _build_single_rule_content) instead of re-sending
+    # it on each of the rule x sample calls. The pool's first wave writes the
+    # cache; back-to-back calls keep its TTL warm so the rest read it cheaply.
+    context_block = _rule_context_block(case_summary, source_excerpts, case_type_label)
+
     # Build the full task list: one task per (rule, sample) + one narrative task.
     tasks = []  # (kind, key, sample_idx)
     for r in llm_rules:
@@ -332,7 +386,7 @@ def judge_rules(
     narrative = ""
     errors = []
 
-    def _invoke_json(prompt, max_tokens=900):
+    def _invoke_json(prompt, max_tokens=900, model_id=None):
         """Invoke, parsing strictly first, then salvaging dirty/truncated JSON.
 
         The judge occasionally prefixes the JSON with prose or gets cut off at
@@ -340,22 +394,29 @@ def judge_rules(
         rule silently degrades to a neutral default. Mirror analyze_source.
         """
         try:
-            return _invoke_once(prompt, max_tokens=max_tokens, usage=usage)
+            return _invoke_once(
+                prompt, max_tokens=max_tokens, model_id=model_id, usage=usage
+            )
         except json.JSONDecodeError:
-            return _invoke_once_salvaged(prompt, max_tokens=max_tokens, usage=usage)
+            return _invoke_once_salvaged(
+                prompt, max_tokens=max_tokens, model_id=model_id, usage=usage
+            )
 
     def _run(task):
         kind, key, _i = task
         if kind == "narrative":
+            # Narrative is low-stakes prose -> cheaper tier.
             parsed = _invoke_json(
                 _build_narrative_prompt(case_summary, source_excerpts, case_type_label),
                 max_tokens=300,
+                model_id=getattr(
+                    settings, "BEDROCK_MODEL_ID_CHEAP", settings.BEDROCK_MODEL_ID
+                ),
             )
             return ("narrative", None, parsed)
-        prompt = _build_single_rule_prompt(
-            case_summary, source_excerpts, case_type_label, by_key[key]
-        )
-        parsed = _invoke_json(prompt)
+        rule = by_key[key]
+        content = _build_single_rule_content(context_block, rule)
+        parsed = _invoke_json(content, model_id=_model_for_rule(rule))
         return ("rule", key, parsed)
 
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:

--- a/review/bedrock_judge.py
+++ b/review/bedrock_judge.py
@@ -205,13 +205,18 @@ def _invoke_text(content, max_tokens, model_id=None, usage=None):
     return text
 
 
-def _invoke_once(content, max_tokens=900, model_id=None, usage=None):
-    return json.loads(_invoke_text(content, max_tokens, model_id, usage))
+def _invoke_json(content, max_tokens=900, model_id=None, usage=None):
+    """Invoke the judge once and parse its JSON, salvaging dirty/truncated output.
 
-
-def _invoke_once_salvaged(content, max_tokens=900, model_id=None, usage=None):
-    """Like _invoke_once but tolerant of truncated/dirty JSON (source analysis)."""
-    return _salvage_json(_invoke_text(content, max_tokens, model_id, usage))
+    The judge occasionally prefixes the JSON with prose or gets cut off at
+    max_tokens. We fetch the assistant text a single time and recover locally
+    rather than re-invoking the model, which would double the call's cost/latency.
+    """
+    text = _invoke_text(content, max_tokens, model_id, usage)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return _salvage_json(text)
 
 
 def _model_for_rule(rule):
@@ -301,11 +306,7 @@ def analyze_source(case_summary, source, case_type_label, usage=None):
         }
     try:
         prompt = _build_source_analysis_prompt(case_summary, source, case_type_label)
-        try:
-            return _invoke_once(prompt, max_tokens=2000, usage=usage)
-        except json.JSONDecodeError:
-            # Retry parse with salvage for truncated/dirty JSON from large sources.
-            return _invoke_once_salvaged(prompt, max_tokens=2000, usage=usage)
+        return _invoke_json(prompt, max_tokens=2000, usage=usage)
     except Exception as e:  # noqa: BLE001
         return {
             "error": str(e),
@@ -386,22 +387,6 @@ def judge_rules(
     narrative = ""
     errors = []
 
-    def _invoke_json(prompt, max_tokens=900, model_id=None):
-        """Invoke, parsing strictly first, then salvaging dirty/truncated JSON.
-
-        The judge occasionally prefixes the JSON with prose or gets cut off at
-        max_tokens; without the salvage fallback such a sample is dropped and the
-        rule silently degrades to a neutral default. Mirror analyze_source.
-        """
-        try:
-            return _invoke_once(
-                prompt, max_tokens=max_tokens, model_id=model_id, usage=usage
-            )
-        except json.JSONDecodeError:
-            return _invoke_once_salvaged(
-                prompt, max_tokens=max_tokens, model_id=model_id, usage=usage
-            )
-
     def _run(task):
         kind, key, _i = task
         if kind == "narrative":
@@ -412,11 +397,12 @@ def judge_rules(
                 model_id=getattr(
                     settings, "BEDROCK_MODEL_ID_CHEAP", settings.BEDROCK_MODEL_ID
                 ),
+                usage=usage,
             )
             return ("narrative", None, parsed)
         rule = by_key[key]
         content = _build_single_rule_content(context_block, rule)
-        parsed = _invoke_json(content, model_id=_model_for_rule(rule))
+        parsed = _invoke_json(content, model_id=_model_for_rule(rule), usage=usage)
         return ("rule", key, parsed)
 
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:

--- a/review/runner.py
+++ b/review/runner.py
@@ -80,6 +80,8 @@ def process_case(case, config=None, on_stage=None):
     result = scorer.score_case(
         case, converted, rules, cfg, source_analyses=source_analyses, usage=usage
     )
+    # Reports the premium/gate tier. Under tiered routing, non-gate rules and the
+    # narrative may instead use BEDROCK_MODEL_ID_CHEAP (see bedrock_judge).
     result["model_id_used"] = settings.BEDROCK_MODEL_ID
     result["token_usage"] = usage.as_dict()
 

--- a/review/scorer.py
+++ b/review/scorer.py
@@ -184,6 +184,8 @@ def score_case(
                 "description": r.description,
                 "good_examples": r.good_examples,
                 "bad_examples": r.bad_examples,
+                # Routes the judge model tier: gate rules -> premium model.
+                "is_gate": r.is_gate,
             }
             for r in llm_rules
         ]

--- a/tests/test_review_token_usage.py
+++ b/tests/test_review_token_usage.py
@@ -50,7 +50,7 @@ def _fake_bedrock(input_tokens, output_tokens, text='{"score": 90}'):
 def test_invoke_text_records_usage(monkeypatch):
     monkeypatch.setattr(bedrock_judge, "_bedrock", lambda: _fake_bedrock(120, 34))
     usage = UsageAccumulator()
-    parsed = bedrock_judge._invoke_once("grade this", usage=usage)
+    parsed = bedrock_judge._invoke_json("grade this", usage=usage)
     assert parsed == {"score": 90}
     assert usage.input_tokens == 120
     assert usage.output_tokens == 34
@@ -60,4 +60,4 @@ def test_invoke_text_records_usage(monkeypatch):
 def test_invoke_text_without_accumulator_is_optional(monkeypatch):
     monkeypatch.setattr(bedrock_judge, "_bedrock", lambda: _fake_bedrock(1, 1))
     # No usage accumulator passed: must not raise.
-    assert bedrock_judge._invoke_once("grade this") == {"score": 90}
+    assert bedrock_judge._invoke_json("grade this") == {"score": 90}


### PR DESCRIPTION
## Summary

The review poller's Bedrock judge (`review/bedrock_judge.py`) re-sent the **full** case-data + source-excerpt block (up to ~120k chars) on **every** `(rule × sample)` invocation. With the operator's target of hundreds of rules × `n_samples`, that identical context dominated input-token cost. This PR adds two cost levers with **no change to prompts, scoring, or outputs**.

### 1. Prompt caching (biggest win, zero quality loss)
- The shared context (`CASE TYPE` + `CASE DATA` + `SOURCE DOCUMENT EXCERPTS`) is now built **once per case** and sent as a leading content block marked `cache_control: {type: ephemeral}`, followed by the small per-rule instruction.
- Bedrock bills that block once per case (cache write) and reads it back at ~0.1× on every subsequent call. The existing 8-wide `ThreadPoolExecutor` fan-out keeps the cache TTL warm, so after the first wave ~98% of calls are cache reads.
- Kill switch: `BEDROCK_PROMPT_CACHE` (default on) falls back to the original single-string prompt for any region/model where caching is unavailable.

### 2. Tiered model routing
- Hard **GATE** rules (a low score can `REJECT` the case) keep the premium model (`BEDROCK_MODEL_ID`, Opus 4.8). Routine non-gate rules and the narrative use `BEDROCK_MODEL_ID_CHEAP`.
- `BEDROCK_MODEL_ID_CHEAP` **defaults to the premium model id**, so routing is a no-op until an operator sets a real cheaper SKU for their region/account — we never guess a model id that may not exist.
- `scorer.py` now forwards `is_gate` into the judge's rule specs so the router can see it.

## Files
- `review/bedrock_judge.py` — split the per-rule prompt into a cached context block + instruction; thread `model_id` through the invoke helpers; `_model_for_rule` router.
- `review/scorer.py` — forward `is_gate` in `rule_specs`.
- `config/settings.py` — `BEDROCK_PROMPT_CACHE`, `BEDROCK_MODEL_ID_CHEAP`.

## Test plan
- [x] `ruff` + `black` pre-commit hooks pass.
- [x] Module byte-compiles; no stale references to the old prompt builder.
- [ ] Run one real case through the poller and confirm `cache_read_input_tokens` >> `cache_creation_input_tokens` in the Bedrock usage, and that disposition/scores are unchanged vs. a pre-PR run.
- [ ] Optionally set `BEDROCK_MODEL_ID_CHEAP` to a cheaper SKU in staging and spot-check non-gate rule grades.

## Notes / follow-ups
- No automated usage logging yet — measuring the cache hit rate currently requires inspecting the Bedrock response. Happy to add lightweight per-case usage logging to the poller if wanted.
- Each model tier maintains its own cache namespace (premium for gates, cheap for the rest); both still benefit from the shared-prefix caching within their tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Bedrock prompt caching to reuse shared case context across rule evaluations.
  * Introduced tiered model routing so gate rules can use a premium model while other grading can use a cheaper model by default.
  * Added environment-driven settings to control prompt caching and enable model-tier fallback behavior.
* **Tests**
  * Updated review token-usage tests to validate the centralized JSON invocation flow and usage accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->