### PR TITLE
fix(admin): stop inlining all document sources in every evidence row

### DIFF
--- a/cases/static/cases/js/widgets.js
+++ b/cases/static/cases/js/widgets.js
@@ -261,6 +261,15 @@ window.MultiWidgetConfigs = {
             const select = row.querySelector('.source-select');
             const viewBtn = row.querySelector('.view-source-btn');
 
+            // Populate the source dropdown from a single shared option list rather
+            // than inlining ~800 <option>s into every row server-side (which bloated
+            // the case change page to ~1.7MB). Existing rows carry the saved value in
+            // data-selected; new rows start blank.
+            if (select && select.options.length === 0 && manager.config.sourceOptionsHTML) {
+                select.innerHTML = manager.config.sourceOptionsHTML;
+                select.value = select.dataset.selected || '';
+            }
+
             if (select && viewBtn && manager.config.sourceUrlMap) {
                 const updateViewButton = () => {
                     const sourceId = select.value;

--- a/cases/templates/cases/widgets/multi_evidence_widget.html
+++ b/cases/templates/cases/widgets/multi_evidence_widget.html
@@ -37,9 +37,14 @@
 
 <script>
 (function() {
+    // Each option is HTML-escaped (|escape) before being JS-string-escaped (|escapejs):
+    // this string is assigned via innerHTML, so a source title like
+    // "<img src=x onerror=…>" must be neutralised as text, not just kept inside the
+    // JS literal. |escapejs alone would still inject markup once the literal decodes.
     var sourceOptions = [
+        '<option value="">---------</option>',
         {% for source_id, source_title, source_url in sources %}
-        '<option value="{{ source_id }}">{{ source_title|escapejs }}</option>'
+        '<option value="{{ source_id|escape|escapejs }}">{{ source_title|escape|escapejs }}</option>'
         {% if not forloop.last %},{% endif %}
         {% endfor %}
     ].join('');
@@ -47,7 +52,7 @@
     var sourceUrlMap = {
         {% for source_id, source_title, source_url in sources %}
         {% if source_url %}
-        '{{ source_id }}': '{{ source_url|escapejs }}'
+        '{{ source_id|escapejs }}': '{{ source_url|escapejs }}'
         {% if not forloop.last %},{% endif %}
         {% endif %}
         {% endfor %}

--- a/cases/templates/cases/widgets/multi_evidence_widget.html
+++ b/cases/templates/cases/widgets/multi_evidence_widget.html
@@ -8,13 +8,10 @@
         <div class="evidence-field-group">
             <label>Document Source</label>
             <div class="evidence-source-wrapper">
-                <select class="evidence-input source-select">
-                    {% for source_id, source_title, source_url in sources %}
-                    <option value="{{ source_id }}" {% if source_id == item.source_id %}selected{% endif %}>
-                        {{ source_title }}
-                    </option>
-                    {% endfor %}
-                </select>
+                <!-- Options are injected once from the shared sourceOptions list in JS
+                     (see setupRowCallback) rather than inlined per row, which previously
+                     rendered ~800 <option>s in every evidence row and bloated the page. -->
+                <select class="evidence-input source-select" data-selected="{{ item.source_id }}"></select>
                 <a href="#" class="btn btn-sm btn-info view-source-btn" target="_blank"
                    {% if not item.source_id %}style="display: none;"{% endif %}>
                     <i class="fas fa-eye"></i> View
@@ -64,9 +61,7 @@
         '<div class="evidence-field-group">',
         '<label>Document Source</label>',
         '<div class="evidence-source-wrapper">',
-        '<select class="evidence-input source-select">',
-        sourceOptions,
-        '</select>',
+        '<select class="evidence-input source-select"></select>',
         '<a href="#" class="btn btn-sm btn-info view-source-btn" target="_blank" style="display: none;">',
         '<i class="fas fa-eye"></i> View',
         '</a>',
@@ -87,7 +82,8 @@
         'evidence',
         {
             rowTemplate: rowTemplate,
-            sourceUrlMap: sourceUrlMap
+            sourceUrlMap: sourceUrlMap,
+            sourceOptionsHTML: sourceOptions
         }
     );
 })();


### PR DESCRIPTION
## Problem
The case change form (`/admin/cases/case/<id>/change/`) was loading very slowly — reported in the field as "the page is too slow" and "the save/right-side options don't show" (the latter is actually jazzmin's right-hand action column dropping below the fold on narrow/zoomed browsers, a separate browser-side issue).

Root cause of the **slowness**: each evidence row's **Document Source** `<select>` inlined **every** `DocumentSource` (~817) as `<option>` tags. With 6 evidence rows that's ~5,700 option tags, plus another full copy built in JS for new rows.

## Fix
Render the source option list **once** (the `sourceOptions` string the template already builds) and populate each `.source-select` from that single copy in the evidence widget's `setupRowCallback`:
- Existing rows now emit an empty `<select data-selected="…">`; the saved source is reselected client-side.
- New rows (added via the "Add Evidence" button) are filled the same way.

No behavior change: still a `<select>` valued by `source_id`, preselected correctly, and submission still flows through the unchanged hidden-input JSON.

## Impact (measured on a real case, 6 evidence rows, 817 sources)
| | evidence widget HTML | `<option>` tags |
|---|---|---|
| before | 1,357,453 B (1.36 MB) | 5,719 |
| after | 248,262 B (0.25 MB) | 823 |

That takes the whole change page from **~1.74 MB → ~0.63 MB** (~64% smaller).

## Notes
- Existing `EvidenceListField` tests cover validation/submission (unaffected); no test asserts per-row inline options.
- Files: `cases/templates/cases/widgets/multi_evidence_widget.html`, `cases/static/cases/js/widgets.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)