### PR TITLE
Track LLM token usage per review

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -758,12 +758,6 @@ AWS_PROFILE = os.getenv("REVIEW_AWS_PROFILE", os.getenv("AWS_PROFILE", ""))
 AWS_REGION = os.getenv("AWS_REGION", "us-west-2")
 BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "global.anthropic.claude-opus-4-8")
 BEDROCK_MAX_WORKERS = int(os.getenv("BEDROCK_MAX_WORKERS", "8"))
-# Per-million-token USD pricing used to cost each review's LLM usage. Defaults
-# are Anthropic's published Claude Opus rates; override per model/deployment.
-BEDROCK_INPUT_PRICE_PER_MTOK = float(os.getenv("BEDROCK_INPUT_PRICE_PER_MTOK", "15.0"))
-BEDROCK_OUTPUT_PRICE_PER_MTOK = float(
-    os.getenv("BEDROCK_OUTPUT_PRICE_PER_MTOK", "75.0")
-)
 
 # Converted source markdown cache + per-source conversion timeout.
 SOURCE_MARKDOWN_DIR = Path(

--- a/config/settings.py
+++ b/config/settings.py
@@ -758,6 +758,12 @@ AWS_PROFILE = os.getenv("REVIEW_AWS_PROFILE", os.getenv("AWS_PROFILE", ""))
 AWS_REGION = os.getenv("AWS_REGION", "us-west-2")
 BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "global.anthropic.claude-opus-4-8")
 BEDROCK_MAX_WORKERS = int(os.getenv("BEDROCK_MAX_WORKERS", "8"))
