### PR TITLE
Consolidate CIAA extraction tools into scripts/ciaa_extraction bundle

### DIFF
--- a/scripts/ciaa_extraction/extract_annual_report.py
+++ b/scripts/ciaa_extraction/extract_annual_report.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Extract structured JSON from 28th CIAA annual report (FY 2074/75) likhit markdown.
+
+Supports three section types:
+  Type A: Simple bribery table  (2.6.1)
+  Type C: Mixed narrative + defendant table (2.6.6 revenue leakage, 2.6.7 misc)
+"""
+
+import argparse
+import json
+import re
+
+FISCAL_YEAR = "2074/75"
+REPORT_NAME = "28th CIAA Annual Report"
+
+
+def to_arabic(text):
+    table = str.maketrans("०१२३४५६७८९", "0123456789")
+    return text.translate(table)
+
+
+def arabic_int(s):
+    s = to_arabic(str(s)).strip()
+    s = s.replace(",", "").replace("¸", "").replace(" ", "")
+    if not s:
+        return None
+    try:
+        return int(float(s))
+    except ValueError:
+        return None
+
+
+def norm_date(s):
+    s = to_arabic(str(s)).strip()
+    m = re.search(r"(\d{4})[।\./](\d{1,2})[।\./](\d{1,2})", s)
+    if m:
+        return f"{m.group(1)}-{int(m.group(2)):02d}-{int(m.group(3)):02d}"
+    return s
+
+
+def parse_bigo(s):
+    s = to_arabic(str(s)).strip()
+    s = s.replace("रु.", "").replace("रु", "")
+    s = s.replace("।-", ".").replace("।", ".")
+    s = s.replace(",", "")
+    s = s.replace(" ", "").replace("-", "")
+    s = s.rstrip(".")
+    if not s or s == "-":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def extract_bribery_cases(lines, start_idx):
+    """Type A: Extract bribery cases from the सि.नं. table in section 2.6.1."""
+    cases = []
+    i = start_idx
+    table_started = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        if "सि.नं." in line and "आयोगको निर्णय" in line and "प्रतिवादीको नाम" in line:
+            table_started = True
+            i += 1
+            continue
+
+        if table_started and line.strip().startswith("```"):
+            break
+
+        if table_started:
+            m = re.match(r"([\d०-९]+)[।\.]\s*\|?\s*(.*)", to_arabic(line))
+            if m:
+                serial = int(m.group(1))
+                rest = m.group(2)
+                parts = rest.split("|")
+                if len(parts) >= 3:
+                    decision_date = norm_date(parts[0])
+                    filing_date = norm_date(parts[1])
+                    name_pos = parts[2].strip()
+                    # With only 3 parts there is no separate bigo column;
+                    # parts[-1] would alias name_pos, so leave bigo empty.
+                    bigo_text = parts[3].strip() if len(parts) >= 4 else ""
+
+                    j = i + 1
+                    extra_name = []
+                    while (
+                        j < len(lines)
+                        and not re.match(r"([\d०-९]+)[।\.]", to_arabic(lines[j]))
+                        and not lines[j].strip().startswith("```")
+                        and not lines[j].strip().startswith("सि.नं")
+                    ):
+                        extra_name.append(lines[j].strip().rstrip(","))
+                        j += 1
+
+                    full_name_pos = name_pos + " " + " ".join(extra_name)
+
+                    cases.append(
+                        {
+                            "serial": serial,
+                            "decision_date_bs": decision_date,
+                            "filing_date_bs": filing_date,
+                            "defendants_raw": full_name_pos.strip(),
+                            "bigo_amount_npr": parse_bigo(bigo_text),
+                        }
+                    )
+                    i = j
+                    continue
+
+        if i > start_idx and "2.6.२" in line:
+            break
+        i += 1
+
+    return cases
+
+
+def extract_type_c_defendant_table(lines, table_start_line, case_context):
+    """Type C: Extract defendants from a mixed narrative+table section.
+
+    Handles multi-line rows where columns (Serial|Name|Karsur|Magdabi|Bigo)
+    span across lines. Each new defendant starts with a Devanagari numeral.
+    """
+    defendants = []
+    i = table_start_line
+
+    # Find the opening ```text
+    while i < len(lines):
+        if lines[i].strip().startswith("```"):
+            i += 1
+            break
+        i += 1
+
+    # Collect lines grouped by defendant
+    defendant_blocks = []
+    current_block = None
+
+    while i < len(lines):
+        line = lines[i]
+
+        if line.strip().startswith("```"):
+            if current_block:
+                defendant_blocks.append(current_block)
+                current_block = None
+            break
+
+        stripped = line.strip()
+        if not stripped:
+            i += 1
+            continue
+
+        arabic_stripped = to_arabic(stripped)
+
+        if "क्र.स." in stripped or stripped in ("रु.", "रु"):
+            i += 1
+            continue
+
+        m = re.match(r"^([\d०-९]+)[।\.]", arabic_stripped)
+        if m:
+            if current_block:
+                defendant_blocks.append(current_block)
+            current_block = {
+                "serial": int(m.group(1)),
+                "lines": [stripped],
+            }
+        elif current_block is not None:
+            current_block["lines"].append(stripped)
+
+        i += 1
+
+    if current_block:
+        defendant_blocks.append(current_block)
+
+    for block in defendant_blocks:
+        name_parts = []
+        karsur_parts = []
+        magdabi_parts = []
+        bigo_value = None
+
+        for idx, line in enumerate(block["lines"]):
+            clean = line
+            if idx == 0:
+                clean = re.sub(r"^[\d०-९]+[।\.]\s*", "", line)
+
+            if "|" in line:
+                cols = [c.strip() for c in clean.split("|")]
+
+                if idx == 0:
+                    # First line: cols = [name, karsur, magdabi, bigo] or [name, bigo].
+                    # A 2-col row must be handled exactly once: cols[1] is the bigo,
+                    # not a karsur, so the column-count cases are mutually exclusive.
+                    if cols:
+                        name_parts.append(cols[0])
+                    if len(cols) == 2:
+                        bigo_value = parse_bigo(cols[1])
+                    elif len(cols) >= 3:
+                        karsur_parts.append(cols[1])
+                        magdabi_parts.extend(cols[2:-1])
+                        bigo_value = parse_bigo(cols[-1])
+                else:
+                    # Continuation line with pipes: align from col 0
+                    if cols:
+                        name_parts.append(cols[0])
+                    if len(cols) >= 3:
+                        karsur_parts.append(cols[1])
+                        magdabi_parts.append(cols[2])
+                    elif len(cols) == 2:
+                        karsur_parts.append(cols[1])
+            else:
+                # No pipe — likely name continuation
+                name_parts.append(clean)
+
+        defendant = {
+            "serial": block["serial"],
+            "name_pad": " ".join(name_parts).strip(),
+            "karsur": " ".join(karsur_parts).strip(),
+            "magdabi": " ".join(magdabi_parts).strip(),
+            "bigo_amount_npr": bigo_value,
+            "case_type": case_context.get("case_type", "unknown"),
+            "case_type_nepali": case_context.get("case_type_nepali", ""),
+            "fy": FISCAL_YEAR,
+            "description": case_context.get("description", ""),
+            "decision_date_bs": case_context.get("decision_date_bs"),
+            "filing_date_bs": case_context.get("filing_date_bs"),
+        }
+        defendants.append(defendant)
+
+    return defendants
+
+
+def extract_case_narrative(lines, table_start_line):
+    """Extract case metadata from narrative text immediately preceding a table.
+
+    Scans backwards from table_start_line to find decision date,
+    filing date, and case description.
+    """
+    context = {}
+    search_end = max(0, table_start_line - 60)
+    narrative_lines = []
+
+    for i in range(table_start_line - 1, search_end, -1):
+        line = lines[i]
+        normalized_line = to_arabic(line)
+
+        # Extract filing date: "मिति 2074।8।12 मा विशेष अदालत...आरोपपत्र दायर"
+        # Digit classes accept Devanagari too so dates like २०७५.४.२ match even
+        # if an unnormalized line slips through.
+        m_file = re.search(
+            r"मिति\s+([\d०-९]{4}[।\.][\d०-९]{1,2}[।\.][\d०-९]{1,2})\s+मा\s+विशेष\s+अदालत.*?आरोपपत्र\s+दायर",
+            normalized_line,
+        )
+        if m_file and "filing_date_bs" not in context:
+            context["filing_date_bs"] = norm_date(m_file.group(1))
+
+        # Extract decision date: "आयोगको मिति २०७५।२।७ को"
+        m_dec = re.search(
+            r"आयोगको\s+मिति\s+([\d०-९]{4}[।\.][\d०-९]{1,2}[।\.][\d०-९]{1,2})",
+            normalized_line,
+        )
+        if m_dec and "decision_date_bs" not in context:
+            context["decision_date_bs"] = norm_date(m_dec.group(1))
+
+        stripped = line.strip()
+        if stripped and not stripped.isdigit():
+            narrative_lines.append(stripped)
+
+        # Stop at case number marker (trailing space optional: a standalone
+        # marker like "१." loses its whitespace after stripping).
+        if re.match(r"^[\d०-९]+[।\.](\s|$)", to_arabic(stripped)):
+            break
+
+    context["description"] = "\n".join(reversed(narrative_lines[:5]))
+    return context
+
+
+def extract_summary_table(lines, start_idx):
+    """Extract summary statistics table."""
+    summary = {}
+    i = start_idx
+
+    while i < len(lines):
+        line = lines[i]
+        if line.strip().startswith("```"):
+            i += 1
+            continue
+
+        if line.startswith("जम्मा"):
+            parts = [p.strip() for p in line.split("|")]
+            if len(parts) >= 5:
+                summary["total"] = {
+                    "cases": arabic_int(parts[2]),
+                    "defendants_male": (
+                        arabic_int(parts[3].split()[0]) if parts[3] else None
+                    ),
+                    "defendants_female": (
+                        arabic_int(parts[3].split()[1])
+                        if len(parts[3].split()) > 1
+                        else None
+                    ),
+                    "defendants_total": (
+                        arabic_int(parts[3].split()[2])
+                        if len(parts[3].split()) > 2
+                        else None
+                    ),
+                    "bigo_amount_npr": parse_bigo(parts[4]) if len(parts) > 4 else None,
+                }
+            break
+
+        m = re.match(r"[\d०-९]+[।\.]\s*\|?\s*(.*)", to_arabic(line))
+        if m:
+            parts = [p.strip() for p in m.group(1).split("|")]
+            if len(parts) >= 4:
+                case_type_nepali = parts[0]
+                case_type = _map_case_type(case_type_nepali)
+
+                j = i + 1
+                while j < len(lines) and re.match(
+                    r"^(हानि|नोक्सानी|पुर्याएको)", lines[j].strip()
+                ):
+                    case_type_nepali += " " + lines[j].strip()
+                    j += 1
+                    i = j - 1
+
+                # Column layout (serial stripped by the regex above):
+                #   parts[0]=case type, parts[1]=cases,
+                #   parts[2]=defendants "male female total" (single combined cell),
+                #   parts[3]=bigo
+                defendants_field = (
+                    parts[2].split() if len(parts) > 2 and parts[2] else []
+                )
+                summary[case_type] = {
+                    "case_type_nepali": case_type_nepali.strip(),
+                    "cases": arabic_int(parts[1]),
+                    "defendants_male": (
+                        arabic_int(defendants_field[0]) if defendants_field else None
+                    ),
+                    "defendants_female": (
+                        arabic_int(defendants_field[1])
+                        if len(defendants_field) > 1
+                        else None
+                    ),
+                    "defendants_total": (
+                        arabic_int(defendants_field[2])
+                        if len(defendants_field) > 2
+                        else None
+                    ),
+                    "bigo_amount_npr": (
+                        parse_bigo(parts[3]) if len(parts) > 3 else None
+                    ),
+                }
+
+        i += 1
+
+    return summary
+
+
+def find_all_code_blocks(lines, section_start, section_end):
+    """Find all ```text code blocks within a section."""
+    blocks = []
+    i = section_start
+    while i < section_end:
+        if lines[i].strip().startswith("```"):
+            blocks.append(i)
+            i += 1
+            while i < section_end and not lines[i].strip().startswith("```"):
+                i += 1
+            i += 1
+        else:
+            i += 1
+    return blocks
+
+
+def _map_case_type(nepali_type):
+    mapping = {
+        "घुस": "bribery",
+        "रिसवत": "bribery",
+        "झुठा": "fake_certificate",
+        "शैक्षिक": "fake_certificate",
+        "सार्वजनिक": "public_damage",
+        "सम्पत्तिको": "public_damage",
+        "गैरकानूनी": "illegal_income",
+        "सम्पत्ति": "illegal_income",
+        "लाभ": "illegal_benefit",
+        "राजस्व": "revenue_leakage",
+        "चुहावट": "revenue_leakage",
+        "विविध": "other",
+    }
+    for key, val in mapping.items():
+        if key in nepali_type:
+            return val
+    return "other"
+
+
+DEFAULT_OUTPUT = "ciaa-28th-2074-75.json"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Extract structured JSON from the 28th CIAA annual report markdown."
+    )
+    parser.add_argument("input_markdown", help="path to the likhit markdown file")
+    parser.add_argument(
+        "output_json",
+        nargs="?",
+        default=DEFAULT_OUTPUT,
+        help="output JSON path (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    with open(args.input_markdown) as f:
+        text = f.read()
+
+    lines = text.split("\n")
+
+    result = {
+        "fy": FISCAL_YEAR,
+        "report": REPORT_NAME,
+        "source": "likhit-markdown",
+        "summary": {},
+        "cases": [],
+        "extraction_notes": [],
+    }
+
+    # Find key sections
+    summary_idx = None
+    bribery_idx = None
+    fake_cert_idx = None
+    public_damage_idx = None
+    illegal_benefit_idx = None
+    illegal_income_idx = None
+    revenue_leakage_idx = None
+    misc_idx = None
+    next_section_idx = None
+
+    for i, line in enumerate(lines):
+        arabic = to_arabic(line)
+        if "आ.व.०७४/७५ को मुद्दासम्बन्धी निर्णय विवरण" in line:
+            summary_idx = i
+        elif "2.६.1 घुस" in line or "2.६.1 घुस" in arabic:
+            bribery_idx = i
+        elif "2.6.२ झुठा" in line:
+            fake_cert_idx = i
+        elif "2.6.३ सार्वजनिक" in line:
+            public_damage_idx = i
+        elif "2.6.४ गैरकानूनी लाभ" in line:
+            illegal_benefit_idx = i
+        elif "2.6.५ गैरकानूनी सम्पत्ति" in line:
+            illegal_income_idx = i
+        elif "2.6.6 राजस्व चुहावट" in arabic:
+            revenue_leakage_idx = i
+        elif "2.6.7 विविध" in line:
+            misc_idx = i
+        elif "2.7 पुनरावेदन" in line:
+            next_section_idx = i
+
+    # Extract summary
+    if summary_idx:
+        result["summary"] = extract_summary_table(lines, summary_idx)
+
+    # Type A: Bribery
+    if bribery_idx:
+        bribery_cases = extract_bribery_cases(lines, bribery_idx)
+        for c in bribery_cases:
+            c["case_type"] = "bribery"
+            c["case_type_nepali"] = "घुस (रिसवत)"
+            c["fy"] = FISCAL_YEAR
+        result["cases"].extend(bribery_cases)
+        result["extraction_notes"].append(
+            f"Extracted {len(bribery_cases)} bribery cases"
+        )
+
+    # Type C: Revenue leakage (2.6.6)
+    if revenue_leakage_idx:
+        rl_end = misc_idx or next_section_idx or len(lines)
+        blocks = find_all_code_blocks(lines, revenue_leakage_idx, rl_end)
+        rl_defendants = []
+        for block_start in blocks:
+            case_ctx = extract_case_narrative(lines, block_start)
+            case_ctx["case_type"] = "revenue_leakage"
+            case_ctx["case_type_nepali"] = "राजस्व चुहावट"
+            defendants = extract_type_c_defendant_table(lines, block_start, case_ctx)
+            rl_defendants.extend(defendants)
+        result["cases"].extend(rl_defendants)
+        result["extraction_notes"].append(
+            f"Extracted {len(rl_defendants)} defendants from revenue leakage section"
+        )
+
+    # Type C: Misc (2.6.7)
+    if misc_idx:
+        misc_end = next_section_idx if next_section_idx else len(lines)
+        blocks = find_all_code_blocks(lines, misc_idx, misc_end)
+        misc_defendants = []
+        for block_start in blocks:
+            case_ctx = extract_case_narrative(lines, block_start)
+            case_ctx["case_type"] = "other"
+            case_ctx["case_type_nepali"] = "विविध"
+            defendants = extract_type_c_defendant_table(lines, block_start, case_ctx)
+            misc_defendants.extend(defendants)
+        result["cases"].extend(misc_defendants)
+        result["extraction_notes"].append(
+            f"Extracted {len(misc_defendants)} defendants from misc section"
+        )
+
+    # Count remaining sections
+    if fake_cert_idx:
+        result["extraction_notes"].append(
+            f"Fake certificate section found (line {fake_cert_idx})"
+        )
+    if public_damage_idx:
+        result["extraction_notes"].append(
+            f"Public damage section found (line {public_damage_idx})"
+        )
+    if illegal_benefit_idx:
+        result["extraction_notes"].append(
+            f"Illegal benefit section found (line {illegal_benefit_idx})"
+        )
+    if illegal_income_idx:
+        result["extraction_notes"].append(
+            f"Illegal income section found (line {illegal_income_idx})"
+        )
+
+    output_path = args.output_json
+    with open(output_path, "w") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    print(f"Written {len(result['cases'])} defendant records to {output_path}")
+    print(f"Summary: {result['summary']}")
+    for note in result["extraction_notes"]:
+        print(f"  - {note}")

--- a/scripts/ciaa_extraction/extract_narrative.py
+++ b/scripts/ciaa_extraction/extract_narrative.py
@@ -1,0 +1,609 @@
+"""
+LLM-assisted extraction of defendant entities from CIAA 28th annual report
+narrative sections (2.6.3 Public Damage, 2.6.4 Illegal Benefit, 2.6.5 Illegal Income).
+
+Standalone script (no Django). Usage:
+
+    # Extract all sections to stdout (JSON only)
+    python3 scripts/ciaa_extraction/extract_narrative.py
+
+    # Extract a specific section
+    python3 scripts/ciaa_extraction/extract_narrative.py --section 2.6.3
+
+    # Output to file
+    python3 scripts/ciaa_extraction/extract_narrative.py --output extracted.json
+
+    # Dry-run / preview chunks (no LLM call)
+    python3 scripts/ciaa_extraction/extract_narrative.py --dry-run
+
+    # Limit chunks
+    python3 scripts/ciaa_extraction/extract_narrative.py --limit 3
+
+    # Custom model
+    python3 scripts/ciaa_extraction/extract_narrative.py --llm-model claude-sonnet-4-5
+
+    # Explicit report path (takes precedence over ANNUAL_REPORT_PATH env var)
+    python3 scripts/ciaa_extraction/extract_narrative.py --report-path /path/to/report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+SECTION_LABELS = {
+    "2.6.3": "सार्वजनिक सम्पत्तिको हानि नोक्सानी",
+    "2.6.4": "गैरकानूनी लाभ",
+    "2.6.5": "गैरकानूनी सम्पत्ति आर्जन",
+}
+
+# Serial number patterns at line start. The markdown mixes Devanagari (१. / १।)
+# and Arabic (1.) serials depending on OCR quality.
+# Devanagari digits followed by danda OR full-stop.
+_DV_SERIAL = re.compile(r"^[\s\xa0]*([१२३४५६७८९०]+)[।.]\s", re.MULTILINE)
+# Arabic 1-2 digit serials (avoid matching dates like 2074.4.2 / amounts like 2,60,000).
+_AR_SERIAL_SAFE = re.compile(r"^[ \t]*(\d{1,2})[\.।]\s+", re.MULTILINE)
+
+# Map digits between Devanagari and Arabic.
+_DV_TO_AR = str.maketrans("१२३४५६७८९०", "1234567890")
+_AR_TO_DV = str.maketrans("1234567890", "१२३४५६७८९०")
+
+SYSTEM_PROMPT = """You are a Nepali legal document analyst. Extract defendant information from CIAA case descriptions written in Nepali prose.
+
+For each case paragraph, extract ALL defendants mentioned. Each defendant is a person who is charged/accused in the case.
+
+Output a JSON object with this structure:
+{
+  "case": {
+    "serial_number": 1,
+    "section": "2.6.3",
+    "section_label": "सार्वजनिक सम्पत्तिको हानि नोक्सानी"
+  },
+  "defendants": [
+    {
+      "name": "Full name of defendant in Devanagari",
+      "position": "Position/title at time of offense (e.g., तत्कालीन गा.वि.स. सचिव)",
+      "office": "Office/institution where they worked",
+      "charge_sections": ["भ्रष्टाचार निवारण ऐन, २०५९ को दफा १७", "दफा ३(१)"],
+      "bigo": "Disputed amount in Nepali format (e.g., रु.2,45,000।-)",
+      "bigo_numeric": "Bigo as pure number (e.g., 245000)",
+      "decision_date_bs": "BS date of CIAA decision (e.g., 2074.4.2)",
+      "filing_date_bs": "BS date of case filing in Special Court (e.g., 2074.4.4)",
+      "is_primary": true
+    }
+  ]
+}
+
+EXTRACTION RULES:
+1. Names: Extract the FULL name exactly as written in the document. Include middle initials.
+2. Position: Extract the position title (e.g., तत्कालीन गा.वि.स. सचिव, प्रधानाध्यापक, लेखापाल). The prefix तत्कालीन means "then" — include it.
+3. Office: Extract the office/location context (e.g., जिल्ला हुलाक कार्यालय, रौतहट).
+4. Charge sections: Extract all दफा (section) references from the Corruption Prevention Act (भ्रष्टाचार निवारण ऐन).
+5. Bigo: Extract the रु. amount. Normalize by removing commas but keep the।- suffix.
+6. Bigo numeric: Convert the Nepali amount to a plain integer (remove commas, रु., ।-).
+7. Decisions/filing dates: Extract BS dates (usually in 2074.XX.XX format).
+8. is_primary: Mark the primary defendant(s) — usually the first-named or the person with highest authority.
+9. Single-defendant cases: mark is_primary = true.
+10. Multiple defendants: mark at least one is_primary = true.
+
+CRITICAL: If a case has multiple defendants (e.g., a committee chair, secretary, and treasurer), extract ALL of them with their respective roles and bigo amounts. Do NOT merge defendants.
+
+IMPORTANT: Return ONLY the JSON object. No additional text, no markdown fences, no commentary."""
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+class PermanentLLMError(Exception):
+    """Non-retryable failure (auth, client 4xx, malformed-but-returned body)."""
+
+
+class TransientLLMError(Exception):
+    """Retryable failure (network, timeout, 5xx, 429)."""
+
+
+def _dv_to_int(text: str) -> int:
+    return int(text.translate(_DV_TO_AR))
+
+
+def _find_serials(text: str) -> list[tuple[int, int, int]]:
+    """Find serial markers, returning (serial_number, start_pos, end_pos) sorted by pos.
+
+    Handles both Devanagari (१. / १।) and Arabic (1.) serials.
+    """
+    markers: list[tuple[int, int, int]] = []  # (pos, serial, end_pos)
+
+    for m in _DV_SERIAL.finditer(text):
+        markers.append((m.start(), _dv_to_int(m.group(1)), m.end()))
+
+    for m in _AR_SERIAL_SAFE.finditer(text):
+        markers.append((m.start(), int(m.group(1)), m.end()))
+
+    markers.sort(key=lambda x: x[0])
+
+    # Only valid case serials (1-99), not year numbers like 2068.
+    return [(serial, start, end) for start, serial, end in markers if 1 <= serial <= 99]
+
+
+def _split_cases(text: str) -> list[tuple[int, str]]:
+    """Split a section into per-case paragraphs by serial numbers."""
+    serials = _find_serials(text)
+    if not serials:
+        return []
+
+    cases: list[tuple[int, str]] = []
+    for i, (serial, _start, end) in enumerate(serials):
+        body_start = end
+        body_end = serials[i + 1][1] if i + 1 < len(serials) else len(text)
+        body = text[body_start:body_end].strip()
+        if body:
+            cases.append((serial, body))
+    return cases
+
+
+def _is_page_artifact(line: str) -> bool:
+    stripped = line.strip()
+    if stripped.isdigit() and len(stripped) <= 3:
+        return True
+    if "परिच्छेद-२" in stripped:
+        return True
+    if not stripped:
+        return True
+    return False
+
+
+def _clean_section_text(text: str) -> str:
+    lines = [line for line in text.split("\n") if not _is_page_artifact(line)]
+    cleaned = "\n".join(lines)
+    # Remove code fences and their content (tabular data embedded in narrative).
+    cleaned = re.sub(r"```text.*?```", "", cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _section_to_dv(section: str) -> str:
+    """Convert Arabic section number to Devanagari variant, e.g. "2.6.3" -> "2.6.३"."""
+    parts = section.rsplit(".", 1)
+    if len(parts) == 2 and parts[1].isdigit():
+        dv_digit = str(int(parts[1])).translate(_AR_TO_DV)
+        return f"{parts[0]}.{dv_digit}"
+    return section
+
+
+def _read_section(file_path: Path, section: str) -> str | None:
+    """Read a section from header line up to the next section header.
+
+    Handles Devanagari digits in section numbers (e.g. 2.6.३ for section 2.6.3),
+    both when entering a section and when locating the next header to stop at.
+    """
+    content = file_path.read_text(encoding="utf-8")
+
+    header_pattern = re.compile(rf"^{re.escape(section)}\s", re.MULTILINE)
+    match = header_pattern.search(content)
+
+    if not match:
+        dv_section = _section_to_dv(section)
+        if dv_section != section:
+            header_pattern = re.compile(rf"^{re.escape(dv_section)}\s", re.MULTILINE)
+            match = header_pattern.search(content)
+
+    if not match:
+        return None
+
+    start = match.start()
+
+    # Next 2.6.X header where X is one or more Arabic OR Devanagari digits,
+    # so a Devanagari-numbered next header (e.g. 2.6.४) ends the current section.
+    next_header = re.compile(r"^2\.6\.[\d१२३४५६७८९०]+[\s:-]", re.MULTILINE)
+    next_match = next_header.search(content, start + 1)
+    end = next_match.start() if next_match else len(content)
+
+    return _clean_section_text(content[start:end])
+
+
+def _retry_on_transient(fn, *, max_retries: int):
+    """Call fn() retrying only TransientLLMError with exponential backoff + jitter.
+
+    PermanentLLMError (and any other exception) propagates immediately.
+    """
+    for attempt in range(1, max_retries + 2):  # 1 initial + N retries
+        try:
+            return fn()
+        except TransientLLMError as exc:
+            if attempt > max_retries:
+                raise
+            wait = min(2 ** (attempt - 1), 120)
+            wait *= 1.0 + random.uniform(-0.2, 0.2)  # noqa: S311 — not crypto
+            wait = max(0.0, wait)
+            _log(
+                f"    Attempt {attempt}/{max_retries} failed: {exc}. "
+                f"Retrying in {wait:.1f}s..."
+            )
+            time.sleep(wait)
+    raise AssertionError("unreachable")
+
+
+def _try_parse_response(raw: str) -> dict | None:
+    """Parse an LLM HTTP body, handling SSE/streaming interleaved with JSON."""
+    # Strategy 1: plain JSON.
+    try:
+        obj = json.loads(raw)
+        if isinstance(obj, dict) and "choices" in obj:
+            return obj
+    except json.JSONDecodeError:
+        pass
+
+    # Strategy 2: SSE lines with data: prefix.
+    if "data:" in raw:
+        assembled: list[str] = []
+        final_meta = None
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                chunk = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(chunk, dict):
+                continue
+            final_meta = chunk
+            choices = chunk.get("choices", [])
+            if choices and isinstance(choices[0], dict):
+                piece = choices[0].get("delta", {}).get("content", "")
+                if piece:
+                    assembled.append(piece)
+        if assembled and final_meta is not None:
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "".join(assembled),
+                        },
+                        "finish_reason": "stop",
+                        "index": 0,
+                    }
+                ]
+            }
+
+    # Strategy 3: multiple JSON objects separated by newlines.
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("data:"):
+            continue
+        try:
+            obj = json.loads(line)
+            if isinstance(obj, dict) and "choices" in obj:
+                return obj
+        except json.JSONDecodeError:
+            continue
+
+    return None
+
+
+def _parse_llm_json(text: str) -> dict:
+    """Extract the JSON object emitted by the model from its message content."""
+    text = text.strip()
+    if text.startswith("```"):
+        start = text.find("\n")
+        end = text.rfind("```")
+        if start != -1 and end != -1:
+            text = text[start + 1 : end].strip()
+
+    brace_start = text.find("{")
+    if brace_start == -1:
+        raise PermanentLLMError(f"No JSON object found in LLM response: {text[:200]}")
+    depth = 0
+    brace_end = -1
+    for i, ch in enumerate(text[brace_start:], brace_start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                brace_end = i
+                break
+    if brace_end == -1:
+        raise PermanentLLMError("Unmatched brace in LLM response")
+    try:
+        return json.loads(text[brace_start : brace_end + 1])
+    except json.JSONDecodeError as exc:
+        raise PermanentLLMError(f"Malformed JSON in LLM response: {exc}") from exc
+
+
+def _call_llm_for_case(
+    *,
+    session: requests.Session,
+    section_label: str,
+    serial: int,
+    case_text: str,
+    model: str,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    use_anthropic: bool,
+) -> dict:
+    """Call the LLM once to extract defendant data from a single case paragraph."""
+    user_prompt = f"""Extract defendants from CIAA annual report case {serial} in section {section_label}.
+
+CASE TEXT (Nepali):
+{case_text}"""
+
+    if use_anthropic:
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=api_key)
+        try:
+            response = client.messages.create(
+                model=model if "claude" in model else "claude-3-5-sonnet-20241022",
+                max_tokens=2000,
+                system=SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+                temperature=0.1,
+            )
+        except anthropic.APIStatusError as exc:
+            status = getattr(exc, "status_code", None)
+            if status == 429 or (status is not None and status >= 500):
+                raise TransientLLMError(f"Anthropic {status}: {exc}") from exc
+            raise PermanentLLMError(f"Anthropic {status}: {exc}") from exc
+        except (anthropic.APIConnectionError, anthropic.APITimeoutError) as exc:
+            raise TransientLLMError(str(exc)) from exc
+        return _parse_llm_json(response.content[0].text)
+
+    url = f"{base_url.rstrip('/')}/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+    }
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.1,
+        "max_tokens": 2000,
+    }
+
+    try:
+        resp = session.post(url, headers=headers, json=payload, timeout=timeout)
+    except (requests.Timeout, requests.ConnectionError) as exc:
+        raise TransientLLMError(str(exc)) from exc
+
+    status = resp.status_code
+    if status == 429 or status >= 500:
+        raise TransientLLMError(f"HTTP {status} from LLM proxy")
+    if status >= 400:
+        raise PermanentLLMError(f"HTTP {status} from LLM proxy: {resp.text[:300]}")
+
+    raw = resp.text.strip()
+    data = _try_parse_response(raw)
+    if data is None:
+        raise PermanentLLMError(f"LLM returned unparseable response: {raw[:500]}")
+
+    choices = data.get("choices", [])
+    if not choices:
+        raise PermanentLLMError(f"LLM returned no choices: {data}")
+
+    content = choices[0].get("message", {}).get("content", "")
+    if not content:
+        raise PermanentLLMError("LLM returned empty content")
+
+    return _parse_llm_json(content)
+
+
+def _resolve_report_path(args: argparse.Namespace) -> Path:
+    """Resolve report path from --report-path then ANNUAL_REPORT_PATH env var."""
+    candidate = args.report_path or os.environ.get("ANNUAL_REPORT_PATH")
+    if not candidate:
+        raise SystemExit(
+            "No annual report path. Pass --report-path or set the "
+            "ANNUAL_REPORT_PATH env var."
+        )
+    path = Path(candidate)
+    if not path.exists():
+        raise SystemExit(f"Annual report not found at {path}.")
+    return path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract defendant entities from CIAA 28th annual report narrative "
+            "sections via LLM."
+        )
+    )
+    parser.add_argument(
+        "--section",
+        default=None,
+        help="Section to extract: 2.6.3, 2.6.4, 2.6.5 (default: all)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output JSON file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print case chunks without calling LLM",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process only N case paragraphs",
+    )
+    parser.add_argument(
+        "--llm-model",
+        default=os.environ.get("JAWAFDEHI_ALLEGATION_MODEL", "ocg/qwen3.6-plus"),
+        help="LLM model name",
+    )
+    parser.add_argument(
+        "--report-path",
+        default=None,
+        help="Path to the annual report markdown (overrides ANNUAL_REPORT_PATH)",
+    )
+    parser.add_argument(
+        "--llm-base-url",
+        default=os.environ.get(
+            "JAWAFDEHI_LLM_PROXY_URL",
+            "https://llm-proxy.jawafdehi.org/v1",
+        ),
+    )
+    parser.add_argument(
+        "--llm-api-key",
+        default=None,
+        help="Override API key from env",
+    )
+    parser.add_argument(
+        "--llm-timeout",
+        type=int,
+        default=300,
+        help="LLM API timeout in seconds",
+    )
+    parser.add_argument(
+        "--use-anthropic",
+        action="store_true",
+        help="Use direct Anthropic API",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Number of retries on transient LLM failure",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    sections_to_extract = (
+        [args.section] if args.section else ["2.6.3", "2.6.4", "2.6.5"]
+    )
+
+    is_dry_run = args.dry_run
+    api_key = (
+        args.llm_api_key
+        or os.environ.get("JAWAFDEHI_LLM_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("OPENCODE_API_KEY")
+    )
+    if not is_dry_run and not api_key:
+        raise SystemExit(
+            "No API key found. Set --llm-api-key, JAWAFDEHI_LLM_API_KEY, "
+            "ANTHROPIC_API_KEY, or OPENCODE_API_KEY."
+        )
+
+    report_path = _resolve_report_path(args)
+
+    # Single reused session for HTTP connection pooling across all calls.
+    session = requests.Session()
+
+    all_results: dict[str, list[dict]] = {}
+    total_defendants = 0
+    total_cases_processed = 0
+    total_errors = 0
+
+    for section in sections_to_extract:
+        section_label = SECTION_LABELS.get(section, section)
+        _log(f"\n{'=' * 60}")
+        _log(f"Section {section}: {section_label}")
+
+        raw = _read_section(report_path, section)
+        if raw is None:
+            _log(f"  Section {section} not found")
+            continue
+
+        cases = _split_cases(raw)
+        _log(f"  Found {len(cases)} case paragraphs")
+
+        if args.limit:
+            cases = cases[: args.limit]
+
+        section_results: list[dict] = []
+        for serial, case_text in cases:
+            _log(f"  Processing case {serial}...")
+            total_cases_processed += 1
+
+            if is_dry_run:
+                section_results.append(
+                    {
+                        "serial": serial,
+                        "narrative_chars": len(case_text),
+                        "narrative_preview": case_text[:150],
+                    }
+                )
+                continue
+
+            try:
+                result = _retry_on_transient(
+                    lambda st=section_label, sr=serial, ct=case_text: _call_llm_for_case(
+                        session=session,
+                        section_label=st,
+                        serial=sr,
+                        case_text=ct,
+                        model=args.llm_model,
+                        base_url=args.llm_base_url,
+                        api_key=api_key,
+                        timeout=args.llm_timeout,
+                        use_anthropic=args.use_anthropic,
+                    ),
+                    max_retries=args.retries,
+                )
+            except Exception as exc:  # noqa: BLE001 — log and continue per case
+                _log(f"    Failed: {exc}")
+                total_errors += 1
+                continue
+
+            section_results.append(result)
+            n_def = len(result.get("defendants", []))
+            total_defendants += n_def
+            _log(f"    → {n_def} defendant(s) extracted")
+
+        all_results[section] = section_results
+
+    _log(f"\n{'=' * 60}")
+    _log("SUMMARY")
+    if is_dry_run:
+        _log(f"  Cases previewed: {total_cases_processed}")
+    else:
+        _log(f"  Cases processed: {total_cases_processed}")
+        _log(f"  Defendants extracted: {total_defendants}")
+        _log(f"  Errors: {total_errors}")
+
+    output = {
+        "source": str(report_path),
+        "sections_extracted": sections_to_extract,
+        "total_cases": total_cases_processed,
+        "total_defendants": total_defendants,
+        "section_data": all_results,
+    }
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(output, f, ensure_ascii=False, indent=2)
+        _log(f"\nOutput written to {args.output}")
+    else:
+        json.dump(output, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ciaa_extraction/extract_sheet.py
+++ b/scripts/ciaa_extraction/extract_sheet.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Extract all per-case data from CIAA Cases Progress Tracker Google Sheets into normalized JSON.
+
+Usage:
+    export GSHEETS_CREDENTIALS=/path/to/oauth_token.json   (or GOOGLE_APPLICATION_CREDENTIALS)
+    python scripts/extract_ciaa_sheet.py [--output-dir /path/to/output] [--format json|jsonl]
+
+Output: cases_FY_XXYY.json per fiscal year in the output directory (default: ./data/ciaa/).
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Google Sheets
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+# Nepali date conversion
+from nepali_datetime import date as nepali_date
+
+logger = logging.getLogger(__name__)
+
+SPREADSHEET_ID = "1O8U9VA1FSCSocGwJHYgbm8sVoMkjYnQbOADvOlBhSJ0"
+
+# Sheet definitions: (tab_name, fiscal_year_label, is_per_case, header_row_index, format_type)
+SHEET_DEFS = [
+    # Per-case detailed sheets (these contain actual case records)
+    ("2081/2082", "2081_2082", True, 0, "detailed_v2"),
+    ("2080/2081", "2080_2081", True, 0, "detailed_v1"),
+    ("2076/2077", "2076_2077", True, 1, "bribery_simple"),
+    ("75/76", "2075_2076", True, 1, "bribery_simple"),
+    ("2073/2074", "2073_2074", True, 1, "bribery_simple"),
+    # The '080/081 cases to work' tab is a subset of 2080/2081
+    ("080/081 cases to work", "2080_2081_work", True, 5, "work_list"),
+    # Summary/aggregate sheets - NOT per-case data
+    ("79/80", "2079_2080", False, 1, "summary"),
+    ("2078/2079", "2078_2079", False, 1, "summary"),
+    ("74/75", "2074_2075", False, 1, "summary"),
+    ("71/72", "2071_2072", False, 1, "summary"),
+    # Special sheets
+    ("CaseProgress", "case_progress", False, 0, "case_progress"),
+    ("पनुरावेदन", "appeals", True, 1, "appeals"),
+    ("082/083", "2082_2083", True, 0, "minimal"),
+    ("Sheet39", "sheet39", False, 0, "empty"),
+]
+
+
+def normalize_header(header):
+    """Normalize a sheet header for robust matching.
+
+    Headers vary across tabs (spaces vs underscores, stray dots, ASCII case),
+    so collapse all whitespace/underscores/hyphens/dots to a single underscore
+    and case-fold ASCII before comparison.
+    """
+    if header is None:
+        return ""
+    text = str(header).strip()
+    text = re.sub(r"[\s\-_.]+", "_", text)
+    text = text.strip("_")
+    return text.casefold()
+
+
+def build_row(headers, values):
+    """Build a dict keyed by normalized headers from a raw value row."""
+    row = {}
+    for i, h in enumerate(headers):
+        if h is None or str(h).strip() == "":
+            continue
+        row[normalize_header(h)] = values[i] if i < len(values) else ""
+    return row
+
+
+def get_field(row, *names, default=""):
+    """Look up a field by any of the given header names, normalized."""
+    for name in names:
+        key = normalize_header(name)
+        if key in row:
+            return row[key]
+    return default
+
+
+def get_credentials():
+    """Get Google API credentials from a token file.
+
+    The path must be supplied via GSHEETS_CREDENTIALS or
+    GOOGLE_APPLICATION_CREDENTIALS; there is no default so no personal path is
+    ever assumed.
+    """
+    creds_file = os.environ.get("GSHEETS_CREDENTIALS") or os.environ.get(
+        "GOOGLE_APPLICATION_CREDENTIALS"
+    )
+    if not creds_file:
+        raise RuntimeError(
+            "No credentials path set. Export GSHEETS_CREDENTIALS (or "
+            "GOOGLE_APPLICATION_CREDENTIALS) pointing to your OAuth token JSON."
+        )
+    if not os.path.exists(creds_file):
+        raise FileNotFoundError(f"Credentials file not found: {creds_file}")
+    try:
+        with open(creds_file) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in credentials file: {creds_file} — {e}") from e
+    except OSError as e:
+        raise OSError(f"Could not read credentials file: {creds_file} — {e}") from e
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Credentials file must contain a JSON object: {creds_file}")
+
+    required_keys = {
+        "token",
+        "refresh_token",
+        "token_uri",
+        "client_id",
+        "client_secret",
+        "scopes",
+    }
+    missing = required_keys - data.keys()
+    if missing:
+        raise ValueError(
+            f"Credentials file missing required keys {sorted(missing)}: {creds_file}"
+        )
+
+    creds = Credentials(
+        token=data["token"],
+        refresh_token=data["refresh_token"],
+        token_uri=data["token_uri"],
+        client_id=data["client_id"],
+        client_secret=data["client_secret"],
+        scopes=data["scopes"],
+    )
+    if creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(Request())
+        except Exception as e:
+            print(f"Warning: failed to refresh credentials: {e}", file=sys.stderr)
+    return creds
+
+
+def parse_nepali_date_bs(bs_str):
+    """Parse a BS date string to (year, month, day) or None.
+    Handles formats: YYYY/MM/DD, YYYY-MM-DD, YYYY.MM.DD, M/D/YYYY, MM/DD/YYYY
+    """
+    if not bs_str or not isinstance(bs_str, str):
+        return None
+    bs_str = bs_str.strip()
+    if not bs_str:
+        return None
+
+    # Try YYYY/MM/DD, YYYY-MM-DD, YYYY.MM.DD
+    m = re.match(r"(\d{4})[/\-\.](\d{1,2})[/\-\.](\d{1,2})$", bs_str)
+    if m:
+        y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if 2000 <= y <= 2100:
+            return (y, mo, d)
+
+    # Try M/D/YYYY or MM/DD/YYYY (e.g., "4/6/2076" = Baisakh 6, 2076)
+    m = re.match(r"(\d{1,2})/(\d{1,2})/(\d{4})$", bs_str)
+    if m:
+        mo, d, y = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if 2000 <= y <= 2100:
+            return (y, mo, d)
+
+    return None
+
+
+def bs_to_ad(year_bs, month_bs, day_bs):
+    """Convert BS date to AD date string."""
+    try:
+        d = nepali_date(year_bs, month_bs, day_bs)
+        ad = d.to_datetime_date()
+        return ad.strftime("%Y-%m-%d")
+    except (ValueError, OverflowError, TypeError) as e:
+        logger.warning(
+            "BS date conversion failed: %d/%d/%d — %s", year_bs, month_bs, day_bs, e
+        )
+        return None
+
+
+def convert_date_field(bs_str):
+    """Parse a BS date string to AD date, returning both formats."""
+    parsed = parse_nepali_date_bs(bs_str)
+    if parsed:
+        y, mo, d = parsed
+        ad_date = bs_to_ad(y, mo, d)
+        bs_formatted = f"{y}-{mo:02d}-{d:02d}"
+        return {"bs": bs_formatted, "ad": ad_date}
+    return {"bs": bs_str if bs_str else None, "ad": None}
+
+
+def clean_text(text):
+    """Clean and normalize text fields."""
+    if not text:
+        return ""
+    if isinstance(text, str):
+        # Unescape common escape sequences from Sheets API
+        text = text.replace("\\n", "\n").replace("\\t", " ")
+        # Normalize whitespace around newlines (non-regex to avoid ReDoS)
+        lines = text.split("\n")
+        text = "\n".join(line.strip() for line in lines)
+        return text.strip()
+    return str(text)
+
+
+def parse_bigo(value):
+    """Parse bigo amount string to numeric (float or None).
+    Handles: "1,00,000 ", "13,160,000.00", "2602556.11", "1,47,10,85,483", ""
+    """
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip().replace(",", "")
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def extract_defendants_detailed(row, headers):
+    """Extract defendants from detailed formats (v1/v2)."""
+    return {
+        "name": clean_text(get_field(row, "प्रतिवादीको_नाम")),
+        "position_office": clean_text(get_field(row, "पद_र_कार्यालय")),
+        "offence_law": clean_text(get_field(row, "कसुर_सजाय_मागदाबी")),
+        "bigo": parse_bigo(get_field(row, "बिगो_रकम", default=None)),
+    }
+
+
+def extract_defendants_simple(row, headers):
+    """Extract defendant info from the 'bribery_simple' format (2076/2077, 75/76, 2073/2074)."""
+    return {
+        "name": clean_text(get_field(row, "प्रतिवादीको_नाम")),
+        "position_office": clean_text(get_field(row, "पद_र_कार्यालय")),
+        "bigo": parse_bigo(get_field(row, "बिगो_रकम", default=None)),
+    }
+
+
+def normalize_row(headers, values, sheet_name, format_type):
+    """Convert a raw row of values to a normalized case dict."""
+
+    # Build keyed dict from header-value pairs with normalized headers
+    row = build_row(headers, values)
+
+    case = {
+        "_source_sheet": sheet_name,
+        "_source_format": format_type,
+    }
+
+    if format_type == "detailed_v2":
+        # 2081/2082: 12 columns
+        case.update(
+            {
+                "serial_no": clean_text(get_field(row, "क्र_सं")),
+                "complaint_summary": clean_text(get_field(row, "उजुरीको_व्यहोरा")),
+                "investigation_finding": clean_text(
+                    get_field(row, "अनुसन्धानबाट_पुष्टि_भएको_व्यहोरा")
+                ),
+                "commission_decision_date": convert_date_field(
+                    get_field(row, "आयोगको_निर्णय.आयोगको_निर्णय_मिति")
+                ),
+                "indictment_filing_date": convert_date_field(
+                    get_field(row, "आयोगको_निर्णय.आरोपपत्र_दायर_मिति")
+                ),
+                "case_number": clean_text(get_field(row, "आयोगको_निर्णय.मुद्दा_नं")),
+                "defendant_count": get_field(row, "आयोगको_निर्णय.प्रतिवादी_सङ्ख्या"),
+                "defendant": extract_defendants_detailed(row, headers),
+                "case_type": clean_text(get_field(row, "case type")),
+            }
+        )
+
+    elif format_type == "detailed_v1":
+        # 2080/2081: columns up to W (illegal benefit)
+        case.update(
+            {
+                "serial_no": clean_text(get_field(row, "क्र_सं")),
+                "complaint_summary": clean_text(get_field(row, "उजुरीको_व्यहोरा")),
+                "investigation_finding": clean_text(
+                    get_field(row, "अनुसन्धानबाट_पुष्टि_भएको_व्यहोरा")
+                ),
+                "commission_decision_date": convert_date_field(
+                    get_field(row, "आयोगको_निर्णय_मिति")
+                ),
+                "indictment_filing_date": convert_date_field(
+                    get_field(row, "आरोपपत्र_दायर_मिति")
+                ),
+                "case_number": clean_text(get_field(row, "मुद्दा_नं")),
+                "defendant_count": get_field(row, "प्रतिवादी_सङ्ख्या"),
+                "defendant": extract_defendants_detailed(row, headers),
+                "case_type": clean_text(get_field(row, "illegal benefit")),
+            }
+        )
+
+    elif format_type == "bribery_simple":
+        # 2076/2077, 75/76, 2073/2074: simpler format
+        case.update(
+            {
+                "serial_no": clean_text(get_field(row, "क्र_सं")),
+                "commission_decision_date": convert_date_field(
+                    get_field(row, "आयोगको_निर्णय_मिति")
+                ),
+                "indictment_filing_date": convert_date_field(
+                    get_field(row, "आरोपपत्र_दायर_मिति")
+                ),
+                "defendant_count": get_field(row, "प्रतिवादी_सङ्ख्या"),
+                "defendant": extract_defendants_simple(row, headers),
+            }
+        )
+
+    elif format_type == "work_list":
+        # 080/081 cases to work: prioritized subset
+        case.update(
+            {
+                "serial_no": clean_text(get_field(row, "क्र.सं.")),
+                "case_number": clean_text(get_field(row, "मुद्दा_नं")),
+                "complaint_summary": clean_text(get_field(row, "उजुरीको_व्यहोरा")),
+                "investigation_finding": clean_text(
+                    get_field(row, "अनुसन्धानबाट_पुष्टि_भएको_व्यहोरा")
+                ),
+                "defendant_name": clean_text(get_field(row, "प्रतिवादीको_नाम_(पहिलो)")),
+                "bigo": parse_bigo(get_field(row, "बिगो_रकम_(रु.)")),
+                "full_text_available": clean_text(get_field(row, "पुर्णपाठ")),
+            }
+        )
+
+    elif format_type == "appeals":
+        case.update(
+            {
+                "serial_no": clean_text(get_field(row, "क्र_सं")),
+                "special_court_case_no": clean_text(
+                    get_field(row, "विशेष_अदालतको_मुद्दा_नं")
+                ),
+                "special_court_verdict_date": convert_date_field(
+                    get_field(row, "विशेष_अदालतको_फैसला_मिति")
+                ),
+                "commission_appeal_decision_date": convert_date_field(
+                    get_field(row, "आयोगको_पुनरावेदन_गर्ने_निर्णय_मिति")
+                ),
+                "appeal_registration_date": convert_date_field(
+                    get_field(row, "पुनरावेदन_दर्ता_मिति")
+                ),
+                "defendant_details": clean_text(
+                    get_field(row, "प्रत्यार्थी_प्रतिवादीको_विवरण")
+                ),
+                "defendant_count": get_field(row, "प्रत्यार्थी_प्रतिवादीको_सङ्ख्या"),
+                "supreme_court_case_no": clean_text(
+                    get_field(row, "सर्वोच्च_अदालतको_मुद्दा_नं")
+                ),
+            }
+        )
+
+    elif format_type == "minimal":
+        # 082/083 only has case number (e.g., "080-CR-0058")
+        case.update(
+            {
+                "case_number": values[0] if values else "",
+            }
+        )
+
+    return case
+
+
+def is_header_row(row_values):
+    """Check if a row looks like a header (all text, no data)."""
+    if not row_values:
+        return False
+    # Look for known header patterns (normalized so spacing/dots don't matter)
+    header_keywords = {
+        normalize_header(kw)
+        for kw in (
+            "क्र_सं",
+            "उजुरीको_व्यहोरा",
+            "आयोगको_निर्णय_मिति",
+            "मुद्दा_नं",
+            "प्रतिवादीको_नाम",
+            "बिगो_रकम",
+            "case type",
+            "bribery",
+            "विषय",
+            "description",
+        )
+    }
+    cells = {normalize_header(v) for v in row_values if v}
+    return any(kw in cells for kw in header_keywords)
+
+
+def extract_sheet(service, sheet_name):
+    """Extract all rows from a sheet."""
+    range_name = f"'{sheet_name}'!A:ZZ"
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(
+            spreadsheetId=SPREADSHEET_ID,
+            range=range_name,
+            valueRenderOption="FORMATTED_VALUE",
+        )
+        .execute()
+    )
+    return result.get("values", [])
+
+
+def group_into_cases(rows, headers, sheet_name, format_type):
+    """Group multi-defendant rows into single case objects.
+
+    In detailed_v1 and detailed_v2 formats, the first row of a case
+    has serial_no and case identifiers filled in, while subsequent
+    defendant rows have those fields empty.
+    """
+    if format_type not in ("detailed_v1", "detailed_v2"):
+        # For simple formats, each row is one case (with sometimes
+        # multiple defendants in one field)
+        cases = []
+        for vals in rows:
+            case = normalize_row(headers, vals, sheet_name, format_type)
+            # Skip empty or header-only rows
+            if not any(v for v in vals if v and str(v).strip()):
+                continue
+            if is_header_row(vals):
+                continue
+            cases.append(case)
+        return cases
+
+    # Group multi-defendant case rows
+    cases = []
+    current_case = None
+    row_count = 0
+
+    for vals in rows:
+        # Skip empty rows
+        if not vals or not any(v for v in vals if v and str(v).strip()):
+            continue
+
+        # Build keyed row
+        row = build_row(headers, vals)
+
+        # Check if this is a new case (has serial_no or case_number)
+        sn = clean_text(get_field(row, "क्र_सं", "क्र.सं."))
+        case_no = clean_text(
+            get_field(row, "मुद्दा_नं") or get_field(row, "आयोगको_निर्णय.मुद्दा_नं")
+        )
+
+        is_new = False
+        if sn:
+            if re.match(r"^[\d१२३४५६७८९०]+$", sn):
+                is_new = True
+        if not is_new and case_no:
+            is_new = True
+
+        if is_new:
+            if current_case:
+                cases.append(current_case)
+            current_case = normalize_row(headers, vals, sheet_name, format_type)
+            row_count += 1
+        elif current_case is not None:
+            # Add as additional defendant
+            extract_fn = extract_defendants_detailed
+            d = extract_fn(row, headers)
+            if d["name"] or d["position_office"]:
+                if "additional_defendants" not in current_case:
+                    current_case["additional_defendants"] = []
+                current_case["additional_defendants"].append(d)
+
+    if current_case:
+        cases.append(current_case)
+
+    return cases
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract CIAA sheet data to normalized JSON"
+    )
+    parser.add_argument(
+        "--output-dir", default="./data/ciaa", help="Output directory for JSON files"
+    )
+    parser.add_argument(
+        "--format",
+        default="json",
+        choices=("json", "jsonl"),
+        help="Output format for per-case files (json or jsonl)",
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Authenticating with Google Sheets API...")
+    creds = get_credentials()
+    service = build("sheets", "v4", credentials=creds)
+
+    summary = {}
+
+    for tab_name, fy_label, is_per_case, header_row, fmt_type in SHEET_DEFS:
+        print(f"\nReading {tab_name} ({fmt_type})...")
+        raw = extract_sheet(service, tab_name)
+
+        if not raw:
+            print(f"  WARNING: No data in {tab_name}")
+            summary[fy_label] = {"rows": 0, "cases": 0}
+            continue
+
+        # Find the actual header row (might not be row 0)
+        header_idx = header_row
+        headers = raw[header_idx] if header_idx < len(raw) else []
+
+        # For detailed sheets, clean up header names
+        if fmt_type in ("detailed_v1", "detailed_v2"):
+            # [''', 'bribery'] style headers at the top - find the real header
+            if not any("क्र" in str(h) for h in headers):
+                for i, r in enumerate(raw[header_idx:], start=header_idx):
+                    if any("क्र" in str(c) for c in r):
+                        headers = r
+                        header_idx = i
+                        break
+
+        print(f"  Raw rows: {len(raw)}, Header row: {header_idx}")
+        print(f"  Headers: {headers}")
+
+        # For per-case sheets, extract cases
+        if is_per_case:
+            data_rows = raw[header_idx + 1 :]
+            print(f"  Data rows (after header): {len(data_rows)}")
+            cases = group_into_cases(data_rows, headers, tab_name, fmt_type)
+            summary[fy_label] = {"rows": len(data_rows), "cases": len(cases)}
+
+            ext = "jsonl" if args.format == "jsonl" else "json"
+            output_file = output_dir / f"cases_{fy_label}.{ext}"
+            if args.format == "jsonl":
+                with open(output_file, "w", encoding="utf-8") as f:
+                    for case in cases:
+                        f.write(
+                            json.dumps(case, ensure_ascii=False, default=str) + "\n"
+                        )
+            else:
+                with open(output_file, "w", encoding="utf-8") as f:
+                    json.dump(cases, f, ensure_ascii=False, indent=2, default=str)
+            print(f"  Wrote {len(cases)} cases to {output_file}")
+        else:
+            # Summary sheets: save raw data with metadata
+            output_file = output_dir / f"summary_{fy_label}.json"
+            with open(output_file, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "sheet": tab_name,
+                        "fiscal_year": fy_label,
+                        "format": fmt_type,
+                        "headers": headers,
+                        "rows": raw[header_idx:],
+                    },
+                    f,
+                    ensure_ascii=False,
+                    indent=2,
+                    default=str,
+                )
+            print(f"  Wrote summary to {output_file}")
+
+    # Save extraction manifest
+    manifest = {
+        "spreadsheet_id": SPREADSHEET_ID,
+        "spreadsheet_name": "CIAA Cases Progress Tracker",
+        "extraction_date": datetime.now().isoformat(),
+        "sheets": summary,
+    }
+    manifest_file = output_dir / "extraction_manifest.json"
+    with open(manifest_file, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+    print(f"\nManifest: {manifest_file}")
+
+    total_cases = sum(v.get("cases", 0) for v in summary.values())
+    total_rows = sum(v.get("rows", 0) for v in summary.values())
+    print(f"\nTotal: {total_rows} raw rows, {total_cases} case records extracted")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ciaa_extraction/validate.py
+++ b/scripts/ciaa_extraction/validate.py
@@ -1,0 +1,778 @@
+#!/usr/bin/env python3
+"""
+Phase 6: Validation & Quality Control
+
+Cross-checks totals vs CIAA published statistics, FY distribution analysis,
+entity consistency, case number format validation, date sanity checks,
+coverage matrix generation, quality tier classification.
+
+Outputs: validation-report.json, coverage-matrix.csv
+"""
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import unicodedata
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+GOLD_MIN_SCORE = 7
+SILVER_MIN_SCORE = 4
+
+DEFAULT_DATA_DIR = Path(os.environ.get("CORRUPTION_DB_DIR", "corruption-case-db"))
+DEFAULT_OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", Path(__file__).resolve().parent))
+
+# ── Load all data sources ──────────────────────────────────────────────────
+
+
+def load_json(path, label):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"  ERROR: {label} — {e}")
+        sys.exit(1)
+
+
+def load_all(data_dir):
+    print("Loading data sources...")
+    extracted_dir = data_dir / "extracted-data"
+    consolidated_dir = extracted_dir / "consolidated"
+    sources = {}
+
+    sources["enriched_cases"] = load_json(
+        extracted_dir / "enriched-ciaa-cases.json", "enriched-ciaa-cases.json"
+    )
+
+    sources["unified_cases"] = load_json(
+        extracted_dir / "unified-ciaa-cases.json", "unified-ciaa-cases.json"
+    )
+
+    sources["cross_ref"] = load_json(
+        consolidated_dir / "cross-reference-details.json",
+        "cross-reference-details.json",
+    )
+
+    sources["annual_report"] = load_json(
+        extracted_dir / "ciaa-annual-report-cases.json",
+        "ciaa-annual-report-cases.json",
+    )
+
+    sources["ngm_cases"] = load_json(
+        data_dir / "ngm-special-court-cases.json", "ngm-special-court-cases.json"
+    )
+
+    sources["entities_raw"] = load_json(
+        extracted_dir / "entities_raw.json", "entities_raw.json"
+    )
+
+    print(f"  enriched-ciaa-cases.json:   {len(sources['enriched_cases'])} records")
+    print(f"  unified-ciaa-cases.json:    {len(sources['unified_cases'])} records")
+    print(f"  cross-reference-details:    {len(sources['cross_ref'])} records")
+    print(
+        f"  ciaa-annual-report-cases:   {len(sources['annual_report'].get('fiscal_year_stats', {}))} FY stats"
+    )
+    print(
+        f"  ngm-special-court-cases:    {len(sources['ngm_cases'].get('cases', []))} cases"
+    )
+    print(f"  entities_raw.json:          {len(sources['entities_raw'])} entities")
+
+    return sources
+
+
+# ── 1. Case Number Format Validation ──────────────────────────────────────
+
+
+def validate_case_numbers(sources):
+    print("\n═══ 1. Case Number Format Validation ═══")
+    issues = []
+    patterns_seen = Counter()
+
+    UNIFIED_FMT = re.compile(r"^(\d{2})-CR-(\d{4})$")
+
+    for r in sources["unified_cases"]:
+        cn = r.get("case_number") or ""
+        fy = r.get("fy", "???")
+
+        if not cn.strip():
+            issues.append(
+                {
+                    "severity": "info",
+                    "check": "case_number_empty",
+                    "fy": fy,
+                    "value": cn,
+                    "detail": "Empty case_number",
+                }
+            )
+            patterns_seen["(empty)"] += 1
+            continue
+
+        m = UNIFIED_FMT.match(cn)
+        if m:
+            yr_part = int(m.group(1))
+            # Year prefix should be plausible: 60-82 for BS years 2060-2082
+            if yr_part < 40 or yr_part > 99:
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "check": "case_number_year_outlier",
+                        "fy": fy,
+                        "value": cn,
+                        "detail": f"Year prefix {yr_part} outside typical range 40-99",
+                    }
+                )
+            patterns_seen["XX-CR-NNNN"] += 1
+        else:
+            issues.append(
+                {
+                    "severity": "warning",
+                    "check": "case_number_format",
+                    "fy": fy,
+                    "value": cn,
+                    "detail": "Does not match XX-CR-NNNN pattern",
+                }
+            )
+            patterns_seen[cn[:30]] += 1
+
+    # Check cross-ref cases
+    for r in sources["cross_ref"]:
+        cn = r.get("case_number", "")
+        if cn and not UNIFIED_FMT.match(cn):
+            issues.append(
+                {
+                    "severity": "warning",
+                    "check": "xref_case_number_format",
+                    "fy": r.get("fy", "???"),
+                    "value": cn,
+                    "detail": "Cross-ref case number doesn't match XX-CR-NNNN",
+                }
+            )
+
+    print(f"  Patterns: {dict(patterns_seen.most_common(5))}")
+    print(f"  Issues: {len(issues)}")
+    return issues
+
+
+# ── 2. Date Sanity Checks ─────────────────────────────────────────────────
+
+
+def validate_dates(sources):
+    print("\n═══ 2. Date Sanity Checks ═══")
+    issues = []
+
+    BS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+    AD_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+    for r in sources["enriched_cases"]:
+        fy = r.get("fy", "???")
+        cn = r.get("case_number", "???")
+
+        # Check BS dates
+        for field in ["filing_date_bs", "verdict_date_bs", "verdict_date_bs_extracted"]:
+            val = r.get(field)
+            if val and isinstance(val, str):
+                if not BS_RE.match(val):
+                    issues.append(
+                        {
+                            "severity": "error",
+                            "check": f"bad_bs_date_{field}",
+                            "fy": fy,
+                            "case_number": cn,
+                            "value": val,
+                            "detail": f"{field} doesn't match YYYY-MM-DD",
+                        }
+                    )
+                else:
+                    parts = val.split("-")
+                    y, m, d = int(parts[0]), int(parts[1]), int(parts[2])
+                    if y < 2040 or y > 2090:
+                        issues.append(
+                            {
+                                "severity": "error",
+                                "check": "bs_date_year_outlier",
+                                "fy": fy,
+                                "case_number": cn,
+                                "value": val,
+                                "detail": f"{field} year {y} outside BS range 2040-2090",
+                            }
+                        )
+                    if m < 1 or m > 12:
+                        issues.append(
+                            {
+                                "severity": "error",
+                                "check": "bs_date_month_invalid",
+                                "fy": fy,
+                                "case_number": cn,
+                                "value": val,
+                                "detail": f"{field} month {m} invalid",
+                            }
+                        )
+                    if d < 1 or d > 32:
+                        issues.append(
+                            {
+                                "severity": "error",
+                                "check": "bs_date_day_invalid",
+                                "fy": fy,
+                                "case_number": cn,
+                                "value": val,
+                                "detail": f"{field} day {d} invalid",
+                            }
+                        )
+
+        # Check AD dates
+        ad_val = r.get("filing_date_ad")
+        if ad_val and isinstance(ad_val, str) and AD_RE.match(ad_val):
+            y = int(ad_val.split("-")[0])
+            if y < 2000 or y > 2030:
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "check": "ad_date_year_outlier",
+                        "fy": fy,
+                        "case_number": cn,
+                        "value": ad_val,
+                        "detail": f"filing_date_ad year {y} outside expected range 2000-2030",
+                    }
+                )
+
+        # Filing date should precede verdict date
+        fd_bs = r.get("filing_date_bs")
+        vd_bs = r.get("verdict_date_bs")
+        if fd_bs and vd_bs and BS_RE.match(fd_bs) and BS_RE.match(vd_bs):
+            if vd_bs < fd_bs:
+                issues.append(
+                    {
+                        "severity": "error",
+                        "check": "verdict_before_filing",
+                        "fy": fy,
+                        "case_number": cn,
+                        "value": f"filed={fd_bs} verdict={vd_bs}",
+                        "detail": "Verdict date precedes filing date",
+                    }
+                )
+
+    # Check verdict_date_ad field which appears to contain raw text
+    ad_raw = Counter()
+    for r in sources["enriched_cases"]:
+        vda = r.get("verdict_date_ad", "")
+        if vda and not AD_RE.match(str(vda)):
+            ad_raw[str(vda)[:40]] += 1
+
+    if ad_raw:
+        issues.append(
+            {
+                "severity": "info",
+                "check": "verdict_date_ad_nonstandard",
+                "fy": "multiple",
+                "case_number": "multiple",
+                "value": str(dict(ad_raw.most_common(5))),
+                "detail": "verdict_date_ad has non-AD values (likely raw BS text)",
+            }
+        )
+
+    print(f"  Issues: {len(issues)}")
+    return issues
+
+
+# ── 3. Entity Consistency Check ───────────────────────────────────────────
+
+
+def extract_entity_variants(sources):
+    print("\n═══ 3. Entity Consistency Check ═══")
+    issues = []
+
+    # Collect all entity names across all sources
+    all_names = defaultdict(list)  # normalized -> [(original, source, fy, case_number)]
+
+    def norm(name):
+        """Normalize for comparison: NFC, lowercase, collapse internal whitespace, remove common prefixes."""
+        if not name:
+            return None
+        n = unicodedata.normalize("NFC", name.strip().lower())
+        n = re.sub(r"\s+", " ", n)  # collapse internal whitespace, don't strip all
+        n = re.sub(r"[\.\,\-]", "", n)
+        # Remove common Nepali honorifics/prefixes
+        n = re.sub(r"^(श्री|स्वर्गीय|श्रीमती|श्रीयुत)", "", n)
+        return n
+
+    # From enriched cases — defendant/plaintiff fields
+    for r in sources["enriched_cases"]:
+        fy = r.get("fy", "???")
+        cn = r.get("case_number", "???")
+        for field in ["defendant", "plaintiff"]:
+            val = r.get(field)
+            if val and isinstance(val, str) and val.strip():
+                key = norm(val)
+                if key and len(key) >= 3:
+                    all_names[key].append((val.strip(), "enriched", fy, cn, field))
+
+        # From ngm_entities
+        entities = r.get("ngm_entities", {})
+        if isinstance(entities, dict):
+            for role, names_list in entities.items():
+                if isinstance(names_list, list):
+                    for e in names_list:
+                        if isinstance(e, dict):
+                            name = e.get("name", e.get("full_name", ""))
+                        elif isinstance(e, str):
+                            name = e
+                        else:
+                            continue
+                        if name and name.strip():
+                            key = norm(name)
+                            if key and len(key) >= 3:
+                                all_names[key].append(
+                                    (name.strip(), "ngm_entity", fy, cn, role)
+                                )
+
+    # From unified cases — defendants list
+    for r in sources["unified_cases"]:
+        fy = r.get("fy", "???")
+        cn = r.get("case_number", "???")
+        defendants = r.get("defendants", [])
+        if isinstance(defendants, list):
+            for d in defendants:
+                if isinstance(d, dict):
+                    name = d.get("name", d.get("full_name", ""))
+                elif isinstance(d, str):
+                    name = d
+                else:
+                    continue
+                if name and name.strip():
+                    key = norm(name)
+                    if key and len(key) >= 3:
+                        all_names[key].append(
+                            (name.strip(), "unified", fy, cn, "defendant")
+                        )
+
+    # Find variants: same normal form but different display strings
+    variant_count = 0
+    for key, entries in all_names.items():
+        originals = set(e[0] for e in entries)
+        if len(originals) > 1:
+            variant_count += 1
+            if variant_count <= 30:  # Limit output
+                # Show the most common variant
+                counts = Counter(e[0] for e in entries)
+                most_common = counts.most_common()
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "check": "entity_spelling_variant",
+                        "fy": "multiple",
+                        "value": f"{most_common[0][0]} ({most_common[0][1]}x) vs {len(originals)-1} other form(s)",
+                        "detail": f"Normalized key '{key}' has {len(originals)} display variants: {[(n, c) for n, c in most_common[:5]]}",
+                        "sample_cases": list({e[3] for e in entries})[:5],
+                    }
+                )
+
+    total_names = len(all_names)
+    print(f"  Unique normalized names: {total_names}")
+    print(f"  Variants (same entity, diff spelling): {variant_count}")
+    print(f"  Reported: {min(30, variant_count)}")
+
+    return issues
+
+
+# ── 4. FY Distribution Analysis ───────────────────────────────────────────
+
+
+def analyze_fy_distribution(sources):
+    print("\n═══ 4. FY Distribution Analysis ═══")
+    issues = []
+
+    # Count cases per FY from each source
+    enriched_fy = Counter(r.get("fy") for r in sources["enriched_cases"])
+    unified_fy = Counter(r.get("fy") for r in sources["unified_cases"])
+    cross_ref_fy = Counter(r.get("fy") for r in sources["cross_ref"])
+
+    # Reference: CIAA published stats
+    annual_stats = sources["annual_report"].get("fiscal_year_stats", {})
+
+    print(f"  {'FY':<12} {'Enriched':>10} {'Unified':>10} {'XRef':>8} {'CIAA Pub':>10}")
+    print(f"  {'-'*50}")
+
+    all_fys = sorted(
+        set(enriched_fy.keys())
+        | set(unified_fy.keys())
+        | set(cross_ref_fy.keys())
+        | set(annual_stats.keys())
+    )
+
+    for fy in all_fys:
+        # Normalize FY key (some use underscore, some slash)
+        e_cnt = enriched_fy.get(fy, 0)
+        u_cnt = unified_fy.get(fy, 0)
+        x_cnt = cross_ref_fy.get(fy, 0)
+
+        # Try matching CIAA stats
+        fy_underscore = fy.replace("/", "_")
+        ciaa_filed = None
+        if fy_underscore in annual_stats:
+            ciaa_filed = annual_stats[fy_underscore].get("cases_filed_special_court")
+
+        ciaa_str = str(ciaa_filed) if ciaa_filed else "-"
+        print(f"  {fy:<12} {e_cnt:>10} {u_cnt:>10} {x_cnt:>8} {ciaa_str:>10}")
+
+        # Check for large discrepancies
+        if ciaa_filed and u_cnt > 0:
+            ratio = u_cnt / ciaa_filed
+            if ratio > 2.0:
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "check": "fy_case_count_exceeds_ciaa",
+                        "fy": fy,
+                        "value": f"unified={u_cnt} ciaa_published={ciaa_filed}",
+                        "detail": f"Unified case count ({u_cnt}) > 2x CIAA published ({ciaa_filed})",
+                    }
+                )
+            elif u_cnt < ciaa_filed * 0.3 and u_cnt > 0:
+                issues.append(
+                    {
+                        "severity": "info",
+                        "check": "fy_case_count_low_vs_ciaa",
+                        "fy": fy,
+                        "value": f"unified={u_cnt} ciaa_published={ciaa_filed}",
+                        "detail": f"Unified case count ({u_cnt}) < 30% of CIAA published ({ciaa_filed})",
+                    }
+                )
+
+    print(f"  Issues: {len(issues)}")
+    return issues
+
+
+# ── 5. Source Coverage Matrix ─────────────────────────────────────────────
+
+
+def coverage_matrix(sources, output_dir):
+    print("\n═══ 5. Coverage Matrix ═══")
+
+    rows = []
+
+    # Enriched cases per FY per source
+    fy_source = defaultdict(lambda: Counter())
+    for r in sources["enriched_cases"]:
+        fy = r.get("fy", "unknown")
+        src = r.get("source", "unknown")
+        fy_source[fy][src] += 1
+
+    for fy in sorted(fy_source.keys()):
+        src_counts = fy_source[fy]
+        total = sum(src_counts.values())
+        # Count distinct coverage buckets
+        coverage_groups = {
+            "ngm_only": src_counts.get("ngm_only", 0),
+            "ngm_annual_report": sum(
+                src_counts.get(k, 0) for k in ["ngm_annual_report", "all_three"]
+            ),
+            "annual_report_only": src_counts.get("annual_report_only", 0),
+            "sheets": sum(
+                src_counts.get(k, 0)
+                for k in ["sheets_only", "sheets_annual_report", "both"]
+            ),
+        }
+
+        # Source labels with counts
+        ngm_label = f"NGM:{coverage_groups['ngm_only']}"
+        ar_label = f"AR:{coverage_groups['ngm_annual_report'] + coverage_groups['annual_report_only']}"
+        ss_label = f"SS:{coverage_groups['sheets']}"
+
+        # Look up CIAA published figure
+        fy_u = fy.replace("/", "_")
+        ciaa_filed = None
+        ar_stats = sources["annual_report"].get("fiscal_year_stats", {})
+        if fy_u in ar_stats:
+            ciaa_filed = ar_stats[fy_u].get("cases_filed_special_court")
+
+        has_ngm = (
+            "Y"
+            if coverage_groups["ngm_only"] or coverage_groups["ngm_annual_report"]
+            else "N"
+        )
+        has_ar = (
+            "Y"
+            if coverage_groups["ngm_annual_report"]
+            or coverage_groups["annual_report_only"]
+            else "N"
+        )
+        has_ss = "Y" if coverage_groups["sheets"] else "N"
+
+        # CIAA match: if we have CIAA published figure, check coverage ratio
+        coverage_pct = (
+            round(total / ciaa_filed * 100, 1)
+            if ciaa_filed and ciaa_filed > 0
+            else None
+        )
+
+        rows.append(
+            {
+                "fy": fy,
+                "total_cases": total,
+                "ciaa_published": ciaa_filed or "-",
+                "coverage_pct": coverage_pct if coverage_pct is not None else "-",
+                "ngm_only": coverage_groups["ngm_only"],
+                "ngm_annual_report": coverage_groups["ngm_annual_report"],
+                "annual_report_only": coverage_groups["annual_report_only"],
+                "sheets": coverage_groups["sheets"],
+                "has_ngm": has_ngm,
+                "has_ar": has_ar,
+                "has_ss": has_ss,
+                "sources_summary": f"{ngm_label} {ar_label} {ss_label}",
+            }
+        )
+
+    # Write CSV
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "coverage-matrix.csv"
+    fieldnames = [
+        "fy",
+        "total_cases",
+        "ciaa_published",
+        "coverage_pct",
+        "ngm_only",
+        "ngm_annual_report",
+        "annual_report_only",
+        "sheets",
+        "has_ngm",
+        "has_ar",
+        "has_ss",
+        "sources_summary",
+    ]
+    with open(csv_path, "w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"  FYs covered: {len(rows)}")
+    print(f"  CSV: {csv_path}")
+    return rows
+
+
+# ── 6. Quality Tier Classification ────────────────────────────────────────
+
+
+def classify_quality_tiers(sources):
+    print("\n═══ 6. Quality Tier Classification ═══")
+
+    tiers = {"Gold": [], "Silver": [], "Bronze": []}
+
+    for r in sources["enriched_cases"]:
+        scores = []
+
+        # Case number present and valid
+        cn = r.get("case_number", "")
+        scores.append(1 if cn and re.match(r"^\d{2,3}-CR-\d+", cn) else 0)
+
+        # Filing date present
+        scores.append(1 if r.get("filing_date_bs") or r.get("filing_date_ad") else 0)
+
+        # Verdict date present
+        scores.append(1 if r.get("verdict_date_bs") or r.get("verdict_date_ad") else 0)
+
+        # Defendant name present
+        scores.append(1 if r.get("defendant") else 0)
+
+        # Plaintiff name present
+        scores.append(1 if r.get("plaintiff") else 0)
+
+        # NGM entities populated
+        entities = r.get("ngm_entities", {})
+        scores.append(1 if isinstance(entities, dict) and len(entities) > 0 else 0)
+
+        # Hearing count available
+        hc = r.get("hearing_count")
+        scores.append(1 if hc is not None and hc > 0 else 0)
+
+        # Verdict judge present
+        scores.append(1 if r.get("verdict_judge") else 0)
+
+        # Source cross-referenced (not ngm_only)
+        src = r.get("source", "")
+        scores.append(1 if src != "ngm_only" and src != "unknown" else 0)
+
+        total_score = sum(scores)
+        max_score = len(scores)
+
+        if total_score >= GOLD_MIN_SCORE:
+            tier = "Gold"
+        elif total_score >= SILVER_MIN_SCORE:
+            tier = "Silver"
+        else:
+            tier = "Bronze"
+
+        tiers[tier].append(
+            {
+                "case_number": cn,
+                "fy": r.get("fy", "???"),
+                "source": src,
+                "score": total_score,
+                "max_score": max_score,
+                "details": {
+                    "has_case_number": bool(scores[0]),
+                    "has_filing_date": bool(scores[1]),
+                    "has_verdict_date": bool(scores[2]),
+                    "has_defendant": bool(scores[3]),
+                    "has_plaintiff": bool(scores[4]),
+                    "has_entities": bool(scores[5]),
+                    "has_hearings": bool(scores[6]),
+                    "has_judge": bool(scores[7]),
+                    "cross_referenced": bool(scores[8]),
+                },
+            }
+        )
+
+    denom = max(len(sources["enriched_cases"]), 1)
+    print(f"  Gold:   {len(tiers['Gold'])} ({len(tiers['Gold'])/denom*100:.1f}%)")
+    print(f"  Silver: {len(tiers['Silver'])} ({len(tiers['Silver'])/denom*100:.1f}%)")
+    print(f"  Bronze: {len(tiers['Bronze'])} ({len(tiers['Bronze'])/denom*100:.1f}%)")
+    print(f"  Total:  {sum(len(v) for v in tiers.values())}")
+    return tiers
+
+
+# ── 7. Cross-Reference Validation ─────────────────────────────────────────
+
+
+def validate_cross_reference(sources):
+    print("\n═══ 7. Cross-Reference Validation ═══")
+    issues = []
+
+    xref = sources["cross_ref"]
+    enriched = sources["enriched_cases"]
+
+    enriched_case_nums = set(
+        r.get("case_number") for r in enriched if r.get("case_number")
+    )
+
+    orphaned_xref = 0
+    for r in xref:
+        cn = r.get("case_number", "")
+        if cn and cn not in enriched_case_nums:
+            orphaned_xref += 1
+
+    if orphaned_xref:
+        issues.append(
+            {
+                "severity": "warning",
+                "check": "orphaned_cross_ref",
+                "fy": "multiple",
+                "value": str(orphaned_xref),
+                "detail": f"{orphaned_xref} cross-reference records have no matching enriched case",
+            }
+        )
+
+    # Check for enriched cases with source=all_three but not in cross_ref
+    xref_case_nums = set(r.get("case_number") for r in xref if r.get("case_number"))
+    enriched_in_xref = sum(1 for cn in enriched_case_nums if cn in xref_case_nums)
+    print(
+        f"  Enriched cases in cross-ref: {enriched_in_xref}/{len(enriched_case_nums)}"
+    )
+    print(f"  Orphaned cross-refs: {orphaned_xref}")
+    print(f"  Issues: {len(issues)}")
+    return issues
+
+
+# ── Main Pipeline ─────────────────────────────────────────────────────────
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_DATA_DIR,
+        help="Directory containing the corruption-case dataset (env: CORRUPTION_DB_DIR).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory to write validation-report.json and coverage-matrix.csv (env: OUTPUT_DIR).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    sources = load_all(args.data_dir)
+    all_issues = []
+
+    all_issues += validate_case_numbers(sources)
+    all_issues += validate_dates(sources)
+    all_issues += extract_entity_variants(sources)
+    all_issues += analyze_fy_distribution(sources)
+    matrix_rows = coverage_matrix(sources, args.output_dir)
+    tiers = classify_quality_tiers(sources)
+    all_issues += validate_cross_reference(sources)
+
+    # ── Build Report ──────────────────────────────────────────────────────
+    report = {
+        "pipeline": "Phase 6: Validation & Quality Control",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "data_sources": {
+            k: (
+                len(v)
+                if isinstance(v, list)
+                else (
+                    len(v.get("fiscal_year_stats", {})) if isinstance(v, dict) else "?"
+                )
+            )
+            for k, v in sources.items()
+        },
+        "total_issues": len(all_issues),
+        "issues": all_issues,
+        "coverage_matrix": matrix_rows,
+        "quality_tiers": {
+            "gold_count": len(tiers["Gold"]),
+            "silver_count": len(tiers["Silver"]),
+            "bronze_count": len(tiers["Bronze"]),
+            "gold_pct": round(
+                len(tiers["Gold"]) / max(len(sources["enriched_cases"]), 1) * 100, 1
+            ),
+            "silver_pct": round(
+                len(tiers["Silver"]) / max(len(sources["enriched_cases"]), 1) * 100, 1
+            ),
+            "bronze_pct": round(
+                len(tiers["Bronze"]) / max(len(sources["enriched_cases"]), 1) * 100, 1
+            ),
+        },
+        "summary": {
+            "total_enriched_cases": len(sources["enriched_cases"]),
+            "total_unified_cases": len(sources["unified_cases"]),
+            "total_cross_ref_records": len(sources["cross_ref"]),
+            "fiscal_years_in_stats": len(
+                sources["annual_report"].get("fiscal_year_stats", {})
+            ),
+            "quality_issues_found": len(all_issues),
+        },
+    }
+
+    # Write validation report
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.output_dir / "validation-report.json"
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+    print("\n═══ Validation Report ═══")
+    print(f"  Report: {report_path}")
+    print(f"  Total issues: {len(all_issues)}")
+
+    # Severity breakdown
+    severity_counts = Counter(i["severity"] for i in all_issues)
+    for sev, cnt in severity_counts.most_common():
+        print(f"    {sev}: {cnt}")
+
+    return report
+
+
+if __name__ == "__main__":
+    report = main()
+    error_count = sum(
+        1 for i in report.get("issues", []) if i.get("severity") == "error"
+    )
+    if error_count > 0:
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
## Summary
Consolidates the four outstanding CIAA data-extraction/validation tools into a single standalone script bundle under `scripts/ciaa_extraction/`, and addresses the open Gemini/CodeRabbit review comments from each original PR. Supersedes #163, #181, #185, #167.

| File (bundle) | From | Purpose |
|----|----|----|
| `extract_sheet.py` | #163 | Extract CIAA case data from Google Sheets → JSON |
| `extract_annual_report.py` | #181 | Parse 28th annual report markdown (Type A tables + Type C mixed sections) → JSON |
| `extract_narrative.py` | #185 | LLM-extract defendants from narrative report sections (§2.6.3–2.6.5) → JSON |
| `validate.py` | #167 | Data-quality validation pipeline → report + coverage matrix |

## Review fixes applied
- **extract_sheet.py** — robust header normalization (space/underscore/case tolerant); Google creds path from env (`GSHEETS_CREDENTIALS`/`GOOGLE_APPLICATION_CREDENTIALS`, no hardcoded personal path); creds-file error handling; `--format json/jsonl` now functional.
- **extract_annual_report.py** — corrected off-by-one summary column indices (critical); fixed 2-column double-assignment of `cols[1]`; standalone serial markers (`१.` on its own line); 3-part-row bigo duplication; Devanagari date digits; argparse input validation.
- **extract_narrative.py** — converted from Django management command to a standalone script; single reused `requests.Session`; retries restricted to transient failures (network/timeout/5xx/429); stdout is JSON-only (progress → stderr); Devanagari serial (`१.`/`१।`) + Devanagari section-boundary handling; configurable `--report-path`/`ANNUAL_REPORT_PATH` (no hardcoded path).
- **validate.py** — dynamic `generated_at` timestamp; configurable `--data-dir`/`--output-dir`; utf-8 encodings on all reads/writes; named tier-threshold constants; non-zero exit on error-severity findings.

Generated artifacts (`validation-report.json`, `coverage-matrix.csv`) are intentionally excluded from the repo.

## Test plan
- [x] All four scripts byte-compile (`python -m py_compile`)
- [x] `ruff check` + `black` clean
- [ ] Run each script against real report/sheet inputs and spot-check output JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated data extraction tools for CIAA annual reports supporting both markdown and spreadsheet sources
  * Implemented AI-powered extraction of defendant information from narrative documentation with resilient error handling
  * Introduced comprehensive validation suite with quality tier classification and coverage analysis for extracted datasets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->