### PR TITLE
fix(casework): harden title parsing + share the acceptance predicate

### DIFF
--- a/casework/common.py
+++ b/casework/common.py
@@ -535,6 +535,9 @@ def get_target_cases(api, args, skip_field):
     """Yield the case dicts to enrich, honoring --slug / --court-case /
     --fiscal-year / --limit / --force. `skip_field` is the case field that, when
     already populated, skips the case unless --force (e.g. 'timeline', 'tags').
+    Pass ``skip_field=None`` to select every matching case (no field-based skip),
+    for enrichers whose 'already done' check isn't a single field's presence
+    (e.g. the title enricher, which decides on title validity per-case).
 
     Cases are selected by slug or court case number (e.g. 081-CR-0121); there is
     no internal case_id selector. --slug and --court-case fetch the case in ANY
@@ -831,6 +834,19 @@ def title_has_headcount(title) -> bool:
     return bool(_HEADCOUNT_RE.search(title or ""))
 
 
+def title_is_acceptable(title, court_number) -> bool:
+    """True when a title satisfies the full public contract: it ends with its
+    special-court number in parentheses AND carries no defendant headcount. The
+    shared predicate behind both the 'current title already good, skip it'
+    idempotency check and the 'accept this regenerated title' write gate."""
+    return (
+        bool(title)
+        and bool(court_number)
+        and validate_title(title, court_number) is None
+        and not title_has_headcount(title)
+    )
+
+
 def format_bigo(bigo) -> str:
     """Render the बिगो for a prompt: thousands-separated NPR, or '(unknown)'."""
     try:
@@ -897,9 +913,12 @@ def parse_title(response_text):
             if title:
                 return title
 
-    # No JSON object — accept a bare single-line title (but not multi-line prose,
-    # which signals the model didn't follow the contract).
-    if text and "{" not in text and "\n" not in text:
+    # No JSON object — accept a bare single-line title ONLY when it looks like a
+    # title: one line, no stray brace, and carrying a court-case number (every
+    # valid headline ends in one). This keeps the fallback for frugal models that
+    # emit the bare title while rejecting prose/chatter the model wasn't asked
+    # for (e.g. a confirmation sentence), which must never be PATCHed as a title.
+    if text and "{" not in text and "\n" not in text and COURT_RE.search(text):
         return text
     return None
 

--- a/casework/enrich_title.py
+++ b/casework/enrich_title.py
@@ -53,6 +53,7 @@ from casework.common import (
     setup_logging,
     special_court_number,
     title_has_headcount,
+    title_is_acceptable,
     validate_title,
 )
 
@@ -61,12 +62,6 @@ logger = logging.getLogger(__name__)
 # A snippet of the existing description is plenty of context for a headline and
 # keeps this single, no-source-fetch call token-frugal.
 DESCRIPTION_SNIPPET_BUDGET = 2000
-
-# get_target_cases skips a case when summary[skip_field] is truthy, but
-# "title already valid" is not a case field — so select on a key cases never
-# carry (nothing is skipped at selection) and do the already-valid idempotency
-# check per-case in _process_case instead.
-_NO_SKIP_FIELD = "__title_always_consider__"
 
 SYSTEM_PROMPT = (
     """\
@@ -147,7 +142,9 @@ def main():
 
     usage = UsageAccumulator()
 
-    cases = list(get_target_cases(api, args, skip_field=_NO_SKIP_FIELD))
+    # skip_field=None: select every matching case (no field-presence skip); the
+    # "already valid title" idempotency check happens per-case in _process_case.
+    cases = list(get_target_cases(api, args, skip_field=None))
     total = len(cases)
     if total == 0:
         print("No CIAA draft cases to process.", file=sys.stderr)
@@ -197,18 +194,6 @@ def main():
         print(render_usage_table(usage.as_dict()["by_provider"], title="title usage"))
 
 
-def _title_is_valid(title, court_number) -> bool:
-    """A title is 'already valid' when it ends with its special-court number in
-    parens AND carries no defendant headcount — the contract the review gate
-    enforces. Such titles are skipped unless --force."""
-    return (
-        bool(title)
-        and bool(court_number)
-        and validate_title(title, court_number) is None
-        and not title_has_headcount(title)
-    )
-
-
 def _process_case(case, idx, total, dry_run, force, api, usage, invoke_text, stats):
     """Process one case: fetch detail, regenerate the title, validate, PATCH."""
     stats["cases_processed"] += 1
