### PR TITLE
fix(review): cut false-positive rule firings + tighten integrity gates

### DIFF
--- a/review/casetype.py
+++ b/review/casetype.py
@@ -78,13 +78,16 @@ def detect(case):
     # COURT_ORDER source type == "Court Order/Verdict"; title keywords are a
     # fallback. Mirrors court_record, so a COURT_ORDER-typed document whose title
     # carries no आदेश/फैसला keyword still classifies the case as HAS_VERDICT.
-    # The title-keyword fallback is allowed ONLY for non-NEWS sources. A NEWS
-    # headline that merely reports an INTERIM court order (e.g. "...खाता विवरण
-    # झिकाउन आदेश") must NOT promote a pre-verdict case to HAS_VERDICT — only a
-    # COURT_ORDER-typed document does (a genuine final verdict is also caught by
-    # `has_verdict` via the फैसला/verdict keyword on any source type).
+    # The title-keyword fallback is allowed ONLY for non-NEWS, non-social-media
+    # sources. A NEWS / SOCIAL_MEDIA headline that merely reports an INTERIM court
+    # order (e.g. "...खाता विवरण झिकाउन आदेश") must NOT promote a pre-verdict case
+    # to HAS_VERDICT — only a COURT_ORDER-typed document does (a genuine final
+    # verdict is also caught by `has_verdict` via the फैसला/verdict keyword on any
+    # source type).
     has_court_order = any(
-        st == "COURT_ORDER" or (st != "NEWS" and _any(t, _COURT_ORDER)) for t, st in tt
+        st == "COURT_ORDER"
+        or (st not in ("NEWS", "SOCIAL_MEDIA") and _any(t, _COURT_ORDER))
+        for t, st in tt
     )
     has_special_court = any(_any(t, _SPECIAL_COURT) for t, _ in tt)
     has_court_case_no = bool(court_cases)

--- a/review/casetype.py
+++ b/review/casetype.py
@@ -78,7 +78,14 @@ def detect(case):
     # COURT_ORDER source type == "Court Order/Verdict"; title keywords are a
     # fallback. Mirrors court_record, so a COURT_ORDER-typed document whose title
     # carries no आदेश/फैसला keyword still classifies the case as HAS_VERDICT.
-    has_court_order = any(st == "COURT_ORDER" or _any(t, _COURT_ORDER) for t, st in tt)
+    # The title-keyword fallback is allowed ONLY for non-NEWS sources. A NEWS
+    # headline that merely reports an INTERIM court order (e.g. "...खाता विवरण
+    # झिकाउन आदेश") must NOT promote a pre-verdict case to HAS_VERDICT — only a
+    # COURT_ORDER-typed document does (a genuine final verdict is also caught by
+    # `has_verdict` via the फैसला/verdict keyword on any source type).
+    has_court_order = any(
+        st == "COURT_ORDER" or (st != "NEWS" and _any(t, _COURT_ORDER)) for t, st in tt
+    )
     has_special_court = any(_any(t, _SPECIAL_COURT) for t, _ in tt)
     has_court_case_no = bool(court_cases)
 

--- a/review/rule_defaults.py
+++ b/review/rule_defaults.py
@@ -94,7 +94,17 @@ DEFAULT_RULES = [
             "ordering, a malformed markdown table, minor wording — belong in "
             "`notes`, not `issues`, and must not lower the score; only a "
             "substantive failure (missing the core allegation/amount/status, or "
-            "contradicting the sources) is a scored issue."
+            "contradicting the sources) is a scored issue.\n\n"
+            "CONTRADICTION WITH OWN SOURCES (scored issue): the description must "
+            "NOT assert that an outcome / verdict / per-defendant result / figure "
+            "is unavailable or unknown when one of the case's OWN attached sources "
+            "actually reports it — flag it and cite the source. When this same "
+            "fact is also the root cause of a `gap_honesty` flag, score it HERE "
+            "and downgrade the parallel gap_honesty mention to a note. A lead "
+            "figure that is internally consistent with the case bigo but disputed "
+            "on fiscal-year grounds is a bigo/data issue (score under "
+            "`bigo_matches_press_release`), not a description failure — note it "
+            "here, do not double-deduct."
         ),
         "good_examples": "A reader who only reads the description understands the whole case and it matches the sources.",
         "bad_examples": "Description omits the core allegation, the amount, or contradicts the sources; or is a stub.",
