### PR TITLE
feat(casework): include IN_REVIEW cases in batch enricher selection

### DIFF
--- a/casework/common.py
+++ b/casework/common.py
@@ -541,7 +541,8 @@ def get_target_cases(api, args, skip_field):
 
     Cases are selected by slug or court case number (e.g. 081-CR-0121); there is
     no internal case_id selector. --slug and --court-case fetch the case in ANY
-    state; the batch path (no selector) scans DRAFT CORRUPTION CIAA cases.
+    state; the batch path (no selector) scans DRAFT and IN_REVIEW CORRUPTION
+    CIAA cases (PUBLISHED cases are left untouched).
     """
     count = 0
     limit = getattr(args, "limit", None)
@@ -607,7 +608,9 @@ def get_target_cases(api, args, skip_field):
         scanned += 1
         if scanned % 500 == 0:
             log.info("  scanned %d cases (matched %d so far)...", scanned, count)
-        if summary.get("state") != "DRAFT":
+        # Enrich pre-publication cases: DRAFT and IN_REVIEW (the priority set has
+        # been promoted to IN_REVIEW). PUBLISHED cases are left untouched.
+        if summary.get("state") not in ("DRAFT", "IN_REVIEW"):
             continue
         if not is_ciaa_special_court_case(summary):
             continue


### PR DESCRIPTION
## Summary
- `get_target_cases` batch path selected only `DRAFT` cases (`state != "DRAFT"` skip), so `--priority` / fiscal-year / unfiltered runs of every batch enricher (`enrich_evidence`, `enrich_title`, `enrich_short_description`, …) silently matched **zero** once the priority case set was promoted `DRAFT → IN_REVIEW`.
- Now select **DRAFT + IN_REVIEW** (pre-publication). `PUBLISHED` cases remain untouched, so live published content is never rewritten.
- Updated the `get_target_cases` docstring to match.

## Context
The 51 priority CIAA Special Court cases were all promoted to `IN_REVIEW`, which made `--priority` a no-op for batch enrichers. The `--slug` / `--court-case` selectors were already state-agnostic; this brings the batch path in line for pre-publication states.

This was used to backfill source descriptions (previously empty) and upgrade evidence-entry descriptions (previously thin auto-stubs) across all 51 priority cases via `enrich_evidence --priority` (Opus 4.8 1m).

## Test plan
- [ ] `--priority` now selects IN_REVIEW priority cases (verified: 51 loaded, matches found)
- [ ] `--priority` does NOT select PUBLISHED cases
- [ ] `--dry-run` unaffected; existing `--slug` / `--court-case` paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated case processing to include cases in IN_REVIEW state alongside DRAFT state cases for enrichment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->