### PR TITLE
Make location gate an LLM rule that allows central-gov cases

### DIFF
--- a/review/code_rules.py
+++ b/review/code_rules.py
@@ -38,6 +38,9 @@ class CodeRule:
         self.weight = spec.get("weight", 1.0)
         self.is_gate = spec.get("is_gate", False)
         self.gate_min = spec.get("gate_min", 50)
+        # Optional model-tier override for LLM rules ("premium"/"cheap"). Empty
+        # means "auto": gate rules -> premium, routine rules -> cheap.
+        self.tier = spec.get("tier", "")
         self.enabled = spec.get("enabled", True)
         self.order = spec.get("order", 100)
 
@@ -82,6 +85,7 @@ def as_dict(rule):
         "weight": rule.weight,
         "is_gate": rule.is_gate,
         "gate_min": rule.gate_min,
+        "tier": rule.tier,
         "enabled": rule.enabled,
         "order": rule.order,
     }

--- a/review/judge.py
+++ b/review/judge.py
@@ -253,9 +253,17 @@ each contribution list to at most 6 short items. Reply EXACTLY in this JSON shap
 
 
 def _tier_for_rule(rule):
-    """Hard GATE rules (a low score can REJECT the case) get the premium tier;
-    routine rules get the cheaper one. Mirrors the narrative, which is low-stakes
-    prose and also runs on the cheap tier."""
+    """Pick the judge model tier for a rule.
+
+    An explicit per-rule `tier` ("premium"/"cheap") wins — this lets a gate rule
+    opt into the cheap model when its judgment is robust enough not to need the
+    premium one (e.g. the location rule). Otherwise the default applies: hard
+    GATE rules (a low score can REJECT the case) get premium, routine rules get
+    the cheaper one — mirroring the narrative, which is low-stakes prose on cheap.
+    """
+    tier = rule.get("tier")
+    if tier in ("premium", "cheap"):
+        return tier
     return "premium" if rule.get("is_gate") else "cheap"
 
 