@@ -127,7 +137,20 @@ DEFAULT_RULES = [
             "an actual contradiction with the authoritative figure is an `issue`.\n\n"
             "If the case is a certified no-bigo case (empty `bigo` with a "
             "`NO_BIGO:` marker in `internal_notes`), there is no figure to match — "
-            "keep the score at 100."
+            "keep the score at 100.\n\n"
+            "Honor a documented convention: if `internal_notes` carries a "
+            "`BIGO_CONVENTION:` line naming the bigo figure and its basis (the "
+            "court-determined / अदालतले कायम गरेको amount vs the higher "
+            "CIAA-alleged loss the court reduced or rejected; or a deliberate "
+            "lead-defendant vs scheme-total choice) AND that figure is internally "
+            "consistent with the cited court order / press release, score 100 and "
+            "record the divergence as a NOTE. The court-determined बिगो is "
+            "AUTHORITATIVE for a decided case and is NOT a mismatch against the "
+            "higher CIAA-alleged amount. Fire a scored issue only when (a) no "
+            "convention is documented AND the figure contradicts the "
+            "authoritative source, or (b) the figure traces to a DIFFERENT case / "
+            "wrong fiscal year (e.g. the identical bigo appears on a sibling case "
+            "for a different आ.व.)."
         ),
         "good_examples": (
             "Press release states रु. ३.२१ अर्ब and `bigo` is 3,218,377,182 — the "
@@ -166,7 +189,13 @@ DEFAULT_RULES = [
             "ONLY a bare code, number, or hash with no descriptive words — or when "
             "it is misleading relative to what the case is actually about. Judge "
             "whether a member of the public reading the slug would correctly "
-            "anticipate the case's title, summary and key allegations."
+            "anticipate the case's title, summary and key allegations.\n\n"
+            "Naming a genuine party or the scheme — even a SECONDARY one — is "
+            "acceptable: do NOT deduct merely because a DIFFERENT party would have "
+            "made a better lead. A better-lead-available situation is a NOTE, "
+            "never a sub-90 issue. Reserve scored deductions for slugs that are "
+            "opaque (a bare code/hash with no descriptive words), name the WRONG "
+            "party, or contradict the title."
         ),
         "good_examples": (
             "`baluwatar-land-grab-singha-durbar` for a case about a land-grab "
@@ -199,7 +228,13 @@ DEFAULT_RULES = [
         "description": (
             "Language is neutral and non-speculative. Unproven claims are hedged "
             "as **alleged** (आरोप). No editorialising, loaded adjectives, or "
-            "conclusions stated as established fact before a verdict."
+            "conclusions stated as established fact before a verdict.\n\n"
+            "PRECISION: tie a loaded-term deduction to verdict status. A vivid but "
+            "accurate offence term (भ्रष्टाचार, अनियमितता — or घोटाला where a "
+            "conviction stands) is acceptable; deduct specifically when the term "
+            "asserts guilt the record does not support — e.g. labelling a matter "
+            "घोटाला / 'scam' where the defendants were acquitted or the verdict is "
+            "still pending."
         ),
         "good_examples": '"X is accused of (आरोप) misappropriating Rs. Y" — hedged, factual.',
         "bad_examples": '"X is a corrupt official who stole Rs. Y" — verdict asserted, loaded.',
@@ -375,7 +410,15 @@ DEFAULT_RULES = [
             "RAW being a URL is fine), each source has a single RAW, and extra "
             "links use the right roles. Lower the score the more sources put a "
             "bare web page as a non-news RAW, carry multiple RAW links, or "
-            "mis-file supporting links as RAW."
+            "mis-file supporting links as RAW.\n\n"
+            "ROLES NOT OBSERVABLE: if the per-link role assignments are NOT present "
+            "in the data you are given (no role tags are shown on the sources) AND "
+            "the deterministic `source_link_roles_valid` check passes for this "
+            "case, this rule MUST score 100 and record any 'verify the PDF is RAW' "
+            "guidance as a NOTE only — never a deduction. The stored roles are "
+            "already valid; do not penalise on data you cannot see. Reserve "
+            "deductions for cases where the roles ARE visible and a bare web page "
+            "is genuinely tagged as a non-news RAW, or several links are tagged RAW."
         ),
         "good_examples": (
             "A CIAA press-release source whose RAW is the uploaded PDF/scan, with "
@@ -428,7 +471,11 @@ DEFAULT_RULES = [
             "exposed to link rot."
         ),
         "weight": 0.6,
-        "enabled": True,
+        # Web-archiving of ephemeral news sources is NOT REQUIRED (operator
+        # decision 2026-06-29): it never changes a disposition and only adds bulk
+        # noise. Disabled so it is not scored; re-enable if archiving becomes a
+        # requirement.
+        "enabled": False,
         "order": 68.7,
     },
     # ---------------- Timeline ----------------
@@ -505,7 +552,14 @@ DEFAULT_RULES = [
             "Also penalise WRONG or over-tagged locations: an accused person's "
             "home/birthplace/permanent address, the seat of the court or the "
             "CIAA inquiry office tagged as if it were the event location, or a "
-            "long list of marginal places (more than ~5) that dilutes the signal."
+            "long list of marginal places (more than ~5) that dilutes the signal.\n\n"
+            "ILLEGAL-ASSETS EXCEPTION: for illegal-assets / disproportionate-assets "
+            "(अकुत / स्रोत नखुलेको सम्पत्ति) cases, the district(s) where the "
+            "disputed IMMOVABLE assets sit (land, house, family-held property named "
+            "in the press release / charge sheet) ARE the relevant scene and SHOULD "
+            "be tagged, even when the accused works at a central / HQ office. Do "
+            "NOT treat such a case as location-exempt, and do not accept the "
+            "accused's home district as a substitute for the asset district."
         ),
         "good_examples": (
             "A district-level scheme tagged with its district, e.g. "
@@ -538,7 +592,11 @@ DEFAULT_RULES = [
         "description": (
             "The case **should** tag at least one **related** entity — anything "
             "that is neither the accused nor a location (e.g. a related "
-            "organisation, official body, or other involved party)."
+            "organisation, official body, or other involved party). For a "
+            "public-office corruption or illegal-assets case, the accused's own "
+            "employing body (the ministry / municipality / authority / office "
+            "named in the charge sheet) is the canonical related entity and should "
+            "be tagged."
         ),
         "weight": 1.0,
         "enabled": True,
@@ -638,7 +696,16 @@ DEFAULT_RULES = [
             "NGM defendants that were not captured as accused.\n\n"
             "If `ngm_court_record.court_refs` is empty (no court number) or a "
             "lookup error is present, say the match could not be verified rather "
-            "than penalising heavily."
+            "than penalising heavily.\n\n"
+            "IMPORTANT — the charge sheet beats NGM: the `ngm_court_record` list "
+            "is a truncated, OCR-error-prone mirror of supremecourt.gov.np, and "
+            "the charge sheet / court-order excerpt is AUTHORITATIVE. When an "
+            "accused entity is present in the charge sheet/court-order excerpt "
+            "but absent from `ngm_court_record` (JV/firm/deceased-heir defendants "
+            "are exactly what NGM truncates), treat the charge sheet as correct "
+            "and KEEP the score high — an NGM-only absence is NEVER by itself a "
+            "scored issue. Only flag when an accused appears in NEITHER NGM nor "
+            "the charge-sheet/court-order excerpt, or directly contradicts them."
         ),
         "good_examples": (
             "All accused entities appear among the NGM defendants for the "
@@ -674,7 +741,21 @@ DEFAULT_RULES = [
             "are not missing from the case's entities.\n\n"
             "Flag any non-accused entity that cannot be traced to a source "
             "(possible mis-tag), and any clearly-relevant party/place in the "
-            "sources that was not captured."
+            "sources that was not captured.\n\n"
+            "TRUNCATION GUARD: when the provided source excerpt is visibly "
+            "truncated / cut off (it ends mid-table or mid-listing), a non-accused "
+            "entity that is plausibly named in the unshown portion (a family "
+            "member, co-defendant, bank / insurer, consultant, asset counterparty) "
+            "MUST be recorded as a NOTE (verify-against-full-document), NOT a "
+            "scored issue — keep the score at 100. The caseworker tags from the "
+            "FULL document, not the truncated machine view; only score an issue "
+            "when the entity is implausible for the document type, clearly "
+            "contradicts the sources, or the full untruncated document is "
+            "available and the entity is genuinely absent.\n\n"
+            "If the SAME party (modulo spelling / spacing / script — e.g. व↔ब, "
+            "इ↔ई, a Devanagari name vs its English form) is tagged BOTH `accused` "
+            "and `related`, flag it as a removable DUPLICATE (delete the "
+            "non-accused copy) — a clean one-line fix, not a sourcing gap."
         ),
         "good_examples": (
             "Every related organisation and location tagged on the case is named "
@@ -758,7 +839,15 @@ DEFAULT_RULES = [
             "from `missing_details` is **not** a gap-honesty problem.\n\n"
             "Still flag genuine **dishonesty**: a contested or unconfirmed figure "
             "presented as settled fact, or the case leaning on a source while "
-            "hiding that the primary document was never obtained."
+            "hiding that the primary document was never obtained.\n\n"
+            "BANDING — a placement miss is not dishonesty: when `missing_details` "
+            "is null/empty BUT the case narrative / description already honestly "
+            "discloses the same source/document gap, this is at most a minor NOTE "
+            "(cap any deduction at ~10 pts) — never a sub-70 integrity score. "
+            "De-duplication: where a structured figure (bigo) contradicts the "
+            "authoritative per-document figure, DEFER the figure scoring to "
+            "`bigo_matches_press_release` and keep only the disclosure aspect here "
+            "— do not double-count one defect across two rules."
         ),
         "good_examples": (
             "`missing_details` states that the full charge sheet and the signed "

--- a/review/rule_defaults.py
+++ b/review/rule_defaults.py
@@ -113,6 +113,50 @@ DEFAULT_RULES = [
         "order": 40,
     },
     {
+        "key": "key_allegation_consolidation",
+        "title": "Key allegations are consolidated by scheme",
+        "category": "Accuracy",
+        "kind": "llm",
+        "detector": "",
+        "condition_text": "Always active.",
+        "applies_to": ALL,
+        "description": (
+            "The `key_allegations` must identify and CONSOLIDATE the CIAA's core "
+            "claims — not list every fact / paragraph in the charge sheet as a "
+            "separate allegation. Facts arising from the SAME conduct, "
+            "transaction, scheme, or course of conduct belong in ONE key "
+            "allegation. Create SEPARATE allegations only when the nature of the "
+            "accusation, the legal question, or the accused's role genuinely "
+            "differs.\n\n"
+            "Score by SUBSTANCE, not count. A single consolidated allegation is "
+            "fully correct for a single-scheme case and MUST NOT be penalised as "
+            "'thin'; equally, do NOT reward inflating the count. Lower the score "
+            "when several listed allegations are facets of one scheme that should "
+            "be merged (over-splitting), or when genuinely distinct conducts are "
+            "mashed into one. Cosmetic wording goes in `notes`."
+        ),
+        "good_examples": (
+            "Illegal-assets case as ONE allegation: 'अभियुक्तले सार्वजनिक सेवामा "
+            "रहँदा आफ्नो वैध आयस्रोतले नधानेको सम्पत्ति (जग्गा, घर, शेयर, बैंक "
+            "मौज्दात तथा अन्य लगानी) आर्जन गरी अस्वाभाविक उच्च जीवनस्तर कायम गरेको।' "
+            "Splitting ONLY where roles differ: (1) some accused made fake "
+            "documents and registered public land in private names; (2) other "
+            "accused then illegally sold that land for gain — two allegations, "
+            "because the conduct and the accused's roles differ."
+        ),
+        "bad_examples": (
+            "Four allegations that are one illegal-assets scheme — 'bought land' / "
+            "'deposited money in the bank' / 'spent on a house' / 'bought shares' — "
+            "facets of the single claim that the accused acquired assets beyond "
+            "lawful income; they must be merged into one. Likewise splitting one "
+            "private-company scheme into 'bought shares' / 'became director' / "
+            "'signed the contract' / 'took salary' / 'took profit'."
+        ),
+        "weight": 1.0,
+        "enabled": True,
+        "order": 40.5,
+    },
+    {
         "key": "bigo_matches_press_release",
         "title": "Bigo amount matches the press release",
         "category": "Accuracy",
@@ -215,6 +259,47 @@ DEFAULT_RULES = [
         "weight": 1.0,
         "enabled": True,
         "order": 45,
+    },
+    {
+        "key": "case_overview_date_format",
+        "title": "Case Overview dates are well-formed (Devanagari + era marker)",
+        "category": "Completeness",
+        "kind": "llm",
+        "detector": "",
+        "condition_text": "Always active.",
+        "applies_to": ALL,
+        "description": (
+            "Dates that the case AUTHORS write in the Case Overview / description "
+            "and narrative must be reader-friendly and consistent: **Devanagari "
+            "numerals**, **YYYY-MM-DD** order, each prefixed with its Nepali era "
+            "marker — **`वि सं`** for Bikram Sambat or **`सन्`** for the "
+            "Gregorian / AD year. Do NOT use Latin numerals, English month names "
+            "(e.g. 'October'), or Latin 'AD' / 'BS' markers, and do not leave a BS "
+            "date bare without `वि सं`. Each date carries its own marker; pairing "
+            "BS and AD is encouraged but not required.\n\n"
+            "EXEMPTIONS (never penalise): (1) a date QUOTED verbatim inside a "
+            "source excerpt / source title is out of scope — only AUTHORED case "
+            "text is judged; (2) a year-only date is fine when only the year is "
+            "known (do not invent a month / day). Score 100 when every authored "
+            "date is Devanagari + era-marked (or legitimately year-only); lower "
+            "the score per malformed authored date (Latin numerals, an English "
+            "month, or a missing era marker)."
+        ),
+        "good_examples": (
+            "'अभियुक्त सन् १९९८-१०-२२ मा सार्वजनिक सेवामा नियुक्त भएका थिए।'; "
+            "'अख्तियारले वि. सं २०८०-०३-०७ मा विशेष अदालतमा आरोपपत्र दायर गरेको "
+            "थियो।'; 'अभियुक्तको जाँच अवधि वि सं २०५४/०७/०५ देखि २०७८/०८/२१ सम्म "
+            "कायम गरिएको।'"
+        ),
+        "bad_examples": (
+            "'AD 22 October 1998' (Latin numerals + English month); a bare "
+            "'२०५४/०७/०५' with no वि सं marker; 'BS 2080-03-07' / 'AD 2023-03-07' "
+            "(Latin numerals + Latin era markers); mixing '2054/07/05 ... 6 "
+            "December 2021' in one paragraph."
+        ),
+        "weight": 0.8,
+        "enabled": True,
+        "order": 45.5,
     },
     # ---------------- Tonal neutrality (LLM) ----------------
     {

--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -189,7 +189,11 @@ def bigo_amount_present(case):
         # via the marker. Keep the gate passing (don't regress legitimate no-bigo
         # cases on a heuristic) but surface a warning for the caseworker.
         blob = f"{case.get('title') or ''} {case.get('short_description') or ''}"
-        if re.search(r"रु[\.\s]?\s*[०-९\d]|[०-९\d]\s*(अर्ब|करोड|लाख)", blob):
+        if re.search(
+            r"(?i)(?:रु|rs\.?|npr)[\.\s]?\s*[०-९\d]"
+            r"|[०-९\d]\s*(?:अर्ब|करोड|लाख|हजार|crore|lakh|million|billion|thousand)",
+            blob,
+        ):
             return 100, [
                 "A NO_BIGO marker is recorded, but the title/description states a "
                 "monetary amount — verify a real bigo is not being suppressed "

--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -183,6 +183,18 @@ def bigo_amount_present(case):
         # value == 0 falls through to the no-bigo certification check below.
 
     if _has_no_bigo_marker(case.get("internal_notes")):
+        # A NO_BIGO certification is only valid for genuinely unquantified
+        # (record/process) offences. If the title / short_description states a
+        # concrete monetary amount, the figure should be POPULATED, not suppressed
+        # via the marker. Keep the gate passing (don't regress legitimate no-bigo
+        # cases on a heuristic) but surface a warning for the caseworker.
+        blob = f"{case.get('title') or ''} {case.get('short_description') or ''}"
+        if re.search(r"रु[\.\s]?\s*[०-९\d]|[०-९\d]\s*(अर्ब|करोड|लाख)", blob):
+            return 100, [
+                "A NO_BIGO marker is recorded, but the title/description states a "
+                "monetary amount — verify a real bigo is not being suppressed "
+                "(NO_BIGO is for record/process offences with no monetised harm)."
+            ]
         return 100, []
     return 0, [
         "Bigo (बिगो) amount is not set and no NO_BIGO justification is recorded "
@@ -217,16 +229,21 @@ def structural_completeness(case):
     tags = case.get("tags") or []
     pts = 0
     pts += 14 if desc else 0
-    pts += min(len(allegations) / 4.0, 1.0) * 24
-    pts += min(len(timeline) / GOLD_TIMELINE, 1.0) * 22
+    # Presence-and-materiality, NOT raw count: a single consolidated key
+    # allegation is fully correct (don't reward inflating the count), and timeline
+    # depth/conciseness is judged by the dedicated key-allegation / timeline
+    # rules. Credit presence and reach full at the org minimum; keep a floor only
+    # for genuinely empty fields.
+    pts += 24 if allegations else 0
+    pts += min(len(timeline) / 3.0, 1.0) * 22
     pts += min(len(evidence) / GOLD_SOURCES, 1.0) * 20
     pts += min(len(entities) / 3.0, 1.0) * 12
     pts += min(len(tags) / 3.0, 1.0) * 8
     issues = []
-    if len(allegations) < 2:
-        issues.append(f"Only {len(allegations)} key allegations (org min: 2).")
-    if len(timeline) < 3:
-        issues.append(f"Only {len(timeline)} timeline events (org min: 3).")
+    if not allegations:
+        issues.append("No key allegations populated.")
+    if len(timeline) < 2:
+        issues.append(f"Only {len(timeline)} timeline event(s) populated.")
     if not entities:
         issues.append("No entities populated.")
     return _clamp(pts), issues
@@ -367,22 +384,23 @@ def timeline(case):
     n = len(tl)
     with_bs = sum(1 for t in tl if t.get("date_bs"))
     with_ad = sum(1 for t in tl if t.get("date"))
-    detailed = sum(1 for t in tl if len((t.get("description") or "")) > 60)
     dates = [t.get("date") for t in tl if t.get("date")]
     ordered = dates == sorted(dates)
     pts = 0
-    pts += min(n / GOLD_TIMELINE, 1.0) * 35
-    pts += (with_ad / n) * 15
-    pts += (with_bs / n) * 15
-    pts += (detailed / n) * 25
-    pts += 10 if ordered else 0
+    # Completeness = event COUNT + dual BS/AD dates + chronological order. There
+    # is deliberately NO per-event character-length reward/penalty: a concise
+    # "date + brief event" entry is the editorial standard, so the old <60-char
+    # "thin" check punished correct timelines and rewarded verbose
+    # mini-paragraphs. Its 25 points are redistributed to the real signals.
+    pts += min(n / GOLD_TIMELINE, 1.0) * 45
+    pts += (with_ad / n) * 20
+    pts += (with_bs / n) * 20
+    pts += 15 if ordered else 0
     issues = []
     if with_bs < n:
         issues.append(f"{n - with_bs} events missing Bikram Sambat (date_bs).")
     if not ordered:
         issues.append("Timeline events are not in chronological order.")
-    if detailed < n:
-        issues.append(f"{n - detailed} timeline events are thin (<60 chars).")
     return _clamp(pts), issues
 
 


### PR DESCRIPTION
## Summary
The round-2 audit of the 51 priority cases (50 PASS / 1 REJECT) surfaced that the CaseReview rubric over-fires on benign conditions (snapshot/display artifacts, concise-but-complete fields, news-headline keywords) while under-guarding a few real integrity cases. This applies **all 17** planned amendments across `review/casetype.py`, `review/rules_engine.py`, and `review/rule_defaults.py` (**29 rules** total).

## Cohort / gates
- **`casetype`** — a NEWS-headline order keyword (आदेश) no longer promotes a pre-verdict case to `CIAA_HAS_VERDICT` (needs a `COURT_ORDER` source type or a फैसला/verdict keyword). Fixes the false `court_record_attached=0` on interim-order / pending cases.
- **`bigo_amount_present`** — non-blocking warning when a `NO_BIGO:` marker coexists with a stated monetary amount.

## Stop false-positive families
- **`timeline_completeness`** — drop the `<60-char` "thin event" penalty; score on count + dual BS/AD dates + chronological order.
- **`structural_completeness`** — presence-and-materiality, not raw count.
- **`ephemeral_sources_archived`** — disabled (web-archiving not required; never changed a disposition).
- **`non_accused_entities_in_sources`** — truncation guard + flag accused-also-related duplicates.
- **`source_raw_link_quality`** — score 100 when link roles are unobservable and the deterministic `source_link_roles_valid` already passes.
- **`gap_honesty`** — band the placement-miss to a note, not a sub-70 integrity score.

## Tighten / harden
- **`bigo_matches_press_release`** — honor a documented `BIGO_CONVENTION:` marker; detect wrong-fiscal-year cross-case bigo copies.
- **`accused_list_matches_court_record`** — charge sheet is authoritative over NGM's truncated Special-Court mirror.
- **`description_summarises_case`** — scored sub-check for asserting a fact is unavailable when an attached source reports it.
- **`location_entity_count`** — tag the asset district for illegal-assets cases.
- **`related_entity_present`, `slug_public_view_quality`, `tonal_neutrality`** — guidance + precision clauses.

## New rules (from caseworker editorial standards + worked examples)
- **`key_allegation_consolidation`** — consolidate the CIAA's core claims by scheme; a single consolidated allegation is correct for a single-scheme case and the count must not be inflated. Split only when the accused's role / legal nature genuinely differs.
- **`case_overview_date_format`** — authored dates in Devanagari numerals, `YYYY-MM-DD`, each prefixed with its Nepali era marker (`वि सं` / `सन्`); ships with year-only + quoted-source exemptions so it does not false-fire.

## Validation
- `py_compile` clean; `rule_defaults` loads (**29 rules**; `ephemeral` disabled; no dup keys / order collisions).
- Behavioural spot-checks vs real snapshots: 0158 → `CIAA_BASIC` (false court_record gone); 0141's 2-event timeline no longer penalised (structural 84); 0084's `NO_BIGO` not falsely flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case classification so interim court-order headlines in news or social posts no longer trigger a full court-order status.
  * Refined scoring and guidance across several review checks to reduce duplicate deductions and false positives.
  * Better handling of missing or truncated source details, with clearer pass/fail behavior in borderline cases.
  * Timeline and allegation checks now score more consistently, with clearer messages for incomplete or out-of-order case information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->