### PR TITLE
feat(newsroom): route Wagtail admin login through OIDC SSO

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -929,3 +929,8 @@ OIDC_OP_JWKS_ENDPOINT = OIDC_JWKS_URL
 LOGIN_REDIRECT_URL = "/admin/"
 LOGOUT_REDIRECT_URL = "/admin/login/"
 LOGIN_URL = "/oidc/authenticate/"
+# Route the Wagtail admin (/newsroom) through the same OIDC SSO flow instead of
+# Wagtail's built-in username/password form. require_admin_access redirects
+# unauthenticated users here (with ?next=), so the OIDC callback returns them to
+# the newsroom. The /newsroom/login/ form is also redirected (see config/urls.py).
+WAGTAILADMIN_LOGIN_URL = LOGIN_URL

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic.base import RedirectView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -53,6 +54,14 @@ urlpatterns = [
     # OIDC authentication for admin SSO
     path("oidc/", include("mozilla_django_oidc.urls")),
     # Wagtail CMS: editorial admin, document serving, and headless API v2.
+    # Retire Wagtail's built-in password form — send /newsroom/login/ to OIDC SSO.
+    # Must precede the wagtailadmin include so it wins URL resolution.
+    path(
+        "newsroom/login/",
+        RedirectView.as_view(
+            url="/oidc/authenticate/?next=/newsroom/", query_string=False
+        ),
+    ),
     path("newsroom/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("api/cms/v2/", wagtail_api_router.urls),


### PR DESCRIPTION
## Why
`/newsroom` (Wagtail admin) still shows a username/password form even though admin SSO via Zitadel/`mozilla_django_oidc` is integrated. Wagtail uses its **own** login view (independent of `LOGIN_URL`), so it never hits the OIDC flow.

## Change
- `WAGTAILADMIN_LOGIN_URL = LOGIN_URL` (`/oidc/authenticate/`). Wagtail's `require_admin_access` redirects unauthenticated admin access to this URL (with `?next=`), so the newsroom now goes through Zitadel; `JawafdehiOIDCBackend` maps the user → groups, and the `access_admin` + page/collection perms granted to `Admin`/`Moderator`/`Contributor` let them in.
- Redirect `/newsroom/login/` → `/oidc/authenticate/?next=/newsroom/` (placed before the `wagtailadmin` include) so the built-in password form is fully retired — SSO-only.

## Verification (local, this branch's code)
Django test client over HTTPS:
```
/newsroom/        -> 302  Location: /oidc/authenticate/?next=/newsroom/
/newsroom/login/  -> 302  Location: /oidc/authenticate/?next=/newsroom/
```

## Test plan
- [ ] After deploy, `GET /newsroom/` (unauthenticated) 302s to `/oidc/authenticate/`, completing via Zitadel.
- [ ] A user in `Admin`/`Moderator`/`Contributor` lands in the newsroom; a user without `access_admin` is denied.
- [ ] `/newsroom/login/` no longer serves the password form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)