### PR TITLE
ci(docker): run manage.py check during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ COPY content ./content
 COPY static ./static
 COPY templates ./templates
 
+# Fail the build early if the app can't load (missing module, broken URLconf, etc.)
+RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org python manage.py check
+
 # Collect static files
 RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org python manage.py collectstatic --noinput
 

--- a/Dockerfile.poller
+++ b/Dockerfile.poller
@@ -53,6 +53,10 @@ COPY content ./content
 COPY static ./static
 COPY templates ./templates
 
+# Fail the build early if the app can't load (missing module, broken URLconf, etc.)
+RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org \
+    python manage.py check
+
 # Collect static files (parity with the API image).
 RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org \
     python manage.py collectstatic --noinput


### PR DESCRIPTION
## Why
The recent prod outage (`ModuleNotFoundError: No module named 'sourcing'`) shipped in a "successfully built" image because the build's only Django step is `collectstatic`, which **doesn't load the URLconf** — so a missing runtime module / broken import isn't caught until requests hit prod (every route 500s).

## Change
Add `python manage.py check` before `collectstatic` in both `Dockerfile` and `Dockerfile.poller`. `check` loads the app registry **and** URLconf, so this class of error fails the **build** instead of reaching production. No DB needed (uses the same `DEBUG=False SECRET_KEY=… ALLOWED_HOSTS=…` env as the existing collectstatic step).

## Test plan
- [ ] Image build runs `manage.py check` and passes on current `main`.
- [ ] (Regression) Reverting the `COPY sourcing` line would now fail the build at the `check` step rather than producing a broken image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build processes to validate application configuration during image assembly, ensuring early detection of configuration issues before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->