### PR TITLE
feat(observability): per-endpoint Prometheus metrics (django-prometheus)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry config virtualenvs.create false && poetry install --only main --extras llm-all --no-interaction --no-root
 
 COPY manage.py ./
+COPY gunicorn.conf.py ./
 COPY config ./config
 COPY cases ./cases
 COPY case_workflows ./case_workflows
@@ -42,4 +43,4 @@ RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org python man
 
 EXPOSE 8080
 
-CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8080", "--workers", "2", "--threads", "4", "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "config.wsgi:application"]

--- a/config/settings.py
+++ b/config/settings.py
@@ -196,6 +196,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_prometheus",
     "rest_framework",
     "rest_framework.authtoken",
     "mozilla_django_oidc",
@@ -230,6 +231,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # Must be first: starts the per-request timer / in-flight gauge.
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "config.middleware.RequestIdMiddleware",
     "config.middleware.ForcePrimaryReadsMiddleware",
@@ -243,6 +246,8 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "config.middleware.JWTAuditlogMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    # Must be last: records latency/status/count, labelled by resolved view.
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/config/urls.py
+++ b/config/urls.py
@@ -31,6 +31,9 @@ from content.api import api_router as wagtail_api_router
 urlpatterns = [
     path("", index, name="index"),
     path("docs/", docs, name="docs"),
+    # Prometheus exposition (django-prometheus). Scraped in-cluster by vmagent on
+    # the pod IP; blocked from the public ingress via a Traefik ipAllowList.
+    path("", include("django_prometheus.urls")),
     path("admin/", admin.site.urls),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,21 @@
+"""Gunicorn config.
+
+Carries the same bind/worker settings the Dockerfile CMD used to pass as flags,
+plus the multiprocess hook django-prometheus needs: with >1 worker process each
+worker writes its metrics to a shared dir (PROMETHEUS_MULTIPROC_DIR, an emptyDir
+in the k8s deployment) and the /metrics view aggregates across them. When a worker
+dies its db files must be reaped so its counters stop being double-counted.
+"""
+
+bind = "0.0.0.0:8080"
+workers = 2
+threads = 4
+timeout = 60
+accesslog = "-"
+errorlog = "-"
+
+
+def child_exit(server, worker):
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)

--- a/poetry.lock
+++ b/poetry.lock
@@ -851,6 +851,22 @@ Django = "*"
 testing = ["django-modelcluster"]
 
 [[package]]
+name = "django-prometheus"
+version = "2.5.0"
+description = "Django middlewares to monitor your application with Prometheus.io."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134"},
+    {file = "django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e"},
+]
+
+[package.dependencies]
+Django = ">=4.2,<5.0.dev0 || >=5.1.dev0,<6.1"
+prometheus-client = ">=0.7"
+
+[[package]]
 name = "django-storages"
 version = "1.14.6"
 description = "Support for many storage backends in Django"
@@ -3597,6 +3613,23 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
+    {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
+]
+
+[package.extras]
+aiohttp = ["aiohttp"]
+django = ["django"]
+twisted = ["twisted"]
+
+[[package]]
 name = "protobuf"
 version = "6.33.1"
 description = ""
@@ -6153,4 +6186,4 @@ llm-all = ["langchain", "langchain-google-genai", "langchain-openai", "openai"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "5e726193d27d1a992f79c8400af21f3517533f2ed64f4fe8baa5f0f073aa571a"
+content-hash = "e51daae6b172c577c4b6a561704221aeb0a7e37efe7a101dbb21761177d2f1d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ langchain-google-genai = {version = "^4.2.1", optional = true}
 openai = {version = ">=2.30.0,<3.0.0", optional = true}
 structlog = "^25.5.0"
 wagtail = "^7.4.2"
+django-prometheus = "^2.4.1"
 
 [tool.poetry.extras]
 llm-all = ["langchain", "langchain-openai", "langchain-google-genai", "openai"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,22 @@
+"""Tests for the Prometheus /metrics exposition (django-prometheus wiring)."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class MetricsEndpointTest(TestCase):
+    def test_metrics_endpoint_exposes_per_view_red_metrics(self):
+        # Generate one observation so the per-view series exist.
+        self.client.get(reverse("index"))
+
+        response = self.client.get("/metrics")
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+
+        # Per-endpoint RED families are registered and exported.
+        self.assertIn("django_http_requests_latency_seconds_by_view_method", body)
+        self.assertIn("django_http_responses_total_by_status_view", body)
+        self.assertIn("django_http_requests_total_by_view_transport_method", body)
+
+        # The view label is present, proving per-endpoint attribution works.
+        self.assertIn('view="index"', body)


### PR DESCRIPTION
## Summary
- Adds a `/metrics` endpoint (django-prometheus) so we get **per-Django-view** RED metrics: request count, latency histograms, and status codes — i.e. **fatals (5xx), throttles (429), latency and count per API endpoint**.
- Wires `PrometheusBeforeMiddleware` (first) / `PrometheusAfterMiddleware` (last) and a gunicorn `child_exit` hook so the 2 worker processes aggregate via `PROMETHEUS_MULTIPROC_DIR` (an emptyDir set in the k8s deployment).
- `/metrics` is scraped in-cluster by vmagent on the pod IP and **blocked from the public ingress** via a Traefik ipAllowList (infra repo).

## Metrics exposed (per `view`)
- `django_http_requests_total_by_view_transport_method` — count
- `django_http_requests_latency_seconds_by_view_method` — latency p50/p95/p99
- `django_http_responses_total_by_status_view` — 5xx fatals / 429 throttles

## Infra (separate `services/infra` change, applied after this deploys)
- Deployment: `PROMETHEUS_MULTIPROC_DIR` + emptyDir
- vmagent `jawafdehi-api` scrape job (app ns, :8080/metrics, keep `django_*`)
- `jawafdehi-api-allow-metrics-scrape` NetworkPolicy + Traefik ipAllowList on `/metrics`
- Grafana "Jawafdehi API" dashboard gains a per-endpoint section

## Test plan
- [x] `tests/test_metrics.py`: `/metrics` returns 200, exposes the per-view families, and `view="index"` label present
- [x] `python manage.py check` clean
- [ ] After deploy: confirm `django_http_*{namespace="app"}` series in VictoriaMetrics and per-endpoint panels populate; `curl https://portal.jawafdehi.org/metrics` from outside returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now exposes performance metrics including request latency, response counts, and status tracking via a dedicated endpoint.

* **Tests**
  * Added test coverage for metrics endpoint validation.

* **Chores**
  * Updated dependencies and configuration to support metrics collection and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->