### PR TITLE
feat(review): retune rules from caseworker feedback

### DIFF
--- a/review/judge.py
+++ b/review/judge.py
@@ -193,6 +193,20 @@ def _chunk(seq, size):
         yield seq[i : i + size]
 
 
+def _as_str_list(val):
+    """Coerce an LLM-returned field to a list[str].
+
+    The judge sometimes returns a bare string (or a list with non-string items)
+    where a list of strings is expected; normalise so callers that iterate the
+    value don't walk a string character-by-character.
+    """
+    if isinstance(val, str):
+        return [val.strip()] if val.strip() else []
+    if isinstance(val, list):
+        return [str(x).strip() for x in val if str(x).strip()]
+    return []
+
+
 def _build_narrative_prompt(case_summary, source_excerpts, case_type_label):
     return f"""Give a 2-3 sentence overall editorial assessment (narrative) of this
 Jawafdehi case quality. Reply with JSON only.
@@ -380,12 +394,15 @@ def judge_rules(
             samples[key].append(int(round(sc)))
         if parsed.get("rationale"):
             last_rationale[key] = parsed["rationale"]
+        # These come straight from LLM output, which sometimes returns a bare
+        # string instead of a list; coerce so downstream iteration never walks a
+        # string character-by-character.
         if parsed.get("issues"):
-            last_issues[key] = parsed["issues"]
+            last_issues[key] = _as_str_list(parsed["issues"])
         if parsed.get("notes"):
-            last_notes[key] = parsed["notes"]
+            last_notes[key] = _as_str_list(parsed["notes"])
         if parsed.get("suggestions"):
-            last_suggestions[key] = parsed["suggestions"]
+            last_suggestions[key] = _as_str_list(parsed["suggestions"])
 
     def _run(task):
         kind = task[0]

--- a/review/judge.py
+++ b/review/judge.py
@@ -65,6 +65,20 @@ REVIEW_SYSTEM = (
     "English. You ALWAYS reply with a single valid JSON object and nothing else."
 )
 
+# Shared guidance that keeps the score focused on material problems. Trivial /
+# cosmetic findings are still surfaced (for transparency) but in a separate,
+# non-scoring `notes` channel so they do not drag the grade down.
+_MATERIALITY_GUIDANCE = (
+    "Separate MATERIAL problems from TRIVIAL ones. `issues` and your SCORE are "
+    "for MATERIAL problems only — things that genuinely affect the case's "
+    "accuracy, completeness, sourcing, fairness, or a reader's understanding. "
+    "Cosmetic / sub-material findings — paisa-level rounding, a single news "
+    "outlet's typo'd figure when the authoritative figure matches, markdown "
+    "formatting, description length/ordering — go in `notes` (informational). "
+    "Such trivial findings MUST NOT appear in `issues` and MUST NOT reduce the "
+    "score; surface them in `notes` so the caseworker still sees them."
+)
+
 
 def _rule_context_block(case_summary, source_excerpts, case_type_label):
     """The case data + source excerpts shared verbatim by every rule call.
@@ -94,13 +108,18 @@ against the ONE rule below. Reply with JSON only.
 RULE TO GRADE:
 {block}
 
