### PR TITLE
fix(cors): allow *.jawafdehi.org subdomains in default origin regexes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 # Allow all subdomains of newnepal.workers.dev and jawafdehi.org
 CORS_ALLOWED_ORIGIN_REGEXES=^https://([a-z0-9-]+\.)?newnepal\.workers\.dev$,^https://([a-z0-9-]+\.)?jawafdehi\.org$
-# For browser cookie-based writes from workers.dev / jawafdehi.org subdomains
-CSRF_TRUSTED_ORIGINS=https://*.newnepal.workers.dev,https://*.jawafdehi.org
+# For browser cookie-based writes from workers.dev / jawafdehi.org. Django CSRF
+# wildcards match subdomains only, so the apex domains are listed explicitly.
+CSRF_TRUSTED_ORIGINS=https://*.newnepal.workers.dev,https://newnepal.workers.dev,https://*.jawafdehi.org,https://jawafdehi.org
 NES_API_URL=https://nes.jawafdehi.org/api
 DATABASE_URL=postgresql://user:password@localhost:5432/jawafdehi
 NGM_DATABASE_URL=postgresql://user:password@localhost:5432/ngm

--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,10 @@ DEBUG=False
 # ALLOWED_HOSTS is required when DEBUG=False
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
-# Allow all subdomains of newnepal.workers.dev
-CORS_ALLOWED_ORIGIN_REGEXES=^https://[a-zA-Z0-9-]+\.newnepal\.workers\.dev$
-# For browser cookie-based writes from workers.dev subdomains
-CSRF_TRUSTED_ORIGINS=https://*.newnepal.workers.dev
+# Allow all subdomains of newnepal.workers.dev and jawafdehi.org
+CORS_ALLOWED_ORIGIN_REGEXES=^https://([a-z0-9-]+\.)?newnepal\.workers\.dev$,^https://([a-z0-9-]+\.)?jawafdehi\.org$
+# For browser cookie-based writes from workers.dev / jawafdehi.org subdomains
+CSRF_TRUSTED_ORIGINS=https://*.newnepal.workers.dev,https://*.jawafdehi.org
 NES_API_URL=https://nes.jawafdehi.org/api
 DATABASE_URL=postgresql://user:password@localhost:5432/jawafdehi
 NGM_DATABASE_URL=postgresql://user:password@localhost:5432/ngm

--- a/config/settings.py
+++ b/config/settings.py
@@ -616,13 +616,15 @@ CORS_ALLOWED_ORIGINS = get_env_list(
     "CORS_ALLOWED_ORIGINS",
     "http://localhost:8080,http://127.0.0.1:8080,https://jawafdehi.org,https://beta.jawafdehi.org",
 )
-# Allow the casework portal SPA served from the project's Cloudflare workers.dev
-# domain — newnepal.workers.dev and its per-version preview subdomains
-# (e.g. abc123.newnepal.workers.dev) — to call the API (e.g. the JWT token
-# endpoint) cross-origin.
+# Allow the casework portal SPA cross-origin from:
+#   - the project's Cloudflare workers.dev domain and its per-version preview
+#     subdomains (e.g. abc123.newnepal.workers.dev)
+#   - any jawafdehi.org subdomain (e.g. beta., portal., preview hosts)
+# to call the API (e.g. the JWT token endpoint).
 CORS_ALLOWED_ORIGIN_REGEXES = get_env_list(
     "CORS_ALLOWED_ORIGIN_REGEXES",
-    r"^https://([a-z0-9-]+\.)?newnepal\.workers\.dev$",
+    r"^https://([a-z0-9-]+\.)?newnepal\.workers\.dev$,"
+    r"^https://([a-z0-9-]+\.)?jawafdehi\.org$",
 )
 CORS_ALLOW_METHODS = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
 CORS_ALLOW_HEADERS = [

--- a/config/settings.py
+++ b/config/settings.py
@@ -623,8 +623,12 @@ CORS_ALLOWED_ORIGINS = get_env_list(
 # to call the API (e.g. the JWT token endpoint).
 CORS_ALLOWED_ORIGIN_REGEXES = get_env_list(
     "CORS_ALLOWED_ORIGIN_REGEXES",
-    r"^https://([a-z0-9-]+\.)?newnepal\.workers\.dev$,"
-    r"^https://([a-z0-9-]+\.)?jawafdehi\.org$",
+    ",".join(
+        [
+            r"^https://([a-z0-9-]+\.)?newnepal\.workers\.dev$",
+            r"^https://([a-z0-9-]+\.)?jawafdehi\.org$",
+        ]
+    ),
 )
 CORS_ALLOW_METHODS = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
 CORS_ALLOW_HEADERS = [


### PR DESCRIPTION
## Summary
Extends the `CORS_ALLOWED_ORIGIN_REGEXES` **default** to also match any `*.jawafdehi.org` subdomain, alongside the existing `*.newnepal.workers.dev` preview domains. Updates `.env.example` (`CSRF_TRUSTED_ORIGINS`) to match.

- Regex matches apex + single-label subdomains (`jawafdehi.org`, `beta.`, `portal.`, `pr-123.`), https-only, anchored so spoofs like `jawafdehi.org.evil.com` / `evil-jawafdehi.org` are rejected.
- **Context:** production CORS is currently driven by these code defaults (no `CORS_*` key exists in the API's secret/env). The live deployment has since been given an explicit `CORS_ALLOWED_ORIGIN_REGEXES` env (infra repo) that supersedes this default, so this PR is a baseline-hardening change for non-prod/other environments rather than the thing that flipped prod.

## Test plan
- [ ] `pytest tests/test_origin_settings.py`
- [ ] Confirm a request from `https://foo.jawafdehi.org` gets a reflected `Access-Control-Allow-Origin`, and `https://evil-jawafdehi.org` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)