@@ -225,7 +210,7 @@ def _process_case(case, idx, total, dry_run, force, api, usage, invoke_text, sta
     current_title = detail.get("title", current_title)
     court_number = special_court_number(detail)
 
-    if not force and _title_is_valid(current_title, court_number):
+    if not force and title_is_acceptable(current_title, court_number):
         stats["cases_processed"] -= 1
         stats["cases_already_valid"] += 1
         print("  Current title already valid — skipping (use --force)")

--- a/tests/casework/test_enrich_title.py
+++ b/tests/casework/test_enrich_title.py
@@ -68,6 +68,12 @@ class TestParseTitle:
     def test_rejects_multiline_prose(self):
         assert c.parse_title("Here is your title:\nमुद्दा (080-CR-0047)") is None
 
+    def test_rejects_bare_line_without_court_number(self):
+        # A confirmation sentence (no court-case number) must NOT be accepted as
+        # a title and PATCHed — the fallback only takes title-shaped bare lines.
+        assert c.parse_title("Sure, here is your headline") is None
+        assert c.parse_title("शीर्षक तयार छ।") is None
+
     def test_empty_returns_none(self):
         assert c.parse_title("") is None
 
@@ -90,21 +96,21 @@ def test_format_bigo():
     assert c.format_bigo(None) == "(unknown)"
 
 
-# ── script idempotency helper ────────────────────────────────────────────────
+# ── shared title-acceptance predicate ────────────────────────────────────────
 
 
-class TestTitleIsValid:
+class TestTitleIsAcceptable:
     def test_valid(self):
-        assert et._title_is_valid("मुद्दा (080-CR-0047)", "080-CR-0047")
+        assert c.title_is_acceptable("मुद्दा (080-CR-0047)", "080-CR-0047")
 
     def test_headcount_invalid(self):
-        assert not et._title_is_valid("१२ जना (080-CR-0047)", "080-CR-0047")
+        assert not c.title_is_acceptable("१२ जना (080-CR-0047)", "080-CR-0047")
 
     def test_missing_court_number_context_invalid(self):
-        assert not et._title_is_valid("मुद्दा (080-CR-0047)", None)
+        assert not c.title_is_acceptable("मुद्दा (080-CR-0047)", None)
 
     def test_no_trailing_number_invalid(self):
-        assert not et._title_is_valid("कुनै मुद्दा", "080-CR-0047")
+        assert not c.title_is_acceptable("कुनै मुद्दा", "080-CR-0047")
 
 
 # ── prompt assembly ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Follow-up to #238, addressing self-review findings on the title enricher:

- **`parse_title` hardening** — the bare-line fallback (for frugal models that emit the title without JSON) now only accepts a single line that **carries a court-case number**. Previously any one-line response ending in the court number could be PATCHed as a title, so stray model chatter (e.g. `Sure, here is your headline`) could slip past. JSON output — the actual contract — is unaffected.
- **Share the acceptance predicate** — lifted the "title satisfies the public contract (court number in trailing parens, no headcount)" check into `common.title_is_acceptable()` and reuse it for `enrich_title`'s already-valid idempotency skip, instead of a script-local `_title_is_valid` copy. The regenerated-title write gate keeps its specific per-reason diagnostics.
- **Drop the `_NO_SKIP_FIELD` sentinel** — `get_target_cases` now documents `skip_field=None` to mean "select every match" (the title enricher's real intent); it already supported this since `dict.get(None)` is falsy.

## Findings intentionally not changed
- Strict trailing-paren check in `validate_title` is kept deliberately: it mirrors the review gate's `court_number_in_title` detector, so a title the gate would reject shouldn't be generated.
- The detail-fetch→summary fallback (on HTTP error) is unchanged: it matches the sibling `enrich_description`, and the title stays grounded in allegations/entities/bigo carried by the list summary.

## Test plan
- [x] `tests/casework/` green (88 passed); ruff + black clean.
- [x] New tests: `parse_title` rejects bare prose without a court number; `title_is_acceptable` covers valid / headcount / missing-court-number / no-trailing-number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)