### PR TITLE
fix(cases): don't mistype news-about-a-court-action as a court document

### DIFF
--- a/cases/services/source_classifier.py
+++ b/cases/services/source_classifier.py
@@ -70,6 +70,9 @@ NEWS_DOMAINS = frozenset(
         "moneymitra.com",
         "sharesansar.com",
         "janaaastha.com",
+        "shuvabihani.com",
+        "khabarhub.com",
+        "palpalkokhabar.com",
         "bbc.com",
         "bbc.co.uk",
     }
@@ -187,6 +190,18 @@ def _domain_matches(host: str, domains: frozenset[str]) -> bool:
     return any(host == d or host.endswith(f".{d}") for d in domains)
 
 
+def _is_official_host(host: str) -> bool:
+    """True if *host* is a Nepal government / court host.
+
+    Primary official documents — court orders and filings, charge sheets,
+    press releases, audit reports, laws — are published on the ``*.gov.np``
+    namespace (ciaa.gov.np, supremecourt.gov.np, lawcommission.gov.np, …). A
+    generic non-``.gov.np`` web host is therefore third-party coverage, never
+    the primary court record itself.
+    """
+    return host == "gov.np" or host.endswith(".gov.np")
+
+
 def _keyword_in(corpus: str, keyword: str) -> bool:
     """Whether *keyword* occurs in (already-lowercased) *corpus*.
 
@@ -297,6 +312,19 @@ def classify_source_type(
     if hit is None:
         hit = _match_keywords(f"{title} {description}".lower(), clean_urls)
     if hit is not None:
+        # Guard: a court order/filing is a primary court record, published on a
+        # *.gov.np host or held in our own storage — it is never hosted *only*
+        # on a generic external web domain. When the sole external host is such
+        # a domain (a news/blog outlet not in NEWS_DOMAINS), court keywords in
+        # the headline (फैसला, पुनरावेदन, सर्वोच्च अदालत …) are reporting *about*
+        # the case, not the document itself — so the source is coverage (NEWS).
+        # This stops a news article on an unlisted outlet from being mistyped a
+        # court document just because its title quotes the verdict/appeal.
+        if hit in (SourceType.COURT_ORDER, SourceType.COURT_FILING_OTHER):
+            has_official_host = any(_is_official_host(h) for h in signal_hosts)
+            has_external_web_host = any(not _is_official_host(h) for h in signal_hosts)
+            if has_external_web_host and not has_official_host:
+                return SourceType.NEWS
         return hit
 
     # 4: legislation by issuing-body domain (no document keyword present).

--- a/tests/test_source_classifier.py
+++ b/tests/test_source_classifier.py
@@ -177,3 +177,86 @@ def test_ambiguous_legacy_label_falls_through_to_misc():
         )
         == SourceType.MISC
     )
+
+
+# ── News-about-a-court-action must not be typed a court document ──────────────
+# Regression for the Supreme-Court-appeal mistyping bug: a news article whose
+# headline quotes the verdict/appeal (फैसला, पुनरावेदन, सर्वोच्च अदालत) was being
+# classified COURT_ORDER / COURT_FILING_OTHER instead of NEWS.
+
+
+def test_appeal_news_on_unlisted_outlet_is_news_not_court_order():
+    """A news report about a Supreme Court appeal, hosted on an outlet NOT in
+    NEWS_DOMAINS, is coverage (NEWS) — not the court order it talks about.
+
+    The headline contains फैसला (a COURT_ORDER keyword); without the structural
+    guard the keyword rule wins and mistypes it. The only external host is a
+    generic web domain (no *.gov.np), so it must resolve to NEWS.
+    """
+    assert (
+        classify_source_type(
+            "विशेष अदालतको फैसलामा चित्त नबुझेपछि अख्तियारले दियो सर्वोच्चमा पुनरावेदन",
+            "आयोगका प्रवक्ताका अनुसार वैशाख १३ को फैसला विरुद्ध सर्वोच्चमा पुनरावेदन।",
+            [
+                "https://www.some-unlisted-outlet.com/archives/7103",
+                "https://s3.jawafdehi.org/case_uploads/abc.md",
+            ],
+        )
+        == SourceType.NEWS
+    )
+
+
+def test_filing_report_on_unlisted_outlet_is_news_not_court_filing():
+    """A news report that a writ/appeal was *filed*, on an unlisted outlet, is
+    NEWS — the COURT_FILING_OTHER keyword (पुनरावेदन/रिट) is reporting on it."""
+    assert (
+        classify_source_type(
+            "अख्तियारले सर्वोच्चमा पुनरावेदन दर्ता गर्‍यो",
+            "",
+            ["https://www.another-unlisted-portal.com/artha-banijya/1431"],
+        )
+        == SourceType.NEWS
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.shuvabihani.com/archives/7103",
+        "https://english.khabarhub.com/2025/14/457912/",
+        "https://palpalkokhabar.com/artha-banijya/1431",
+    ],
+)
+def test_newly_listed_outlets_classify_as_news(url):
+    """The three outlets confirmed in the audit (cases 0014/0070/0071) are now
+    recognised news domains, so they classify as NEWS by publisher identity."""
+    assert classify_source_type("सर्वोच्चमा पुनरावेदन", "", [url]) == SourceType.NEWS
+
+
+def test_court_order_in_own_storage_still_classifies_as_court_order():
+    """Guard must NOT over-reach: a genuine uploaded court order (RAW on our
+    ngm-store, no external host at all) keeps COURT_ORDER."""
+    assert (
+        classify_source_type(
+            "Court Order - 080-CR-0014",
+            "विशेष अदालतको फैसला",
+            [
+                "https://ngm-store.jawafdehi.org/uploads/court-orders/special/080-CR-0014.1.pdf",
+                "https://s3.jawafdehi.org/case_uploads/abc.md",
+            ],
+        )
+        == SourceType.COURT_ORDER
+    )
+
+
+def test_court_order_on_government_host_still_classifies_as_court_order():
+    """A court record published on a *.gov.np host is the primary document and
+    must stay COURT_ORDER even though a .gov.np host is present."""
+    assert (
+        classify_source_type(
+            "Supreme Court verdict",
+            "",
+            ["https://supremecourt.gov.np/web/judgment/12345"],
+        )
+        == SourceType.COURT_ORDER
+    )


### PR DESCRIPTION
## Problem

The deterministic source classifier (`cases/services/source_classifier.py`) types a source as `COURT_ORDER` / `COURT_FILING_OTHER` whenever its headline contains a court keyword (`फैसला`, `पुनरावेदन`, `सर्वोच्च अदालत`, `verdict`, `appeal`, …). For a **news article reporting on a Supreme Court appeal** hosted on an outlet that isn't in `NEWS_DOMAINS`, the keyword rule fires and the article is mistyped as the court record it merely describes.

Confirmed in the priority-case audit:
- **080-CR-0014** — `shuvabihani.com` appeal report ("विशेष अदालतको फैसलामा चित्त नबुझेपछि अख्तियारले दियो सर्वोच्चमा पुनरावेदन") typed `COURT_ORDER`
- **080-CR-0070** — `khabarhub.com` appeal report typed `COURT_ORDER`
- **080-CR-0071** — `palpalkokhabar.com` filing report typed `COURT_FILING_OTHER`

Likely root cause as seen in the data: a case with a linked `supreme:*` appeal `court_case` plus a court-keyword news headline yields a fake court document instead of `NEWS` coverage.

## Fix

The classifier already intends **publisher identity to beat soft keywords** — known news/social domains short-circuit to `NEWS` before keyword matching (see the comment at the domain step). The gap was that this only covered *known* news domains; an unlisted outlet falls through to keyword matching and gets mistyped.

Add a **structural guard**: a primary court record (order/filing) is published on a `*.gov.np` host or held in our own storage (`s3`/`ngm-store`) — it is never hosted *only* on a generic external web host. When a court-document keyword classification's **sole external signal host is such a host (and none is `*.gov.np`)**, downgrade it to `NEWS`.

This is robust to outlets we haven't enumerated, while leaving genuine court records untouched:
- a real court order uploaded to `ngm-store` (no external host) stays `COURT_ORDER`
- a court record on a `*.gov.np` host stays `COURT_ORDER`

Also adds the three audit-confirmed outlets (`shuvabihani.com`, `khabarhub.com`, `palpalkokhabar.com`) to `NEWS_DOMAINS` so they classify by publisher identity directly.

## Tests

`tests/test_source_classifier.py`:
- appeal/filing reports on **unlisted** outlets → `NEWS` (the guard)
- the three newly listed outlets → `NEWS`
- regression: a real court order in own-storage **or** on a `*.gov.np` host stays `COURT_ORDER` (guard does not over-reach)

All 42 classifier tests pass; `ruff` + `black` clean.

## Follow-up (not in this PR)

A one-off backfill should re-run the classifier over existing `COURT_ORDER`/`COURT_FILING_OTHER` sources whose only external host is a non-gov web host to correct already-stored rows (e.g. the three cases above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source classification so news articles quoting court-related terms are less likely to be misidentified as official court documents.
  * Better distinguishes genuine court orders from third-party reporting pages and other non-official hosts.
  * Added support for additional publisher domains so more news sources are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->