### PR TITLE
fix(casework): gate नजिर to Supreme Court + drop procedural orders from description

### DIFF
--- a/casework/common.py
+++ b/casework/common.py
@@ -871,7 +871,8 @@ Capture ONLY what the judgment states — never infer or invent:
 - नि.नं. / मुद्दा नं. and the parties (वादी / प्रतिवादीहरू).
 - For EACH defendant: the outcome — दोषी (convicted, with कैद/जरिवाना/बिगो असुल) or
   सफाई (acquitted) — and the court's key reasoning for it.
-- Any legal principle / नजिर the court established.
+- Any legal principle the court applied or relied on, noting whether it cites a
+  Supreme Court precedent (नजिर) — a Special Court ruling does not itself set one.
 - The disputed बिगो the court accepted or rejected, and why.
 - Every concrete DATE the judgment cites for a factual event (the alleged conduct,
   bids, committee decisions, payments, registrations, complaint, chargesheet) —

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -107,19 +107,29 @@ Markdown table (क्र.सं | प्रतिवादी | भूमिक
 
 ### ग) विशेष अदालतको फैसलाको सार
 The verdict: the judgment date, the bench (इजलास / न्यायाधीशहरू), and the outcome
-for each defendant (दोषी / सफाई). Briefly state the court's reasoning and any
-legal principle (नजिर) it established.
+for each defendant (दोषी / सफाई), with the बिगो/sentence and the court's key
+reasoning. Do NOT include procedural or registry orders — the appeal म्याद
+(e.g. "३५ दिनभित्र पुनरावेदन गर्न"), धरौटी सदर/फिर्ता, लगत कायम, and similar routine
+"अन्य आदेश" are court-procedure, not the substantive फैसला; leave them out. A
+विशेष अदालत ruling does NOT set precedent, so do not call its reasoning a नजिर here.
 
 ### घ) पुनरावेदनको सार
-Only if the sources or a supreme-court reference show an appeal: the grounds and
-legal basis of the appeal and who filed it.
+Only if the sources or a supreme-court reference show an appeal was ACTUALLY
+filed: the grounds and legal basis of the appeal and who filed it. The routine
+appeal म्याद granted in the verdict (e.g. "३५ दिनभित्र पुनरावेदन गर्न जाने") is NOT
+an appeal — do not emit this section for it; OMIT the section entirely unless an
+appeal was really lodged.
 
 ### ङ) सर्वोच्च अदालतको फैसलाको सार
 Only if a Supreme Court judgment is in the sources: date, bench, and final
 outcome.
 
 ### च) नजिरको सार
-Only if the judgment establishes a precedent: state the key principle only.
+Include ONLY when a सर्वोच्च अदालत (Supreme Court) judgment in the sources
+establishes a legal principle — ideally one published in the Nepal Kanoon Patrika
+(नेपाल कानून पत्रिका). A विशेष अदालत (Special Court) decision is NEVER a precedent;
+if no qualifying Supreme Court principle is in the sources, OMIT this section
+entirely. State only the key principle.
 
 QUALITY RULES:
 - Ground every sentence in the provided sources/case data. Do NOT fabricate


### PR DESCRIPTION
## Summary
Two correctness fixes to the case **description** enricher, from caseworker review (Rujit):

1. **Precedent (नजिर) gated to the Supreme Court.** A विशेष अदालत (Special Court) ruling is never a precedent. Section **च) नजिरको सार** is now emitted *only* when a सर्वोच्च अदालत judgment in the sources establishes a legal principle (ideally Nepal Kanoon Patrika–published), otherwise omitted. Section **ग** no longer claims the Special Court "established a नजिर", and the shared verdict summariser (`common.py`) no longer asserts it either.
2. **Procedural "Other Orders" dropped.** The routine अन्य आदेश — appeal म्याद ("३५ दिनभित्र पुनरावेदन"), धरौटी सदर/फिर्ता, लगत कायम — are court-procedure, not the substantive फैसला. Section **ग** now excludes them, and section **घ** is emitted only for an appeal *actually filed* (not the bare 35-day म्याद).

Follow-up to #237 (timeline). Charge-sheet-dependent items (separate "Charge Sheet Conclusions", बयान completeness) are out of scope — the charge sheet is unavailable for ~all priority cases.

## Validation
Dry-run on **080-CR-0195** with the `claude -p` Opus 4.8 [1m] harness (no API writes), the case that previously exhibited both bugs:

| check | before | after |
|---|---|---|
| `अन्य आदेश` block | present | **absent** |
| spurious `च) नजिरको सार` (from a Special Court verdict) | present | **absent** |
| section घ emitted for the bare appeal म्याद | yes | **no** |

Section ग still renders the full per-defendant outcome (दोषी/सफाई), बिगो/sentence and reasoning.

## Test plan
- [ ] CI green (ruff + black 26.3.0 + pytest); verified locally on the changed files
- [ ] Spot-check a case with a genuine Supreme Court precedent still renders section च (none in the validation sample — Special-Court-only cases correctly omit it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)