### PR TITLE
fix(docker): COPY sourcing/ into the image (prod 500 hotfix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY nesq ./nesq
 COPY ngm ./ngm
 COPY review ./review
 COPY llm ./llm
+COPY sourcing ./sourcing
 COPY content ./content
 COPY static ./static
 COPY templates ./templates

--- a/Dockerfile.poller
+++ b/Dockerfile.poller
@@ -48,6 +48,7 @@ COPY nesq ./nesq
 COPY ngm ./ngm
 COPY review ./review
 COPY llm ./llm
+COPY sourcing ./sourcing
 COPY content ./content
 COPY static ./static
 COPY templates ./templates


### PR DESCRIPTION
## Why (prod incident)
Deploying current `main` took the API down — every route returned **500** with:
```
ModuleNotFoundError: No module named 'sourcing'
  File "/app/review/case_provider.py", line 25, in <module>
    from sourcing import jds_client
```
`review/*` imports the top-level **`sourcing`** package (`case_provider`, `runner`, `scorer`, and management commands — 6 call sites), but **neither Dockerfile COPYs `sourcing/`**, so it's absent from the image. That breaks `manage.py collectstatic` during the build *and* URL loading at runtime (so all requests 500). Introduced when the `sourcing` import landed (#217) without a matching Dockerfile change.

Prod has been **temporarily pinned to the last-known-good digest** (`sha256:131c114…`) to restore service; merging this and letting the new image build/deploy is the real fix.

## Change
Add `COPY sourcing ./sourcing` to both `Dockerfile` and `Dockerfile.poller` (placed with the other app COPYs). Verified `sourcing/` is the only un-copied top-level module imported at runtime by the shipped apps.

## After merge
1. Let the `main` image build + deploy (un-pin from the digest — Keel/`:main` will track again).
2. Then run the Wagtail/CMS migrations (`manage.py migrate`) — that work is already on `main` but couldn't run while the image was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)