### PR TITLE
Build review-poller image for arm64 (native arm runner)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,10 +44,12 @@ jobs:
           cache-to: type=gha,mode=max
 
   # review-poller image: API image + node + the claude/codex CLIs. Build-tested on
-  # every PR (push:false); published on main so Keel can pull it. amd64-only because
-  # the codex npm native binary is unreliable to install under arm64 QEMU emulation.
+  # every PR (push:false); published on main so Keel can pull it. Built linux/arm64
+  # on a NATIVE arm64 runner (not QEMU): the review-poller is scheduled on the arm64
+  # Oracle nodes, and the codex npm native binary is unreliable to install under
+  # arm64 QEMU emulation — building natively avoids that.
   build-and-push-poller:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
@@ -71,7 +73,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.poller
-          platforms: linux/amd64
+          platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.poller
+++ b/Dockerfile.poller
@@ -3,8 +3,8 @@
 # (`casework/review_runner.py`). Mirrors the main API Dockerfile but adds Node.js +
 # the claude/codex CLIs (codex_cli / claude_cli judge providers), LibreOffice +
 # the document-conversion deps (so evidence PDFs/docs convert to text instead of
-# 0 chars). Built amd64-only (the codex npm package ships a native binary that is
-# unreliable to install under arm64 QEMU emulation) — schedule on an amd64 node.
+# 0 chars). Built linux/arm64 on a native arm64 CI runner (the codex npm native
+# binary is unreliable under arm64 QEMU) — scheduled on the arm64 Oracle nodes.
 
 FROM python:3.12-slim
 


### PR DESCRIPTION
## Summary

The review-poller is being scheduled on the **arm64 Oracle nodes** (oci-instance1/2), so its image must be arm64. The previous build was amd64-only.

- Build `build-and-push-poller` on a **native `ubuntu-24.04-arm` runner** with `platforms: linux/arm64` (no QEMU). The codex npm native binary is unreliable to install under arm64 QEMU emulation — building natively on arm avoids that.
- Update Dockerfile.poller header to match.

## Test plan
- [ ] CI `build-and-push-poller` runs on the arm runner and the linux/arm64 image builds (incl. `npm i -g @openai/codex` and LibreOffice) — this is the key validation.
- [ ] After merge, the `:main` arm64 image is pulled by the review-poller deployment (pinned to `kubernetes.io/arch=arm64`).

> Pairs with the infra deployment change pinning review-poller to the arm64 nodes with 2Gi RAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)