### PR TITLE
fix(poller): make legacy .doc conversion work on the arm64 review-poller

### DIFF
--- a/Dockerfile.poller
+++ b/Dockerfile.poller
@@ -25,10 +25,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # uses to turn scanned/legacy PDFs and office docs (.doc/.docx/.xls/.ppt) into a
 # form MarkItDown/likhit can read; without it those sources convert to 0 chars.
 # Writer/Calc/Impress pull in libreoffice-core (which carries soffice).
+# `antiword` is the likhit fallback for legacy `.doc`; the Debian arm64 package
+# replaces pyantiword's bundled x86_64 binary (which fails "Exec format error" on
+# the arm64 poller node) so the fallback still works if LibreOffice is disabled.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libreoffice-writer \
     libreoffice-calc \
     libreoffice-impress \
+    antiword \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js 22 LTS (claude-code + codex require a recent Node).

--- a/config/settings.py
+++ b/config/settings.py
@@ -880,10 +880,12 @@ CONVERT_SOURCE_TIMEOUT = int(os.getenv("CONVERT_SOURCE_TIMEOUT", "180"))
 
 # Use LibreOffice (headless) to convert legacy Word .doc / .docx sources to a
 # clean .docx before markdown extraction. LibreOffice handles files the bundled
-# antiword crashes on or rejects, but it is a heavy dependency (~1GB installed)
-# that prod does NOT ship, so this defaults OFF and the converter uses the
-# lighter likhit/antiword path. An operator running the reprocess command on a
-# box that HAS LibreOffice (e.g. a one-off backfill host) can opt in with
+# antiword crashes on or rejects, but it is a heavy dependency (~1GB installed).
+# The lean API image does NOT ship it, so this defaults OFF here and the converter
+# uses the lighter likhit/antiword path. The review-poller image DOES ship it
+# (see Dockerfile.poller), and config.settings_scripts (which the poller boots)
+# overrides this default to ON. An operator running the reprocess command on a
+# box that HAS LibreOffice (e.g. a one-off backfill host) can also opt in with
 # LIBREOFFICE_DOC_CONVERSION=true. When enabled but the binary is absent, the
 # converter degrades to the fallback automatically (no hard dependency).
 LIBREOFFICE_DOC_CONVERSION = (

--- a/config/settings_scripts.py
+++ b/config/settings_scripts.py
@@ -21,6 +21,17 @@ os.environ.setdefault("ALLOWED_HOSTS", "localhost")
 
 from config.settings import *  # noqa: F401,F403,E402
 
+# The review-poller image (Dockerfile.poller) ships LibreOffice, so default the
+# legacy .doc/.docx → soffice conversion ON here, overriding config.settings'
+# OFF default (which targets the lean API image that does not ship soffice).
+# This is the more robust path on the arm64 poller, where pyantiword's bundled
+# x86_64 binary fails with "Exec format error". An operator can still force it
+# off with LIBREOFFICE_DOC_CONVERSION=false; the converter degrades to the
+# antiword fallback automatically if soffice is somehow absent.
+LIBREOFFICE_DOC_CONVERSION = (
+    os.getenv("LIBREOFFICE_DOC_CONVERSION", "true").lower() == "true"
+)
+
 # Force a throwaway in-memory DB and disable routing; scripts never query the ORM.
 DATABASES = {
     "default": {


### PR DESCRIPTION
## Summary
Review 159 (case 080-CR-0172) errored converting a `.doc` evidence source:

> Conversion failed: LegacyWordConverter threw ExtractionError — pyantiword bundled binary is not compatible with this OS/architecture … Exec format error: …/pyantiword/antiword

Two compounding gaps:
1. `Dockerfile.poller` ships LibreOffice but **not `antiword`**, so the likhit `LegacyWordConverter` fell back to pyantiword's **bundled x86_64 binary**, which fails "Exec format error" on the **arm64** poller (oci2).
2. `LIBREOFFICE_DOC_CONVERSION` defaulted **false**, so `.doc` files never used the already-installed, more robust LibreOffice path and fell through to the broken antiword fallback.

A live `kubectl set env deploy/review-poller LIBREOFFICE_DOC_CONVERSION=true` was applied as an immediate fix; this PR persists it in code and adds belt-and-suspenders.

## Changes
- **`Dockerfile.poller`** — install Debian's arm64 `antiword` so the likhit fallback works even if the LibreOffice path is ever disabled/unavailable.
- **`config/settings_scripts.py`** — default `LIBREOFFICE_DOC_CONVERSION` **ON** (the poller image ships LibreOffice and boots these script settings via `review_runner.py`), so a Keel/redeploy won't drop the live env override. Still forceable off with `LIBREOFFICE_DOC_CONVERSION=false`; converter degrades to antiword automatically if soffice is absent.
- **`config/settings.py`** — un-stale the comment that claimed prod never ships LibreOffice (true for the lean API image, false for the poller).

## Not in scope (needs decision)
- Already-failed `.doc` conversions are cached as failed/empty in `SOURCE_MARKDOWN_DIR`; this only fixes **future** conversions. Healing affected cases needs re-convert `--overwrite` + re-grade (deferred per prior discussion). Worth scanning the priority reviews' `source_summary[*].conversion_status` for other `.doc` failures.

## Test plan
- [ ] Build `Dockerfile.poller` on the arm64 runner; confirm `antiword` resolves (Debian arm64 pkg) and the image builds.
- [ ] On the poller pod, convert a `.doc` source and confirm it routes through LibreOffice (no "Exec format error").
- [ ] Confirm `LIBREOFFICE_DOC_CONVERSION=false` still forces the antiword path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved document conversion support for arm64 architecture by adding antiword package to Docker image as a fallback option.
  * Updated documentation and configuration for document conversion settings to clarify behavior across different deployment environments.
  * Added new configuration option to enable or disable LibreOffice-based document conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->