### PR TITLE
casework: card (title + short_description) and evidence/source description enrichers

### DIFF
--- a/casework/common.py
+++ b/casework/common.py
@@ -138,6 +138,33 @@ class CaseworkApi:
         )
         resp.raise_for_status()
 
+    def get_source(self, source_id: str, timeout: int = 30) -> dict:
+        """GET /api/sources/{source_id}/ — a DocumentSource (carries its own
+        `description`, which the case-detail evidence representation omits)."""
+        quoted = urllib.parse.quote(str(source_id).strip(), safe="")
+        return self.get(f"/sources/{quoted}/", timeout=timeout)
+
+    def patch_source(
+        self, source_id: str, field: str, value, timeout: int = 30
+    ) -> None:
+        """Partial-update one DocumentSource field over HTTP.
+
+        Unlike the case endpoint, /api/sources/ uses a plain DRF partial update
+        (DocumentSourceUpdateSerializer), NOT RFC-6902 JSON Patch — so the body
+        is a ``{field: value}`` object, not a list of patch ops.
+        """
+        if not source_id:
+            raise RuntimeError("cannot PATCH a source with no source_id")
+        quoted = urllib.parse.quote(str(source_id).strip(), safe="")
+        url = f"{self._api_root()}/sources/{quoted}/"
+        resp = self.session.patch(
+            url,
+            json={field: value},
+            headers={"Content-Type": "application/json"},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+
     def create_entity(
         self, display_name: str, nes_id: str = "", timeout: int = 30
     ) -> int:
@@ -608,6 +635,108 @@ def parse_extraction_response(response_text, wrapper_keys):
             except json.JSONDecodeError:
                 pass
     return None
+
+
+# ── description-adequacy judge (cheap-model gate for enrichers) ───────────────
+
+# Below this length a text can't carry a real description — judged a placeholder
+# without spending an LLM call.
+_JUDGE_MIN_CHARS = 15
+_JUDGE_TEXT_BUDGET = 2000
+
+_JUDGE_SYSTEM_PROMPT = """\
+You are a strict data-quality reviewer for Jawafdehi, a civic archive of Nepal's \
+anti-corruption cases. You judge whether a given TEXT is an ADEQUATE value for the \
+named field, or merely a PLACEHOLDER / STUB that should be regenerated.
+
+INADEQUATE (adequate=false) when the text is, for example:
+- empty, whitespace, or a placeholder ("description here", "TODO", "N/A", "-",
+  "News Source", "खाली", "विवरण यहाँ");
+- a bare restatement of the title / case number / file name with no substance;
+- auto-generated filler or a generic boilerplate line that fits any case;
+- so vague or truncated that it does not inform a reader.
+
+ADEQUATE (adequate=true) when the text conveys real, specific, substantive
+information appropriate to the field (names, amounts, dates, what the document is
+or what it shows), even if imperfect.
+
+Reply with ONLY a JSON object, no prose:
+{"adequate": true, "reason": "<short reason>"}
+"""
+
+
+def _parse_judge_verdict(response_text):
+    """Parse {"adequate": bool, "reason": str} from the judge response, scanning
+    every '{' so leading prose with braces doesn't abort the parse. Returns
+    (adequate, reason) or None when no object with a boolean `adequate` is found."""
+    import json
+
+    text = (response_text or "").strip()
+    if "```" in text:
+        start = text.find("```")
+        nl = text.find("\n", start)
+        end = text.find("```", nl + 1) if nl != -1 else -1
+        if nl != -1 and end != -1:
+            text = text[nl + 1 : end].strip()
+
+    for obj_start in range(len(text)):
+        if text[obj_start] != "{":
+            continue
+        block = balanced_object(text, obj_start)
+        if block is None:
+            continue
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("adequate"), bool):
+            reason = obj.get("reason")
+            reason = reason.strip() if isinstance(reason, str) else ""
+            return obj["adequate"], reason or "(no reason given)"
+    return None
+
+
+def judge_description_adequacy(
+    text, *, kind, invoke_text, usage=None, context="", tier="cheap"
+):
+    """Judge whether ``text`` is an adequate value for a ``kind`` field.
+
+    Returns ``(adequate, reason)``. Blank or sub-``_JUDGE_MIN_CHARS`` text is
+    judged inadequate WITHOUT an LLM call. Otherwise the cheap tier decides. The
+    judge fails toward ``adequate=False`` (regenerate) on an unparseable or failed
+    response — a needless regeneration is recoverable; silently keeping a
+    placeholder is not.
+
+    ``invoke_text`` is the ``llm.invoke.invoke_text`` callable (passed in after
+    bootstrap, per the casework convention of not importing ``llm`` in common).
+    """
+    stripped = (text or "").strip()
+    if len(stripped) < _JUDGE_MIN_CHARS:
+        return False, f"blank or too short (<{_JUDGE_MIN_CHARS} chars)"
+
+    user_prompt = (
+        f"FIELD: {kind}\n"
+        + (f"CONTEXT: {context}\n" if context else "")
+        + f'\nTEXT TO JUDGE:\n"""\n{stripped[:_JUDGE_TEXT_BUDGET]}\n"""\n\n'
+        "Return ONLY the JSON object."
+    )
+    try:
+        response_text = invoke_text(
+            system=_JUDGE_SYSTEM_PROMPT,
+            content=user_prompt,
+            max_tokens=300,
+            tier=tier,
+            usage=usage,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("adequacy judge call failed (%s): %s", kind, exc)
+        return False, f"judge call failed: {exc}"
+
+    verdict = _parse_judge_verdict(response_text)
+    if verdict is None:
+        log.warning("adequacy judge returned an unparseable verdict for %s", kind)
+        return False, "judge response unparseable; treating as inadequate"
+    return verdict
 
 
 # ── summary ──────────────────────────────────────────────────────────────────

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -210,8 +210,13 @@ def _process_case(
     want_title = only in ("title", "both")
     want_short = only in ("short", "both")
 
-    need_title = want_title and (
-        force or not _title_is_valid(current_title, court_number)
+    # Without a court number the title can never satisfy the format contract
+    # (must end in "(<court-number>)"), so regenerating would only burn an LLM
+    # call on a title that's guaranteed to be rejected — skip it.
+    need_title = (
+        want_title
+        and bool(court_number)
+        and (force or not _title_is_valid(current_title, court_number))
     )
     need_short = False
     if want_short:

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python
+"""Enrich a case's listing-card fields — TITLE and SHORT_DESCRIPTION — in one
+DB-free pass over the Jawafdehi HTTP API (no source documents fetched).
+
+Both fields derive from the case's ALREADY-enriched `description` (falling back to
+`key_allegations`), so this is a cheap, single LLM call that produces both:
+
+  * title           — a concise, searchable Nepali headline that MUST end with the
+                      special-court case number in parens, with no defendant
+                      headcount. Regenerated only when the current title fails that
+                      format contract (or with --force).
+  * short_description — the one-line card teaser the public list renders verbatim
+                      (CaseListSerializer ships it with no title/description
+                      fallback, so a blank one means an empty card). Regenerated
+                      when blank/placeholder per the cheap adequacy judge (or
+                      --force).
+
+Combining them is deliberate: same source (the existing description) and one LLM
+call yields both fields.
+
+Usage:
+    python casework/enrich_card.py --dry-run
+    python casework/enrich_card.py --slug case-0123
+    python casework/enrich_card.py --priority --force
+    python casework/enrich_card.py --only title --dry-run
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from typing import Optional
+
+# Ensure the api dir is in sys.path so imports work when run as a file
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from casework.common import (
+    CaseworkApi,
+    add_common_args,
+    balanced_object,
+    bootstrap,
+    get_target_cases,
+    judge_description_adequacy,
+    print_summary,
+    setup_logging,
+)
+
+logger = logging.getLogger(__name__)
+
+# A court case number like 080-CR-0047 / 081-WO-1234 (case-insensitive, anchored).
+COURT_RE = re.compile(r"(?<![\dA-Za-z])\d{2,3}-[A-Za-z]{1,3}-\d{3,4}(?![\dA-Za-z])")
+# Defendant-headcount the title must avoid (digit + जना/व्यक्ति/प्रतिवादी). The
+# court number itself won't match — it has no such trailing noun.
+HEADCOUNT_RE = re.compile(r"[०-९0-9]+\s*(जना|व्यक्ति|प्रतिवादी)")
+
+DESCRIPTION_SNIPPET_BUDGET = 3000
+MAX_SHORT_DESCRIPTION_CHARS = 320
+
+SYSTEM_PROMPT = """\
+You are a Nepali editor writing the public listing-card fields for a case in \
+Jawafdehi, a civic accountability archive of Nepal's anti-corruption cases \
+investigated by the CIAA and tried at the Special Court (विशेष अदालत). You are \
+given the case's current title, bigo (बिगो) amount, key allegations, and a snippet \
+of its full description. Produce up to two fields in formal Nepali (देवनागरी; keep \
+English technical/proper terms — "CR", company names — as-is).
+
+TITLE (when requested):
+- A concise, engaging, SEARCHABLE headline naming the real subject — the
+  institution/scheme and/or the principal accused, ideally the बिगो amount or the
+  nature of the offence. Vary construction across cases; be catchy but strictly
+  factual, grounded only in the provided data.
+- NEVER put a defendant HEADCOUNT in the title (no "<संख्या> जना", "X प्रतिवादी",
+  "समेत X जना", etc.). Many defendants → name the ONE principal accused/institution
+  with "लगायत"/"सहित" and NO number.
+- The title MUST end with the special-court case number in parentheses, exactly as
+  given, e.g. "… (080-CR-0047)". Keep it under ~160 characters.
+
+SHORT_DESCRIPTION (when requested):
+- A SINGLE punchy teaser, 1–2 sentences, ideally under 200 characters — the essence
+  (who/what/how much) at a glance. Plain prose: no court number, no markdown, no
+  headings/bullets. Neutral, factual, grounded in the provided data.
+
+Never invent names, amounts, sections, dates, or outcomes.
+
+OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose.
+Include only the requested key(s); set an unrequested key to null:
+{"title": "नेपाली शीर्षक (080-CR-0047)", "short_description": "एक-वाक्य सारांश"}
+"""
+
+USER_PROMPT = """\
+{request_note}
+
+Current title: {title}
+Special-court case number (MUST end any regenerated title): {court_number}
+Bigo (बिगो), NPR: {bigo}
+
+KEY ALLEGATIONS:
+{key_allegations}
+
+DESCRIPTION (snippet — the basis for both fields):
+{description}
+
+Return ONLY the JSON object described in the system prompt.
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Enrich case listing-card fields (title + short_description) "
+        "via LLM, DB-free over HTTP.",
+    )
+    add_common_args(ap)
+    ap.add_argument(
+        "--only",
+        choices=("title", "short", "both"),
+        default="both",
+        help="Which card field(s) to (re)generate (default: both).",
+    )
+    args = ap.parse_args()
+
+    setup_logging(args.verbose)
+
+    try:
+        bootstrap(args.provider, args.model)
+    except Exception as exc:
+        print(f"Bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    from llm.invoke import invoke_text
+    from llm.usage import UsageAccumulator, render_usage_table
+
+    try:
+        api = CaseworkApi(base_url=args.api_base_url, token=args.api_token)
+    except RuntimeError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    usage = UsageAccumulator()
+
+    # short_description is the natural skip signal: nothing populates it today, so
+    # virtually every card is processed and both fields get evaluated. A populated
+    # short_description skips the case unless --force.
+    cases = list(get_target_cases(api, args, skip_field="short_description"))
+    total = len(cases)
+    if total == 0:
+        print("No CIAA draft cases to process.", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Found {total} CIAA draft case(s) to process. Target: {args.only}")
+    if args.dry_run:
+        print("  [DRY RUN] No changes will be saved.")
+
+    stats = {
+        "cases_processed": 0,
+        "titles_enriched": 0,
+        "short_descriptions_enriched": 0,
+        "fields_already_ok": 0,
+        "cases_no_content": 0,
+        "cases_llm_error": 0,
+    }
+
+    for idx, case in enumerate(cases, 1):
+        try:
+            _process_case(
+                case=case,
+                idx=idx,
+                total=total,
+                only=args.only,
+                force=args.force,
+                dry_run=args.dry_run,
+                api=api,
+                usage=usage,
+                invoke_text=invoke_text,
+                stats=stats,
+            )
+        except Exception as exc:  # noqa: BLE001 — one case must not abort the batch
+            stats["cases_llm_error"] += 1
+            print(f"Unhandled error processing case: {exc}", file=sys.stderr)
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+
+    print_summary(stats, args.dry_run, "Card (title + short_description) enrichment")
+    if usage.calls > 0:
+        print()
+        print(render_usage_table(usage.as_dict()["by_provider"], title="card usage"))
+
+
+def _process_case(
+    case, idx, total, only, force, dry_run, api, usage, invoke_text, stats
+):
+    stats["cases_processed"] += 1
+    case_id = case.get("case_id", "?")
+    current_title = case.get("title", "")
+    print(f"\n[{idx}/{total}] {case_id} — {current_title[:80]}")
+
+    try:
+        detail = api.get_case(case.get("slug") or case_id)
+    except Exception:  # noqa: BLE001
+        detail = case
+        print("  (using summary instead of detail)")
+
+    current_title = detail.get("title", current_title)
+    court_number = _special_court_number(detail)
+
+    # Decide which fields need work.
+    want_title = only in ("title", "both")
+    want_short = only in ("short", "both")
+
+    need_title = want_title and (
+        force or not _title_is_valid(current_title, court_number)
+    )
+    need_short = False
+    if want_short:
+        if force:
+            need_short = True
+        else:
+            adequate, reason = judge_description_adequacy(
+                detail.get("short_description") or "",
+                kind="case card short description (one-line teaser)",
+                invoke_text=invoke_text,
+                usage=usage,
+                context=f"title={current_title[:80]}",
+            )
+            need_short = not adequate
+            if adequate:
+                print(f"  short_description already adequate ({reason})")
+
+    if not need_title and not need_short:
+        stats["fields_already_ok"] += 1
+        print("  Nothing to do (use --force to regenerate)")
+        return
+
+    description = (detail.get("description") or "").strip()
+    allegations = detail.get("key_allegations") or []
+    if not description and not allegations:
+        stats["cases_no_content"] += 1
+        print("  No description or allegations to derive from — skipping")
+        return
+
+    try:
+        result = _generate(
+            detail=detail,
+            court_number=court_number,
+            need_title=need_title,
+            need_short=need_short,
+            invoke_text=invoke_text,
+            usage=usage,
+        )
+    except Exception as exc:  # noqa: BLE001
+        stats["cases_llm_error"] += 1
+        print(f"  LLM generation failed: {exc}")
+        return
+    if not result:
+        stats["cases_llm_error"] += 1
+        print("  LLM returned no parseable result — skipping")
+        return
+
+    case_slug = detail.get("slug") or case.get("slug")
+
+    # ── title ──
+    if need_title:
+        new_title = (result.get("title") or "").strip()
+        issue = _validate_title(new_title, court_number) if new_title else "no title"
+        if not new_title or issue or _title_has_headcount(new_title):
+            why = issue or "contains a defendant headcount"
+            print(f"  TITLE rejected ({why}) — not writing")
+        else:
+            print(f"  TITLE: {new_title}")
+            if dry_run:
+                print("    [DRY RUN] would PATCH /title")
+            else:
+                try:
+                    api.patch_field(case_slug, "title", new_title)
+                    stats["titles_enriched"] += 1
+                    print("    [TITLE UPDATED]")
+                except Exception as exc:  # noqa: BLE001
+                    stats["cases_llm_error"] += 1
+                    print(f"    title PATCH failed: {exc}")
+
+    # ── short_description ──
+    if need_short:
+        new_short = (result.get("short_description") or "").strip()
+        if not new_short:
+            print("  SHORT rejected (empty) — not writing")
+        elif len(new_short) > MAX_SHORT_DESCRIPTION_CHARS:
+            print(
+                f"  SHORT rejected (too long: {len(new_short)} > "
+                f"{MAX_SHORT_DESCRIPTION_CHARS}) — not writing"
+            )
+        else:
+            print(f"  SHORT: {new_short}")
+            if dry_run:
+                print("    [DRY RUN] would PATCH /short_description")
+            else:
+                try:
+                    api.patch_field(case_slug, "short_description", new_short)
+                    stats["short_descriptions_enriched"] += 1
+                    print("    [SHORT UPDATED]")
+                except Exception as exc:  # noqa: BLE001
+                    stats["cases_llm_error"] += 1
+                    print(f"    short_description PATCH failed: {exc}")
+
+
+def _generate(detail, court_number, need_title, need_short, invoke_text, usage):
+    wanted = []
+    if need_title:
+        wanted.append("title")
+    if need_short:
+        wanted.append("short_description")
+    request_note = (
+        "Produce the title AND the short_description."
+        if len(wanted) == 2
+        else f"Only the {wanted[0]} is needed; set the other key to null."
+    )
+    description = (detail.get("description") or "").strip()
+    prompt = USER_PROMPT.format(
+        request_note=request_note,
+        title=detail.get("title", ""),
+        court_number=court_number or "(unknown)",
+        bigo=_format_bigo(detail.get("bigo")),
+        key_allegations=_format_list(detail.get("key_allegations")),
+        description=description[:DESCRIPTION_SNIPPET_BUDGET] or "(none)",
+    )
+    response_text = invoke_text(
+        system=SYSTEM_PROMPT,
+        content=prompt,
+        max_tokens=1000,
+        tier="cheap",
+        usage=usage,
+    )
+    return _parse_response(response_text)
+
+
+def _parse_response(response_text: str) -> Optional[dict]:
+    """Parse {title, short_description} from the response, scanning every '{' so
+    leading prose with braces doesn't abort the parse."""
+    text = (response_text or "").strip()
+    if "```" in text:
+        start = text.find("```")
+        nl = text.find("\n", start)
+        end = text.find("```", nl + 1) if nl != -1 else -1
+        if nl != -1 and end != -1:
+            text = text[nl + 1 : end].strip()
+
+    for obj_start in range(len(text)):
+        if text[obj_start] != "{":
+            continue
+        block = balanced_object(text, obj_start)
+        if block is None:
+            continue
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and ("title" in obj or "short_description" in obj):
+            return obj
+    logger.warning("No card JSON object found in LLM response")
+    return None
+
+
+def _special_court_number(case: dict) -> Optional[str]:
+    for ref in case.get("court_cases") or []:
+        if isinstance(ref, str) and ref.startswith("special:"):
+            return ref.split(":", 1)[1]
+    for ref in case.get("court_cases") or []:
+        if isinstance(ref, str) and ":" in ref:
+            return ref.split(":", 1)[1]
+    return None
+
+
+def _title_is_valid(title: str, court_number: Optional[str]) -> bool:
+    """A title is already valid when it ends with its special-court number in
+    parens AND carries no defendant headcount."""
+    if not title or not court_number:
+        return False
+    return _validate_title(title, court_number) is None and not _title_has_headcount(
+        title
+    )
+
+
+def _validate_title(title: str, court_number: Optional[str]) -> Optional[str]:
+    nums = {m.group(0).upper() for m in COURT_RE.finditer(title)}
+    if not nums:
+        return "no court case number"
+    if court_number and court_number.upper() not in nums:
+        return (
+            f"title number(s) {sorted(nums)} do not include the special-court "
+            f"number {court_number}"
+        )
+    if court_number:
+        expected = f"({court_number.upper()})"
+        if not title.upper().rstrip().endswith(expected):
+            return f"title must end with the case number in parentheses, e.g. '… {expected}'"
+    return None
+
+
+def _title_has_headcount(title: str) -> bool:
+    return bool(HEADCOUNT_RE.search(title or ""))
+
+
+def _format_bigo(bigo) -> str:
+    try:
+        value = int(bigo)
+    except (TypeError, ValueError):
+        return "(unknown)"
+    return f"{value:,}" if value > 0 else "(unknown)"
+
+
+def _format_list(items) -> str:
+    if not items:
+        return "(none provided)"
+    return "\n".join(f"- {x}" for x in items)
+
+
+if __name__ == "__main__":
+    main()

--- a/casework/enrich_evidence.py
+++ b/casework/enrich_evidence.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python
+"""Enrich the two description fields attached to a case's sources, in ONE
+source-fetching pass over the Jawafdehi HTTP API (DB-free):
+
+  1. DocumentSource.description — a REUSABLE, case-agnostic abstract of the
+     document itself (what it is, who issued it, when, identifiers, parties, a
+     short factual précis). Written via PATCH /api/sources/{source_id}/. Because a
+     source can be cited by many cases, it is written at most once per source per
+     run and only when blank/placeholder; the prompt hard-guards it against any
+     case-specific framing.
+
+  2. Evidence-entry description — a CASE-SPECIFIC note on the source's probative
+     role for THIS case's allegations. Written back into Case.evidence by replacing
+     the /evidence array.
+
+The expensive step — converting the source document to text — is shared: one fetch
++ one LLM call per evidence entry yields BOTH descriptions. Whether a field needs
+regenerating is decided by the cheap adequacy judge; --force regenerates regardless.
+
+Usage:
+    python casework/enrich_evidence.py --dry-run
+    python casework/enrich_evidence.py --slug case-0123
+    python casework/enrich_evidence.py --priority --target source
+    python casework/enrich_evidence.py --slug case-0123 --force
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Optional
+
+# Ensure the api dir is in sys.path so imports work when run as a file
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from casework.common import (
+    CaseworkApi,
+    add_common_args,
+    balanced_object,
+    bootstrap,
+    get_target_cases,
+    judge_description_adequacy,
+    print_summary,
+    setup_logging,
+)
+
+logger = logging.getLogger(__name__)
+
+SOURCE_TEXT_BUDGET = 40000
+CONVERTIBLE_ROLES = ("RAW", "ALTERNATE", "SOURCE_PAGE")
+
+SYSTEM_PROMPT = """\
+You are a Nepali legal editor for Jawafdehi, a civic accountability archive of \
+Nepal's anti-corruption cases. You are given ONE source document (its type, title \
+and full text) and the case that cites it (title, key allegations, named \
+entities). Produce TWO descriptions in formal Nepali (देवनागरी; keep English \
+technical and proper terms — "CR", company names — as-is).
+
+1. source_description — a REUSABLE, CASE-AGNOSTIC abstract of the DOCUMENT ITSELF:
+   what kind of document it is (अभियोगपत्र / फैसला / press release / audit report /
+   news article), its issuer or outlet, the key date stated in it, any identifiers
+   (CR / नि.नं. / मुद्दा नं.), the parties named in it, and a 1–3 line factual précis
+   of its contents.
+   CRITICAL: this text is shared by EVERY case that cites this document. It MUST NOT
+   mention "this case" (यस मुद्दा), the citing case's allegations, or frame the
+   document as evidence/proof. Describe ONLY the document. 2–5 sentences.
+
+2. evidence_description — a CASE-SPECIFIC note on the document's PROBATIVE ROLE for
+   THIS case: which allegation(s) it bears on and whether it is a primary record,
+   corroboration, or background context. Frame the role/weight relative to the
+   allegation; do NOT merely re-summarise the document's facts. 1–3 sentences.
+
+Ground every statement in the provided document text and case data; never invent
+names, amounts, sections, dates, or outcomes. If the document text is insufficient
+for a field, write a faithful minimal description from what is available rather than
+fabricating.
+
+OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose:
+{"source_description": "…", "evidence_description": "…"}
+"""
+
+USER_PROMPT = """\
+{targets_note}
+
+SOURCE DOCUMENT
+Type: {source_type}
+Title: {source_title}
+
+CITING CASE
+Title: {case_title}
+Court case: {court_number}
+Key allegations:
+{allegations}
+Named entities:
+{entities}
+
+DOCUMENT TEXT:
+{source_text}
+
+Return ONLY the JSON object described in the system prompt.
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Enrich DocumentSource + evidence-entry descriptions via LLM, "
+        "DB-free over HTTP.",
+    )
+    add_common_args(ap)
+    ap.add_argument(
+        "--target",
+        choices=("source", "evidence", "both"),
+        default="both",
+        help="Which description(s) to regenerate (default: both).",
+    )
+    args = ap.parse_args()
+
+    setup_logging(args.verbose)
+
+    try:
+        bootstrap(args.provider, args.model)
+    except Exception as exc:
+        print(f"Bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    from llm.invoke import invoke_text
+    from llm.usage import UsageAccumulator, render_usage_table
+
+    try:
+        api = CaseworkApi(base_url=args.api_base_url, token=args.api_token)
+    except RuntimeError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    usage = UsageAccumulator()
+
+    # Evidence enrichment maps to no single case field; the per-entry judge decides
+    # what to regenerate. Pass an empty skip_field so every DRAFT CIAA case is
+    # scanned (case.get("") is None → never skipped at the list stage).
+    cases = list(get_target_cases(api, args, skip_field=""))
+    total = len(cases)
+    if total == 0:
+        print("No CIAA draft cases to process.", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Found {total} CIAA draft case(s) to process. Target: {args.target}")
+    if args.dry_run:
+        print("  [DRY RUN] No changes will be saved.")
+
+    # Source-level descriptions are reusable: once a source_id is handled in this
+    # run, later cases citing it must not re-judge or re-write it.
+    sources_done: set[str] = set()
+    stats = {
+        "cases_processed": 0,
+        "sources_enriched": 0,
+        "evidence_enriched": 0,
+        "entries_already_ok": 0,
+        "entries_no_content": 0,
+        "llm_errors": 0,
+    }
+
+    for idx, case in enumerate(cases, 1):
+        try:
+            _process_case(
+                case=case,
+                idx=idx,
+                total=total,
+                target=args.target,
+                force=args.force,
+                dry_run=args.dry_run,
+                api=api,
+                usage=usage,
+                invoke_text=invoke_text,
+                sources_done=sources_done,
+                stats=stats,
+            )
+        except Exception as exc:  # noqa: BLE001 — one case must not abort the batch
+            stats["llm_errors"] += 1
+            print(f"Unhandled error processing case: {exc}", file=sys.stderr)
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+
+    print_summary(stats, args.dry_run, "Evidence/source description enrichment")
+    if usage.calls > 0:
+        print()
+        print(
+            render_usage_table(usage.as_dict()["by_provider"], title="evidence usage")
+        )
+
+
+def _process_case(
+    case,
+    idx,
+    total,
+    target,
+    force,
+    dry_run,
+    api,
+    usage,
+    invoke_text,
+    sources_done,
+    stats,
+):
+    stats["cases_processed"] += 1
+    case_id = case.get("case_id", "?")
+    print(f"\n[{idx}/{total}] {case_id} — {case.get('title', '')[:80]}")
+
+    try:
+        detail = api.get_case(case.get("slug") or case_id)
+    except Exception:  # noqa: BLE001
+        detail = case
+        print("  (using summary instead of detail)")
+
+    slug = detail.get("slug") or case.get("slug")
+    court_number = _special_court_number(detail)
+    case_title = detail.get("title", "")
+    allegations = detail.get("key_allegations")
+    entities = detail.get("entities")
+
+    evidence = detail.get("evidence") or []
+    if not evidence:
+        print("  No evidence — skipping")
+        return
+
+    writable = _writable_evidence(evidence)
+    evidence_changed = False
+
+    for pos, entry in enumerate(evidence):
+        source_id = _resolve_source_id(entry)
+        if not source_id:
+            continue
+        src = entry.get("source") or {}
+        source_type = src.get("source_type") or "MISC"
+        source_title = src.get("title") or ""
+        urls = src.get("urls") or []
+        evidence_desc = entry.get("description") or ""
+
+        do_source = target in ("source", "both") and source_id not in sources_done
+        do_evidence = target in ("evidence", "both")
+
+        need_source = False
+        if do_source:
+            current_src_desc = ""
+            try:
+                current_src_desc = (api.get_source(source_id) or {}).get(
+                    "description", ""
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("  source GET failed for %s: %s", source_id, exc)
+            if force:
+                need_source = True
+            else:
+                adequate, reason = judge_description_adequacy(
+                    current_src_desc,
+                    kind="document source description (what the document is)",
+                    invoke_text=invoke_text,
+                    usage=usage,
+                    context=f"source_type={source_type}; title={source_title[:80]}",
+                )
+                need_source = not adequate
+                if adequate:
+                    sources_done.add(source_id)
+
+        need_evidence = False
+        if do_evidence:
+            if force:
+                need_evidence = True
+            else:
+                adequate, _ = judge_description_adequacy(
+                    evidence_desc,
+                    kind="evidence relevance note (a source's probative role for an allegation)",
+                    invoke_text=invoke_text,
+                    usage=usage,
+                    context=f"case={case_title[:80]}",
+                )
+                need_evidence = not adequate
+
+        if not need_source and not need_evidence:
+            stats["entries_already_ok"] += 1
+            continue
+
+        source_text = _source_text(urls)
+        if not source_text:
+            stats["entries_no_content"] += 1
+            print(f"  {source_id}: no convertible source content — skip")
+            if do_source:
+                sources_done.add(source_id)  # don't retry an empty source elsewhere
+            continue
+
+        try:
+            result = _generate(
+                source_type=source_type,
+                source_title=source_title,
+                case_title=case_title,
+                court_number=court_number,
+                allegations=allegations,
+                entities=entities,
+                source_text=source_text,
+                need_source=need_source,
+                need_evidence=need_evidence,
+                invoke_text=invoke_text,
+                usage=usage,
+            )
+        except Exception as exc:  # noqa: BLE001
+            stats["llm_errors"] += 1
+            print(f"  {source_id}: LLM failed: {exc}")
+            continue
+        if not result:
+            stats["llm_errors"] += 1
+            print(f"  {source_id}: no parseable result — skip")
+            continue
+
+        # ── source description (reusable) ──
+        new_src = (result.get("source_description") or "").strip()
+        if need_source and new_src:
+            sources_done.add(source_id)
+            print(f"  {source_id} SOURCE: {new_src[:140]}")
+            if dry_run:
+                print("    [DRY RUN] would PATCH /api/sources/")
+            else:
+                try:
+                    api.patch_source(source_id, "description", new_src)
+                    stats["sources_enriched"] += 1
+                    print("    [SOURCE UPDATED]")
+                except Exception as exc:  # noqa: BLE001
+                    stats["llm_errors"] += 1
+                    print(f"    source PATCH failed: {exc}")
+
+        # ── evidence description (case-specific) ──
+        new_ev = (result.get("evidence_description") or "").strip()
+        if need_evidence and new_ev:
+            print(f"  {source_id} EVIDENCE: {new_ev[:140]}")
+            writable[pos]["description"] = new_ev
+            evidence_changed = True
+
+    if evidence_changed:
+        if dry_run:
+            print("  [DRY RUN] would PATCH /evidence")
+        else:
+            try:
+                api.patch_field(slug, "evidence", writable)
+                stats["evidence_enriched"] += 1
+                print(f"  [EVIDENCE UPDATED] {case_id}")
+            except Exception as exc:  # noqa: BLE001
+                stats["llm_errors"] += 1
+                print(f"  evidence PATCH failed: {exc}")
+
+
+# ── source text acquisition (body only; not the existing evidence description) ──
+
+
+def _source_text(urls: list) -> Optional[str]:
+    """Convert a source's url list to document text: prefer a MARKDOWN-role link,
+    else convert a RAW/ALTERNATE/SOURCE_PAGE link. Unlike
+    common.content_from_evidence_entry this never falls back to the evidence
+    description (that would be circular — we are writing descriptions ABOUT the
+    document). Returns None when no sufficient text can be obtained."""
+    if not urls:
+        return None
+    md_link = next(
+        (
+            u["link"]
+            for u in urls
+            if isinstance(u, dict) and u.get("role") == "MARKDOWN" and u.get("link")
+        ),
+        None,
+    )
+    if md_link:
+        try:
+            from sourcing import jds_client
+
+            content, _ = jds_client.download_source_file(md_link)
+            text = content.decode("utf-8", errors="replace")
+            if len(text) > 200:
+                return text[:SOURCE_TEXT_BUDGET]
+        except Exception:  # noqa: BLE001
+            pass
+
+    convertible = [
+        u["link"]
+        for u in urls
+        if isinstance(u, dict) and u.get("link") and u.get("role") in CONVERTIBLE_ROLES
+    ]
+    if convertible:
+        try:
+            from sourcing import converter as source_converter
+
+            result = source_converter.convert_source({"url": convertible})
+            if result.get("status") in ("converted", "attached"):
+                text = (result.get("markdown") or "").strip()
+                if len(text) > 200:
+                    return text[:SOURCE_TEXT_BUDGET]
+        except Exception:  # noqa: BLE001
+            pass
+    return None
+
+
+# ── LLM generation ────────────────────────────────────────────────────────────
+
+
+def _generate(
+    source_type,
+    source_title,
+    case_title,
+    court_number,
+    allegations,
+    entities,
+    source_text,
+    need_source,
+    need_evidence,
+    invoke_text,
+    usage,
+) -> Optional[dict]:
+    wanted = []
+    if need_source:
+        wanted.append("source_description")
+    if need_evidence:
+        wanted.append("evidence_description")
+    targets_note = (
+        "Produce BOTH descriptions."
+        if len(wanted) == 2
+        else f"Only the {wanted[0]} is needed (still return the JSON object with "
+        "both keys; the other may be an empty string)."
+    )
+    prompt = USER_PROMPT.format(
+        targets_note=targets_note,
+        source_type=source_type,
+        source_title=source_title or "(untitled)",
+        case_title=case_title or "(unknown)",
+        court_number=court_number or "(unknown)",
+        allegations=_format_list(allegations),
+        entities=_format_entities(entities),
+        source_text=source_text,
+    )
+    response_text = invoke_text(
+        system=SYSTEM_PROMPT,
+        content=prompt,
+        max_tokens=1500,
+        tier="premium",
+        usage=usage,
+    )
+    return _parse_response(response_text)
+
+
+def _parse_response(response_text: str) -> Optional[dict]:
+    text = (response_text or "").strip()
+    if "```" in text:
+        start = text.find("```")
+        nl = text.find("\n", start)
+        end = text.find("```", nl + 1) if nl != -1 else -1
+        if nl != -1 and end != -1:
+            text = text[nl + 1 : end].strip()
+
+    for obj_start in range(len(text)):
+        if text[obj_start] != "{":
+            continue
+        block = balanced_object(text, obj_start)
+        if block is None:
+            continue
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and (
+            "source_description" in obj or "evidence_description" in obj
+        ):
+            return obj
+    logger.warning("No description JSON object found in LLM response")
+    return None
+
+
+# ── evidence helpers ──────────────────────────────────────────────────────────
+
+
+def _resolve_source_id(entry: dict) -> Optional[str]:
+    """Extract the string source_id from an evidence entry (the API may embed it
+    as a dict, mirroring CaseDetailSerializer.resolve_source_id)."""
+    sid = entry.get("source_id")
+    if isinstance(sid, dict):
+        return sid.get("source_id") or sid.get("link")
+    return sid if isinstance(sid, str) and sid else None
+
+
+def _writable_evidence(evidence: list) -> list[dict]:
+    """Reduce read-shape evidence (each entry carries a nested `source`) to the
+    writable [{source_id, description}] shape CasePatchSerializer expects,
+    preserving order and existing descriptions."""
+    out = []
+    for entry in evidence:
+        out.append(
+            {
+                "source_id": _resolve_source_id(entry) or "",
+                "description": entry.get("description") or "",
+            }
+        )
+    return out
+
+
+def _special_court_number(case: dict) -> Optional[str]:
+    for ref in case.get("court_cases") or []:
+        if isinstance(ref, str) and ref.startswith("special:"):
+            return ref.split(":", 1)[1]
+    for ref in case.get("court_cases") or []:
+        if isinstance(ref, str) and ":" in ref:
+            return ref.split(":", 1)[1]
+    return None
+
+
+def _format_list(items) -> str:
+    if not items:
+        return "(none provided)"
+    return "\n".join(f"- {x}" for x in items)
+
+
+def _format_entities(entities) -> str:
+    if not entities:
+        return "(none provided)"
+    lines = []
+    for e in entities:
+        if not isinstance(e, dict):
+            continue
+        name = e.get("display_name") or ""
+        etype = e.get("type") or ""
+        line = f"- [{etype}] {name}"
+        if e.get("notes"):
+            line += f" — {e['notes']}"
+        lines.append(line)
+    return "\n".join(lines) or "(none provided)"
+
+
+if __name__ == "__main__":
+    main()

--- a/casework/enrich_evidence.py
+++ b/casework/enrich_evidence.py
@@ -220,9 +220,14 @@ def _process_case(
     allegations = detail.get("key_allegations")
     entities = detail.get("entities")
 
-    evidence = detail.get("evidence") or []
+    # Only entries with a resolvable source_id: the loop skips the rest anyway,
+    # and including them would put an empty source_id into the /evidence replace
+    # payload, which fails EvidenceListField validation and aborts the whole
+    # PATCH. Filtering here keeps `evidence` and `writable` index-aligned. Validly
+    # stored evidence always carries a source_id, so nothing real is dropped.
+    evidence = [e for e in (detail.get("evidence") or []) if _resolve_source_id(e)]
     if not evidence:
-        print("  No evidence — skipping")
+        print("  No valid evidence entries — skipping")
         return
 
     writable = _writable_evidence(evidence)


### PR DESCRIPTION
## Summary

Two new DB-free `casework/` enrichment scripts (the post-#217 pattern — not Django management commands), plus a shared cheap-model adequacy judge in `casework/common.py`.

- **`casework/enrich_card.py`** — regenerates a case's listing-card fields, **title** and **short_description**, in one LLM call derived from the already-enriched `description` (fallback `key_allegations`); no source documents fetched. Title is gated by the court-number-in-parens format contract + headcount guard; short_description by the adequacy judge. `short_description` had no enricher and the public list card renders it verbatim with no fallback, so a blank one = an empty card.
- **`casework/enrich_evidence.py`** — in one source-fetching pass, regenerates the **reusable, case-agnostic `DocumentSource.description`** (PATCH `/api/sources/`, written once per source via a run dedup set) **and** the **case-specific evidence-entry probative note** (replace `/evidence`). One fetch + one LLM call yields both fields.
- **`casework/common.py`** — `judge_description_adequacy()` (cheap-tier gate: blank/short text short-circuits with no call; fails toward regenerate on an unparseable verdict) + `CaseworkApi.get_source()`/`patch_source()` for the DocumentSource endpoint (plain DRF partial update, not RFC-6902).

## Design notes

- **Title vs short_description combined** deliberately: same source (existing description), one call yields both.
- **Source vs evidence split** for `enrich_evidence`: source description describes the *document* (case-agnostic, reusable across citing cases); evidence note describes the *probative role* for this case (references the allegation/court number). The prompt hard-guards the source description against case framing.
- All scripts follow the `casework/` conventions: `bootstrap()`, `CaseworkApi`, `get_target_cases(skip_field=…)`, `--provider/--model/--dry-run/--priority/--force`, LLM via `llm.invoke`, usage table.

## Validation (dry-run on priority cases via `claude-opus-4-8[1m]`)

- `enrich_card --priority --limit 3 --dry-run`: produced accurate Nepali one-liners; titles already format-valid so correctly left untouched. ~$0.13/3 cases.
- `enrich_evidence --priority --limit 5 --dry-run`: source/evidence split held in practice (e.g. a news article tagged as *background/supporting, not a primary record*); judge + dedup gating worked (8 source descriptions vs 23 evidence notes across 5 cases); 0 errors. ~$2.77/5 cases.

## Test plan

Per the `casework/` convention these DB-free scripts are validated by dry-run, not unit tests.

- [ ] `python casework/enrich_card.py --priority --limit 5 --dry-run` — eyeball titles/short_descriptions
- [ ] `python casework/enrich_evidence.py --priority --limit 5 --dry-run` — confirm source (document abstract) vs evidence (probative role) stay distinct
- [ ] A `--force` `enrich_card` run to exercise the title-regeneration path (not hit in dry-run since priority titles were already valid)
- [ ] Live run with a **write-capable** token on a small `--limit` before any batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source document retrieval and update capabilities via API
  * Introduced case card enrichment with automatic title and description field generation
  * Introduced evidence description enrichment with integrated source document support
  * Added description adequacy evaluation to optimize when regeneration is needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->