### PR TITLE
feat(casework): add LLM slug enricher (proposals file)

### DIFF
--- a/casework/enrich_slug.py
+++ b/casework/enrich_slug.py
@@ -9,9 +9,9 @@ letters/numbers/hyphens, starts with a letter, max 50 chars).
 
 Default behaviour WRITES A PROPOSALS FILE (``--output``, default
 ``slug-enrichment-proposals.json``) — a list of records each carrying the current
-slug, the proposed slug, and a ready-to-apply RFC-6902 ``patch_ops`` — for a human
-to review and PATCH manually afterwards. Pass ``--apply`` to PATCH valid proposals
-directly (the API only allows a slug change while the case is in DRAFT).
+slug, the proposed slug, and whether it is valid — for a human to review and patch
+manually afterwards. Pass ``--apply`` to PATCH valid proposals directly (the API
+only allows a slug change while the case is in DRAFT).
 
 Like the sibling enrichers, this reads cases entirely over the Jawafdehi HTTP API
 and never touches the database.
@@ -293,18 +293,15 @@ def _process_case(case, idx, total, args, api, usage, invoke_text, stats, propos
     else:
         stats["slugs_proposed"] += 1
 
-    record = {
-        "case_id": case_id,
-        "slug_current": slug_current,
-        "slug_proposed": slug_proposed,
-        "valid": valid,
-        "validation_error": error,
-    }
-    if valid:
-        record["patch_ops"] = [
-            {"op": "replace", "path": "/slug", "value": slug_proposed}
-        ]
-    proposals.append(record)
+    proposals.append(
+        {
+            "case_id": case_id,
+            "slug_current": slug_current,
+            "slug_proposed": slug_proposed,
+            "valid": valid,
+            "validation_error": error,
+        }
+    )
 
     if args.apply and valid and not args.dry_run:
         try:

--- a/casework/enrich_slug.py
+++ b/casework/enrich_slug.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python
+"""Propose clean, readable URL slugs for CIAA Special Court cases via an LLM (DB-free).
+
+For each DRAFT CIAA Special Court case this asks the LLM, with short instructions,
+for a single human-readable English slug that MUST include the special court case
+number (e.g. ``sunil-poudel-land-fraud-080-cr-0047``). The slug is lightly
+validated with the same ``validate_slug`` rule the API enforces (lowercase
+letters/numbers/hyphens, starts with a letter, max 50 chars).
+
+Default behaviour WRITES A PROPOSALS FILE (``--output``, default
+``slug-enrichment-proposals.json``) — a list of records each carrying the current
+slug, the proposed slug, and a ready-to-apply RFC-6902 ``patch_ops`` — for a human
+to review and PATCH manually afterwards. Pass ``--apply`` to PATCH valid proposals
+directly (the API only allows a slug change while the case is in DRAFT).
+
+Like the sibling enrichers, this reads cases entirely over the Jawafdehi HTTP API
+and never touches the database.
+
+Usage:
+    python casework/enrich_slug.py --priority --dry-run
+    python casework/enrich_slug.py --priority --output slugs.json
+    python casework/enrich_slug.py --slug case-0123 --apply
+    python casework/enrich_slug.py --court-case 081-CR-0095 --apply
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+import requests
+
+# Ensure the api dir is in sys.path so imports work when run as a file
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from casework.common import (
+    CaseworkApi,
+    add_common_args,
+    balanced_object,
+    bootstrap,
+    format_bigo,
+    format_entities,
+    get_target_cases,
+    print_summary,
+    setup_logging,
+    special_court_number,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT = "slug-enrichment-proposals.json"
+
+SYSTEM_PROMPT = """\
+You write short, readable URL slugs (in English) for cases in Jawafdehi, a civic \
+archive of Nepal's anti-corruption cases.
+
+Rules:
+- Use only lowercase letters, numbers and hyphens; start with a letter; max 50 characters.
+- The slug MUST include the special court case number, given to you as a hyphenated
+  token (e.g. 080-cr-0047).
+- Use the main accused's name and the nature of the offence; transliterate Nepali
+  names to plain English (no Devanagari, no accents).
+- Keep it concise and readable.
+
+Return ONLY a JSON object, no prose: {"slug": "sunil-poudel-land-fraud-080-cr-0047"}
+"""
+
+USER_PROMPT = """\
+Write the URL slug for this CIAA Special Court case.
+
+Title: {title}
+Special court case number (MUST appear in the slug): {court_number}
+Bigo (बिगो), NPR: {bigo}
+
+Named entities (accused / related / location):
+{entities}
+
+Return ONLY the JSON object described in the system prompt.
+"""
+
+
+def parse_slug(response_text):
+    """Pull the slug out of an LLM response.
+
+    Prefers a ``{"slug": "..."}`` JSON object (scanning every ``{`` so leading
+    prose with braces doesn't abort the parse); falls back to a bare single-line
+    token. Returns the slug string (stripped, lowercased) or None.
+    """
+    text = (response_text or "").strip()
+    if "```" in text:
+        start = text.find("```")
+        nl = text.find("\n", start)
+        end = text.find("```", nl + 1) if nl != -1 else -1
+        if nl != -1 and end != -1:
+            text = text[nl + 1 : end].strip()
+
+    for obj_start in range(len(text)):
+        if text[obj_start] != "{":
+            continue
+        block = balanced_object(text, obj_start)
+        if block is None:
+            continue
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("slug"), str):
+            slug = obj["slug"].strip().lower()
+            if slug:
+                return slug
+
+    # Bare single-line token fallback (a frugal model may emit just the slug).
+    if text and "{" not in text and "\n" not in text and " " not in text:
+        return text.strip().lower()
+    return None
+
+
+def _validate_slug(slug):
+    """Return None if `slug` passes the API's validate_slug rule, else the error
+    message. Imported lazily so Django is configured (by bootstrap/pytest) first."""
+    from django.core.exceptions import ValidationError
+
+    from cases.validators import validate_slug
+
+    try:
+        validate_slug(slug)
+    except ValidationError as exc:
+        return "; ".join(exc.messages)
+    return None
+
+
+def _court_suffix(court_number):
+    """The slugified court number used both in the prompt and the idempotency
+    check, e.g. '080-CR-0047' -> '080-cr-0047'."""
+    from django.utils.text import slugify
+
+    return slugify(court_number or "")
+
+
+def _build_parser():
+    ap = argparse.ArgumentParser(
+        description=(
+            "Propose readable URL slugs (court case id included) for CIAA Special "
+            "Court cases via an LLM; writes a proposals file by default."
+        ),
+        epilog="Reads over HTTP via JAWAFDEHI_API_TOKEN; --apply PATCHes valid slugs.",
+    )
+    add_common_args(ap)
+    ap.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT,
+        help=f"Proposals file to write (default {DEFAULT_OUTPUT}).",
+    )
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="PATCH valid proposals directly (DRAFT-only) in addition to writing the file.",
+    )
+    # Slugs are short transliterations — a real Opus via the local `claude -p`
+    # subscription harness writes cleaner names than the opus->deepseek proxy.
+    ap.set_defaults(provider="claude_cli")
+    return ap
+
+
+def main():
+    args = _build_parser().parse_args()
+
+    setup_logging(args.verbose)
+
+    try:
+        bootstrap(args.provider, args.model)
+    except Exception as exc:
+        print(f"Bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    from llm.invoke import invoke_text
+    from llm.usage import UsageAccumulator, render_usage_table
+
+    try:
+        api = CaseworkApi(base_url=args.api_base_url, token=args.api_token)
+    except RuntimeError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    usage = UsageAccumulator()
+
+    # skip_field=None: select every matching case; the "slug already looks
+    # enriched" idempotency check happens per-case in _process_case.
+    cases = list(get_target_cases(api, args, skip_field=None))
+    total = len(cases)
+    if total == 0:
+        print("No CIAA draft cases to process.", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Found {total} CIAA draft case(s) to process.")
+    if args.apply:
+        print("  --apply: valid proposals will be PATCHed (DRAFT-only)")
+    if args.dry_run:
+        print("  [DRY RUN] No changes will be saved.")
+
+    stats = {
+        "cases_processed": 0,
+        "slugs_proposed": 0,
+        "slugs_invalid": 0,
+        "slugs_applied": 0,
+        "cases_skipped": 0,
+        "cases_llm_error": 0,
+    }
+    proposals = []
+
+    for idx, case in enumerate(cases, 1):
+        try:
+            _process_case(
+                case=case,
+                idx=idx,
+                total=total,
+                args=args,
+                api=api,
+                usage=usage,
+                invoke_text=invoke_text,
+                stats=stats,
+                proposals=proposals,
+            )
+        except Exception as exc:
+            stats["cases_llm_error"] += 1
+            print(f"Unhandled error processing case: {exc}", file=sys.stderr)
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+
+    _write_proposals(args.output, proposals)
+    print(f"\nWrote {len(proposals)} proposal(s) to {args.output}")
+
+    print_summary(stats, args.dry_run, "Slug enrichment")
+
+    if usage.calls > 0:
+        print()
+        print(render_usage_table(usage.as_dict()["by_provider"], title="slug usage"))
+
+
+def _process_case(case, idx, total, args, api, usage, invoke_text, stats, proposals):
+    """Process one case: regenerate the slug, validate, record a proposal, apply."""
+    stats["cases_processed"] += 1
+    case_id = case.get("case_id", "?")
+    slug_current = case.get("slug") or ""
+    print(f"\n[{idx}/{total}] {case_id} — {slug_current}")
+
+    try:
+        detail = api.get_case(slug_current or case_id)
+    except requests.HTTPError:
+        detail = case
+        print("  (using summary instead of detail)")
+
+    slug_current = detail.get("slug") or slug_current
+    court_number = special_court_number(detail)
+    if not court_number:
+        stats["cases_skipped"] += 1
+        print("  No special court number — skipping")
+        return
+
+    court_suffix = _court_suffix(court_number)
+    if not args.force and slug_current.endswith(court_suffix):
+        stats["cases_processed"] -= 1
+        stats["cases_skipped"] += 1
+        print("  Slug already ends with the court number — skipping (use --force)")
+        return
+
+    try:
+        slug_proposed = _generate_slug(detail, court_suffix, invoke_text, usage)
+    except Exception as exc:
+        stats["cases_llm_error"] += 1
+        print(f"  LLM generation failed: {exc}")
+        if logger.level == logging.DEBUG:
+            import traceback
+
+            traceback.print_exc()
+        return
+
+    if not slug_proposed:
+        stats["cases_skipped"] += 1
+        print("  LLM returned no slug — skipping")
+        return
+
+    print(f"  SLUG: {slug_proposed}")
+
+    error = _validate_slug(slug_proposed)
+    valid = error is None
+    if not valid:
+        stats["slugs_invalid"] += 1
+        print(f"  INVALID ({error}) — recorded but will not be applied")
+    else:
+        stats["slugs_proposed"] += 1
+
+    record = {
+        "case_id": case_id,
+        "slug_current": slug_current,
+        "slug_proposed": slug_proposed,
+        "valid": valid,
+        "validation_error": error,
+    }
+    if valid:
+        record["patch_ops"] = [
+            {"op": "replace", "path": "/slug", "value": slug_proposed}
+        ]
+    proposals.append(record)
+
+    if args.apply and valid and not args.dry_run:
+        try:
+            api.patch_field(slug_current, "slug", slug_proposed)
+            stats["slugs_applied"] += 1
+            print(f"  [UPDATED] {case_id}")
+        except Exception as exc:
+            stats["cases_llm_error"] += 1
+            print(f"  Failed to PATCH: {exc}")
+
+
+def _generate_slug(detail, court_suffix, invoke_text, usage):
+    """Build the slug prompt from the case fields and call the LLM."""
+    prompt = USER_PROMPT.format(
+        title=detail.get("title", ""),
+        court_number=court_suffix or "(unknown)",
+        bigo=format_bigo(detail.get("bigo")),
+        entities=format_entities(detail.get("entities")),
+    )
+    response_text = invoke_text(
+        system=SYSTEM_PROMPT,
+        content=prompt,
+        tier="premium",
+        usage=usage,
+        max_tokens=300,
+    )
+    return parse_slug(response_text)
+
+
+def _write_proposals(path, proposals):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(proposals, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/casework/test_enrich_slug.py
+++ b/tests/casework/test_enrich_slug.py
@@ -129,7 +129,7 @@ def _run(case, llm_slug, *, apply=False, dry_run=False, force=False):
     return api, stats, proposals
 
 
-def test_valid_slug_recorded_with_patch_ops():
+def test_valid_slug_recorded():
     api, stats, proposals = _run(_case(), "sunil-poudel-land-fraud-080-cr-0047")
     assert api.patched == []  # default does not apply
     assert stats["slugs_proposed"] == 1
@@ -137,13 +137,7 @@ def test_valid_slug_recorded_with_patch_ops():
     record = proposals[0]
     assert record["valid"] is True
     assert record["slug_proposed"] == "sunil-poudel-land-fraud-080-cr-0047"
-    assert record["patch_ops"] == [
-        {
-            "op": "replace",
-            "path": "/slug",
-            "value": "sunil-poudel-land-fraud-080-cr-0047",
-        }
-    ]
+    assert "patch_ops" not in record
 
 
 def test_apply_patches_valid_slug():
@@ -207,9 +201,6 @@ def test_write_proposals_is_well_formed_json(tmp_path):
             "slug_proposed": "sunil-poudel-080-cr-0047",
             "valid": True,
             "validation_error": None,
-            "patch_ops": [
-                {"op": "replace", "path": "/slug", "value": "sunil-poudel-080-cr-0047"}
-            ],
         }
     ]
     out = tmp_path / "proposals.json"

--- a/tests/casework/test_enrich_slug.py
+++ b/tests/casework/test_enrich_slug.py
@@ -1,0 +1,231 @@
+"""Tests for the DB-free standalone slug enricher (casework/enrich_slug.py).
+
+Cover slug parsing, the light validate_slug gate, and the per-case pipeline
+against a fake CaseworkApi + fake invoke_text. No database and no network are
+touched (validate_slug / slugify run under pytest-django's configured settings).
+"""
+
+import json
+
+from casework import enrich_slug as es
+
+# ── slug parsing ─────────────────────────────────────────────────────────────
+
+
+class TestParseSlug:
+    def test_parses_json_object(self):
+        assert es.parse_slug('{"slug": "sunil-poudel-080-cr-0047"}') == (
+            "sunil-poudel-080-cr-0047"
+        )
+
+    def test_parses_json_in_code_fence(self):
+        text = '```json\n{"slug": "ram-thapa-080-cr-0047"}\n```'
+        assert es.parse_slug(text) == "ram-thapa-080-cr-0047"
+
+    def test_parses_json_after_prose_with_braces(self):
+        text = 'Here {x}: {"slug": "ram-thapa-080-cr-0047"}'
+        assert es.parse_slug(text) == "ram-thapa-080-cr-0047"
+
+    def test_lowercases(self):
+        assert es.parse_slug('{"slug": "Ram-Thapa-080-CR-0047"}') == (
+            "ram-thapa-080-cr-0047"
+        )
+
+    def test_accepts_bare_single_token(self):
+        assert es.parse_slug("ram-thapa-080-cr-0047") == "ram-thapa-080-cr-0047"
+
+    def test_rejects_bare_line_with_spaces(self):
+        assert es.parse_slug("here is your slug") is None
+
+    def test_empty_returns_none(self):
+        assert es.parse_slug("") is None
+
+
+# ── validate_slug gate ───────────────────────────────────────────────────────
+
+
+class TestValidateSlug:
+    def test_valid(self):
+        assert es._validate_slug("sunil-poudel-land-fraud-080-cr-0047") is None
+
+    def test_rejects_leading_digit(self):
+        assert es._validate_slug("080-cr-0047-sunil") is not None
+
+    def test_rejects_too_long(self):
+        assert es._validate_slug("a" * 51) is not None
+
+    def test_rejects_spaces(self):
+        assert es._validate_slug("sunil poudel") is not None
+
+
+# ── per-case pipeline (fake API + fake LLM) ──────────────────────────────────
+
+
+class FakeApi:
+    """Minimal CaseworkApi stand-in recording PATCHes."""
+
+    def __init__(self, detail):
+        self._detail = detail
+        self.patched = []
+
+    def get_case(self, slug, timeout=30):
+        return self._detail
+
+    def patch_field(self, slug, field, value, timeout=30):
+        self.patched.append((slug, field, value))
+
+
+class Args:
+    def __init__(self, *, apply=False, dry_run=False, force=False):
+        self.apply = apply
+        self.dry_run = dry_run
+        self.force = force
+        self.verbose = False
+
+
+def _case(**overrides):
+    base = {
+        "case_id": "case-0001",
+        "slug": "case-0001-old-hash",
+        "title": "Some draft case",
+        "court_cases": ["special:080-CR-0047"],
+        "entities": [],
+        "bigo": 1000000,
+    }
+    base.update(overrides)
+    return base
+
+
+def _fixed_llm(slug):
+    def invoke_text(system, content, tier=None, usage=None, max_tokens=None):
+        return json.dumps({"slug": slug})
+
+    return invoke_text
+
+
+def _run(case, llm_slug, *, apply=False, dry_run=False, force=False):
+    api = FakeApi(case)
+    args = Args(apply=apply, dry_run=dry_run, force=force)
+    stats = {
+        "cases_processed": 0,
+        "slugs_proposed": 0,
+        "slugs_invalid": 0,
+        "slugs_applied": 0,
+        "cases_skipped": 0,
+        "cases_llm_error": 0,
+    }
+    proposals = []
+    es._process_case(
+        case=case,
+        idx=1,
+        total=1,
+        args=args,
+        api=api,
+        usage=None,
+        invoke_text=_fixed_llm(llm_slug),
+        stats=stats,
+        proposals=proposals,
+    )
+    return api, stats, proposals
+
+
+def test_valid_slug_recorded_with_patch_ops():
+    api, stats, proposals = _run(_case(), "sunil-poudel-land-fraud-080-cr-0047")
+    assert api.patched == []  # default does not apply
+    assert stats["slugs_proposed"] == 1
+    assert len(proposals) == 1
+    record = proposals[0]
+    assert record["valid"] is True
+    assert record["slug_proposed"] == "sunil-poudel-land-fraud-080-cr-0047"
+    assert record["patch_ops"] == [
+        {
+            "op": "replace",
+            "path": "/slug",
+            "value": "sunil-poudel-land-fraud-080-cr-0047",
+        }
+    ]
+
+
+def test_apply_patches_valid_slug():
+    api, stats, proposals = _run(
+        _case(), "sunil-poudel-land-fraud-080-cr-0047", apply=True
+    )
+    assert api.patched == [
+        ("case-0001-old-hash", "slug", "sunil-poudel-land-fraud-080-cr-0047")
+    ]
+    assert stats["slugs_applied"] == 1
+
+
+def test_apply_with_dry_run_does_not_patch():
+    api, stats, proposals = _run(
+        _case(), "sunil-poudel-land-fraud-080-cr-0047", apply=True, dry_run=True
+    )
+    assert api.patched == []
+    assert stats["slugs_applied"] == 0
+    assert proposals[0]["valid"] is True  # still recorded
+
+
+def test_invalid_slug_recorded_not_applied():
+    api, stats, proposals = _run(_case(), "080-cr-0047-leading-digit", apply=True)
+    assert api.patched == []
+    assert stats["slugs_invalid"] == 1
+    record = proposals[0]
+    assert record["valid"] is False
+    assert record["validation_error"]
+    assert "patch_ops" not in record
+
+
+def test_idempotent_skip_when_slug_ends_with_court_number():
+    case = _case(slug="ram-thapa-080-cr-0047")
+    api, stats, proposals = _run(case, "new-slug-080-cr-0047")
+    assert proposals == []
+    assert stats["cases_skipped"] == 1
+
+
+def test_force_regenerates_already_enriched_slug():
+    case = _case(slug="ram-thapa-080-cr-0047")
+    api, stats, proposals = _run(case, "new-slug-080-cr-0047", force=True)
+    assert len(proposals) == 1
+    assert proposals[0]["slug_proposed"] == "new-slug-080-cr-0047"
+
+
+def test_skips_case_without_court_number():
+    case = _case(court_cases=[])
+    api, stats, proposals = _run(case, "whatever-080-cr-0047")
+    assert proposals == []
+    assert stats["cases_skipped"] == 1
+
+
+# ── file writing ─────────────────────────────────────────────────────────────
+
+
+def test_write_proposals_is_well_formed_json(tmp_path):
+    proposals = [
+        {
+            "case_id": "case-0001",
+            "slug_current": "case-0001-old",
+            "slug_proposed": "sunil-poudel-080-cr-0047",
+            "valid": True,
+            "validation_error": None,
+            "patch_ops": [
+                {"op": "replace", "path": "/slug", "value": "sunil-poudel-080-cr-0047"}
+            ],
+        }
+    ]
+    out = tmp_path / "proposals.json"
+    es._write_proposals(str(out), proposals)
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded == proposals
+
+
+# ── provider default ─────────────────────────────────────────────────────────
+
+
+def test_defaults_to_claude_cli_provider():
+    args = es._build_parser().parse_args([])
+    assert args.provider == "claude_cli"
+
+
+def test_output_default():
+    args = es._build_parser().parse_args([])
+    assert args.output == es.DEFAULT_OUTPUT


### PR DESCRIPTION
## Summary
- Adds `casework/enrich_slug.py`, a standalone enricher (sibling of `enrich_title.py`, reusing `casework/common.py`) that asks the LLM for **one clean, readable English URL slug** per priority DRAFT CIAA Special Court case, with the **special court case number embedded** (e.g. `sunil-poudel-land-fraud-080-cr-0047`).
- Slugs get a **light `validate_slug` check** (lowercase letters/numbers/hyphens, starts with a letter, ≤50 chars). No composition/truncation/uniqueness-repair machinery — the LLM owns the format; we only validate and report.
- **Default = write a JSON proposals file** (`--output`, default `slug-enrichment-proposals.json`); each record carries `case_id`, `slug_current`, `slug_proposed`, `valid`, `validation_error` — for human review + manual patching. `--apply` PATCHes valid proposals directly (from `slug_proposed`).
- Reads happen entirely over the HTTP API (no ORM). Idempotent: a case whose slug already ends with its court number is skipped unless `--force`.

## Why
Auto-generated slugs (`Case._generate_unique_slug`) look like `{court}-{title-fragment}-{md5}` and appear in public `jawafdehi.org/case/<slug>` URLs. This proposes human-readable replacements.

## Notes
- Slug changes are **DRAFT-only** — enforced by `partial_update` (`cases/api_views.py`) + `Case.save()` (`cases/models.py`); non-DRAFT → 422. No API change needed (`slug` is already a patch `scalar_field`).
- Default provider is `claude_cli` (real Opus; the shared proxy relabels opus→deepseek).

## Test plan
- [x] `pytest tests/casework/test_enrich_slug.py` — 21 tests (LLM + API mocked), green; ruff + black clean.
- [x] Live dry-run against all priority cases via `claude_cli` / `claude-opus-4-8[1m]`: 42 processed → 42 valid after a manual conflict/length pass (e.g. 4 co-filed Godavari export-tax cases differentiated by court number; two >50-char slugs trimmed).
- [ ] Reviewer eyeballs a proposals file before any `--apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)