-Score the rule 0-100 with a short rationale, the concrete issues you found, and
-a list of concrete, actionable SUGGESTIONS the caseworker can apply to improve
-the case against THIS rule (each suggestion an imperative one-liner, e.g.
+Score the rule 0-100 with a short rationale, the concrete (material) issues you
+found, any trivial/cosmetic observations as `notes`, and a list of concrete,
+actionable SUGGESTIONS the caseworker can apply to improve the case against THIS
+rule (each suggestion an imperative one-liner, e.g.
 "Add the special-court verdict date to the timeline"). If the rule is fully
-satisfied, return an empty suggestions list. Judge ONLY against this rule.
+satisfied, return empty `issues` and `suggestions` lists. Judge ONLY against
+this rule.
+
+{_MATERIALITY_GUIDANCE}
+
 Reply EXACTLY in this JSON shape:
-{{"score": <int 0-100>, "rationale": "<str>", "issues": ["<str>"], "suggestions": ["<str>"]}}"""
+{{"score": <int 0-100>, "rationale": "<str>", "issues": ["<str>"], "notes": ["<str>"], "suggestions": ["<str>"]}}"""
 
 
 def _build_single_rule_content(context_block, rule):
@@ -141,11 +160,16 @@ against EACH of the {len(rules)} rules below. Reply with JSON only.
 RULES TO GRADE:
 {rules_block}
 
-For EACH rule: score 0-100 with a short rationale, the concrete issues you found,
-and a list of concrete, actionable SUGGESTIONS (imperative one-liners; empty list
-if the rule is fully satisfied). Judge each rule INDEPENDENTLY against ONLY that
-rule. Return exactly one entry per rule key. Reply EXACTLY in this JSON shape:
-{{"rules": {{"<rule_key>": {{"score": <int 0-100>, "rationale": "<str>", "issues": ["<str>"], "suggestions": ["<str>"]}}}}}}"""
+For EACH rule: score 0-100 with a short rationale, the concrete (material) issues
+you found, any trivial/cosmetic observations as `notes`, and a list of concrete,
+actionable SUGGESTIONS (imperative one-liners; empty list if the rule is fully
+satisfied). Judge each rule INDEPENDENTLY against ONLY that rule. Return exactly
+one entry per rule key.
+
+{_MATERIALITY_GUIDANCE}
+
+Reply EXACTLY in this JSON shape:
+{{"rules": {{"<rule_key>": {{"score": <int 0-100>, "rationale": "<str>", "issues": ["<str>"], "notes": ["<str>"], "suggestions": ["<str>"]}}}}}}"""
 
 
 def _build_batch_content(context_block, rules):
@@ -338,6 +362,7 @@ def judge_rules(
     samples = {k: [] for k in keys}
     last_rationale = {k: "" for k in keys}
     last_issues = {k: [] for k in keys}
+    last_notes = {k: [] for k in keys}
     last_suggestions = {k: [] for k in keys}
     narrative = ""
     errors = []
@@ -357,6 +382,8 @@ def judge_rules(
             last_rationale[key] = parsed["rationale"]
         if parsed.get("issues"):
             last_issues[key] = parsed["issues"]
+        if parsed.get("notes"):
+            last_notes[key] = parsed["notes"]
         if parsed.get("suggestions"):
             last_suggestions[key] = parsed["suggestions"]
 
@@ -423,6 +450,7 @@ def judge_rules(
             "samples": vals,
             "rationale": last_rationale[k],
             "issues": last_issues[k],
+            "notes": last_notes[k],
             "suggestions": last_suggestions[k],
         }
     return out

--- a/review/rule_defaults.py
+++ b/review/rule_defaults.py
@@ -184,81 +184,6 @@ DEFAULT_RULES = [
         "enabled": True,
         "order": 45,
     },
-    # ---------------- Title quality (LLM) ----------------
-    {
-        "key": "title_quality",
-        "title": "Title is a clear, strong headline",
-        "category": "Completeness",
-        "kind": "llm",
-        "detector": "",
-        "condition_text": "Always active (judges the case `title` only, not section headings).",
-        "applies_to": ALL,
-        "description": (
-            "The case `title` is the public headline, so it should read like a "
-            "good news headline — not a bureaucratic file label. Judge ONLY the "
-            "title string (ignore the slug and the in-body section headings).\n\n"
-            "A strong title:\n"
-            "1. **Leads with the recognisable subject** — the named scheme "
-            "(e.g. `टेरामक्स (TERAMOCS)`), the place / project / institution "
-            "(`भरत ताल`, `औरही गाउँपालिका १५ शैय्या अस्पताल`), or a notable "
-            "person.\n"
-            "2. **Names the offence** (`गैरकानूनी सम्पत्ति आर्जन`, `भ्रष्टाचार`, "
-            "`घोटाला`, `ठेक्का अनियमितता`).\n"
-            "3. Is a **concise headline, not a clause-stuffed sentence**.\n"
-            "4. Uses **clean grammar and spelling**.\n\n"
-            "**Memorability hook — REWARD WHEN WARRANTED, never required.** A clean "
-            "plain title is already full marks when the case has nothing dramatic "
-            "to surface (e.g. a routine procurement case). Reward a hook only when "
-            "the case data actually supports one, and only mark a title "
-            "'could be stronger' (a MILD deduction, never a fail) when the case "
-            "carries a salient fact that the title **buries**. Hooks worth "
-            "surfacing, drawn from the case data:\n"
-            "- a large `bigo` / loss amount in words (`३.२ अर्ब`, `३३ करोड`) — "
-            "e.g. a 3.2-arba procurement case whose title omits the figure is "
-            "weaker than it could be;\n"
-            "- a count of accused (`X समेत १८ जना विरुद्ध`);\n"
-            "- a marquee named scheme or public figure;\n"
-            "- a vivid concrete scale (`१५ शैय्याको अस्पताल`).\n"
-            "A colon split (`<punchy lead>: <detail>`) is a good way to carry a "
-            "hook. Do NOT force a hook onto a small/routine case, and do NOT "
-            "deduct for its absence there.\n\n"
-            "**Accuracy guard.** A number in the title must not contradict the "
-            "case's own figures: if the title states an amount that conflicts with "
-            "`bigo` / the cited loss (allowing for the legitimate loss-vs-bigo "
-            "distinction and rounding), flag it — a catchy but wrong headline is "
-            "worse than a plain one. (Deep figure-vs-source matching stays with "
-            "the bigo rule; here just catch an internally contradictory number.)\n\n"
-            "**Do NOT penalise** the title for carrying the court case number in "
-            "parentheses (e.g. `(081-CR-0095)`) — that is required and enforced "
-            "elsewhere. Score the headline quality, not the presence of the "
-            "number."
-        ),
-        "good_examples": (
-            "`NTC मा ३३ करोडको घोटाला: सुनिल पौडेलसमेत १८ जनाविरुद्ध मुद्दा "
-            "(081-CR-0111)` — subject + amount + count, colon headline. "
-            "`टेरामक्स (TERAMOCS) खरिदमा ३.२ अर्बको भ्रष्टाचार मुद्दा (081-CR-0095)` "
-            "— named scheme with the big number surfaced. "
-            "`औरही गाउँपालिकामा १५ शैय्याको अस्पताल निर्माण ठेक्कामा भ्रष्टाचार "
-            "(081-CR-0121)` — concise, vivid scale hook. "
-            "`पशुपति शवदाह गृह मेसिन खरिद भ्रष्टाचार मुद्दा (081-CR-0129)` — plain "
-            "but clear; full marks because the case has no salient quantifiable to "
-            "surface."
-        ),
-        "bad_examples": (
-            "`CIAA Special Court Case 93-068-0194: विश्वनाथ प्रसाद तेली` — "
-            "bureaucratic file label: court number + a bare name, no subject or "
-            "offence. "
-            "`काठमाडौँ महानगरपालिका तत्कालीन इन्जिनियर (उपनिर्देशक) रामबाबु महतो "
-            "कोईरी उपर गैरकानूनी सम्पत्ति आर्जन भ्रष्टाचार मुद्दा (081-CR-0116)` — "
-            "reads like a clause-stuffed sentence, not a headline. "
-            "A title whose stated amount (`छपन्न करोड` / 56 cr) contradicts the "
-            "case's own `bigo` (~5.67 cr) — catchy but internally inconsistent. "
-            "A title with spelling errors (`बिरुद्द`, `भष्ट्राचार`)."
-        ),
-        "weight": 1.0,
-        "enabled": True,
-        "order": 46,
-    },
     # ---------------- Tonal neutrality (LLM) ----------------
     {
         "key": "tonal_neutrality",
@@ -800,5 +725,84 @@ DEFAULT_RULES = [
         "weight": 0.6,
         "enabled": True,
         "order": 100,
+    },
+    # ---------------- Title quality (LLM) ----------------
+    # NOTE: appended at the END of the list on purpose. CodeRule.id is the
+    # definition index (+1), so inserting mid-list would renumber every later
+    # rule's id. `order: 46` keeps it in its intended DISPLAY slot (right after
+    # the slug rule) without shifting any existing ids.
+    {
+        "key": "title_quality",
+        "title": "Title is a clear, strong headline",
+        "category": "Completeness",
+        "kind": "llm",
+        "detector": "",
+        "condition_text": "Always active (judges the case `title` only, not section headings).",
+        "applies_to": ALL,
+        "description": (
+            "The case `title` is the public headline, so it should read like a "
+            "good news headline — not a bureaucratic file label. Judge ONLY the "
+            "title string (ignore the slug and the in-body section headings).\n\n"
+            "A strong title:\n"
+            "1. **Leads with the recognisable subject** — the named scheme "
+            "(e.g. `टेरामक्स (TERAMOCS)`), the place / project / institution "
+            "(`भरत ताल`, `औरही गाउँपालिका १५ शैय्या अस्पताल`), or a notable "
+            "person.\n"
+            "2. **Names the offence** (`गैरकानूनी सम्पत्ति आर्जन`, `भ्रष्टाचार`, "
+            "`घोटाला`, `ठेक्का अनियमितता`).\n"
+            "3. Is a **concise headline, not a clause-stuffed sentence**.\n"
+            "4. Uses **clean grammar and spelling**.\n\n"
+            "**Memorability hook — REWARD WHEN WARRANTED, never required.** A clean "
+            "plain title is already full marks when the case has nothing dramatic "
+            "to surface (e.g. a routine procurement case). Reward a hook only when "
+            "the case data actually supports one, and only mark a title "
+            "'could be stronger' (a MILD deduction, never a fail) when the case "
+            "carries a salient fact that the title **buries**. Hooks worth "
+            "surfacing, drawn from the case data:\n"
+            "- a large `bigo` / loss amount in words (`३.२ अर्ब`, `३३ करोड`) — "
+            "e.g. a 3.2-arba procurement case whose title omits the figure is "
+            "weaker than it could be;\n"
+            "- a count of accused (`X समेत १८ जना विरुद्ध`);\n"
+            "- a marquee named scheme or public figure;\n"
+            "- a vivid concrete scale (`१५ शैय्याको अस्पताल`).\n"
+            "A colon split (`<punchy lead>: <detail>`) is a good way to carry a "
+            "hook. Do NOT force a hook onto a small/routine case, and do NOT "
+            "deduct for its absence there.\n\n"
+            "**Accuracy guard.** A number in the title must not contradict the "
+            "case's own figures: if the title states an amount that conflicts with "
+            "`bigo` / the cited loss (allowing for the legitimate loss-vs-bigo "
+            "distinction and rounding), flag it — a catchy but wrong headline is "
+            "worse than a plain one. (Deep figure-vs-source matching stays with "
+            "the bigo rule; here just catch an internally contradictory number.)\n\n"
+            "**Do NOT penalise** the title for carrying the court case number in "
+            "parentheses (e.g. `(081-CR-0095)`) — that is required and enforced "
+            "elsewhere. Score the headline quality, not the presence of the "
+            "number."
+        ),
+        "good_examples": (
+            "`NTC मा ३३ करोडको घोटाला: सुनिल पौडेलसमेत १८ जनाविरुद्ध मुद्दा "
+            "(081-CR-0111)` — subject + amount + count, colon headline. "
+            "`टेरामक्स (TERAMOCS) खरिदमा ३.२ अर्बको भ्रष्टाचार मुद्दा (081-CR-0095)` "
+            "— named scheme with the big number surfaced. "
+            "`औरही गाउँपालिकामा १५ शैय्याको अस्पताल निर्माण ठेक्कामा भ्रष्टाचार "
+            "(081-CR-0121)` — concise, vivid scale hook. "
+            "`पशुपति शवदाह गृह मेसिन खरिद भ्रष्टाचार मुद्दा (081-CR-0129)` — plain "
+            "but clear; full marks because the case has no salient quantifiable to "
+            "surface."
+        ),
+        "bad_examples": (
+            "`CIAA Special Court Case 93-068-0194: विश्वनाथ प्रसाद तेली` — "
+            "bureaucratic file label: court number + a bare name, no subject or "
+            "offence. "
+            "`काठमाडौँ महानगरपालिका तत्कालीन इन्जिनियर (उपनिर्देशक) रामबाबु महतो "
+            "कोईरी उपर गैरकानूनी सम्पत्ति आर्जन भ्रष्टाचार मुद्दा (081-CR-0116)` — "
+            "reads like a clause-stuffed sentence, not a headline. "
+            "A title whose stated amount (`छपन्न करोड` / 56 cr) contradicts the "
+            "case's own `bigo` (~5.67 cr) — catchy but internally inconsistent. "
+            "A title with spelling errors (`बिरुद्द`, `भष्ट्राचार`)."
+        ),
+        "weight": 1.0,
+        "enabled": True,
+        "order": 46,
     },
 ]

--- a/review/rule_defaults.py
+++ b/review/rule_defaults.py
@@ -89,7 +89,12 @@ DEFAULT_RULES = [
             "The `description` must accurately and completely **summarise the "
             "case**: who is accused, what they allegedly did, the amount/scheme, "
             "the agency (CIAA etc.), and the current status — faithful to the "
-            "source documents."
+            "source documents.\n\n"
+            "Score on substance. Cosmetic matters — overall length, section "
+            "ordering, a malformed markdown table, minor wording — belong in "
+            "`notes`, not `issues`, and must not lower the score; only a "
+            "substantive failure (missing the core allegation/amount/status, or "
+            "contradicting the sources) is a scored issue."
         ),
         "good_examples": "A reader who only reads the description understands the whole case and it matches the sources.",
         "bad_examples": "Description omits the core allegation, the amount, or contradicts the sources; or is a stub.",
@@ -114,7 +119,12 @@ DEFAULT_RULES = [
             "the `bigo` figure. Allow for unit phrasing (e.g. arba/karod/lakh vs. "
             "plain rupees) and rounding, but flag a genuine mismatch in the "
             "figure. If the press release states the amount in a foreign currency "
-            "with an NPR conversion, compare against the NPR total."
+            "with an NPR conversion, compare against the NPR total.\n\n"
+            "Treat paisa-level rounding (e.g. dropping a trailing `.85`) and a "
+            "single divergent news-outlet figure — when the authoritative "
+            "press-release / charge-sheet amount still matches `bigo` — as a "
+            "`notes` observation, NOT a scored issue: keep the score at 100. Only "
+            "an actual contradiction with the authoritative figure is an `issue`."
         ),
         "good_examples": (
             "Press release states रु. ३.२१ अर्ब and `bigo` is 3,218,377,182 — the "
@@ -173,6 +183,81 @@ DEFAULT_RULES = [
         "weight": 1.0,
         "enabled": True,
         "order": 45,
+    },
+    # ---------------- Title quality (LLM) ----------------
+    {
+        "key": "title_quality",
+        "title": "Title is a clear, strong headline",
+        "category": "Completeness",
+        "kind": "llm",
+        "detector": "",
+        "condition_text": "Always active (judges the case `title` only, not section headings).",
+        "applies_to": ALL,
+        "description": (
+            "The case `title` is the public headline, so it should read like a "
+            "good news headline — not a bureaucratic file label. Judge ONLY the "
+            "title string (ignore the slug and the in-body section headings).\n\n"
+            "A strong title:\n"
+            "1. **Leads with the recognisable subject** — the named scheme "
+            "(e.g. `टेरामक्स (TERAMOCS)`), the place / project / institution "
+            "(`भरत ताल`, `औरही गाउँपालिका १५ शैय्या अस्पताल`), or a notable "
+            "person.\n"
+            "2. **Names the offence** (`गैरकानूनी सम्पत्ति आर्जन`, `भ्रष्टाचार`, "
+            "`घोटाला`, `ठेक्का अनियमितता`).\n"
+            "3. Is a **concise headline, not a clause-stuffed sentence**.\n"
+            "4. Uses **clean grammar and spelling**.\n\n"
+            "**Memorability hook — REWARD WHEN WARRANTED, never required.** A clean "
+            "plain title is already full marks when the case has nothing dramatic "
+            "to surface (e.g. a routine procurement case). Reward a hook only when "
+            "the case data actually supports one, and only mark a title "
+            "'could be stronger' (a MILD deduction, never a fail) when the case "
+            "carries a salient fact that the title **buries**. Hooks worth "
+            "surfacing, drawn from the case data:\n"
+            "- a large `bigo` / loss amount in words (`३.२ अर्ब`, `३३ करोड`) — "
+            "e.g. a 3.2-arba procurement case whose title omits the figure is "
+            "weaker than it could be;\n"
+            "- a count of accused (`X समेत १८ जना विरुद्ध`);\n"
+            "- a marquee named scheme or public figure;\n"
+            "- a vivid concrete scale (`१५ शैय्याको अस्पताल`).\n"
+            "A colon split (`<punchy lead>: <detail>`) is a good way to carry a "
+            "hook. Do NOT force a hook onto a small/routine case, and do NOT "
+            "deduct for its absence there.\n\n"
+            "**Accuracy guard.** A number in the title must not contradict the "
+            "case's own figures: if the title states an amount that conflicts with "
+            "`bigo` / the cited loss (allowing for the legitimate loss-vs-bigo "
+            "distinction and rounding), flag it — a catchy but wrong headline is "
+            "worse than a plain one. (Deep figure-vs-source matching stays with "
+            "the bigo rule; here just catch an internally contradictory number.)\n\n"
+            "**Do NOT penalise** the title for carrying the court case number in "
+            "parentheses (e.g. `(081-CR-0095)`) — that is required and enforced "
+            "elsewhere. Score the headline quality, not the presence of the "
+            "number."
+        ),
+        "good_examples": (
+            "`NTC मा ३३ करोडको घोटाला: सुनिल पौडेलसमेत १८ जनाविरुद्ध मुद्दा "
+            "(081-CR-0111)` — subject + amount + count, colon headline. "
+            "`टेरामक्स (TERAMOCS) खरिदमा ३.२ अर्बको भ्रष्टाचार मुद्दा (081-CR-0095)` "
+            "— named scheme with the big number surfaced. "
+            "`औरही गाउँपालिकामा १५ शैय्याको अस्पताल निर्माण ठेक्कामा भ्रष्टाचार "
+            "(081-CR-0121)` — concise, vivid scale hook. "
+            "`पशुपति शवदाह गृह मेसिन खरिद भ्रष्टाचार मुद्दा (081-CR-0129)` — plain "
+            "but clear; full marks because the case has no salient quantifiable to "
+            "surface."
+        ),
+        "bad_examples": (
+            "`CIAA Special Court Case 93-068-0194: विश्वनाथ प्रसाद तेली` — "
+            "bureaucratic file label: court number + a bare name, no subject or "
+            "offence. "
+            "`काठमाडौँ महानगरपालिका तत्कालीन इन्जिनियर (उपनिर्देशक) रामबाबु महतो "
+            "कोईरी उपर गैरकानूनी सम्पत्ति आर्जन भ्रष्टाचार मुद्दा (081-CR-0116)` — "
+            "reads like a clause-stuffed sentence, not a headline. "
+            "A title whose stated amount (`छपन्न करोड` / 56 cr) contradicts the "
+            "case's own `bigo` (~5.67 cr) — catchy but internally inconsistent. "
+            "A title with spelling errors (`बिरुद्द`, `भष्ट्राचार`)."
+        ),
+        "weight": 1.0,
+        "enabled": True,
+        "order": 46,
     },
     # ---------------- Tonal neutrality (LLM) ----------------
     {
@@ -680,27 +765,37 @@ DEFAULT_RULES = [
         "condition_text": "Always active.",
         "applies_to": ALL,
         "description": (
-            "Known gaps and uncertainties in the record must be **openly "
-            "declared** (in `missing_details` / notes) rather than papered over "
-            "or hidden.\n\n"
-            "Judge honesty, not just presence: compare what the description and "
-            "sources imply is still unknown or unverified against what the case "
-            "actually declares as missing. The case should acknowledge things "
-            "like undisclosed amounts, pending documents, unconfirmed parties, or "
-            "unresolved status — instead of stating uncertain things as settled "
-            "fact or silently omitting them.\n\n"
-            "Flag where the record glosses over an obvious gap, and credit a "
-            "case that candidly lists what it still lacks."
+            "`missing_details` is for honest disclosure of the **sources and "
+            "documents the caseworker could not obtain** while researching the "
+            "case — research/sourcing limitations — NOT a restatement of every "
+            "uncertain case fact.\n\n"
+            "Judge whether the case is honest about what **evidence it is "
+            "missing**: name primary documents that were sought but not found or "
+            "not yet available (e.g. the full charge sheet, the signed "
+            "special-court verdict text, an audit report), and flag any claim that "
+            "rests on secondary reporting because the primary record could not be "
+            "retrieved.\n\n"
+            "Do **NOT** penalise the case for failing to declare an uncertain "
+            "*case fact* as 'missing' — e.g. whether an appeal was filed, the "
+            "appellate outcome, or a still-pending status. Those belong in the "
+            "narrative / timeline, not in `missing_details`, and their absence "
+            "from `missing_details` is **not** a gap-honesty problem.\n\n"
+            "Still flag genuine **dishonesty**: a contested or unconfirmed figure "
+            "presented as settled fact, or the case leaning on a source while "
+            "hiding that the primary document was never obtained."
         ),
         "good_examples": (
-            "`missing_details` notes that the special-court verdict is still "
-            "pending and the exact bigo for two defendants is not yet confirmed — "
-            "matching gaps visible in the sources."
+            "`missing_details` states that the full charge sheet and the signed "
+            "special-court verdict could not be obtained, so some figures rely on "
+            "the CIAA press release and news reporting — an honest disclosure of "
+            "which sources are missing."
         ),
         "bad_examples": (
-            "The narrative presents a contested or unconfirmed figure as final "
-            "and declares no missing details, even though the sources show the "
-            "case is still sub judice."
+            "The case relies on a news figure as if it were the official "
+            "charge-sheet amount without noting the primary document was never "
+            "retrieved; or it presents a contested bigo as final fact. NOT bad: "
+            "simply not listing 'appeal status unknown' in `missing_details` — "
+            "that is a case fact, not a source gap, and must not be penalised."
         ),
         "weight": 0.6,
         "enabled": True,

--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -202,8 +202,8 @@ def structural_completeness(case):
     pts += min(len(entities) / 3.0, 1.0) * 12
     pts += min(len(tags) / 3.0, 1.0) * 8
     issues = []
-    if len(allegations) < 3:
-        issues.append(f"Only {len(allegations)} key allegations (org min: 3).")
+    if len(allegations) < 2:
+        issues.append(f"Only {len(allegations)} key allegations (org min: 2).")
     if len(timeline) < 3:
         issues.append(f"Only {len(timeline)} timeline events (org min: 3).")
     if not entities:

--- a/review/scorer.py
+++ b/review/scorer.py
@@ -222,6 +222,7 @@ def score_case(
                 variance = jd["variance"]
                 std = jd["std"]
                 issues = jd.get("issues", [])
+                notes = jd.get("notes", [])
                 suggestions = jd.get("suggestions", [])
                 rationale = jd.get("rationale", "")
                 samples = jd.get("samples", [])
@@ -233,6 +234,7 @@ def score_case(
                 # judge failed -> neutral default, explicitly low confidence
                 score, variance, std, samples = 50, 0.0, 0.0, []
                 issues = []
+                notes = []
                 suggestions = []
                 rationale = (
                     f"Judge unavailable: {judge_err}" if judge_err else "Judge not run."
@@ -243,6 +245,7 @@ def score_case(
             if fn is None:
                 continue
             score, issues = fn(case)
+            notes = []
             suggestions = []
             variance, std, samples = 0.0, 0.0, []
             rationale = ""
@@ -272,6 +275,7 @@ def score_case(
                 "std": std,
                 "samples": samples,
                 "issues": issues,
+                "notes": notes,
                 "suggestions": suggestions,
                 "rationale": rationale,
                 "description": r.description,
@@ -317,6 +321,13 @@ def score_case(
         for issue in rr["issues"]:
             gaps.append({"rule": rr["title"], "issue": issue})
 
+    # Informational, non-scoring notes (trivial / cosmetic findings). Surfaced
+    # separately from `gaps` so they are visible without reading as grading gaps.
+    info = []
+    for rr in rule_results:
+        for note in rr["notes"]:
+            info.append({"rule": rr["title"], "note": note})
+
     return {
         "slug": case.get("slug"),
         "title": case.get("title"),
@@ -330,6 +341,7 @@ def score_case(
         "gates_pass": gates_pass,
         "narrative": narrative,
         "gaps": gaps,
+        "info": info,
         "judge_error": judge_err,
         "llm_samples": n_samples,
         "thresholds": {"pass": pass_t, "revise": revise_t},


### PR DESCRIPTION
## Summary

Incorporates lead-reviewer (Rujit) feedback on the casework review system, calibrated against the **080-CR-0047** review pair (review #21 `REJECT` → #74 `PASS`). Four targeted rule changes:

1. **Allegations floor 3 → 2** (`rules_engine.py`) — the number of key allegations follows the case facts, so stop flagging a 2-allegation case. Now only flags below 2 (`org min: 2`).
2. **Re-scope "Gap honesty"** (`rule_defaults.py`) — `missing_details` is for honest disclosure of **un-obtained source documents**, not a restatement of every uncertain case fact. Not declaring an appeal/pending status in `missing_details` is no longer penalised; genuine dishonesty (a contested figure stated as final) still is.
3. **Trivial findings are informative, not graded** (`judge.py`, `scorer.py`) — a new non-scoring `notes` channel carries cosmetic/sub-material observations (paisa rounding, single-outlet typo figures, formatting/length). They surface in a new top-level `info` list but no longer drag the score down. Reinforced in the `bigo_matches_press_release` and `description_summarises_case` rules.
4. **New `title_quality` rule (title-only)** (`rule_defaults.py`) — an LLM rule rewarding a clear, strong headline (subject-lead + offense + concise + clean grammar) with a **reward-when-warranted** memorability hook (amount / count / named scheme / vivid scale), never penalising a clean plain title, plus an internal amount-consistency guard. Good/bad examples drawn from a survey of real published titles.

### Design calls worth a reviewer's eye
- Title-rule **scope is title only**; section-heading grading was deliberately deferred.
- On two points that were still open in discussion, this PR takes a default: hook = *reward-when-warranted (no penalty for plain)*, and the title rule does a *light self-consistency check* on amounts while deep figure-matching stays with the bigo rule. Easy to dial back.
- The `notes`/`info` additions are backward-compatible (`.get(..., [])` defaults); `result` is stored wholesale so `info` flows to the API with no serializer change.

## Test plan
- [x] `ruff` + `black` pre-commit hooks pass
- [x] `py_compile` of all four files; `DEFAULT_RULES` loads (27 rules, unique keys, `title_quality` registered)
- [x] `structural_completeness` unit-checked: flags only at <2 allegations
- [x] Judge prompts render the `notes` field + materiality guidance (single + batch paths)
- [ ] **Run the DB-backed pytest suite** (`pytest-django` + Postgres) in CI — could not run locally
- [ ] Spot-check a live re-review of 080-CR-0047 to confirm the prior noise gaps now land in `info`, not `gaps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added title quality scoring rule for evaluating case headlines based on clarity and presentation standards

* **Improvements**
  * Refined rule scoring to distinguish material findings from cosmetic/formatting observations
  * Reduced minimum key allegations requirement for case evaluation
  * Non-scoring observational notes now tracked and displayed separately from scored issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->