### PR TITLE
Copy templates/ into the API image (admin SSO login button)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY ngm ./ngm
 COPY review ./review
 COPY llm ./llm
 COPY static ./static
+COPY templates ./templates
 
 # Collect static files
 RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org python manage.py collectstatic --noinput


### PR DESCRIPTION
## Summary
The Dockerfile copies app dirs explicitly (`config`, `cases`, … `static`) and omitted **`templates/`**, so `templates/admin/login.html` — the admin "Log in with Jawafdehi Auth (SSO)" override from #214 — never shipped in the image. Adds `COPY templates ./templates`.

Without this, `/admin/login/` shows the stock password form (admin SSO still works via `/oidc/authenticate/`, just no button).

## Test plan
- [x] `templates/admin/login.html` present in repo
- [ ] After deploy: `/admin/login/` shows the SSO button