### PR TITLE
feat(cases): make anonymous public GET responses edge-cacheable

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -3,6 +3,7 @@ import uuid
 import structlog
 from auditlog.middleware import AuditlogMiddleware as _BaseAuditlogMiddleware
 from django.conf import settings
+from django.utils.cache import patch_cache_control
 from django.utils.functional import SimpleLazyObject
 
 from config.db_router import force_primary_reads
@@ -61,6 +62,75 @@ class RequestIdMiddleware:
         response[REQUEST_ID_HEADER] = request_id
         structlog.contextvars.unbind_contextvars("request_id")
 
+        return response
+
+
+def _strip_vary_cookie(response):
+    """Remove the ``Cookie`` token from a response's ``Vary`` header.
+
+    DRF ``SessionAuthentication`` makes Django add ``Vary: Cookie``, which marks
+    the response uncacheable by shared caches. We drop only ``Cookie`` and keep
+    any other tokens (``Origin``, ``Accept-Encoding``, …); there is no stdlib
+    helper that removes a Vary token, only one that adds.
+    """
+    vary = response.headers.get("Vary")
+    if not vary:
+        return
+    kept = [tok.strip() for tok in vary.split(",") if tok.strip().lower() != "cookie"]
+    if kept:
+        response.headers["Vary"] = ", ".join(kept)
+    else:
+        del response.headers["Vary"]
+
+
+class PublicCacheHeadersMiddleware:
+    """Make anonymous public GET responses edge-cacheable.
+
+    For an anonymous (no ``Authorization`` header, no session cookie) GET/HEAD
+    request on an allowlisted path, emit ``Cache-Control: public, s-maxage=…``
+    and strip ``Cookie`` from ``Vary`` so Cloudflare can cache the response at
+    the edge.
+
+    The anonymous gate is the safety boundary: anonymous and staff callers see
+    different data from the same URL (e.g. only staff see DRAFT cases — see
+    ``CaseViewSet.get_queryset``), so authenticated responses must never be made
+    cacheable. Responses that already carry a ``Set-Cookie`` are left alone since
+    a shared cache cannot cache them anyway.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.enabled = getattr(settings, "PUBLIC_CACHE_ENABLED", True)
+        self.smaxage = getattr(settings, "PUBLIC_CACHE_SMAXAGE", 300)
+        self.maxage = getattr(settings, "PUBLIC_CACHE_MAXAGE", 300)
+        self.paths = tuple(getattr(settings, "PUBLIC_CACHE_PATHS", ()))
+
+    def _is_anonymous_public_get(self, request):
+        if request.method not in ("GET", "HEAD"):
+            return False
+        if request.META.get("HTTP_AUTHORIZATION"):
+            return False
+        if settings.SESSION_COOKIE_NAME in request.COOKIES:
+            return False
+        return request.path.startswith(self.paths)
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if not self.enabled or not self.paths:
+            return response
+        # Django keeps cookies in response.cookies until render, so a Set-Cookie
+        # header may not exist yet — check both. A shared cache can't cache a
+        # response that carries a cookie.
+        if response.status_code != 200:
+            return response
+        if response.cookies or response.has_header("Set-Cookie"):
+            return response
+        if not self._is_anonymous_public_get(request):
+            return response
+        patch_cache_control(
+            response, public=True, s_maxage=self.smaxage, max_age=self.maxage
+        )
+        _strip_vary_cookie(response)
         return response
 
 

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -76,7 +76,11 @@ def _strip_vary_cookie(response):
     vary = response.headers.get("Vary")
     if not vary:
         return
-    kept = [tok.strip() for tok in vary.split(",") if tok.strip().lower() != "cookie"]
+    kept = [
+        tok.strip()
+        for tok in vary.split(",")
+        if tok.strip() and tok.strip().lower() != "cookie"
+    ]
     if kept:
         response.headers["Vary"] = ", ".join(kept)
     else:
@@ -107,6 +111,13 @@ class PublicCacheHeadersMiddleware:
 
     def _is_anonymous_public_get(self, request):
         if request.method not in ("GET", "HEAD"):
+            return False
+        # DRF auth runs inside the view (before this post-processing) and writes
+        # request.user through to the HttpRequest, so by now an authenticated
+        # principal is visible here regardless of *how* it authenticated. This is
+        # the backstop that keeps any non-anonymous response out of the cache.
+        user = getattr(request, "user", None)
+        if user is not None and user.is_authenticated:
             return False
         if request.META.get("HTTP_AUTHORIZATION"):
             return False

--- a/config/settings.py
+++ b/config/settings.py
@@ -262,7 +262,7 @@ MIDDLEWARE = [
 # PublicCacheHeadersMiddleware: which anonymous GET endpoints may be edge-cached,
 # and for how long. Only anonymous (unauthenticated, no session) GETs on these
 # path prefixes get `Cache-Control: public, s-maxage=...` + Vary:Cookie stripped.
-PUBLIC_CACHE_ENABLED = os.getenv("PUBLIC_CACHE_ENABLED", "true").lower() == "true"
+PUBLIC_CACHE_ENABLED = env_flag("PUBLIC_CACHE_ENABLED", True)
 PUBLIC_CACHE_SMAXAGE = int(os.getenv("PUBLIC_CACHE_SMAXAGE", "300"))  # CDN edge TTL
 PUBLIC_CACHE_MAXAGE = int(os.getenv("PUBLIC_CACHE_MAXAGE", "300"))  # browser TTL
 PUBLIC_CACHE_PATHS = (

--- a/config/settings.py
+++ b/config/settings.py
@@ -240,6 +240,9 @@ MIDDLEWARE = [
     # Must be first: starts the per-request timer / in-flight gauge.
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    # Outermost app middleware (only PrometheusAfter runs later): rewrites
+    # response cache headers, so it must wrap whatever set Vary:Cookie.
+    "config.middleware.PublicCacheHeadersMiddleware",
     "config.middleware.RequestIdMiddleware",
     "config.middleware.ForcePrimaryReadsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -255,6 +258,19 @@ MIDDLEWARE = [
     # Must be last: records latency/status/count, labelled by resolved view.
     "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
+
+# PublicCacheHeadersMiddleware: which anonymous GET endpoints may be edge-cached,
+# and for how long. Only anonymous (unauthenticated, no session) GETs on these
+# path prefixes get `Cache-Control: public, s-maxage=...` + Vary:Cookie stripped.
+PUBLIC_CACHE_ENABLED = os.getenv("PUBLIC_CACHE_ENABLED", "true").lower() == "true"
+PUBLIC_CACHE_SMAXAGE = int(os.getenv("PUBLIC_CACHE_SMAXAGE", "300"))  # CDN edge TTL
+PUBLIC_CACHE_MAXAGE = int(os.getenv("PUBLIC_CACHE_MAXAGE", "300"))  # browser TTL
+PUBLIC_CACHE_PATHS = (
+    "/api/statistics/",
+    "/api/cases/",  # list + retrieve; anon sees PUBLISHED only
+    "/api/entities/",
+    "/api/oembed/",
+)
 
 ROOT_URLCONF = "config.urls"
 

--- a/tests/test_public_cache_headers.py
+++ b/tests/test_public_cache_headers.py
@@ -1,0 +1,98 @@
+"""Tests for PublicCacheHeadersMiddleware (config/middleware.py).
+
+Pure unit tests: a RequestFactory request plus a fake get_response, no database.
+The middleware reads its settings at __init__, so each test configures the
+``settings`` fixture first and then builds the middleware.
+"""
+
+import pytest
+from django.conf import settings as django_settings
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from config.middleware import PublicCacheHeadersMiddleware
+
+PATHS = ("/api/statistics/", "/api/cases/")
+
+rf = RequestFactory()
+
+
+@pytest.fixture
+def cache_settings(settings):
+    settings.PUBLIC_CACHE_ENABLED = True
+    settings.PUBLIC_CACHE_SMAXAGE = 300
+    settings.PUBLIC_CACHE_MAXAGE = 300
+    settings.PUBLIC_CACHE_PATHS = PATHS
+    return settings
+
+
+def _mw(response):
+    return PublicCacheHeadersMiddleware(lambda request: response)
+
+
+@pytest.mark.usefixtures("cache_settings")
+class TestPublicCacheHeaders:
+    def test_anon_get_allowlisted_is_cacheable(self):
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie, Origin"
+        out = _mw(resp)(rf.get("/api/statistics/"))
+
+        cc = out["Cache-Control"]
+        assert "public" in cc
+        assert "s-maxage=300" in cc
+        assert "max-age=300" in cc
+        assert "cookie" not in out["Vary"].lower()
+        assert "Origin" in out["Vary"]
+
+    def test_vary_header_dropped_when_only_cookie(self):
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie"
+        out = _mw(resp)(rf.get("/api/cases/"))
+        assert not out.has_header("Vary")
+
+    def test_authorization_header_bypasses(self):
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie"
+        out = _mw(resp)(rf.get("/api/statistics/", HTTP_AUTHORIZATION="Bearer x"))
+        assert not out.has_header("Cache-Control")
+        assert out["Vary"] == "Cookie"
+
+    def test_session_cookie_bypasses(self):
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie"
+        request = rf.get("/api/statistics/")
+        request.COOKIES[django_settings.SESSION_COOKIE_NAME] = "abc123"
+        out = _mw(resp)(request)
+        assert not out.has_header("Cache-Control")
+        assert out["Vary"] == "Cookie"
+
+    def test_non_allowlisted_path_untouched(self):
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie"
+        out = _mw(resp)(rf.get("/api/search/"))
+        assert not out.has_header("Cache-Control")
+        assert out["Vary"] == "Cookie"
+
+    def test_non_get_method_untouched(self):
+        resp = HttpResponse("ok")
+        out = _mw(resp)(rf.post("/api/statistics/"))
+        assert not out.has_header("Cache-Control")
+
+    def test_non_200_untouched(self):
+        resp = HttpResponse("nope", status=404)
+        out = _mw(resp)(rf.get("/api/statistics/"))
+        assert not out.has_header("Cache-Control")
+
+    def test_response_with_set_cookie_untouched(self):
+        resp = HttpResponse("ok")
+        resp.set_cookie("foo", "bar")
+        out = _mw(resp)(rf.get("/api/statistics/"))
+        assert not out.has_header("Cache-Control")
+
+    def test_disabled_is_noop(self, cache_settings):
+        cache_settings.PUBLIC_CACHE_ENABLED = False
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie"
+        out = _mw(resp)(rf.get("/api/statistics/"))
+        assert not out.has_header("Cache-Control")
+        assert out["Vary"] == "Cookie"

--- a/tests/test_public_cache_headers.py
+++ b/tests/test_public_cache_headers.py
@@ -66,6 +66,18 @@ class TestPublicCacheHeaders:
         assert not out.has_header("Cache-Control")
         assert out["Vary"] == "Cookie"
 
+    def test_authenticated_user_bypasses(self):
+        class FakeUser:
+            is_authenticated = True
+
+        resp = HttpResponse("ok")
+        resp["Vary"] = "Cookie"
+        request = rf.get("/api/statistics/")
+        request.user = FakeUser()
+        out = _mw(resp)(request)
+        assert not out.has_header("Cache-Control")
+        assert out["Vary"] == "Cookie"
+
     def test_non_allowlisted_path_untouched(self):
         resp = HttpResponse("ok")
         resp["Vary"] = "Cookie"


### PR DESCRIPTION
## Summary
- Add `PublicCacheHeadersMiddleware`: for **anonymous** GET/HEAD requests (no `Authorization` header, no session cookie) on allowlisted public paths, emit `Cache-Control: public, s-maxage=…, max-age=…` and strip `Cookie` from `Vary` so Cloudflare can edge-cache reads and keep load off the tiny origin cluster.
- Allowlisted paths: `/api/statistics/`, `/api/cases/` (list + retrieve), `/api/entities/`, `/api/oembed/`. Controlled by `PUBLIC_CACHE_ENABLED` / `PUBLIC_CACHE_SMAXAGE` / `PUBLIC_CACHE_MAXAGE` / `PUBLIC_CACHE_PATHS`.
- Registered right after `SecurityMiddleware` (outermost app middleware, so it can override `Vary` set deeper in the stack; Prometheus middleware stays first/last).

## Safety
- **Anonymous-only gate** is the boundary: anonymous and staff callers see different data from the same URL (e.g. only staff see DRAFT cases via `CaseViewSet.get_queryset`), so authenticated responses are never made cacheable.
- Responses carrying a cookie (`response.cookies` or a `Set-Cookie` header) or a non-200 status are left untouched.
- `PUBLIC_CACHE_ENABLED=False` is a full kill switch (no redeploy of logic needed).

## Follow-up (not in this PR)
Actually caching at the edge also needs Cloudflare-side (dashboard) changes: a cache rule honoring origin TTL, and disabling the `__cflb` Load Balancer session-affinity cookie on these paths (it stamps `Set-Cookie` on every response, which defeats caching). Until then responses stay `cf-cache-status: DYNAMIC`.

## Test plan
- [x] Unit tests `tests/test_public_cache_headers.py` (9 cases): anon hit, Vary-only-Cookie dropped, Authorization bypass, session-cookie bypass, non-allowlisted untouched, non-GET, non-200, Set-Cookie untouched, disabled no-op.
- [x] Manual dev-server curl: anon `/api/statistics/` & `/api/cases/` → `200` + `Cache-Control: public, s-maxage=300, max-age=300`, `Vary: origin` (no Cookie); `Authorization` header → not cached; `/api/search/` → untouched (`Vary: Cookie, origin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edge-caching support now available for public anonymous requests on designated endpoints with configurable cache policies.

* **Tests**
  * Added comprehensive test coverage for cache header functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->