### PR TITLE
fix(casework): drop paisa before parsing bigo to stop 10x inflation

### DIFF
--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -74,14 +74,17 @@ CRITICAL RULES (apply in order):
 
 Rule 1 — Output format
 BIGO must be an NPR integer only. No commas, no currency symbols (रू/Rs/NPR), no \
-paisa suffix (/90, /39, etc.), no floats.
-If the extracted amount has a paisa portion (e.g. १,४६,८१,२२५/९०), strip everything \
-after / before returning.
+paisa suffix, no floats.
+CIAA marks paisa with a danda '।' OR a slash '/' (e.g. १,४६,८१,२२५।९० or \
+१,४६,८१,२२५/९०). If the extracted amount has a paisa portion, strip everything \
+after the '।' or '/' before returning — return the rupee part only.
 
 Rule 2 — Numeral normalization
 Before any matching, normalize Devanagari digits to Arabic (०→0, १→1, ... ९→9). CIAA \
 PDFs mix both in the same number.
-Then strip commas. Then strip the paisa suffix. Then parse as integer.
+Then strip commas. Then strip the paisa suffix (everything from the first '।' or \
+'/'). Then parse as integer. Never let paisa digits merge into the rupee figure — \
+e.g. २३,७५,४६,३२४।५७ is 237546324, NOT 2375463245.
 
 Rule 3 — Type-routing first (CHECK THIS BEFORE READING TEXT)
 Before reading any text, determine the press release type:
@@ -539,7 +542,17 @@ def _coerce_bigo_int(value: any) -> Optional[int]:
         return None
 
     normalized = value.translate(_NEPALI_TO_ASCII_DIGITS)
-    digits_only = re.sub(r"[^\d]", "", normalized)
+    # CIAA writes paisa after a danda '।', slash '/', or dot '.' (e.g. ...३२४।५७,
+    # ...२२५/९०, ...324.57). Stripping all non-digits would fold the paisa digits
+    # into the rupee figure and inflate it 10-100x (e.g. 237546324।57 ->
+    # 2375463245). Anchor at the first digit before cutting paisa so a leading
+    # currency prefix ('रु.') isn't mistaken for a paisa separator. Rupee grouping
+    # uses commas only, so cutting at the first '।'/'/'/'.' after the digits is safe.
+    first_digit = re.search(r"\d", normalized)
+    if not first_digit:
+        return None
+    rupees = re.split(r"[।/.]", normalized[first_digit.start() :], maxsplit=1)[0]
+    digits_only = re.sub(r"[^\d]", "", rupees)
     if not digits_only:
         return None
     bigo = int(digits_only)

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -543,15 +543,17 @@ def _coerce_bigo_int(value: any) -> Optional[int]:
 
     normalized = value.translate(_NEPALI_TO_ASCII_DIGITS)
     # CIAA writes paisa after a danda '।', slash '/', or dot '.' (e.g. ...३२४।५७,
-    # ...२२५/९०, ...324.57). Stripping all non-digits would fold the paisa digits
-    # into the rupee figure and inflate it 10-100x (e.g. 237546324।57 ->
-    # 2375463245). Anchor at the first digit before cutting paisa so a leading
-    # currency prefix ('रु.') isn't mistaken for a paisa separator. Rupee grouping
-    # uses commas only, so cutting at the first '।'/'/'/'.' after the digits is safe.
+    # ...२२५/९०, ...324.57). OCR frequently misreads the danda '।' as a vertical
+    # pipe '|', so treat that as a separator too. Stripping all non-digits would
+    # fold the paisa digits into the rupee figure and inflate it 10-100x (e.g.
+    # 237546324।57 -> 2375463245). Anchor at the first digit before cutting paisa
+    # so a leading currency prefix ('रु.') isn't mistaken for a paisa separator.
+    # Rupee grouping uses commas only, so cutting at the first '।'/'|'/'/'/'.'
+    # after the digits is safe.
     first_digit = re.search(r"\d", normalized)
     if not first_digit:
         return None
-    rupees = re.split(r"[।/.]", normalized[first_digit.start() :], maxsplit=1)[0]
+    rupees = re.split(r"[।|/.]", normalized[first_digit.start() :], maxsplit=1)[0]
     digits_only = re.sub(r"[^\d]", "", rupees)
     if not digits_only:
         return None

