### PR TITLE
chore: rename chat service account to sa-chat-jawafdehi-org

### DIFF
--- a/cases/management/commands/setup_chat_service_account.py
+++ b/cases/management/commands/setup_chat_service_account.py
@@ -7,13 +7,13 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    help = "Create or update the chat-jawafdehi-org service account"
+    help = "Create or update the sa-chat-jawafdehi-org service account"
 
     def handle(self, *args, **options):
         user, created = User.objects.get_or_create(
-            username="chat-jawafdehi-org",
+            username="sa-chat-jawafdehi-org",
             defaults={
-                "email": "chat-jawafdehi-org@jawafdehi.org",
+                "email": "sa-chat-jawafdehi-org@jawafdehi.org",
                 "is_active": True,
             },
         )


### PR DESCRIPTION
## Summary
- Update `setup_chat_service_account` to use username `sa-chat-jawafdehi-org` (was `chat-jawafdehi-org`), matching the `sa-` service-account naming convention.

## Context
The live service accounts were renamed to a consistent `sa-` prefix (`sa-enricher`, `sa-review-poller-svc`, `sa-jawafdehi-bot`, `sa-jawafdehi-admin`, `sa-autotester-caseworker`, `sa-chat-jawafdehi-org`, `sa-readonly`) and had `is_staff` dropped (API authz is group-based; `is_staff` only gated Django admin-site access + a throttle shortcut that groups already cover).

`setup_chat_service_account.py` hardcoded `chat-jawafdehi-org`, so without this change a re-run would recreate the old username and rotate its token. This keeps the command consistent with the renamed live user.

## Test plan
- [ ] `python manage.py setup_chat_service_account` resolves the existing `sa-chat-jawafdehi-org` user (no duplicate created)
- [ ] MCP `JAWAFDEHI_API_TOKEN` consumers unaffected (token key unchanged by the DB rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service account identifiers for chat functionality to align with naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->