### PR TITLE
feat(cases): retrieve a case by court case reference

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -503,13 +503,15 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
 
     def _get_object_by_court_case(self, lookup_value):
         court_identifier, _, raw_case_number = lookup_value.partition(":")
-        court_identifier = court_identifier.strip()
+        # court_cases JSON containment is case-sensitive and identifiers are
+        # stored lowercase, so normalize the identifier casing too.
+        court_identifier = court_identifier.strip().lower()
         raw_case_number = raw_case_number.strip()
 
         try:
             case_number = normalize_case_number(raw_case_number)
         except ValueError:
-            raise NotFound(f"No case found for court case '{lookup_value}'.")
+            raise NotFound(f"No case found for court case '{lookup_value}'.") from None
 
         identifier = f"{court_identifier}:{case_number}"
         queryset = self.filter_queryset(self.get_queryset())
@@ -520,15 +522,24 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.filter(court_cases__contains=[identifier])
         else:
             matching_ids = [
-                case.id
-                for case in queryset
-                if case.court_cases and identifier in case.court_cases
+                case_id
+                for case_id, court_cases in queryset.values_list("id", "court_cases")
+                if court_cases and identifier in court_cases
             ]
             queryset = queryset.filter(id__in=matching_ids)
 
-        # Ordered by -created_at in get_queryset(), so when several cases cite
-        # the same court case the most recently created visible one wins.
-        obj = queryset.first()
+        # Ordered by -created_at in get_queryset(). When several cases cite the
+        # same court case, return the most recent one the caller may view, so a
+        # newer unviewable DRAFT does not shadow an older viewable case.
+        obj = next(
+            (
+                case
+                for case in queryset
+                if case.state != CaseState.DRAFT
+                or can_view_case(self.request.user, case)
+            ),
+            None,
+        )
         if obj is None:
             raise NotFound(f"No case found for court case '{identifier}'.")
 

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -25,6 +25,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import filters, mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
+from rest_framework.exceptions import NotFound
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework.renderers import JSONRenderer
@@ -32,6 +33,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from config.oidc import OIDCJWTAuthentication
+from ngm.services import normalize_case_number
 
 from .admin import CaseAdminForm
 from .caseworker_serializers import (
@@ -263,7 +265,13 @@ class UnifiedSearchView(APIView):
         description="""
         Retrieve detailed information about a specific case.
 
-        The endpoint accepts either a numeric ID (deprecated) or a slug (preferred format: kebab-case).
+        The endpoint accepts either a numeric ID (deprecated), a slug (preferred
+        format: kebab-case), or a court case reference of the form
+        `{court_identifier}:{case_number}` (e.g. `supreme:081-CR-0081`). The case
+        number in a court case reference is normalized like NGM (Devanagari
+        digits, casing, zero-padding) and matched against the case's
+        `court_cases` list; when several cases cite the same court case, the most
+        recently created visible one is returned.
 
         This endpoint includes complete case data (title, description, allegations,
         evidence, timeline) and any internal notes.
@@ -280,7 +288,7 @@ class UnifiedSearchView(APIView):
                 name="id",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.PATH,
-                description="Case identifier - either numeric ID (deprecated) or slug",
+                description="Case identifier - numeric ID (deprecated), slug, or court case reference {court_identifier}:{case_number} (e.g. supreme:081-CR-0081)",
                 required=True,
             ),
         ],
@@ -477,9 +485,62 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
         )
         return Response(CaseSerializer(case).data, status=status.HTTP_201_CREATED)
 
+    def get_object(self):
+        """
+        Resolve the detail lookup value as a slug or a court case reference.
+
+        Slugs never contain a colon, so a lookup value shaped like
+        ``{court_identifier}:{case_number}`` (e.g. ``supreme:81-cr-81``) is
+        treated as a court case reference: the case number is normalized the
+        same way NGM normalizes it and matched against the ``court_cases``
+        JSON list. Restricted to retrieve so PATCH keeps its single-target
+        slug semantics.
+        """
+        lookup_value = self.kwargs.get(self.lookup_field) or ""
+        if self.action == "retrieve" and ":" in lookup_value:
+            return self._get_object_by_court_case(lookup_value)
+        return super().get_object()
+
+    def _get_object_by_court_case(self, lookup_value):
+        court_identifier, _, raw_case_number = lookup_value.partition(":")
+        court_identifier = court_identifier.strip()
+        raw_case_number = raw_case_number.strip()
+
+        try:
+            case_number = normalize_case_number(raw_case_number)
+        except ValueError:
+            raise NotFound(f"No case found for court case '{lookup_value}'.")
+
+        identifier = f"{court_identifier}:{case_number}"
+        queryset = self.filter_queryset(self.get_queryset())
+
+        # JSONField containment is only available on PostgreSQL; SQLite (tests)
+        # filters in Python, mirroring the tag-filter path in get_queryset().
+        if connection.vendor == "postgresql":
+            queryset = queryset.filter(court_cases__contains=[identifier])
+        else:
+            matching_ids = [
+                case.id
+                for case in queryset
+                if case.court_cases and identifier in case.court_cases
+            ]
+            queryset = queryset.filter(id__in=matching_ids)
+
+        # Ordered by -created_at in get_queryset(), so when several cases cite
+        # the same court case the most recently created visible one wins.
+        obj = queryset.first()
+        if obj is None:
+            raise NotFound(f"No case found for court case '{identifier}'.")
+
+        self.check_object_permissions(self.request, obj)
+        return obj
+
     def retrieve(self, request, *args, **kwargs):
         """
         GET /api/cases/{id}/
+
+        The detail lookup value may be a slug or a court case reference
+        (``{court_identifier}:{case_number}``); see get_object().
 
         Retrieve a case with permission-based access control:
         - PUBLISHED and IN_REVIEW cases: accessible to everyone

--- a/tests/api/test_case_lookup_by_court_case.py
+++ b/tests/api/test_case_lookup_by_court_case.py
@@ -8,6 +8,7 @@ case's court_cases list.
 """
 
 import pytest
+from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 
 from cases.models import CaseState, CaseType
@@ -106,3 +107,45 @@ def test_court_case_lookup_returns_most_recent_when_multiple_cases_match():
 
     assert response.status_code == 200
     assert response.data["case_id"] == newer.case_id
+
+
+@pytest.mark.django_db
+def test_court_case_lookup_is_case_insensitive_on_court_identifier():
+    case = create_case_with_entities(
+        title="Mixed Case Identifier",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    response = APIClient().get("/api/cases/Supreme:081-CR-0081/")
+
+    assert response.status_code == 200
+    assert response.data["case_id"] == case.case_id
+
+
+@pytest.mark.django_db
+def test_court_case_lookup_does_not_shadow_published_with_unauthorized_draft():
+    older_published = create_case_with_entities(
+        title="Older Published Case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+    create_case_with_entities(
+        title="Newer Draft Case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    user = get_user_model().objects.create_user(
+        username="regular_user", password="password"
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/cases/supreme:081-CR-0081/")
+
+    assert response.status_code == 200
+    assert response.data["case_id"] == older_published.case_id

--- a/tests/api/test_case_lookup_by_court_case.py
+++ b/tests/api/test_case_lookup_by_court_case.py
@@ -1,0 +1,108 @@
+"""
+Tests for retrieving a case by a court case reference.
+
+GET /api/cases/{lookup}/ accepts a slug or a court case reference of the form
+{court_identifier}:{case_number}. The case number is normalized like NGM
+(casing, zero-padding, Devanagari digits) before being matched against the
+case's court_cases list.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from cases.models import CaseState, CaseType
+from tests.conftest import create_case_with_entities
+
+
+@pytest.mark.django_db
+def test_retrieve_published_case_by_exact_court_case_reference():
+    case = create_case_with_entities(
+        title="Court Case Lookup",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    response = APIClient().get("/api/cases/supreme:081-CR-0081/")
+
+    assert response.status_code == 200
+    assert response.data["case_id"] == case.case_id
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "lookup",
+    [
+        "supreme:81-cr-81",  # missing zero-padding
+        "supreme:081-cr-0081",  # lowercase middle code
+        "supreme:०८१-CR-००८१",  # Devanagari digits
+    ],
+)
+def test_retrieve_normalizes_court_case_number(lookup):
+    case = create_case_with_entities(
+        title="Normalize Lookup",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    response = APIClient().get(f"/api/cases/{lookup}/")
+
+    assert response.status_code == 200
+    assert response.data["case_id"] == case.case_id
+
+
+@pytest.mark.django_db
+def test_retrieve_unknown_court_case_returns_404():
+    create_case_with_entities(
+        title="Other Case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    response = APIClient().get("/api/cases/supreme:099-CR-9999/")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_retrieve_invalid_court_case_number_returns_404():
+    response = APIClient().get("/api/cases/supreme:not-a-number/")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_court_case_lookup_does_not_expose_draft_to_anonymous():
+    create_case_with_entities(
+        title="Secret Draft",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    response = APIClient().get("/api/cases/supreme:081-CR-0081/")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_court_case_lookup_returns_most_recent_when_multiple_cases_match():
+    create_case_with_entities(
+        title="Older Case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+    newer = create_case_with_entities(
+        title="Newer Case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.PUBLISHED,
+        court_cases=["supreme:081-CR-0081"],
+    )
+
+    response = APIClient().get("/api/cases/supreme:081-CR-0081/")
+
+    assert response.status_code == 200
+    assert response.data["case_id"] == newer.case_id


### PR DESCRIPTION
## Summary
- The case detail endpoint `GET /api/cases/{lookup}/` now resolves a **court case reference** of the form `{court_identifier}:{case_number}` (e.g. `supreme:081-CR-0081`) in addition to the existing slug lookup. Slugs never contain a colon, so the colon unambiguously signals a court-case lookup.
- The case number is normalized the same way NGM normalizes it (casing, zero-padding, Devanagari → ASCII digits) via `ngm.services.normalize_case_number`, then matched against the case's `court_cases` JSON list (Postgres `__contains`, with a Python fallback for SQLite mirroring the existing tag-filter path).
- Scoped to the `retrieve` action so PATCH keeps its single-target slug semantics. Existing state/visibility and DRAFT authorization rules are unchanged. When several cases cite the same court case, the most recently created *visible* one is returned.
- OpenAPI docs for the retrieve endpoint updated.

## Test plan
- [x] New `tests/api/test_case_lookup_by_court_case.py` (8 tests): exact match, normalization incl. Devanagari, unknown court case → 404, invalid number format → 404, DRAFT not exposed to anonymous, most-recent-on-multiple-matches.
- [x] Existing `tests/api/test_public_api.py` still passes (slug lookup unaffected).
- [x] `ruff` + `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for retrieving cases by court case reference using `{court_identifier}:{case_number}` format in API lookups
  * Automatic normalization of court case numbers including zero-padding, casing, and Devanagari digit conversion
  * Returns the most recently created case when multiple cases match the same court reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->