--- a/tests/casework/test_enrich_missing_bigo.py
+++ b/tests/casework/test_enrich_missing_bigo.py
@@ -18,6 +18,10 @@ class TestCoerceBigoInt:
         # 080-CR-0181
         assert emb._coerce_bigo_int("रु.२६,६३,३७,३९८।१२") == 266337398
 
+    def test_pipe_paisa_dropped(self):
+        # OCR frequently misreads the danda '।' as a vertical pipe '|'.
+        assert emb._coerce_bigo_int("२३,७५,४६,३२४|५७") == 237546324
+
     def test_slash_paisa_dropped(self):
         assert emb._coerce_bigo_int("१,४६,८१,२२५/९०") == 14681225
 

--- a/tests/casework/test_enrich_missing_bigo.py
+++ b/tests/casework/test_enrich_missing_bigo.py
@@ -1,0 +1,46 @@
+"""Tests for the DB-free standalone BIGO enricher (casework/enrich_missing_bigo.py).
+
+Focus on _coerce_bigo_int: CIAA writes paisa after a danda '।', slash '/', or
+dot '.', and blindly stripping non-digits used to fold the paisa digits into the
+rupee figure (a 10-100x inflation that reached production, e.g. 080-CR-0158).
+No database and no network are touched.
+"""
+
+from casework import enrich_missing_bigo as emb
+
+
+class TestCoerceBigoInt:
+    def test_danda_paisa_dropped(self):
+        # 080-CR-0158: २३,७५,४६,३२४।५७ must be 237546324, NOT 2375463245.
+        assert emb._coerce_bigo_int("२३,७५,४६,३२४।५७") == 237546324
+
+    def test_danda_paisa_with_currency_prefix(self):
+        # 080-CR-0181
+        assert emb._coerce_bigo_int("रु.२६,६३,३७,३९८।१२") == 266337398
+
+    def test_slash_paisa_dropped(self):
+        assert emb._coerce_bigo_int("१,४६,८१,२२५/९०") == 14681225
+
+    def test_trailing_slash_dash(self):
+        assert emb._coerce_bigo_int("40,85,74,740/-") == 408574740
+
+    def test_ascii_decimal_paisa_dropped(self):
+        assert emb._coerce_bigo_int("237546324.57") == 237546324
+
+    def test_clean_integer_string(self):
+        assert emb._coerce_bigo_int("237546324") == 237546324
+
+    def test_plain_int_passthrough(self):
+        assert emb._coerce_bigo_int(237546324) == 237546324
+
+    def test_float_truncates(self):
+        assert emb._coerce_bigo_int(237546324.57) == 237546324
+
+    def test_zero_is_none(self):
+        assert emb._coerce_bigo_int(0) is None
+
+    def test_none_is_none(self):
+        assert emb._coerce_bigo_int(None) is None
+
+    def test_empty_string_is_none(self):
+        assert emb._coerce_bigo_int("रु.") is None


### PR DESCRIPTION
## Summary
- CIAA press releases / charge sheets write paisa after a Devanagari danda `।` (e.g. `२३,७५,४६,३२४।५७`). `_coerce_bigo_int` stripped only non-digits, folding the paisa into the rupee figure and inflating bigo 10–100× — it reached prod on **080-CR-0158** (stored `2375463245` instead of `237546324`).
- Fix: anchor at the first digit, then cut at the first `।` / `/` / `.` so paisa is dropped and a leading `रु.` prefix isn't mistaken for a separator. Also names the danda as a paisa marker in the extraction prompt. Paisa is intentionally discarded.

## Notes
- Deterministic fix only — a weak extraction model can still emit a pre-merged wrong integer the coercion can't see into (observed on NTC 081-CR-0111 with haiku). Follow-up: stronger model and/or a magnitude sanity-check.

## Test plan
- [x] `tests/casework/test_enrich_missing_bigo.py` — 11 cases (danda/slash/dot paisa, `रु.` prefix, clean int, float) all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of currency amount parsing by correctly handling fractional units in BIGO values, preventing incorrect digit merging across different input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->