### PR TITLE
Fix anon throttle 429 storm: bucket by real client IP

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -29,7 +29,6 @@ from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
@@ -73,6 +72,7 @@ from .serializers import (
     JawafEntitySerializer,
 )
 from .services.search import UnifiedSearchService
+from .throttles import AnonRateThrottle, get_client_ident
 
 logger = logging.getLogger(__name__)
 
@@ -1226,7 +1226,7 @@ class FeedbackView(APIView):
         if serializer.is_valid():
             # Capture metadata
             feedback = serializer.save(
-                ip_address=self.get_client_ip(request),
+                ip_address=get_client_ident(request),
                 user_agent=request.META.get("HTTP_USER_AGENT", ""),
             )
 
@@ -1238,15 +1238,6 @@ class FeedbackView(APIView):
             {"error": "Validation error", "details": serializer.errors},
             status=status.HTTP_400_BAD_REQUEST,
         )
-
-    def get_client_ip(self, request):
-        """Extract client IP address from request."""
-        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-        if x_forwarded_for:
-            ip = x_forwarded_for.split(",")[0].strip()
-        else:
-            ip = request.META.get("REMOTE_ADDR")
-        return ip
 
 
 OEMBED_CASE_URL_PATTERN = re.compile(

--- a/cases/throttles.py
+++ b/cases/throttles.py
@@ -15,7 +15,36 @@ three small hooks:
 """
 
 from rest_framework.settings import api_settings
+from rest_framework.throttling import AnonRateThrottle as _AnonRateThrottle
 from rest_framework.throttling import SimpleRateThrottle
+
+
+def get_client_ident(request):
+    """Real client IP for throttling, behind Cloudflare + Traefik.
+
+    The edge is Cloudflare and the cluster ingress (klipper-svclb, Cluster
+    externalTrafficPolicy) SNATs the L3 source, so ``REMOTE_ADDR`` is a useless
+    in-cluster proxy IP and every caller would otherwise share one throttle
+    bucket. Cloudflare sets ``CF-Connecting-IP`` to the true client and
+    overwrites any client-supplied value, so it is both correct and unspoofable
+    through the proxy; prefer it. Fall back to the first ``X-Forwarded-For`` hop,
+    then the peer address.
+    """
+    cf_ip = request.META.get("HTTP_CF_CONNECTING_IP")
+    if cf_ip:
+        return cf_ip.strip()
+    xff = request.META.get("HTTP_X_FORWARDED_FOR")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR")
+
+
+class AnonRateThrottle(_AnonRateThrottle):
+    """``AnonRateThrottle`` that buckets by the real client IP (see
+    :func:`get_client_ident`) instead of DRF's proxy-naive ident."""
+
+    def get_ident(self, request):
+        return get_client_ident(request)
 
 
 class RoleBasedRateThrottle(SimpleRateThrottle):
@@ -79,6 +108,9 @@ class RoleBasedRateThrottle(SimpleRateThrottle):
     def get_authenticated_ident(self, request):
         """Cache identity for an authenticated caller. Defaults to user pk."""
         return request.user.pk
+
+    def get_ident(self, request):
+        return get_client_ident(request)
 
     def get_cache_key(self, request, view):
         user = getattr(request, "user", None)

--- a/cases/throttles.py
+++ b/cases/throttles.py
@@ -27,15 +27,20 @@ def get_client_ident(request):
     in-cluster proxy IP and every caller would otherwise share one throttle
     bucket. Cloudflare sets ``CF-Connecting-IP`` to the true client and
     overwrites any client-supplied value, so it is both correct and unspoofable
-    through the proxy; prefer it. Fall back to the first ``X-Forwarded-For`` hop,
-    then the peer address.
+    through the proxy; prefer it. Fall back to the first non-empty
+    ``X-Forwarded-For`` hop, then the peer address.
+
+    Every candidate is stripped and skipped if blank: a whitespace-only header
+    or a leading comma (``", 1.2.3.4"``) must not yield an empty ident, which
+    would collapse those callers back into one shared bucket.
     """
-    cf_ip = request.META.get("HTTP_CF_CONNECTING_IP")
+    cf_ip = (request.META.get("HTTP_CF_CONNECTING_IP") or "").strip()
     if cf_ip:
-        return cf_ip.strip()
-    xff = request.META.get("HTTP_X_FORWARDED_FOR")
-    if xff:
-        return xff.split(",")[0].strip()
+        return cf_ip
+    for hop in (request.META.get("HTTP_X_FORWARDED_FOR") or "").split(","):
+        hop = hop.strip()
+        if hop:
+            return hop
     return request.META.get("REMOTE_ADDR")
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -543,13 +543,13 @@ REST_FRAMEWORK = {
 
 if not TESTING:
     REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
-        "rest_framework.throttling.AnonRateThrottle",
+        "cases.throttles.AnonRateThrottle",
         "cases.throttles.RoleBasedUserRateThrottle",
     ]
     # RoleBasedUserRateThrottle picks the highest tier the user qualifies for:
     # staff (Admin/Moderator/superuser/is_staff) > contributor > user.
     REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
-        "anon": "100/hour",
+        "anon": "1000/hour",
         "user": "1000/hour",
         "contributor": "2500/hour",
         "staff": "5000/hour",

--- a/tests/cases/test_role_based_throttle.py
+++ b/tests/cases/test_role_based_throttle.py
@@ -157,6 +157,32 @@ def test_get_client_ident_falls_back_to_remote_addr():
     assert get_client_ident(request) == REAL_CLIENT_IP
 
 
+def test_get_client_ident_skips_blank_header_values():
+    """Whitespace-only CF header and a leading-comma XFF must not yield an empty
+    ident (which would re-collapse those callers into one bucket)."""
+    factory = APIRequestFactory()
+    request = factory.get(
+        "/api/anything/",
+        REMOTE_ADDR=PROXY_POD_IP,
+        HTTP_CF_CONNECTING_IP="   ",
+        HTTP_X_FORWARDED_FOR=f" , {REAL_CLIENT_IP}",
+    )
+
+    assert get_client_ident(request) == REAL_CLIENT_IP
+
+
+def test_get_client_ident_falls_back_when_all_headers_blank():
+    factory = APIRequestFactory()
+    request = factory.get(
+        "/api/anything/",
+        REMOTE_ADDR=PROXY_POD_IP,
+        HTTP_CF_CONNECTING_IP="",
+        HTTP_X_FORWARDED_FOR="  ,  ",
+    )
+
+    assert get_client_ident(request) == PROXY_POD_IP
+
+
 @pytest.mark.django_db
 def test_anonymous_requests_behind_proxy_bucket_by_real_client_ip():
     """Regression guard for the 429 storm: anonymous callers sharing the

--- a/tests/cases/test_role_based_throttle.py
+++ b/tests/cases/test_role_based_throttle.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import AnonymousUser, Group
 from django.test import override_settings
 from rest_framework.test import APIRequestFactory
 
-from cases.throttles import RoleBasedUserRateThrottle
+from cases.throttles import RoleBasedUserRateThrottle, get_client_ident
 
 User = get_user_model()
 
@@ -118,3 +118,65 @@ def test_anonymous_requests_bucket_by_ip():
         "scope": "user",
         "ident": ANON_IP,
     }
