### PR TITLE
Richer claude harness: effort, full source context, multi-pass verdict digests

### DIFF
--- a/casework/common.py
+++ b/casework/common.py
@@ -393,6 +393,26 @@ def source_content(case: dict, source_types=None):
     return joined, len(joined)
 
 
+def env_int(name: str, default: int) -> int:
+    """Read an int from env, falling back to `default`. Lets the runner widen the
+    source-content caps for big-context models (e.g. claude 1M) without code edits."""
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+def clamp(text: str, limit: int, label: str = "source") -> str:
+    """Truncate `text` to `limit` chars (<=0 = no limit) and PRINT total vs sent,
+    so an operator can see how much of each source actually reached the model."""
+    text = text or ""
+    total = len(text)
+    sent = text if (limit <= 0 or total <= limit) else text[:limit]
+    note = "" if len(sent) == total else f"  (capped at {limit:,})"
+    print(f"    {label}: {total:,} total chars, sent {len(sent):,}{note}")
+    return sent
+
+
 # ── target case selection ────────────────────────────────────────────────────
 
 

--- a/casework/enrich_allegations.py
+++ b/casework/enrich_allegations.py
@@ -30,7 +30,9 @@ from casework.common import (
     CaseworkApi,
     add_common_args,
     bootstrap,
+    clamp,
     content_from_evidence_entry,
+    env_int,
     get_target_cases,
     parse_extraction_response,
     print_summary,
@@ -333,7 +335,11 @@ def _extract_allegations(
     prompt = USER_PROMPT_TEMPLATE.format(
         case_title=case_title,
         bigo=bigo,
-        press_release=press_release_text[:60000],
+        press_release=clamp(
+            press_release_text,
+            env_int("CASEWORK_PRESS_RELEASE_CHARS", 60000),
+            "press release",
+        ),
     )
 
     # Call LLM without tools (plain text generation)

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -67,7 +67,13 @@ COURT_RE = re.compile(r"(?<![\dA-Za-z])\d{2,3}-[A-Za-z]{1,3}-\d{3,4}(?![\dA-Za-z
 # LLM-summarised digest.
 SOURCE_TEXT_BUDGET = env_int("CASEWORK_SOURCE_TEXT_BUDGET", 60000)
 VERDICT_SUMMARY_TRIGGER = env_int("CASEWORK_VERDICT_SUMMARY_TRIGGER", 12000)
-VERDICT_SUMMARY_TARGET = 8000
+VERDICT_SUMMARY_TARGET = env_int("CASEWORK_VERDICT_SUMMARY_TARGET", 8000)
+# Verdicts above the trigger are summarised. Long ones are summarised in MULTIPLE
+# passes (one per chunk) so the WHOLE judgment is covered — a single truncated
+# pass missed the फैसला, which sits at the end of a long document. Per-pass output
+# size and chunk size are tunable for bigger, richer digests.
+VERDICT_SUMMARY_MAX_TOKENS = env_int("CASEWORK_VERDICT_SUMMARY_MAX_TOKENS", 8000)
+VERDICT_SUMMARY_CHUNK_CHARS = env_int("CASEWORK_VERDICT_SUMMARY_CHUNK_CHARS", 150000)
 
 VERDICT_SUMMARY_SYSTEM_PROMPT = """\
 You are a Nepali legal analyst. You are given the full text of a Special Court \
@@ -579,20 +585,48 @@ def _assemble_source_text(
 
 
 def _summarize_verdict(verdict_text: str, invoke_text, usage) -> Optional[str]:
-    """First-pass LLM summary of a long Special Court verdict document."""
-    try:
-        result = invoke_text(
-            system=VERDICT_SUMMARY_SYSTEM_PROMPT,
-            content="Summarise this Special Court judgment as instructed.\n\n"
-            + verdict_text[:120000],
-            tier="premium",
-            usage=usage,
-            max_tokens=4000,
+    """LLM summary of a long Special Court verdict.
+
+    Long judgments are summarised in MULTIPLE passes (one per chunk) and the
+    per-chunk summaries concatenated, so the WHOLE document is covered. The prior
+    single pass over verdict_text[:120000] silently dropped everything past 120k —
+    including the फैसला/ठहर, which sits at the end of a long judgment — and capped
+    the digest at ~4k tokens. Chunk + per-pass output sizes are tunable.
+    """
+    chunk = max(20000, VERDICT_SUMMARY_CHUNK_CHARS)
+    chunks = [verdict_text[i : i + chunk] for i in range(0, len(verdict_text), chunk)]
+    n = len(chunks)
+    summaries: list[str] = []
+    for idx, part in enumerate(chunks):
+        framing = (
+            "Summarise this Special Court judgment as instructed.\n\n"
+            if n == 1
+            else f"This is part {idx + 1} of {n} of a long Special Court judgment "
+            "(split only by length, mid-sentence boundaries possible). Summarise the "
+            "substantive content of THIS part as instructed; the फैसला/ठहर may appear "
+            "in a later part.\n\n"
         )
-        return result.strip() if result else None
-    except Exception as exc:
-        logger.warning("Verdict summarisation failed: %s", exc)
+        try:
+            result = invoke_text(
+                system=VERDICT_SUMMARY_SYSTEM_PROMPT,
+                content=framing + part,
+                tier="premium",
+                usage=usage,
+                max_tokens=VERDICT_SUMMARY_MAX_TOKENS,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Verdict part %d/%d summarisation failed: %s", idx + 1, n, exc
+            )
+            continue
+        if result and result.strip():
+            summaries.append(result.strip())
+    if not summaries:
         return None
+    if n == 1:
+        return summaries[0]
+    logger.info("Verdict summarised in %d passes (of %d parts)", len(summaries), n)
+    return "\n\n".join(f"[खण्ड {i + 1}/{n}]\n{s}" for i, s in enumerate(summaries))
 
 
 def _format_bigo(bigo) -> str:

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -38,8 +38,10 @@ from casework.common import (
     add_common_args,
     balanced_object,
     bootstrap,
+    clamp,
     content_from_evidence_entry,
     convert_date_tool,
+    env_int,
     get_target_cases,
     print_summary,
     setup_logging,
@@ -60,8 +62,11 @@ DESCRIPTION_SOURCE_TYPES = (
 COURT_RE = re.compile(r"(?<![\dA-Za-z])\d{2,3}-[A-Za-z]{1,3}-\d{3,4}(?![\dA-Za-z])")
 
 # Source-budget (characters) fed to the description prompt.
-SOURCE_TEXT_BUDGET = 60000
-VERDICT_SUMMARY_TRIGGER = 12000
+# Env-tunable so the runner can widen them for big-context models (claude 1M):
+# raise the budget + verdict trigger to feed full court orders instead of an
+# LLM-summarised digest.
+SOURCE_TEXT_BUDGET = env_int("CASEWORK_SOURCE_TEXT_BUDGET", 60000)
+VERDICT_SUMMARY_TRIGGER = env_int("CASEWORK_VERDICT_SUMMARY_TRIGGER", 12000)
 VERDICT_SUMMARY_TARGET = 8000
 
 VERDICT_SUMMARY_SYSTEM_PROMPT = """\
@@ -282,6 +287,7 @@ def main():
                 total=total,
                 dry_run=args.dry_run,
                 skip_title=args.skip_title,
+                force=args.force,
                 api=api,
                 usage=usage,
                 invoke_text=invoke_text,
@@ -332,6 +338,7 @@ def _process_case(
     total: int,
     dry_run: bool,
     skip_title: bool,
+    force: bool,
     api: CaseworkApi,
     usage,
     invoke_text,
@@ -352,7 +359,7 @@ def _process_case(
         print("  (using summary instead of detail)")
 
     # Idempotency: skip cases with substantial descriptions unless --force
-    if _has_substantial_description(detail):
+    if not force and _has_substantial_description(detail):
         stats["cases_processed"] -= 1
         stats["cases_already_populated"] += 1
         print("  Already has a substantial description — skipping (use --force)")
@@ -565,7 +572,7 @@ def _assemble_source_text(
         if remaining <= 0:
             logger.warning("Budget spent; dropped a %s source", label)
             break
-        chunk = text[:remaining]
+        chunk = clamp(text, remaining, label)
         parts.append(f"[{label}]\n{chunk}")
         remaining -= len(chunk)
     return "\n\n---\n\n".join(parts)

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -596,7 +596,7 @@ def _summarize_verdict(verdict_text: str, invoke_text, usage) -> Optional[str]:
     chunk = max(20000, VERDICT_SUMMARY_CHUNK_CHARS)
     chunks = [verdict_text[i : i + chunk] for i in range(0, len(verdict_text), chunk)]
     n = len(chunks)
-    summaries: list[str] = []
+    summaries: list[tuple[int, str]] = []
     for idx, part in enumerate(chunks):
         framing = (
             "Summarise this Special Court judgment as instructed.\n\n"
@@ -620,13 +620,15 @@ def _summarize_verdict(verdict_text: str, invoke_text, usage) -> Optional[str]:
             )
             continue
         if result and result.strip():
-            summaries.append(result.strip())
+            summaries.append((idx + 1, result.strip()))
     if not summaries:
         return None
     if n == 1:
-        return summaries[0]
+        return summaries[0][1]
     logger.info("Verdict summarised in %d passes (of %d parts)", len(summaries), n)
-    return "\n\n".join(f"[खण्ड {i + 1}/{n}]\n{s}" for i, s in enumerate(summaries))
+    # Label with the ORIGINAL part index so a failed/skipped chunk doesn't
+    # renumber the survivors (खण्ड 3/5 must stay 3/5, not become 2/5).
+    return "\n\n".join(f"[खण्ड {part_idx}/{n}]\n{s}" for part_idx, s in summaries)
 
 
 def _format_bigo(bigo) -> str:

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -34,6 +34,8 @@ from casework.common import (
     add_common_args,
     balanced_object,
     bootstrap,
+    clamp,
+    env_int,
     get_target_cases,
     print_summary,
     setup_logging,
@@ -412,7 +414,7 @@ def _build_source_context_from_entry(entry: dict) -> str:
     for u in urls:
         if isinstance(u, dict) and u.get("link"):
             parts.append(f"url: {urllib.parse.unquote(u['link'])}")
-    return "\n".join(parts)[:20000]
+    return "\n".join(parts)[: env_int("CASEWORK_BIGO_SOURCE_CHARS", 20000)]
 
 
 def _extract_bigo_from_source(
@@ -428,7 +430,9 @@ def _extract_bigo_from_source(
         case_id=case_id,
         case_title=case_title,
         source_context=source_context,
-        markdown=source_text[:100000],
+        markdown=clamp(
+            source_text, env_int("CASEWORK_BIGO_FEED_CHARS", 100000), "bigo source"
+        ),
     )
 
     # Call LLM (plain chat, no tools)

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -31,6 +31,7 @@ from casework.common import (
     add_common_args,
     bootstrap,
     content_from_evidence_entry,
+    env_int,
     get_target_cases,
     parse_extraction_response,
     print_summary,
@@ -43,12 +44,14 @@ logger = logging.getLogger(__name__)
 # Slicing constants (match the original)
 # ─────────────────────────────────────────────────────────────────────────────
 COURT_ORDER_FULL_THRESHOLD = 8_000
-COURT_ORDER_HEAD_CHARS = 4_000
-COURT_ORDER_TAIL_CHARS = 2_000
-COURT_ORDER_THAHAR_CHARS = 12_000
+COURT_ORDER_HEAD_CHARS = env_int("CASEWORK_RE_COURT_ORDER_HEAD_CHARS", 4_000)
+COURT_ORDER_TAIL_CHARS = env_int("CASEWORK_RE_COURT_ORDER_TAIL_CHARS", 2_000)
+COURT_ORDER_THAHAR_CHARS = env_int("CASEWORK_RE_COURT_ORDER_THAHAR_CHARS", 12_000)
 
-PRESS_RELEASE_CHARS = 3_000
-PRESS_RELEASE_CHARS_NO_COURT = 18_000
+PRESS_RELEASE_CHARS = env_int("CASEWORK_RE_PRESS_RELEASE_CHARS", 3_000)
+PRESS_RELEASE_CHARS_NO_COURT = env_int(
+    "CASEWORK_RE_PRESS_RELEASE_CHARS_NO_COURT", 18_000
+)
 
 PROMPT_HARD_MAX = 25_000
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -850,6 +850,8 @@ CLAUDE_CLI_MODEL_ID = os.getenv("CLAUDE_CLI_MODEL_ID", "")
 # vs routine. Fall back to CLAUDE_CLI_MODEL_ID, then the CLI default.
 CLAUDE_CLI_MODEL_PREMIUM = os.getenv("CLAUDE_CLI_MODEL_PREMIUM", "")
 CLAUDE_CLI_MODEL_CHEAP = os.getenv("CLAUDE_CLI_MODEL_CHEAP", "")
+# claude -p reasoning budget: low/medium/high/xhigh/max ("" -> CLI default).
+CLAUDE_CLI_EFFORT = os.getenv("CLAUDE_CLI_EFFORT", "")
 REVIEW_CLI_MAX_WORKERS = int(os.getenv("REVIEW_CLI_MAX_WORKERS", "2"))
 REVIEW_CLI_TIMEOUT = int(os.getenv("REVIEW_CLI_TIMEOUT", "300"))
 REVIEW_CLI_MAX_RETRIES = int(os.getenv("REVIEW_CLI_MAX_RETRIES", "3"))

--- a/llm/providers/cli.py
+++ b/llm/providers/cli.py
@@ -115,6 +115,12 @@ class ClaudeCliProvider(_CliProvider):
     name = "claude_cli"
     supports_tools = True
 
+    def _effort_args(self):
+        """`--effort <level>` (low/medium/high/xhigh/max) when configured; the CLI
+        reasoning budget. Empty -> CLI default."""
+        eff = getattr(settings, "CLAUDE_CLI_EFFORT", "")
+        return ["--effort", eff] if eff else []
+
     def _claude_env(self):
         """Env for the claude subprocess: subscription auth (no API key)."""
         env = dict(os.environ)
@@ -200,6 +206,7 @@ class ClaudeCliProvider(_CliProvider):
         effective_model = model_id
         if effective_model:
             argv.extend(["--model", effective_model])
+        argv.extend(self._effort_args())
 
         out = self._run(argv, _flatten(content), self._claude_env())
         return self._finalize(out, model_id, effective_model, tier, usage)
@@ -272,6 +279,7 @@ class ClaudeCliProvider(_CliProvider):
                 "--mcp-config",
                 cfg_path,
                 "--strict-mcp-config",
+                *self._effort_args(),
                 "--allowedTools",
                 *[f"mcp__llmtools__{t.name}" for t in exposable],
             ]


### PR DESCRIPTION
Follow-up to #219 — quality dials for the claude_cli (subscription) harness,
which was trading context/reasoning for tokens. Defaults are unchanged, so the
proxy path stays lean; the runner widens them only for the big-context claude
harness (Opus 4.8, 1M window).

## Changes
- **Reasoning:** `CLAUDE_CLI_EFFORT` → `claude -p --effort <level>` (low/medium/
  high/xhigh/max) on both the text and tool paths.
- **Source content:** the per-source caps are now env-tunable (`common.env_int`)
  with the current values as defaults — description budget / verdict trigger,
  allegations press-release, bigo source, related-entities caps. Raising the
  verdict trigger feeds the **full court order** instead of an LLM digest.
- **Visibility:** `common.clamp()` truncates **and logs total-vs-sent chars** per
  source, so you can see how much of each document reached the model.
- **Multi-pass verdict summarisation:** the summariser fed only the first 120k
  chars and capped output at 4k tokens — so on a long judgment it never saw the
  फैसला (at the end) and compressed e.g. a 708k verdict to a ~6.8k sliver. It now
  chunks the full verdict and summarises each part (map), concatenating — the
  whole document is covered. Verified: 708,882 → 44,057 chars in 5 passes.
- **Fix:** `enrich_description` skipped cases with an existing description **even
  under `--force`** (the guard never received force), making re-enrichment
  impossible. Threaded `force` through and gated the guard on it.

## Verified
- `claude -p` runs `claude-opus-4-8[1m] --effort medium`, feeds full sources
  (total-vs-sent logged), `--force` regenerates, and giant verdicts summarise in
  multiple passes.
- A/B'd across effort low/medium/xhigh on 3 cases: the full-verdict descriptions
  are more factually grounded than the prior frugal ones; medium is the
  cost/quality sweet spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)