--- a/review/rule_defaults.py
+++ b/review/rule_defaults.py
@@ -468,16 +468,52 @@ DEFAULT_RULES = [
     },
     {
         "key": "location_entity_count",
-        "title": "Location entities (1-5, 3 preferred)",
+        "title": "Location entities (where applicable)",
         "category": "Entities",
-        "kind": "deterministic",
-        "detector": "location_entity_count",
-        "condition_text": "Always active (hard gate on 0 locations).",
+        "kind": "llm",
+        "detector": "",
+        # Gate stays, but judged on the cheap tier (see _tier_for_rule): the
+        # judgment is simple enough not to need the premium model.
+        "tier": "cheap",
+        "condition_text": "Always active.",
         "applies_to": ALL,
         "description": (
-            "The case **must** be tagged with **1-5 location entities**, with "
-            "**3** being the preferred count. Zero locations fails the gate; "
-            "tagging more than five is treated as over-tagging and is penalised."
+            "Judge whether the case is tagged with the place(s) where the case "
+            "events actually happened or where the assets/funds at issue are "
+            "located — the district (जिल्ला), municipality (नगरपालिका), or "
+            "province. Look at the `entities` list (type `location`) and weigh it "
+            "against the description and sources.\n\n"
+            "**Locations are NOT always required.** Many legitimate cases have no "
+            "district-level scene: central-government procurement, ministry / "
+            "authority / board / corporation HQ-level matters, and policy-level "
+            "cases are administered centrally and may correctly carry **zero** "
+            "location entities. When the case is clearly central / national in "
+            "scope (the related and accused entities are national bodies, the "
+            "events are a head-office procurement or policy decision), zero "
+            "locations is CORRECT — score it high.\n\n"
+            "Score LOW only when the sources or description clearly establish a "
+            "specific district/municipality where the events occurred (a local "
+            "project, a district office, a municipality scheme) and that location "
+            "was NOT tagged. One good location is plenty for a single-district "
+            "case; a few are fine for a case that genuinely spans districts.\n\n"
+            "Also penalise WRONG or over-tagged locations: an accused person's "
+            "home/birthplace/permanent address, the seat of the court or the "
+            "CIAA inquiry office tagged as if it were the event location, or a "
+            "long list of marginal places (more than ~5) that dilutes the signal."
+        ),
+        "good_examples": (
+            "A district-level scheme tagged with its district, e.g. "
+            "'साझा भण्डार सहकारी - सुर्खेत जिल्ला'. A central NTA telecom "
+            "procurement or Nepal Airlines aircraft-purchase case with zero "
+            "location entities, because there is no district-level scene — only "
+            "the head office in Kathmandu, which is correctly left untagged."
+        ),
+        "bad_examples": (
+            "A local municipality embezzlement case whose sources name the "
+            "municipality but carries no location entity. A case tagged only with "
+            "the accused's home district, or with 'काठमाडौं' solely because that "
+            "is where the court / CIAA office sits. A case over-tagged with seven "
+            "loosely-related places."
         ),
         "weight": 1.0,
         "is_gate": True,

--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -393,43 +393,6 @@ def related_entity_present(case):
     return 100, []
 
 
-def location_entity_count(case):
-    """Score the number of LOCATION entities on the case.
-
-    A case should have 1-5 location entities, with 3 being the preferred count:
-      - 3 locations           -> 100 (ideal)
-      - 1, 2, 4 or 5 locations -> within the acceptable band, lightly penalised
-                                  by distance from the preferred 3.
-      - 0 locations            -> 0 (none identified)
-      - more than 5 locations  -> over-tagged; penalised, floors at 40.
-    """
-    entities = case.get("entities") or []
-    locations = [e for e in entities if (e.get("type") or "").lower() == "location"]
-    n = len(locations)
-    issues = []
-
-    if n == 0:
-        return 0, ["No location entities identified (1-5 expected, 3 preferred)."]
-    if n > 5:
-        # Over-tagged: start below the in-band edge (n=5 scores 70) and fall
-        # 10 per extra location, never below 40. 6 -> 60, 7 -> 50, 8 -> 40.
-        score = max(40, 70 - (n - 5) * 10)
-        issues.append(
-            f"{n} location entities; expected 1-5 (3 preferred). Likely over-tagged."
-        )
-        return _clamp(score), issues
-
-    # 1..5 locations: full marks at the preferred 3, -15 per step away from it.
-    score = 100 - abs(n - 3) * 15
-    if n < 3:
-        ent_word = "entity" if n == 1 else "entities"
-        issues.append(
-            f"Are you sure there {'is' if n == 1 else 'are'} only {n} location "
-            f"{ent_word}? 3 are preferred."
-        )
-    return _clamp(score), issues
-
-
 DETECTORS = {
     "court_case_number": court_case_number,
     "additional_description": additional_description,
@@ -444,7 +407,6 @@ DETECTORS = {
     "bigo_amount_present": bigo_amount_present,
     "accused_present": accused_present,
     "related_entity_present": related_entity_present,
-    "location_entity_count": location_entity_count,
 }
 
 

--- a/review/scorer.py
+++ b/review/scorer.py
@@ -186,8 +186,10 @@ def score_case(
                 "description": r.description,
                 "good_examples": r.good_examples,
                 "bad_examples": r.bad_examples,
-                # Routes the judge model tier: gate rules -> premium model.
+                # Routes the judge model tier: an explicit `tier` wins, else
+                # gate rules -> premium model, routine rules -> cheap.
                 "is_gate": r.is_gate,
+                "tier": r.tier,
             }
             for r in llm_rules
         ]


### PR DESCRIPTION
## Summary

The `location_entity_count` rule was a **deterministic gate** that hard-failed any case with **zero** location entities. But many legitimate cases are administered centrally — HQ-level procurement, ministry/authority/board matters, policy-level decisions — and have **no district-level scene**. The related-entity enricher correctly emits zero locations for these, yet the gate then rejected the case.

This converts the rule to an **LLM-judged gate** that:
- scores zero-location **central/national** cases as **correct** (high), and
- still **fails a genuine omission** — where the sources/description clearly name a district/municipality that wasn't tagged — and penalises wrong/over-tagged locations (home address, court/CIAA seat, >5 marginal places).

It keeps its **gate (reject) power** but opts into the **cheap model tier** via a new per-rule `tier` override, threaded `CodeRule` → scorer `rule_specs` → `judge._tier_for_rule`. The now-unused deterministic detector is removed.

## Changes
- `rule_defaults.py` — `location_entity_count` → `kind=llm`, `tier=cheap`, `detector=""`; keeps `is_gate=True`/`gate_min=50`; new judgment-based description + good/bad examples.
- `judge.py` — `_tier_for_rule` honors an explicit per-rule `tier`, falling back to the gate→premium / routine→cheap default.
- `code_rules.py` — `CodeRule` gains a `tier` attribute (exposed in `as_dict`).
- `scorer.py` — threads `tier` into the `rule_specs` handed to the judge.
- `rules_engine.py` — removes the unused `location_entity_count` detector + registry entry.

## Validation
Loaded the rule set and confirmed: `kind=llm, tier='cheap', is_gate=True, gate_min=50`; detector removed; routing returns `cheap` for it while the default still gives gate→premium / routine→cheap; no deterministic rule left without a detector. Pre-commit (ruff + black) passes.

Local dry-run sanity (cheap tier via claude CLI) on real cases:

| Case | Type | Locs | Score | Gate |
|------|------|------|-------|------|
| 080-CR-0141 (NTA telecom) | central | 0 | 93 | PASS |
| 080-CR-0145 (Nepal Airlines) | central | 0 | 95 | PASS |
| 080-CR-0195 (Ratuwamai ward) | local | 0 | 5 | **FAIL** (genuine omission) |
| 080-CR-0066 (school pension) | district | 2 | 80 | PASS |

Both directions verified: central cases pass on zero locations; a real local omission still fails the gate.

## Test plan
- [ ] CI passes (review tests)
- [ ] Re-review confirms central-gov cases (e.g. 0141/0145) clear the location gate
- [ ] Spot-check the cheap-tier judgments on the first batch (gate on cheap model is intentional but new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rules now support optional tier configuration for processing optimization.
  * Location entity evaluation now uses AI-powered scoring instead of hard thresholds, enabling more contextual flexibility.

* **Chores**
  * Removed legacy location entity count detector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->