+
+
+REAL_CLIENT_IP = "203.0.113.5"
+PROXY_POD_IP = "10.42.0.32"
+
+
+def test_get_client_ident_prefers_cf_connecting_ip():
+    """CF-Connecting-IP wins even when XFF is spoofed and REMOTE_ADDR is the
+    in-cluster proxy IP — Cloudflare overwrites CF-Connecting-IP, so it is the
+    only unspoofable signal behind the edge."""
+    factory = APIRequestFactory()
+    request = factory.get(
+        "/api/anything/",
+        REMOTE_ADDR=PROXY_POD_IP,
+        HTTP_CF_CONNECTING_IP=REAL_CLIENT_IP,
+        HTTP_X_FORWARDED_FOR="1.2.3.4, 10.42.0.32",
+    )
+
+    assert get_client_ident(request) == REAL_CLIENT_IP
+
+
+def test_get_client_ident_falls_back_to_first_xff_hop():
+    factory = APIRequestFactory()
+    request = factory.get(
+        "/api/anything/",
+        REMOTE_ADDR=PROXY_POD_IP,
+        HTTP_X_FORWARDED_FOR=f"{REAL_CLIENT_IP}, 10.42.0.32",
+    )
+
+    assert get_client_ident(request) == REAL_CLIENT_IP
+
+
+def test_get_client_ident_falls_back_to_remote_addr():
+    factory = APIRequestFactory()
+    request = factory.get("/api/anything/", REMOTE_ADDR=REAL_CLIENT_IP)
+
+    assert get_client_ident(request) == REAL_CLIENT_IP
+
+
+@pytest.mark.django_db
+def test_anonymous_requests_behind_proxy_bucket_by_real_client_ip():
+    """Regression guard for the 429 storm: anonymous callers sharing the
+    ingress proxy IP must not collapse into one bucket — they key on the real
+    Cloudflare client IP, not REMOTE_ADDR."""
+    factory = APIRequestFactory()
+    throttle = RoleBasedUserRateThrottle()
+    throttle.scope = "user"
+
+    req_a = factory.get(
+        "/api/anything/", REMOTE_ADDR=PROXY_POD_IP, HTTP_CF_CONNECTING_IP="203.0.113.1"
+    )
+    req_a.user = AnonymousUser()
+    req_a.auth = None
+    req_b = factory.get(
+        "/api/anything/", REMOTE_ADDR=PROXY_POD_IP, HTTP_CF_CONNECTING_IP="203.0.113.2"
+    )
+    req_b.user = AnonymousUser()
+    req_b.auth = None
+
+    assert throttle.get_cache_key(req_a, view=None) != throttle.get_cache_key(
+        req_b, view=None
+    )