+# Per-million-token USD pricing used to cost each review's LLM usage. Defaults
+# are Anthropic's published Claude Opus rates; override per model/deployment.
+BEDROCK_INPUT_PRICE_PER_MTOK = float(os.getenv("BEDROCK_INPUT_PRICE_PER_MTOK", "15.0"))
+BEDROCK_OUTPUT_PRICE_PER_MTOK = float(
+    os.getenv("BEDROCK_OUTPUT_PRICE_PER_MTOK", "75.0")
+)
 
 # Converted source markdown cache + per-source conversion timeout.
 SOURCE_MARKDOWN_DIR = Path(

--- a/review/bedrock_judge.py
+++ b/review/bedrock_judge.py
@@ -24,11 +24,11 @@ _client = None
 
 
 class UsageAccumulator:
-    """Thread-safe tally of Bedrock token usage + cost across parallel calls.
+    """Thread-safe tally of Bedrock token usage across parallel calls.
 
     A single instance is shared by every (rule x sample) and per-source
     invocation of one review, so it must be safe to update from the judge's
-    thread pools. Cost is derived from the configured per-Mtok pricing.
+    thread pools.
     """
 
     def __init__(self):
@@ -46,21 +46,12 @@ class UsageAccumulator:
     def as_dict(self):
         with self._lock:
             in_tok, out_tok, calls = self.input_tokens, self.output_tokens, self.calls
-        # Round the per-direction costs before summing so the reported
-        # total_cost_usd is exactly input_cost_usd + output_cost_usd.
-        in_cost = round(in_tok / 1_000_000 * settings.BEDROCK_INPUT_PRICE_PER_MTOK, 6)
-        out_cost = round(
-            out_tok / 1_000_000 * settings.BEDROCK_OUTPUT_PRICE_PER_MTOK, 6
-        )
         return {
             "model_id": settings.BEDROCK_MODEL_ID,
             "calls": calls,
             "input_tokens": in_tok,
             "output_tokens": out_tok,
             "total_tokens": in_tok + out_tok,
-            "input_cost_usd": in_cost,
-            "output_cost_usd": out_cost,
-            "total_cost_usd": round(in_cost + out_cost, 6),
         }
 
 

--- a/review/bedrock_judge.py
+++ b/review/bedrock_judge.py
@@ -46,16 +46,20 @@ class UsageAccumulator:
     def as_dict(self):
         with self._lock:
             in_tok, out_tok, calls = self.input_tokens, self.output_tokens, self.calls
-        in_cost = in_tok / 1_000_000 * settings.BEDROCK_INPUT_PRICE_PER_MTOK
-        out_cost = out_tok / 1_000_000 * settings.BEDROCK_OUTPUT_PRICE_PER_MTOK
+        # Round the per-direction costs before summing so the reported
+        # total_cost_usd is exactly input_cost_usd + output_cost_usd.
+        in_cost = round(in_tok / 1_000_000 * settings.BEDROCK_INPUT_PRICE_PER_MTOK, 6)
+        out_cost = round(
+            out_tok / 1_000_000 * settings.BEDROCK_OUTPUT_PRICE_PER_MTOK, 6
+        )
         return {
             "model_id": settings.BEDROCK_MODEL_ID,
             "calls": calls,
             "input_tokens": in_tok,
             "output_tokens": out_tok,
             "total_tokens": in_tok + out_tok,
-            "input_cost_usd": round(in_cost, 6),
-            "output_cost_usd": round(out_cost, 6),
+            "input_cost_usd": in_cost,
+            "output_cost_usd": out_cost,
             "total_cost_usd": round(in_cost + out_cost, 6),
         }
 

--- a/review/bedrock_judge.py
+++ b/review/bedrock_judge.py
@@ -13,6 +13,7 @@ compute a real **mean + variance (confidence)** per rule.
 
 import json
 import statistics
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
@@ -20,6 +21,44 @@ from botocore.config import Config
 from django.conf import settings
 
 _client = None
+
+
+class UsageAccumulator:
+    """Thread-safe tally of Bedrock token usage + cost across parallel calls.
+
+    A single instance is shared by every (rule x sample) and per-source
+    invocation of one review, so it must be safe to update from the judge's
+    thread pools. Cost is derived from the configured per-Mtok pricing.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.calls = 0
+
+    def add(self, input_tokens, output_tokens):
+        with self._lock:
+            self.input_tokens += int(input_tokens or 0)
+            self.output_tokens += int(output_tokens or 0)
+            self.calls += 1
+
+    def as_dict(self):
+        with self._lock:
+            in_tok, out_tok, calls = self.input_tokens, self.output_tokens, self.calls
+        in_cost = in_tok / 1_000_000 * settings.BEDROCK_INPUT_PRICE_PER_MTOK
+        out_cost = out_tok / 1_000_000 * settings.BEDROCK_OUTPUT_PRICE_PER_MTOK
+        return {
+            "model_id": settings.BEDROCK_MODEL_ID,
+            "calls": calls,
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "total_tokens": in_tok + out_tok,
+            "input_cost_usd": round(in_cost, 6),
+            "output_cost_usd": round(out_cost, 6),
+            "total_cost_usd": round(in_cost + out_cost, 6),
+        }
+
 
 # Bounded parallelism for Bedrock calls. Bedrock throttles aggressively, so we
 # keep this modest; with hundreds of rules this is the wall-clock divisor.
@@ -103,7 +142,12 @@ SOURCE DOCUMENT EXCERPTS:
 Reply EXACTLY: {{"narrative": "<str>"}}"""
 
 
-def _invoke_once(prompt, max_tokens=900):
+def _invoke_text(prompt, max_tokens, usage=None):
+    """Invoke the judge once and return its raw text reply (code-fence stripped).
+
+    When a `usage` accumulator is supplied, the response's token counts are
+    recorded into it for cost tracking.
+    """
     body = {
         "anthropic_version": "bedrock-2023-05-31",
         "max_tokens": max_tokens,
@@ -115,33 +159,24 @@ def _invoke_once(prompt, max_tokens=900):
         body=json.dumps(body),
     )
     payload = json.loads(resp["body"].read())
+    if usage is not None:
+        u = payload.get("usage") or {}
+        usage.add(u.get("input_tokens", 0), u.get("output_tokens", 0))
     text = payload["content"][0]["text"].strip()
     if text.startswith("```"):
         text = text.split("```")[1]
         if text.startswith("json"):
             text = text[4:]
-    return json.loads(text)
+    return text
 
 
-def _invoke_once_salvaged(prompt, max_tokens=900):
+def _invoke_once(prompt, max_tokens=900, usage=None):
+    return json.loads(_invoke_text(prompt, max_tokens, usage))
+
+
+def _invoke_once_salvaged(prompt, max_tokens=900, usage=None):
     """Like _invoke_once but tolerant of truncated/dirty JSON (source analysis)."""
-    body = {
-        "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": max_tokens,
-        "system": SYSTEM,
-        "messages": [{"role": "user", "content": prompt}],
-    }
-    resp = _bedrock().invoke_model(
-        modelId=settings.BEDROCK_MODEL_ID,
-        body=json.dumps(body),
-    )
-    payload = json.loads(resp["body"].read())
-    text = payload["content"][0]["text"].strip()
-    if text.startswith("```"):
-        text = text.split("```")[1]
-        if text.startswith("json"):
-            text = text[4:]
-    return _salvage_json(text)
+    return _salvage_json(_invoke_text(prompt, max_tokens, usage))
 
 
 def _salvage_json(text):
@@ -202,7 +237,7 @@ each contribution list to at most 6 short items. Reply EXACTLY in this JSON shap
   "notes": "<gaps, OCR/quality issues, or why relevance is low; '' if none>"}}"""
 
 
-def analyze_source(case_summary, source, case_type_label):
+def analyze_source(case_summary, source, case_type_label, usage=None):
     """Summarise one converted source + analyse its contribution to the case.
 
     Returns the parsed JSON dict (see prompt), or an {"error": ...} dict on
@@ -224,10 +259,10 @@ def analyze_source(case_summary, source, case_type_label):
     try:
         prompt = _build_source_analysis_prompt(case_summary, source, case_type_label)
         try:
-            return _invoke_once(prompt, max_tokens=2000)
+            return _invoke_once(prompt, max_tokens=2000, usage=usage)
         except json.JSONDecodeError:
             # Retry parse with salvage for truncated/dirty JSON from large sources.
-            return _invoke_once_salvaged(prompt, max_tokens=2000)
+            return _invoke_once_salvaged(prompt, max_tokens=2000, usage=usage)
     except Exception as e:  # noqa: BLE001
         return {
             "error": str(e),
@@ -243,7 +278,7 @@ def analyze_source(case_summary, source, case_type_label):
         }
 
 
-def analyze_sources(case_summary, converted_sources, case_type_label):
+def analyze_sources(case_summary, converted_sources, case_type_label, usage=None):
     """Analyse every converted source in parallel. Returns a list aligned by
     index with `converted_sources` (each item is the analyze_source dict)."""
     if not converted_sources:
@@ -252,7 +287,7 @@ def analyze_sources(case_summary, converted_sources, case_type_label):
     workers = min(MAX_WORKERS, len(converted_sources))
     with ThreadPoolExecutor(max_workers=workers) as ex:
         futs = {
-            ex.submit(analyze_source, case_summary, s, case_type_label): i
+            ex.submit(analyze_source, case_summary, s, case_type_label, usage): i
             for i, s in enumerate(converted_sources)
         }
         for fut in as_completed(futs):
@@ -270,7 +305,9 @@ def analyze_sources(case_summary, converted_sources, case_type_label):
     return results
 
 
-def judge_rules(case_summary, source_excerpts, case_type_label, llm_rules, n_samples=3):
+def judge_rules(
+    case_summary, source_excerpts, case_type_label, llm_rules, n_samples=3, usage=None
+):
     """Sample the judge per rule, n_samples times, all in parallel.
 
     Returns dict:
@@ -308,9 +345,9 @@ def judge_rules(case_summary, source_excerpts, case_type_label, llm_rules, n_sam
         rule silently degrades to a neutral default. Mirror analyze_source.
         """
         try:
-            return _invoke_once(prompt, max_tokens=max_tokens)
+            return _invoke_once(prompt, max_tokens=max_tokens, usage=usage)
         except json.JSONDecodeError:
-            return _invoke_once_salvaged(prompt, max_tokens=max_tokens)
+            return _invoke_once_salvaged(prompt, max_tokens=max_tokens, usage=usage)
 
     def _run(task):
         kind, key, _i = task

--- a/review/runner.py
+++ b/review/runner.py
@@ -50,6 +50,9 @@ def process_case(case, config=None, on_stage=None):
                 pass
 
     t0 = time.monotonic()
+    # Shared across the source-analysis and rule-scoring LLM calls so the result
+    # carries this review's total token usage + cost.
+    usage = bedrock_judge.UsageAccumulator()
 
     # 1+2. Sources from the case + likhit conversion — LOCAL to the poller; the
     #    markdown is not part of the scored result. The shared converter also
@@ -68,16 +71,17 @@ def process_case(case, config=None, on_stage=None):
     stage("analyzing_sources")
     ctype = casetype.detect(case)
     source_analyses = bedrock_judge.analyze_sources(
-        scorer.build_case_summary(case), converted, ctype["label"]
+        scorer.build_case_summary(case), converted, ctype["label"], usage=usage
     )
 
     # 4. Rule-centered scoring (Bedrock). Rules are code-enforced (no DB).
     stage("scoring")
     rules = code_rules.get_enabled_rules()
     result = scorer.score_case(
-        case, converted, rules, cfg, source_analyses=source_analyses
+        case, converted, rules, cfg, source_analyses=source_analyses, usage=usage
     )
     result["model_id_used"] = settings.BEDROCK_MODEL_ID
+    result["token_usage"] = usage.as_dict()
 
     return {
         "case_title": case.get("title", "") or "",

--- a/review/scorer.py
+++ b/review/scorer.py
@@ -102,7 +102,9 @@ def _source_analysis_block(source, analysis):
     return "\n".join(parts)
 
 
-def score_case(case, converted_sources, rules, config, source_analyses=None):
+def score_case(
+    case, converted_sources, rules, config, source_analyses=None, usage=None
+):
     """Score a case against a list of Rule model instances.
 
     `rules` is an iterable of active (enabled) code rules, in display order.
@@ -111,6 +113,8 @@ def score_case(case, converted_sources, rules, config, source_analyses=None):
     per-source summary+contribution dicts from bedrock_judge.analyze_sources;
     when omitted it is computed here. Every review summarises each source and
     analyses its contribution before rule scoring.
+    `usage` is an optional bedrock_judge.UsageAccumulator that LLM calls record
+    their token usage into for cost tracking.
     Returns a structured, rule-centered result dict.
     """
     ctype = casetype.detect(case)
@@ -120,7 +124,7 @@ def score_case(case, converted_sources, rules, config, source_analyses=None):
     #    it contributes to the case (description / timeline / allegations).
     if source_analyses is None:
         source_analyses = bedrock_judge.analyze_sources(
-            build_case_summary(case), converted_sources, ctype["label"]
+            build_case_summary(case), converted_sources, ctype["label"], usage=usage
         )
     analysis_by_idx = {i: a for i, a in enumerate(source_analyses or [])}
 
@@ -190,6 +194,7 @@ def score_case(case, converted_sources, rules, config, source_analyses=None):
                 ctype["label"],
                 rule_specs,
                 n_samples=config.llm_samples,
+                usage=usage,
             )
         except Exception as e:  # noqa: BLE001
             judge_err = str(e)

--- a/tests/test_review_token_usage.py
+++ b/tests/test_review_token_usage.py
@@ -1,7 +1,7 @@
-"""Unit tests for review LLM token-usage + cost accounting.
+"""Unit tests for review LLM token-usage metrics.
 
-The review poller now tallies every Bedrock invocation's token usage into a
-shared UsageAccumulator and reports the total tokens + USD cost on the result.
+The review poller tallies every Bedrock invocation's token usage into a shared
+UsageAccumulator and reports the totals on the result.
 """
 
 import io
@@ -11,10 +11,7 @@ from review import bedrock_judge
 from review.bedrock_judge import UsageAccumulator
 
 
-def test_accumulator_sums_tokens_and_costs(settings):
-    settings.BEDROCK_INPUT_PRICE_PER_MTOK = 15.0
-    settings.BEDROCK_OUTPUT_PRICE_PER_MTOK = 75.0
-
+def test_accumulator_sums_tokens(settings):
     usage = UsageAccumulator()
     usage.add(1_000_000, 200_000)
     usage.add(500_000, 0)
@@ -24,12 +21,6 @@ def test_accumulator_sums_tokens_and_costs(settings):
     assert out["input_tokens"] == 1_500_000
     assert out["output_tokens"] == 200_000
     assert out["total_tokens"] == 1_700_000
-    # 1.5M in @ $15/Mtok = $22.50 ; 0.2M out @ $75/Mtok = $15.00
-    assert out["input_cost_usd"] == 22.5
-    assert out["output_cost_usd"] == 15.0
-    assert out["total_cost_usd"] == 37.5
-    # The reported total must be exactly the sum of the reported parts.
-    assert out["total_cost_usd"] == out["input_cost_usd"] + out["output_cost_usd"]
     assert out["model_id"] == settings.BEDROCK_MODEL_ID
 
 
@@ -39,7 +30,6 @@ def test_accumulator_tolerates_missing_token_counts():
     out = usage.as_dict()
     assert out["calls"] == 1
     assert out["total_tokens"] == 0
-    assert out["total_cost_usd"] == 0.0
 
 
 def _fake_bedrock(input_tokens, output_tokens, text='{"score": 90}'):

--- a/tests/test_review_token_usage.py
+++ b/tests/test_review_token_usage.py
@@ -28,6 +28,8 @@ def test_accumulator_sums_tokens_and_costs(settings):
     assert out["input_cost_usd"] == 22.5
     assert out["output_cost_usd"] == 15.0
     assert out["total_cost_usd"] == 37.5
+    # The reported total must be exactly the sum of the reported parts.
+    assert out["total_cost_usd"] == out["input_cost_usd"] + out["output_cost_usd"]
     assert out["model_id"] == settings.BEDROCK_MODEL_ID
 
 

--- a/tests/test_review_token_usage.py
+++ b/tests/test_review_token_usage.py
@@ -1,0 +1,71 @@
+"""Unit tests for review LLM token-usage + cost accounting.
+
+The review poller now tallies every Bedrock invocation's token usage into a
+shared UsageAccumulator and reports the total tokens + USD cost on the result.
+"""
+
+import io
+import json
+
+from review import bedrock_judge
+from review.bedrock_judge import UsageAccumulator
+
+
+def test_accumulator_sums_tokens_and_costs(settings):
+    settings.BEDROCK_INPUT_PRICE_PER_MTOK = 15.0
+    settings.BEDROCK_OUTPUT_PRICE_PER_MTOK = 75.0
+
+    usage = UsageAccumulator()
+    usage.add(1_000_000, 200_000)
+    usage.add(500_000, 0)
+
+    out = usage.as_dict()
+    assert out["calls"] == 2
+    assert out["input_tokens"] == 1_500_000
+    assert out["output_tokens"] == 200_000
+    assert out["total_tokens"] == 1_700_000
+    # 1.5M in @ $15/Mtok = $22.50 ; 0.2M out @ $75/Mtok = $15.00
+    assert out["input_cost_usd"] == 22.5
+    assert out["output_cost_usd"] == 15.0
+    assert out["total_cost_usd"] == 37.5
+    assert out["model_id"] == settings.BEDROCK_MODEL_ID
+
+
+def test_accumulator_tolerates_missing_token_counts():
+    usage = UsageAccumulator()
+    usage.add(None, None)
+    out = usage.as_dict()
+    assert out["calls"] == 1
+    assert out["total_tokens"] == 0
+    assert out["total_cost_usd"] == 0.0
+
+
+def _fake_bedrock(input_tokens, output_tokens, text='{"score": 90}'):
+    class _FakeClient:
+        def invoke_model(self, modelId, body):
+            payload = {
+                "content": [{"text": text}],
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                },
+            }
+            return {"body": io.BytesIO(json.dumps(payload).encode())}
+
+    return _FakeClient()
+
+
+def test_invoke_text_records_usage(monkeypatch):
+    monkeypatch.setattr(bedrock_judge, "_bedrock", lambda: _fake_bedrock(120, 34))
+    usage = UsageAccumulator()
+    parsed = bedrock_judge._invoke_once("grade this", usage=usage)
+    assert parsed == {"score": 90}
+    assert usage.input_tokens == 120
+    assert usage.output_tokens == 34
+    assert usage.calls == 1
+
+
+def test_invoke_text_without_accumulator_is_optional(monkeypatch):
+    monkeypatch.setattr(bedrock_judge, "_bedrock", lambda: _fake_bedrock(1, 1))
+    # No usage accumulator passed: must not raise.
+    assert bedrock_judge._invoke_once("grade this") == {"score": 90}


### PR DESCRIPTION
## Summary
- The review poller now tallies token usage for every Bedrock LLM call in a review and reports it on the result.
- Added a thread-safe `UsageAccumulator` in `review/bedrock_judge.py` shared across the judge's parallel (rule × sample) and per-source-analysis invocations; each `invoke_model` response's `usage.input_tokens` / `output_tokens` are recorded.
- `runner.process_case` creates one accumulator per review, threads it through `analyze_sources` and `scorer.score_case` → `judge_rules`, and embeds a `token_usage` block in the result JSON (no migration — `CaseReview.result` is a `JSONField`).
- Refactored the two near-duplicate `_invoke_once` / `_invoke_once_salvaged` helpers onto a shared `_invoke_text` that does the usage capture.

The result now carries:
```json
"token_usage": {
  "model_id": "...", "calls": N,
  "input_tokens": N, "output_tokens": N, "total_tokens": N
}
```

## Test plan
- [x] `tests/test_review_token_usage.py`: accumulator sums tokens, tolerates missing counts, `_invoke_text` records usage, usage arg is optional.
- [x] Existing review tests (`test_review_accused_gate`, `test_review_source_link_roles`) still pass.
- [x] ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)