### PR TITLE
feat(casework): sharpen title prompt + add standalone enrich_title

### DIFF
--- a/casework/common.py
+++ b/casework/common.py
@@ -13,6 +13,7 @@ These scripts never touch the ORM; reads and writes go over the API.
 
 import logging
 import os
+import re
 import sys
 import urllib.parse
 
@@ -733,6 +734,173 @@ def parse_extraction_response(response_text, wrapper_keys):
                     return entries
             except json.JSONDecodeError:
                 pass
+    return None
+
+
+# ── title generation (shared by enrich_description + enrich_title) ────────────
+
+# The public-headline contract. Both the description enricher (which regenerates
+# the title as a side-effect of the description pass) and the standalone title
+# enricher embed this verbatim so titles stay consistent across both paths.
+# It is the rules ONLY — each script appends its own OUTPUT FORMAT block, since
+# the description pass emits {"title", "description"} and the title pass {"title"}.
+TITLE_RULES = """\
+TITLE RULES (when asked to regenerate the title):
+- Lead with the real, recognisable subject of the case — a named scheme/project,
+  the institution, or the principal accused — and name the nature of the offence
+  (भ्रष्टाचार / घोटाला / गैरकानूनी सम्पत्ति आर्जन / ठेक्का अनियमितता, etc.).
+- Write a concise, SEARCHABLE headline, not a clause-stuffed sentence. Vary the
+  construction across cases; do not use a rigid template. A colon split is fine
+  ("<subject>: <offence + hook>"). Use clean, idiomatic Nepali grammar/spelling.
+- Be catchy but strictly factual — ground every word in the provided data; never
+  invent names, amounts, sections, or outcomes.
+- HOOK (reward when warranted, never forced): when the case data carries a
+  salient, quantifiable detail, surface it instead of burying it — the बिगो
+  amount in natural scale (e.g. ३.२ अर्ब, ३३ करोड), a marquee named scheme, a
+  notable principal accused, or a vivid concrete scale from the data (e.g.
+  "१५ शैय्या अस्पताल"). A large बिगो or a marquee scheme left out of the title is
+  a missed hook — pull it forward. But do NOT manufacture a hook where the data
+  has none: a plain, clear, accurate title for a routine case is correct and
+  complete, not a weakness.
+- AMOUNT ACCURACY: any monetary figure in the title MUST be the verified बिगो (or
+  a loss/disputed figure stated explicitly in the case data) — never a different
+  or contradictory number. If the figures are uncertain or conflict, OMIT the
+  number and use a non-numeric hook. A catchy-but-wrong number is worse than no
+  number.
+- NEVER put a defendant HEADCOUNT in the title. Forbidden: any "<संख्या> जना",
+  "समेत X जना", "X प्रतिवादी(माथि/मा)", "तीन/चार… अध्यक्षसहित", or similar count
+  of people. This applies even when there are many defendants.
+    * Many defendants → name the ONE principal accused (or the institution) and
+      mark the rest with "समेत" and NO number, e.g.
+      "…सचिव संजय शर्मासमेतविरुद्ध भ्रष्टाचार मुद्दा", NOT "…सचिवसमेत १२ जना…".
+- GRAMMAR — do NOT stack postpositions. Never jam "सहित" or "लगायत" directly onto
+  "विरुद्ध" / "माथि" (WRONG: "रसाईलीसहितविरुद्ध", "भुषाललगायतविरुद्ध",
+  "यादवलगायतमाथि"). Use exactly ONE connective: "<नाम>विरुद्ध …" for a single
+  accused, or "<नाम>समेतविरुद्ध …" when there are co-accused. Keep "विरुद्ध"
+  attached to the name it governs.
+- The title MUST end with the special-court case number in parentheses, exactly
+  as given to you, e.g. "… (080-CR-0047)". Keep the hook from crowding it out.
+- Keep it under ~160 characters."""
+
+# A court case number like 080-CR-0047 / 081-WO-1234. Case-insensitive to match
+# the review gate's detector; the lookbehind/ahead anchor the token so a
+# malformed adjacent token can't match the real number as a substring.
+COURT_RE = re.compile(r"(?<![\dA-Za-z])\d{2,3}-[A-Za-z]{1,3}-\d{3,4}(?![\dA-Za-z])")
+
+# Defendant-headcount patterns a title must avoid: a Devanagari/ASCII number
+# immediately followed by जना / व्यक्ति / प्रतिवादी. The court number itself
+# (080-CR-0098) won't match — no such trailing noun.
+_HEADCOUNT_RE = re.compile(r"[०-९0-9]+\s*(जना|व्यक्ति|प्रतिवादी)")
+
+
+def special_court_number(case: dict):
+    """The special-court case number from court_cases ('special:NNN' preferred,
+    else any 'court:NNN'), or None."""
+    for ref in case.get("court_cases") or []:
+        if isinstance(ref, str) and ref.startswith("special:"):
+            return ref.split(":", 1)[1]
+    for ref in case.get("court_cases") or []:
+        if isinstance(ref, str) and ":" in ref:
+            return ref.split(":", 1)[1]
+    return None
+
+
+def validate_title(title, court_number):
+    """Return a problem string if the title violates the court-number contract
+    (a number present, matching court_number, in trailing parens), else None."""
+    nums = {m.group(0).upper() for m in COURT_RE.finditer(title or "")}
+    if not nums:
+        return "regenerated title has no court case number"
+    if court_number and court_number.upper() not in nums:
+        return (
+            f"title number(s) {sorted(nums)} do not include the special-court "
+            f"number {court_number}"
+        )
+    if court_number:
+        expected = f"({court_number.upper()})"
+        if not (title or "").upper().rstrip().endswith(expected):
+            return (
+                f"title must end with the special-court case number "
+                f"in parentheses, e.g. '… {expected}'"
+            )
+    return None
+
+
+def title_has_headcount(title) -> bool:
+    """True if the title carries a forbidden defendant headcount."""
+    return bool(_HEADCOUNT_RE.search(title or ""))
+
+
+def format_bigo(bigo) -> str:
+    """Render the बिगो for a prompt: thousands-separated NPR, or '(unknown)'."""
+    try:
+        value = int(bigo)
+    except (TypeError, ValueError):
+        return "(unknown)"
+    return f"{value:,}" if value > 0 else "(unknown)"
+
+
+def format_list(items) -> str:
+    """Format a list of strings as prompt bullets, or '(none provided)'."""
+    if not items:
+        return "(none provided)"
+    return "\n".join(f"- {x}" for x in items)
+
+
+def format_entities(entities) -> str:
+    """Format the case entities (accused/related/location) as prompt bullets."""
+    if not entities:
+        return "(none provided)"
+    lines = []
+    for e in entities:
+        if not isinstance(e, dict):
+            continue
+        name = e.get("display_name") or ""
+        etype = e.get("type") or ""
+        notes = e.get("notes") or ""
+        line = f"- [{etype}] {name}"
+        if notes:
+            line += f" — {notes}"
+        lines.append(line)
+    return "\n".join(lines) or "(none provided)"
+
+
+def parse_title(response_text):
+    """Pull the title out of an LLM response.
+
+    Prefers a ``{"title": "..."}`` JSON object (scanning every ``{`` so leading
+    prose with braces doesn't abort the parse); falls back to the whole stripped
+    line when a frugal model returns the bare title. Returns the title or None.
+    """
+    import json
+
+    text = (response_text or "").strip()
+    if "```" in text:
+        start = text.find("```")
+        nl = text.find("\n", start)
+        end = text.find("```", nl + 1) if nl != -1 else -1
+        if nl != -1 and end != -1:
+            text = text[nl + 1 : end].strip()
+
+    for obj_start in range(len(text)):
+        if text[obj_start] != "{":
+            continue
+        block = balanced_object(text, obj_start)
+        if block is None:
+            continue
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("title"), str):
+            title = obj["title"].strip()
+            if title:
+                return title
+
+    # No JSON object — accept a bare single-line title (but not multi-line prose,
+    # which signals the model didn't follow the contract).
+    if text and "{" not in text and "\n" not in text:
+        return text
     return None
 
 

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -23,7 +23,6 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
 import urllib.parse
 from typing import Optional
