### PR TITLE
fix(ngm): accept OIDC bearer on /api/ngm/query_judicial

### DIFF
--- a/ngm/api_views.py
+++ b/ngm/api_views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from cases.throttles import RoleBasedRateThrottle
+from config.oidc import OIDCJWTAuthentication
 from ngm.serializers import CourtCaseDetailSerializer, NGMQuerySerializer
 from ngm.services import (
     execute_select_query,
@@ -64,7 +65,10 @@ class NGMQueryRateThrottle(RoleBasedRateThrottle):
     request=NGMQuerySerializer,
 )
 class NGMJudicialQueryView(APIView):
-    authentication_classes = [TokenAuthentication]
+    # OIDC bearer (e.g. forwarded by jawafdehi-mcp) + DRF token for scripted
+    # access. Previously TokenAuthentication only, which 401s the MCP's
+    # Authorization: Bearer; the per-token throttle falls back to user pk.
+    authentication_classes = [OIDCJWTAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     throttle_classes = [NGMQueryRateThrottle]
 


### PR DESCRIPTION
## Summary
`NGMJudicialQueryView` (`POST /api/ngm/query_judicial`) only declared `authentication_classes = [TokenAuthentication]`, so it was **missed in the OIDC migration** (#227 moved cases / case_workflows / nesq to `OIDCJWTAuthentication`).

When jawafdehi-mcp forwards the user's `Authorization: Bearer <Zitadel JWT>` (for `ngm_query_judicial` / `ngm_extract_case_data`), DRF's `TokenAuthentication` ignores it (wrong `Token` keyword) → no auth class succeeds → **401 "Authentication credentials were not provided."** `/api/cases/` works because it accepts OIDC.

## Fix
Add `OIDCJWTAuthentication` alongside `TokenAuthentication` on the view (one-liner, mirrors the other endpoints). The per-token throttle (`NGMQueryRateThrottle.get_authenticated_ident`) already falls back to `request.user.pk` when there's no token key, so OIDC callers bucket per user and tier limits still resolve from Django groups.

## Repro (prod, before fix)
MCP log: `POST https://portal.jawafdehi.org/api/ngm/query_judicial "HTTP/1.1 401 Unauthorized"` → `{"detail": "Authentication credentials were not provided."}` for an authenticated (admin/staff) chat user, while `/api/cases/` returned 200 for the same bearer.

## Test plan
- [ ] CI (ruff/black/pytest) green
- [ ] `tests/ngm/test_api.py` passes; add/confirm a case for OIDC-bearer auth on `query_judicial`
- [ ] Manual: call `/api/ngm/query_judicial` with a Zitadel bearer → 200 (was 401); with a DRF `Token` → still 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)