### PR TITLE
fix(observability): let in-cluster vmagent reach /metrics

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -694,7 +694,7 @@ if not DEBUG:
     SECURE_HSTS_PRELOAD = env_flag("SECURE_HSTS_PRELOAD", False)
     SECURE_SSL_REDIRECT = True
     # vmagent scrapes http://<pod-ip>:8080/metrics in-cluster; don't 302 it to https.
-    SECURE_REDIRECT_EXEMPT = [r"^metrics$"]
+    SECURE_REDIRECT_EXEMPT = [r"^metrics/?$"]
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_HTTPONLY = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -136,6 +136,12 @@ if not DEBUG and not ALLOWED_HOSTS:
         "Set it to a comma-separated list of allowed hostnames "
         "(e.g. ALLOWED_HOSTS=jawafdehi.org,beta.jawafdehi.org)."
     )
+# In-cluster Prometheus scrapes hit /metrics on the pod IP directly, so the Host
+# header is the pod IP (not a public hostname). Allow the pod's own IP, injected
+# via the downward API (POD_IP), so the scrape isn't rejected as a DisallowedHost.
+_pod_ip = os.getenv("POD_IP")
+if _pod_ip:
+    ALLOWED_HOSTS.append(_pod_ip)
 
 CSRF_TRUSTED_ORIGINS = get_env_list("CSRF_TRUSTED_ORIGINS")
 
@@ -687,6 +693,8 @@ if not DEBUG:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = env_flag("SECURE_HSTS_INCLUDE_SUBDOMAINS", False)
     SECURE_HSTS_PRELOAD = env_flag("SECURE_HSTS_PRELOAD", False)
     SECURE_SSL_REDIRECT = True
+    # vmagent scrapes http://<pod-ip>:8080/metrics in-cluster; don't 302 it to https.
+    SECURE_REDIRECT_EXEMPT = [r"^metrics$"]
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_HTTPONLY = True


### PR DESCRIPTION
Follow-up to #233. The `/metrics` endpoint is live, but vmagent (which scrapes `http://<pod-ip>:8080/metrics` directly) was being rejected by the production security config:

- **`ALLOWED_HOSTS`** doesn't include the pod IP → `DisallowedHost` → 400
- **`SECURE_SSL_REDIRECT=True`** → 302s the plain-http scrape to https

## Change
- Append the downward-API `POD_IP` to `ALLOWED_HOSTS` (only affects in-cluster scrapes; public hostnames unchanged).
- Add `SECURE_REDIRECT_EXEMPT = [r"^metrics$"]` so the in-cluster scrape isn't HTTPS-redirected.

The matching infra change adds the `POD_IP` downward-API env to the deployment.

## Test plan
- [x] `tests/test_metrics.py` still passes
- [x] prod-mode settings resolve: `ALLOWED_HOSTS` includes `POD_IP`, `SECURE_REDIRECT_EXEMPT=['^metrics$']`
- [ ] After deploy: vmagent target up; `django_http_*{namespace="app"}` series populate the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)