@@ -34,6 +33,7 @@ import requests
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from casework.common import (
+    TITLE_RULES,
     VERDICT_SUMMARY_TARGET,
     VERDICT_SUMMARY_TRIGGER,
     CaseworkApi,
@@ -44,10 +44,16 @@ from casework.common import (
     content_from_evidence_entry,
     convert_date_tool,
     env_int,
+    format_bigo,
+    format_entities,
+    format_list,
     get_target_cases,
     print_summary,
     setup_logging,
+    special_court_number,
     summarize_verdict,
+    title_has_headcount,
+    validate_title,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,10 +66,6 @@ DESCRIPTION_SOURCE_TYPES = (
     "COURT_FILING_OTHER",
 )
 
-# A court case number like 080-CR-0047 / 081-WO-1234. Case-insensitive to match
-# the review gate's detector. The negative lookbehind/ahead anchor the token.
-COURT_RE = re.compile(r"(?<![\dA-Za-z])\d{2,3}-[A-Za-z]{1,3}-\d{3,4}(?![\dA-Za-z])")
-
 # Source-budget (characters) fed to the description prompt.
 # Env-tunable so the runner can widen them for big-context models (claude 1M):
 # raise the budget + verdict trigger to feed full court orders instead of an
@@ -71,7 +73,8 @@ COURT_RE = re.compile(r"(?<![\dA-Za-z])\d{2,3}-[A-Za-z]{1,3}-\d{3,4}(?![\dA-Za-z
 # live in casework.common (shared with enrich_timeline).
 SOURCE_TEXT_BUDGET = env_int("CASEWORK_SOURCE_TEXT_BUDGET", 60000)
 
-EXTRACTION_SYSTEM_PROMPT = """\
+EXTRACTION_SYSTEM_PROMPT = (
+    """\
 You are a Nepali legal analyst writing the public case summary (description) for \
 Jawafdehi, a civic accountability archive of Nepal's anti-corruption cases. The \
 case was investigated by the CIAA (अख्तियार दुरुपयोग अनुसन्धान आयोग) and tried at \
@@ -132,29 +135,15 @@ QUALITY RULES:
 - This is an official public record drawn from government/court documents; do not
   soften, editorialise, or add commentary. Neutral, factual tone only.
 
-TITLE RULES (when asked to regenerate the title):
-- Produce a concise, engaging, SEARCHABLE Nepali headline that names the real
-  subject of the case — the institution/scheme and/or the principal accused, and
-  ideally the बिगो amount or the nature of the offence.
-- Vary the construction across cases; do not use a rigid template. Be catchy but
-  strictly factual.
-- NEVER put a defendant HEADCOUNT in the title. Forbidden: any "<संख्या> जना",
-  "समेत X जना", "X प्रतिवादी(माथि/मा)", "तीन/चार… अध्यक्षसहित", or similar count
-  of people. This applies even when there are many defendants.
-    * Many defendants → name the ONE principal accused (or the institution) and
-      use "लगायत" / "सहित" with NO number, e.g.
-      "…सचिव संजय शर्मासहित…", NOT "…सचिवसमेत १२ जना…".
-    * BAD:  "…पदाधिकारीसमेत १२ जना सबैले सफाई" / "…२४९ प्रतिवादीमाथि…"
-      GOOD: "…सामुदायिक वनका पदाधिकारीसहित सबैलाई सफाई" /
-            "…तत्कालीन अध्यक्ष <नाम> लगायतमाथि भ्रष्टाचार अभियोग"
-- The title MUST end with the special-court case number in parentheses, exactly
-  as given to you, e.g. "… (080-CR-0047)".
-- Keep it under ~160 characters.
+"""
+    + TITLE_RULES
+    + """
 
 OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose:
 {"title": "नेपाली शीर्षक (080-CR-0047)", "description": "### क) …\\n…"}
 When title regeneration is disabled you may omit "title" or set it to null.
 """
+)
 
 EXTRACTION_USER_PROMPT = """\
 Write the Jawafdehi case description for the following CIAA Special Court case.
@@ -303,18 +292,6 @@ def _has_substantial_description(case: dict) -> bool:
     return len((case.get("description") or "").strip()) >= 600
 
 
-def _special_court_number(case: dict) -> Optional[str]:
-    """Extract special-court case number from court_cases."""
-    for ref in case.get("court_cases") or []:
-        if isinstance(ref, str) and ref.startswith("special:"):
-            return ref.split(":", 1)[1]
-    # Fall back to any court number present
-    for ref in case.get("court_cases") or []:
-        if isinstance(ref, str) and ":" in ref:
-            return ref.split(":", 1)[1]
-    return None
-
-
 def _process_case(
     case: dict,
     idx: int,
@@ -381,7 +358,7 @@ def _process_case(
             traceback.print_exc()
         return
 
-    court_number = _special_court_number(detail)
+    court_number = special_court_number(detail)
 
     # Generate description via LLM
     try:
@@ -420,12 +397,12 @@ def _process_case(
         print(f"    | ... ({len(description.splitlines())} lines total)")
 
     # Validate title
-    title_issue = _validate_title(new_title, court_number) if new_title else None
+    title_issue = validate_title(new_title, court_number) if new_title else None
     if title_issue:
         print(f"  TITLE WARNING: {title_issue}")
 
-    title_has_headcount = bool(new_title and _title_has_headcount(new_title))
-    if title_has_headcount:
+    has_headcount = bool(new_title and title_has_headcount(new_title))
+    if has_headcount:
         print(
             "  TITLE WARNING: contains a defendant headcount "
             "(e.g. 'X जना' / 'X प्रतिवादी') — title NOT written."
@@ -438,9 +415,7 @@ def _process_case(
     # Decide what to PATCH
     patch_title = (
         new_title
-        if (
-            not skip_title and new_title and not title_issue and not title_has_headcount
-        )
+        if (not skip_title and new_title and not title_issue and not has_headcount)
         else None
     )
 
@@ -561,40 +536,6 @@ def _assemble_source_text(
     return "\n\n---\n\n".join(parts)
 
 
-def _format_bigo(bigo) -> str:
-    """Render the bigo for the prompt."""
-    try:
-        value = int(bigo)
-    except (TypeError, ValueError):
-        return "(unknown)"
-    return f"{value:,}" if value > 0 else "(unknown)"
-
-
-def _format_list(items) -> str:
-    """Format a list of items for the prompt."""
-    if not items:
-        return "(none provided)"
-    return "\n".join(f"- {x}" for x in items)
-
-
-def _format_entities(entities) -> str:
-    """Format entities for the prompt."""
-    if not entities:
-        return "(none provided)"
-    lines = []
-    for e in entities:
-        if not isinstance(e, dict):
-            continue
-        name = e.get("display_name") or ""
-        etype = e.get("type") or ""
-        notes = e.get("notes") or ""
-        line = f"- [{etype}] {name}"
-        if notes:
-            line += f" — {notes}"
-        lines.append(line)
-    return "\n".join(lines) or "(none provided)"
-
-
 def _generate_description(
     detail: dict,
     court_number: Optional[str],
@@ -608,12 +549,12 @@ def _generate_description(
     prompt = EXTRACTION_USER_PROMPT.format(
         case_title=detail.get("title", ""),
         court_number=court_number or "(unknown)",
-        bigo=_format_bigo(detail.get("bigo")),
+        bigo=format_bigo(detail.get("bigo")),
         court_cases=", ".join(detail.get("court_cases") or []) or "(none)",
         title_instruction=TITLE_OFF if skip_title else TITLE_ON,
-        key_allegations=_format_list(detail.get("key_allegations")),
+        key_allegations=format_list(detail.get("key_allegations")),
         timeline=json.dumps(detail.get("timeline") or [], ensure_ascii=False),
-        entities=_format_entities(detail.get("entities")),
+        entities=format_entities(detail.get("entities")),
         ngm_section=_format_ngm_section(ngm_data),
         source_text=source_text,
     )
@@ -662,34 +603,6 @@ def _parse_response(response_text: str) -> Optional[dict]:
             return {"description": desc, "title": title or None}
     logger.warning("No JSON object with a description found in LLM response")
     return None
-
-
-def _validate_title(title: str, court_number: Optional[str]) -> Optional[str]:
-    """Validate the regenerated title."""
-    nums = {m.group(0).upper() for m in COURT_RE.finditer(title)}
-    if not nums:
-        return "regenerated title has no court case number"
-    if court_number and court_number.upper() not in nums:
-        return (
-            f"title number(s) {sorted(nums)} do not include the special-court "
-            f"number {court_number}"
-        )
-    if court_number:
-        expected = f"({court_number.upper()})"
-        if not title.upper().rstrip().endswith(expected):
-            return (
-                f"title must end with the special-court case number "
-                f"in parentheses, e.g. '… {expected}'"
-            )
-    return None
-
-
-_HEADCOUNT_RE = re.compile(r"[०-९0-9]+\s*(जना|व्यक्ति|प्रतिवादी)")
-
-
-def _title_has_headcount(title: str) -> bool:
-    """Check if title contains a defendant headcount."""
-    return bool(_HEADCOUNT_RE.search(title or ""))
 
 
 if __name__ == "__main__":

--- a/casework/enrich_title.py
+++ b/casework/enrich_title.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python
+"""Regenerate CIAA Special Court case TITLES from already-enriched fields (DB-free).
+
+Standalone, no-source-fetch counterpart to enrich_description's title pass: it
+rewrites ``Case.title`` from the case's existing description / key allegations /
+entities / बिगो, WITHOUT downloading or converting any source documents. A case
+that already has a good description has no other path to a fixed title, because
+enrich_description skips its (expensive, source-fetching) description+title pass
+once a substantial description exists — this script is that path.
+
+Shares the TITLE RULES, the court-number validator and the headcount guard with
+enrich_description via ``casework.common``, so titles stay consistent across both.
+
+Like the sibling enrichers, this reads cases and PATCHes the title entirely over
+the Jawafdehi HTTP API and never touches the database. Default behaviour WRITES;
+pass ``--dry-run`` to preview. A title that already passes validation (ends with
+its special-court number in parentheses, carries no headcount) is skipped unless
+``--force``.
+
+Usage:
+    python casework/enrich_title.py --dry-run
+    python casework/enrich_title.py --slug case-0123
+    python casework/enrich_title.py --priority --limit 20 --dry-run
+    python casework/enrich_title.py --court-case 081-CR-0095 --force
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import requests
+
+# Ensure the api dir is in sys.path so imports work when run as a file
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from casework.common import (
+    TITLE_RULES,
+    CaseworkApi,
+    add_common_args,
+    bootstrap,
+    format_bigo,
+    format_entities,
+    format_list,
+    get_target_cases,
+    parse_title,
+    print_summary,
+    setup_logging,
+    special_court_number,
+    title_has_headcount,
+    validate_title,
+)
+
+logger = logging.getLogger(__name__)
+
+# A snippet of the existing description is plenty of context for a headline and
+# keeps this single, no-source-fetch call token-frugal.
+DESCRIPTION_SNIPPET_BUDGET = 2000
+
+# get_target_cases skips a case when summary[skip_field] is truthy, but
+# "title already valid" is not a case field — so select on a key cases never
+# carry (nothing is skipped at selection) and do the already-valid idempotency
+# check per-case in _process_case instead.
+_NO_SKIP_FIELD = "__title_always_consider__"
+
+SYSTEM_PROMPT = (
+    """\
+You are a Nepali legal editor writing the public headline (title) for a case in \
+Jawafdehi, a civic accountability archive of Nepal's anti-corruption cases. The \
+case was investigated by the CIAA (अख्तियार दुरुपयोग अनुसन्धान आयोग) and tried at \
+the Special Court (विशेष अदालत).
+
+You are given the case's current title, its बिगो amount, key allegations, named \
+entities, and a snippet of the already-written case description. From these, write \
+ONE Nepali (देवनागरी) headline following the rules below.
+
+"""
+    + TITLE_RULES
+    + """
+
+OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose:
+{"title": "नेपाली शीर्षक (080-CR-0047)"}
+"""
+)
+
+USER_PROMPT = """\
+Write the Jawafdehi case title for the following CIAA Special Court case.
+
+Current title: {current_title}
+Special-court case number (MUST end the regenerated title): {court_number}
+Bigo (बिगो), NPR: {bigo}
+
+KEY ALLEGATIONS:
+{key_allegations}
+
+NAMED ENTITIES (accused / related / location):
+{entities}
+
+DESCRIPTION (snippet — the factual basis for the headline):
+{description}
+
+Return ONLY the JSON object described in the system prompt.
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=(
+            "Regenerate CIAA Special Court case titles via LLM "
+            "(DB-free, no source fetch)."
+        ),
+        epilog="Reads and writes entirely over HTTP via JAWAFDEHI_API_TOKEN.",
+    )
+    add_common_args(ap)
+    args = ap.parse_args()
+
+    setup_logging(args.verbose)
+
+    try:
+        bootstrap(args.provider, args.model)
+    except Exception as exc:
+        print(f"Bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    from llm.invoke import invoke_text
+    from llm.usage import UsageAccumulator, render_usage_table
+
+    try:
+        api = CaseworkApi(base_url=args.api_base_url, token=args.api_token)
+    except RuntimeError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    usage = UsageAccumulator()
+
+    cases = list(get_target_cases(api, args, skip_field=_NO_SKIP_FIELD))
+    total = len(cases)
+    if total == 0:
+        print("No CIAA draft cases to process.", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Found {total} CIAA draft case(s) to process.")
+    if args.force:
+        print("  --force: regenerating even titles that already pass validation")
+    if args.fiscal_year:
+        print(f"  Fiscal year filter: {args.fiscal_year}")
+    if args.dry_run:
+        print("  [DRY RUN] No changes will be saved.")
+
+    stats = {
+        "cases_processed": 0,
+        "cases_enriched": 0,
+        "cases_skipped": 0,
+        "cases_llm_error": 0,
+        "cases_already_valid": 0,
+    }
+
+    for idx, case in enumerate(cases, 1):
+        try:
+            _process_case(
+                case=case,
+                idx=idx,
+                total=total,
+                dry_run=args.dry_run,
+                force=args.force,
+                api=api,
+                usage=usage,
+                invoke_text=invoke_text,
+                stats=stats,
+            )
+        except Exception as exc:
+            stats["cases_llm_error"] += 1
+            print(f"Unhandled error processing case: {exc}", file=sys.stderr)
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+
+    print_summary(stats, args.dry_run, "Title generation")
+
+    if usage.calls > 0:
+        print()
+        print(render_usage_table(usage.as_dict()["by_provider"], title="title usage"))
+
+
+def _title_is_valid(title, court_number) -> bool:
+    """A title is 'already valid' when it ends with its special-court number in
+    parens AND carries no defendant headcount — the contract the review gate
+    enforces. Such titles are skipped unless --force."""
+    return (
+        bool(title)
+        and bool(court_number)
+        and validate_title(title, court_number) is None
+        and not title_has_headcount(title)
+    )
+
+
+def _process_case(case, idx, total, dry_run, force, api, usage, invoke_text, stats):
+    """Process one case: fetch detail, regenerate the title, validate, PATCH."""
+    stats["cases_processed"] += 1
+    case_id = case.get("case_id", "?")
+    current_title = case.get("title", "")
+    print(f"\n[{idx}/{total}] {case_id} — {current_title[:80]}")
+
+    try:
+        detail = api.get_case(case.get("slug") or case_id)
+    except requests.HTTPError:
+        detail = case
+        print("  (using summary instead of detail)")
+
+    current_title = detail.get("title", current_title)
+    court_number = special_court_number(detail)
+
+    if not force and _title_is_valid(current_title, court_number):
+        stats["cases_processed"] -= 1
+        stats["cases_already_valid"] += 1
+        print("  Current title already valid — skipping (use --force)")
+        return
+
+    try:
+        new_title = _generate_title(detail, court_number, invoke_text, usage)
+    except Exception as exc:
+        stats["cases_llm_error"] += 1
+        print(f"  LLM generation failed: {exc}")
+        if logger.level == logging.DEBUG:
+            import traceback
+
+            traceback.print_exc()
+        return
+
+    if not new_title:
+        stats["cases_skipped"] += 1
+        print("  LLM returned no title — skipping")
+        return
+
+    print(f"  TITLE: {new_title}")
+
+    title_issue = validate_title(new_title, court_number)
+    if title_issue:
+        stats["cases_skipped"] += 1
+        print(f"  TITLE REJECTED ({title_issue}) — not writing")
+        return
+    if title_has_headcount(new_title):
+        stats["cases_skipped"] += 1
+        print("  TITLE REJECTED (contains a defendant headcount) — not writing")
+        return
+
+    if dry_run:
+        print("  [DRY RUN] Would PATCH but --dry-run is set")
+        return
+
+    try:
+        api.patch_field(detail.get("slug") or case.get("slug"), "title", new_title)
+        stats["cases_enriched"] += 1
+        print(f"  [UPDATED] {case_id}")
+    except Exception as exc:
+        stats["cases_llm_error"] += 1
+        print(f"  Failed to PATCH: {exc}")
+
+
+def _generate_title(detail, court_number, invoke_text, usage):
+    """Build the title prompt from the case's already-enriched fields and call
+    the LLM. No source documents are fetched."""
+    description = (detail.get("description") or "").strip()
+    prompt = USER_PROMPT.format(
+        current_title=detail.get("title", ""),
+        court_number=court_number or "(unknown)",
+        bigo=format_bigo(detail.get("bigo")),
+        key_allegations=format_list(detail.get("key_allegations")),
+        entities=format_entities(detail.get("entities")),
+        description=description[:DESCRIPTION_SNIPPET_BUDGET] or "(none)",
+    )
+    response_text = invoke_text(
+        system=SYSTEM_PROMPT,
+        content=prompt,
+        tier="premium",
+        usage=usage,
+        max_tokens=1000,
+    )
+    return parse_title(response_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/casework/enrich_title.py
+++ b/casework/enrich_title.py
@@ -17,6 +17,11 @@ pass ``--dry-run`` to preview. A title that already passes validation (ends with
 its special-court number in parentheses, carries no headcount) is skipped unless
 ``--force``.
 
+The LLM call goes through the llm package, defaulting to the local ``claude -p``
+subscription harness (provider ``claude_cli``) so the headline is written by a
+real Opus — the shared llm-proxy relabels opus->deepseek and can't. Override with
+``--provider`` / ``--model`` (e.g. ``--provider proxy --model <id>``).
+
 Usage:
     python casework/enrich_title.py --dry-run
     python casework/enrich_title.py --slug case-0123
@@ -103,7 +108,7 @@ Return ONLY the JSON object described in the system prompt.
 """
 
 
-def main():
+def _build_parser():
     ap = argparse.ArgumentParser(
         description=(
             "Regenerate CIAA Special Court case titles via LLM "
@@ -112,7 +117,16 @@ def main():
         epilog="Reads and writes entirely over HTTP via JAWAFDEHI_API_TOKEN.",
     )
     add_common_args(ap)
-    args = ap.parse_args()
+    # Title generation must run on a real Opus via the local `claude -p`
+    # subscription harness (the llm package's claude_cli provider): the shared
+    # llm-proxy relabels opus->deepseek, so it can't produce a real Opus headline.
+    # Operators can still override with --provider / --model.
+    ap.set_defaults(provider="claude_cli")
+    return ap
+
+
+def main():
+    args = _build_parser().parse_args()
 
     setup_logging(args.verbose)
 

--- a/tests/casework/test_enrich_title.py
+++ b/tests/casework/test_enrich_title.py
@@ -117,6 +117,21 @@ def test_system_prompt_embeds_shared_rules():
     assert '{"title"' in et.SYSTEM_PROMPT
 
 
+# ── provider default ─────────────────────────────────────────────────────────
+
+
+def test_defaults_to_claude_cli_provider():
+    # Titles must be written by a real Opus via `claude -p`, not the
+    # opus->deepseek-relabelling proxy.
+    args = et._build_parser().parse_args([])
+    assert args.provider == "claude_cli"
+
+
+def test_provider_is_overridable():
+    args = et._build_parser().parse_args(["--provider", "proxy"])
+    assert args.provider == "proxy"
+
+
 # ── per-case pipeline (fake API + fake LLM) ──────────────────────────────────
 
 

--- a/tests/casework/test_enrich_title.py
+++ b/tests/casework/test_enrich_title.py
@@ -1,0 +1,217 @@
+"""Tests for the DB-free standalone title enricher (casework/enrich_title.py).
+
+These cover the shared title contract (validation / headcount / parsing, which
+live in casework.common and are also used by enrich_description) and the
+script's per-case pipeline against a fake CaseworkApi + fake invoke_text. No
+database and no network are touched.
+"""
+
+from casework import common as c
+from casework import enrich_title as et
+
+# ── shared title contract (casework.common) ─────────────────────────────────
+
+
+class TestValidateTitle:
+    def test_requires_court_number(self):
+        assert c.validate_title("No number here", "080-CR-0047") is not None
+
+    def test_requires_matching_number(self):
+        assert c.validate_title("मुद्दा (081-CR-9999)", "080-CR-0047") is not None
+
+    def test_requires_number_at_end_in_parens(self):
+        assert c.validate_title("080-CR-0047 को मुद्दा", "080-CR-0047") is not None
+
+    def test_valid_title_passes(self):
+        assert c.validate_title("मुद्दा (080-CR-0047)", "080-CR-0047") is None
+
+    def test_case_insensitive_match(self):
+        assert c.validate_title("मुद्दा (080-cr-0047)", "080-CR-0047") is None
+
+
+class TestHeadcount:
+    def test_detects_digit_jana(self):
+        assert c.title_has_headcount("१२ जना विरुद्ध (080-CR-0047)")
+
+    def test_detects_pratibadi(self):
+        assert c.title_has_headcount("249 प्रतिवादी (080-CR-0047)")
+
+    def test_detects_vyakti(self):
+        assert c.title_has_headcount("१२ व्यक्ति (080-CR-0047)")
+
+    def test_court_number_not_flagged(self):
+        assert not c.title_has_headcount("मुद्दा (080-CR-0098)")
+
+    def test_spelled_out_count_not_caught(self):
+        # The guard only catches DIGIT-prefixed counts; spelled-out numerals
+        # ("तीन") are discouraged by the prompt but not by the regex.
+        assert not c.title_has_headcount("तीन व्यक्ति (080-CR-0047)")
+
+
+class TestParseTitle:
+    def test_parses_json_object(self):
+        assert (
+            c.parse_title('{"title": "मुद्दा (080-CR-0047)"}') == "मुद्दा (080-CR-0047)"
+        )
+
+    def test_parses_json_in_code_fence(self):
+        text = '```json\n{"title": "मुद्दा (080-CR-0047)"}\n```'
+        assert c.parse_title(text) == "मुद्दा (080-CR-0047)"
+
+    def test_parses_json_after_prose_with_braces(self):
+        text = 'Here is the JSON {title}: {"title": "मुद्दा (080-CR-0047)"}'
+        assert c.parse_title(text) == "मुद्दा (080-CR-0047)"
+
+    def test_accepts_bare_single_line(self):
+        assert c.parse_title("मुद्दा (080-CR-0047)") == "मुद्दा (080-CR-0047)"
+
+    def test_rejects_multiline_prose(self):
+        assert c.parse_title("Here is your title:\nमुद्दा (080-CR-0047)") is None
+
+    def test_empty_returns_none(self):
+        assert c.parse_title("") is None
+
+
+class TestSpecialCourtNumber:
+    def test_prefers_special(self):
+        case = {"court_cases": ["district:1", "special:080-CR-0047"]}
+        assert c.special_court_number(case) == "080-CR-0047"
+
+    def test_falls_back_to_any(self):
+        assert c.special_court_number({"court_cases": ["high:079-CR-1"]}) == "079-CR-1"
+
+    def test_none_when_absent(self):
+        assert c.special_court_number({"court_cases": []}) is None
+
+
+def test_format_bigo():
+    assert c.format_bigo(1568000) == "1,568,000"
+    assert c.format_bigo(0) == "(unknown)"
+    assert c.format_bigo(None) == "(unknown)"
+
+
+# ── script idempotency helper ────────────────────────────────────────────────
+
+
+class TestTitleIsValid:
+    def test_valid(self):
+        assert et._title_is_valid("मुद्दा (080-CR-0047)", "080-CR-0047")
+
+    def test_headcount_invalid(self):
+        assert not et._title_is_valid("१२ जना (080-CR-0047)", "080-CR-0047")
+
+    def test_missing_court_number_context_invalid(self):
+        assert not et._title_is_valid("मुद्दा (080-CR-0047)", None)
+
+    def test_no_trailing_number_invalid(self):
+        assert not et._title_is_valid("कुनै मुद्दा", "080-CR-0047")
+
+
+# ── prompt assembly ──────────────────────────────────────────────────────────
+
+
+def test_system_prompt_embeds_shared_rules():
+    # The script must use the same TITLE_RULES as the description enricher.
+    assert c.TITLE_RULES in et.SYSTEM_PROMPT
+    assert "समेतविरुद्ध" in et.SYSTEM_PROMPT
+    assert '{"title"' in et.SYSTEM_PROMPT
+
+
+# ── per-case pipeline (fake API + fake LLM) ──────────────────────────────────
+
+
+class FakeApi:
+    """Minimal CaseworkApi stand-in recording PATCHes."""
+
+    def __init__(self, detail):
+        self._detail = detail
+        self.patched = []
+
+    def get_case(self, slug, timeout=30):
+        return self._detail
+
+    def patch_field(self, slug, field, value, timeout=30):
+        self.patched.append((slug, field, value))
+
+
+def _case(**overrides):
+    base = {
+        "case_id": "case-0001",
+        "slug": "case-0001-slug",
+        "title": "Some draft case",  # invalid (no trailing court number)
+        "court_cases": ["special:080-CR-0047"],
+        "description": "A long enough description snippet about the case.",
+        "key_allegations": ["Allegation one"],
+        "entities": [],
+        "bigo": 1000000,
+    }
+    base.update(overrides)
+    return base
+
+
+def _fixed_llm(title):
+    def invoke_text(system, content, tier=None, usage=None, max_tokens=None):
+        return f'{{"title": "{title}"}}'
+
+    return invoke_text
+
+
+def _run(case, llm_title, *, dry_run=False, force=False):
+    api = FakeApi(case)
+    stats = {
+        "cases_processed": 0,
+        "cases_enriched": 0,
+        "cases_skipped": 0,
+        "cases_llm_error": 0,
+        "cases_already_valid": 0,
+    }
+    et._process_case(
+        case=case,
+        idx=1,
+        total=1,
+        dry_run=dry_run,
+        force=force,
+        api=api,
+        usage=None,
+        invoke_text=_fixed_llm(llm_title),
+        stats=stats,
+    )
+    return api, stats
+
+
+def test_patch_writes_valid_title():
+    api, stats = _run(_case(), "नयाँ शीर्षक (080-CR-0047)")
+    assert api.patched == [("case-0001-slug", "title", "नयाँ शीर्षक (080-CR-0047)")]
+    assert stats["cases_enriched"] == 1
+
+
+def test_dry_run_does_not_patch():
+    api, stats = _run(_case(), "नयाँ शीर्षक (080-CR-0047)", dry_run=True)
+    assert api.patched == []
+    assert stats["cases_enriched"] == 0
+
+
+def test_rejects_title_missing_court_number():
+    api, stats = _run(_case(), "शीर्षक without number")
+    assert api.patched == []
+    assert stats["cases_skipped"] == 1
+
+
+def test_rejects_headcount_title():
+    api, stats = _run(_case(), "१२ जना (080-CR-0047)")
+    assert api.patched == []
+    assert stats["cases_skipped"] == 1
+
+
+def test_already_valid_skipped_unless_force():
+    case = _case(title="मान्य शीर्षक (080-CR-0047)")
+    api, stats = _run(case, "नयाँ (080-CR-0047)")
+    assert api.patched == []
+    assert stats["cases_already_valid"] == 1
+
+
+def test_force_regenerates_valid_title():
+    case = _case(title="मान्य शीर्षक (080-CR-0047)")
+    api, stats = _run(case, "नयाँ (080-CR-0047)", force=True)
+    assert api.patched == [("case-0001-slug", "title", "नयाँ (080-CR-0047)")]
+    assert stats["cases_enriched"] == 1


### PR DESCRIPTION
## Summary
- Factor the **TITLE RULES** prompt, the court-number validator, the headcount guard, and the prompt-formatting helpers into shared `casework.common` so the description enricher and a new standalone title enricher stay in lockstep (no duplicated rules).
- **Sharpen the title contract** (used by both paths):
  - **Hook, reward-when-warranted**: surface a salient quantifiable (बिगो in natural scale like ३.२ अर्ब / ३३ करोड, a marquee scheme, a notable accused, a vivid concrete scale) instead of burying it — but never *force* a hook; a plain, accurate title for a routine case is correct.
  - **Amount accuracy**: any monetary figure must be the verified बिगो (or an explicitly-stated loss); omit the number rather than print a contradictory one.
  - **Grammar fix**: use `…समेतविरुद्ध…`; never stack `सहित`/`लगायत` directly onto `विरुद्ध`/`माथि` (the old guidance produced `रसाईलीसहितविरुद्ध` / `भुषाललगायतविरुद्ध` / `यादवलगायतमाथि`).
- **Add `casework/enrich_title.py`**: a DB-free, no-source-fetch script that regenerates *just* the title from a case's already-enriched fields. This is the path a case with a good description otherwise lacks, since `enrich_description` skips its (expensive, source-fetching) title pass once a substantial description exists. Default writes; `--dry-run` previews; an already-valid title is skipped unless `--force`.

## Background
A dry run (real Opus 4.8, 10 random `bigo`-bearing DRAFT cases) showed the prior prompt buried large amounts, and the `लगायत`/`सहित`-recommending rule produced ungrammatical postposition stacking. After these changes the regenerated titles lead with subject + offence, surface accurate crore/lakh figures only when material, and use idiomatic `…समेतविरुद्ध…`.

## Test plan
- [x] `tests/casework/test_enrich_title.py` — title validation, headcount guard, JSON/bare-line parsing, special-court-number extraction, the already-valid idempotency skip, and the per-case pipeline (writes valid title / dry-run / rejects missing-number & headcount / `--force`) against a fake API + fake LLM.
- [x] Full `tests/casework/` suite green (85 passed); ruff + black clean.
- [ ] Reviewer: optional live `--dry-run` against the portal to eyeball a fresh sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated title regeneration tool for Jawafdehi CIAA Special Court cases, leveraging existing case data to improve titles.
  * Implemented validation rules ensuring regenerated titles include required court identifiers and proper formatting.

* **Bug Fixes**
  * Enhanced title validation to detect and prevent invalid defendant headcount patterns in case titles.

* **Tests**
  * Added comprehensive test suite covering title validation, parsing, and enrichment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->