### PR DESCRIPTION
## Summary
- The API was returning a storm of HTTP 429s on `portal.jawafdehi.org` — even the UptimeRobot healthcheck (`HEAD /api/statistics/`) was getting throttled, making it look like the deployment was down. The k8s deployment itself is healthy (2/2, 0 restarts); the cause is throttle misconfiguration.
- `AnonRateThrottle` bucketed anonymous callers by `REMOTE_ADDR`. Behind **Cloudflare + klipper-svclb** (`externalTrafficPolicy: Cluster`), the L3 source is SNAT'd to an in-cluster proxy pod IP, so **all** anonymous traffic collapsed into ~3 shared buckets and exhausted the `100/hour` anon limit almost instantly.
- Fix: resolve the real client IP and key the throttle buckets off it, then raise the anon rate.

## Changes
- `cases/throttles.py`: add `get_client_ident()` (`CF-Connecting-IP` → first `X-Forwarded-For` hop → `REMOTE_ADDR`); add a CF-aware `AnonRateThrottle` and override `get_ident()` on `RoleBasedRateThrottle` (the NGM throttle inherits it).
- `config/settings.py`: point `DEFAULT_THROTTLE_CLASSES` at `cases.throttles.AnonRateThrottle`; raise `anon` rate `100/hour` → `1000/hour`.
- `cases/api_views.py`: `FeedbackView` reuses the shared helper; `FeedbackRateThrottle` inherits the CF-aware base.
- Tests: precedence test for `get_client_ident` + regression guard that anonymous callers sharing the ingress proxy IP no longer share a bucket.

### Why `CF-Connecting-IP` and not `NUM_PROXIES`
`NUM_PROXIES` keys off `X-Forwarded-For` counted from the right, which is fragile with Cloudflare's variable hop count. Cloudflare always sets `CF-Connecting-IP` to the true client and overwrites any client-supplied value, so it's both correct and unspoofable through the edge. The `XFF[0]` fallback is the same logic the existing `FeedbackView` already relies on in prod, so this is strictly better than today even if the CF header were ever absent.

## Test plan
- [x] `pytest tests/cases/test_role_based_throttle.py` (15 passed)
- [x] `pytest tests/ngm/test_api.py -k throttle` (NGM token throttling still passes)
- [x] ruff + black pre-commit hooks pass
- [ ] After rollout: `ssh monal-instance1 'sudo kubectl logs -n app -l app=jawafdehi-api --tail=200 | grep -c " 429 "'` drops sharply; UptimeRobot `HEAD /api/statistics/` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced client IP detection for rate limiting to correctly identify requests through proxies (Cloudflare, forwarded headers).
  * Increased anonymous request rate limit from 100/hour to 1000/hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->