### PR TITLE
feat(evals): centralize prompts + model-independent eval layer (first slice)

### DIFF
--- a/docs/llm-prompt-centralization-and-evals.md
+++ b/docs/llm-prompt-centralization-and-evals.md
@@ -1,0 +1,160 @@
+# Design: LLM Prompt Centralization & Model-Independent Eval Layer
+
+## Status: 🟡 PROPOSED (RFC — not yet implemented)
+
+## Overview
+
+We run ~11 LLM "enricher" pipelines (title, description, allegations, timeline, bigo, evidence, card, related-entities, news, tags, missing-bigo) plus an LLM "case review" grader. Every prompt today is an inline Python string constant scattered across `casework/enrich_*.py`, `review/judge.py`, `cases/services/case_scraper.py` and `scripts/`. There is a mature provider/model abstraction (`llm/`), but **no prompt registry, no prompt versioning, and no eval layer at all**. The consequence: we cannot gate prompt edits, cannot prove a cheaper or different model is safe to swap, and cannot measure whether our Nepali LLM-judge is even reliable. This RFC proposes (1) centralizing prompts as versioned data, and (2) a model-independent eval/testing layer built on `pytest` + DeepEval, reusing the abstractions we already have.
+
+## Problem Statement
+
+1. **Prompt fragmentation.** Each enricher carries its own `SYSTEM_PROMPT` / `USER_PROMPT` inline. A single-word edit silently changes pipeline behaviour with no version history, no isolated test, and no fast rollback. There is real copy-paste duplication: the tag keyword dictionaries (`SECTOR_KEYWORDS`, `CORRUPTION_TYPE_KEYWORDS`, `REGION_KEYWORDS`) are defined verbatim in both `casework/enrich_tags.py` and `cases/services/tag_enricher.py`.
+2. **No eval layer.** Existing tests are mocked-transport unit tests (`tests/test_llm_*.py`) plus deterministic rule tests (`tests/test_review_*.py`). There are no golden datasets, no output-quality regression, and no model-comparison harness. The review grader's N-sample variance is a self-consistency signal, not ground truth.
+3. **Model-swap is unprovable.** `llm/routing.py` already lets us point the `premium`/`cheap` tiers at different providers/models, but we have no way to demonstrate that a swap (e.g. moving a routine enricher to the cheap tier, or onto a new model) preserves output quality. Swaps are therefore made on faith.
+4. **Nepali reliability is unmeasured.** All of these prompts operate primarily in Nepali (Devanagari), a low-resource language for current models. We have never measured whether our LLM-judge agrees with our human reviewers on Nepali cases.
+
+## Current State (grounded in the code)
+
+- **Transport / model independence — already solved.** `llm/invoke.py` exposes a 3-function choke point (`invoke_text`, `invoke_json`, `invoke_with_tools`) that every enricher and the judge route through. `llm/routing.py` selects a provider per tier (`premium`/`cheap`); providers are Bedrock, an OpenAI-compatible proxy, Claude CLI and Codex CLI. Models are chosen by env var. `llm/usage.py` (`UsageAccumulator`) already tracks tokens per `(provider, tier, model)`, and `CaseReview.result` already stores `model_id_used` and `token_usage`.
+- **Prompts-as-data — already proven internally.** `review/rule_defaults.py` is exactly the pattern the industry recommends: each rule is a data object with `title`, a markdown `description`, `good_examples` / `bad_examples`, `weight`, `is_gate` / `gate_min`, `applies_to` and `tier`. The judge (`review/judge.py`) samples each LLM rule N× and computes mean/variance/confidence. This is the model we should generalize to the enrichers — we are not inventing a new pattern, we are extending one we already trust.
+- **The gap is everything between the prompt strings and the choke point**: there is no layer that loads prompts as versioned artifacts, validates outputs against a schema, logs which prompt version produced a field, or scores output quality against a reference.
+
+## Industry Findings (2024–2026)
+
+Condensed from a focused literature/tooling sweep (full citations in References).
+
+- **Prompt management.** The consensus is to treat prompts as *immutable, externally-stored, semantically-versioned artifacts*, pinned per-environment, with eval-gated promotion and pointer-based rollback, and to **log the prompt version on every request**. The "prompt-as-code vs prompt-as-data" debate has resolved into *both*: store prompts as data, manage them with code discipline (review, CI, eval). Teams that deliberately avoid heavy SaaS platforms keep **plain prompt files in Git + a registry object + pytest**. The payoff threshold is ~50 prompts; at ~15–20 distinct prompts we are right where it starts paying off.
+- **Eval stack.** Most teams run two layers: a code-first framework for CI gating + an observability layer for production. For a self-hosted Python/Django/pytest shop, the relevant code-first tools are **DeepEval** ("pytest for LLMs", 50+ metrics incl. faithfulness/hallucination, model-agnostic judge) and **promptfoo** (CLI/YAML, zero cloud deps, strong for prompt/model A-B). Braintrust/LangSmith are commercial all-in-one platforms — overkill and at odds with our self-hosting posture.
+- **Golden datasets + CI gating.** Golden sets should come from **real, human-approved data**, expert-annotated to the expected output. Wire evals into PRs; block on regression. Gate on **per-cohort deltas, not the aggregate** — an aggregate can improve while a specific cohort (e.g. `bigo`) silently regresses. Promote escaped failures back into the golden set.
+- **Structured-extraction eval** (most of our enrichers). Standard granularity is **two-tier accuracy**: field-level (proportion of correct fields) *and* document-complete (a doc fails if any field is wrong). Score on **accuracy + hallucination rate + format/schema conformance**, not a single number. Faithfulness must be **strictly grounded** — penalize any field not explicitly supported by the source.
+- **LLM-as-judge reliability.** Use rubrics with concrete examples, separate reasoning from the decision field, match rubric complexity to judge capability (use the premium tier as judge), **pin the judge model independent of the graded model** (avoid self-preference bias), and ensemble/sample for high-stakes calls. Absolute/rubric scoring (not pairwise) is correct when you need a quality threshold and per-criterion diagnostics — which is our case.
+
+## ⚠️ The Nepali Caveat (most important finding)
+
+Multilingual-judging research is blunt: **LLM-as-judge reliability degrades badly in low-resource languages.** Documented, directly-relevant effects: cross-language judge consistency around Fleiss' κ ≈ 0.3 (near-random), worst in low-resource languages, not fixed by bigger models or multilingual fine-tuning; systematic **over-optimistic scoring** and over-assignment of middle-ground scores; and **"translationese bias"** (judges prefer machine-translated text over flawed-but-human references), again worst for low-resource languages. Design implications we will adopt as hard rules:
+
+1. **Lean deterministic for Nepali.** Field-level checks (court-number regex, normalized `bigo` amount match, BS↔AD date validation, headcount guards, schema/format conformance, entity-presence) are language-agnostic and free. Push as much eval as possible onto these. We already have this philosophy in `review/rules_engine.py`.
+2. **Calibrate the judge against our own human gold before trusting it.** We hold a labelled set: the 51 priority cases + round-2 reviews with human dispositions. Measure judge-vs-human agreement (κ) on *our own Nepali data*. If agreement is low, judge numeric scores are advisory, not gates.
+3. **Keep ensembling and bilingual examples.** The N-sample variance the judge already runs, and the Nepali good/bad examples in `rule_defaults.py`, are exactly the recommended mitigations — keep both.
+
+## Proposed Solution
+
+### Phase 1 — Centralize prompts as versioned data
+
+Generalize the `rule_defaults.py` pattern. Each prompt becomes a `PromptSpec` data object, not an inline string.
+
+```
+services/jawafdehi-api/
+  llm/
+    invoke.py            # add invoke_prompt() wrapper; log (prompt_key, version)
+    prompts/
+      __init__.py
+      spec.py            # PromptSpec dataclass + registry loader
+      registry.py        # key -> PromptSpec, version pinning, render()
+      enrich_bigo.py     # one module per prompt (or a YAML/TOML file set)
+      enrich_title.py
+      ...
+```
+
+`PromptSpec` fields (mirrors a rule, plus eval hooks):
+
+- `key` — stable identifier, e.g. `enrich.missing_bigo`.
+- `version` — semantic, immutable; bump on any edit.
+- `system` — system prompt template.
+- `user_template` — user prompt template with **declared** variables (use `string.Template` or Jinja, replacing implicit f-strings so the variable surface is explicit).
+- `tier` — `premium` | `cheap` (drives routing).
+- `max_tokens`.
+- `output_schema` — JSON Schema for the expected output (enables automatic validation + schema-conformance eval).
+- `examples` — golden few-shot / reference pairs in Nepali (doubles as eval seed data).
+
+New thin wrapper in `llm/invoke.py`:
+
+```python
+def invoke_prompt(spec, *, usage=None, **vars) -> dict | str:
+    system = render(spec.system, vars)
+    content = render(spec.user_template, vars)
+    out = invoke_json(system, content, max_tokens=spec.max_tokens, tier=spec.tier, usage=usage)
+    validate_schema(out, spec.output_schema)        # raise/repair on mismatch
+    record_prompt_version(usage, spec.key, spec.version)  # traceability
+    return out
+```
+
+Traceability: extend `UsageAccumulator` (and the `CaseReview.result` / enricher output envelope) to record `(prompt_key, version)` alongside the existing `model_id_used` and `token_usage`. Every produced field then traces back to an exact prompt version.
+
+De-duplication: extract the shared tag keyword dictionaries into a single module (e.g. `casework/tag_vocabulary.py`) imported by both `enrich_tags.py` and `cases/services/tag_enricher.py`.
+
+Rollout is mechanical and per-enricher: move the inline `SYSTEM_PROMPT`/`USER_PROMPT` into a `PromptSpec`, switch the call site to `invoke_prompt`, leave behaviour byte-identical (same text → same output). No behavioural change in Phase 1; it is pure extraction.
+
+### Phase 2 — Model-independent eval layer (DeepEval + pytest)
+
+```
+  evals/
+    __init__.py
+    judge_model.py       # DeepEvalBaseLLM adapter -> llm/routing premium provider
+    datasets/            # golden cases: input doc -> expected fields (versioned, from human-approved cases)
+      enrich_missing_bigo/
+      enrich_title/
+      review/
+    metrics/
+      deterministic.py   # schema-valid, field-match, amount-normalize, court-regex, headcount, format-conformance
+      rubric.py          # G-Eval rubric metrics for open-ended Nepali fields (title/description faithfulness)
+    test_evals.py        # pytest entry: runs golden set, asserts thresholds — gated in CI
+    run_eval.py          # CLI: --model/--tier -> per-field/per-rule delta table for model swaps
+```
+
+Key integration detail (DeepEval is model-agnostic but defaults its judge to OpenAI): we wrap our existing premium provider in a `DeepEvalBaseLLM` subclass (`evals/judge_model.py`) so all G-Eval / faithfulness metrics run **on our own infra through `llm/routing`**, never calling out to OpenAI. This also lets us **pin the judge model independent of the graded model** (the bias-mitigation requirement) and keeps eval inside our data-residency boundary.
+
+Two check types, matching the structured-extraction research:
+
+1. **Deterministic field-level checks** (cheap, language-agnostic, run on every PR): JSON-schema validity, normalized `bigo` amount equality, court-number regex, BS↔AD date validity, headcount guards, entity-presence, format conformance. Implemented as plain `pytest` asserts and/or DeepEval custom `BaseMetric` deterministic metrics. These carry the bulk of the signal at zero LLM cost — critical for the Nepali reliability problem.
+2. **LLM-judge checks** (for open-ended fields only): faithfulness/grounding and rubric quality via DeepEval `GEval`, seeded with the same Nepali good/bad examples we keep in the registry. Run a small slice per-PR (smoke), the full set nightly, on the cheap tier with prompt caching to keep cost down.
+
+Golden datasets: build from data we already have — the 51 priority cases, the round-2 reviews, and enriched NGM cases are human-approved (input → expected fields) pairs. Version the datasets; promote any escaped production failure back into them.
+
+CI gate: a GitHub Actions job runs `evals/test_evals.py` against the `main` baseline on any PR that touches `llm/prompts/**`, `review/rule_defaults.py`, or model-config env. Block the merge on **per-cohort regression** (e.g. bigo-accuracy, title-headcount, description-faithfulness), not just the aggregate. This sits *before* the keel image build, so a regressing prompt never reaches a deployed image.
+
+Model-migration as a first-class command: `python evals/run_eval.py --tier cheap --model <candidate>` produces a per-field / per-rule delta table proving (or disproving) that a cheaper/different model preserves quality — the exact capability we lack today, and the direct answer to "can we move this enricher to the cheap tier safely?".
+
+### Phase 3 — Later / optional
+
+- **Judge calibration (do this early, cheaply):** before trusting any LLM-judge gate, run the existing judge over the 51 human-reviewed cases and compute agreement (κ) with the human dispositions. This is a few hours of work, reuses `review/judge.py`, and tells us whether the judge is a gate or merely advisory for Nepali. Strongly recommended as the very first eval-layer task.
+- **DSPy / GEPA prompt optimization:** only after golden sets exist. The literature is candid that DSPy's real win is the discipline of codified evals + reproducibility + model portability, and that it is "no substitute for careful manual prompting with SMEs" on nuanced tasks. For Nepali legal nuance our human reviewers stay primary; DSPy could later auto-tune few-shot examples for the cheap tier once the eval harness is in place.
+
+## Tooling Decision
+
+**DeepEval (pytest-native), home-hosted, judge routed through our own providers.** Rationale: we are a Python/Django/pytest shop that self-hosts and cares about data residency; DeepEval drops into our existing test suite, ships faithfulness/hallucination/G-Eval metrics out of the box, and — critically — supports a custom judge model so we can route grading through `llm/routing` instead of OpenAI. We deliberately do **not** adopt a SaaS eval platform (Braintrust/LangSmith): it would fight our self-hosting posture and add cost for capability we can reproduce with the provider abstraction, `judge.py`, and `UsageAccumulator` we already own. `promptfoo` may be added later, narrowly, for prompt/model A-B comparison runs; it is not required for the CI gate.
+
+## Migration Order (~11 enrichers + sourcing scripts)
+
+The enrichers are not the whole surface: the **sourcing / extraction scripts** carry LLM prompts too and are in scope for the same treatment. The prompt-bearing ones today are `cases/services/case_scraper.py` (the research-assistant scraper prompt) and `scripts/ciaa_extraction/extract_narrative.py` (defendant extraction from the CIAA annual report); the rest of `sourcing/` (`converter.py`, `jds_client.py`, `ngm_client.py`) and the regex-only extractors (`extract_sheet.py`, `extract_annual_report.py`, `validate.py`) have no prompts and need no prompt registry — but their structured outputs are still worth field-level golden checks.
+
+Sequence by ground-truth availability (deterministic-checkable first, since those evals are free and high-signal):
+
+1. `enrich_missing_bigo` — clean JSON schema, deterministic ground truth (the amount). **First slice (done — see `evals/`).**
+2. `enrich_tags` — controlled vocabulary, set-overlap metrics; also fixes the keyword-dict duplication.
+3. `enrich_title` — deterministic court-number/headcount guards + a rubric metric for headline quality.
+4. `enrich_allegations`, `enrich_timeline`, `enrich_related_entities` — grounding/faithfulness rubric metrics + structural checks.
+5. `enrich_description`, `enrich_card`, `enrich_evidence`, `enrich_news_articles` — mostly rubric/faithfulness; lower deterministic coverage.
+6. **Sourcing scripts:** `scripts/ciaa_extraction/extract_narrative.py` (defendant fields = strong deterministic ground truth: names, charge sections, bigo, dates) then `cases/services/case_scraper.py` (research-assistant prompt → schema + grounding checks). Register their prompts; reuse the same deterministic metrics.
+7. `review/judge.py` rule prompts — already data; bring under the same registry + add the calibration harness.
+
+## Open Questions / Risks
+
+- **Golden-set size vs. cost.** How many annotated cases per enricher is "enough" for a stable gate? Start with ~15–25 per enricher (mix of typical + known-hard edge cases) and grow from escaped failures.
+- **Judge trust for Nepali.** If calibration shows low judge-human agreement, which fields can be gated by LLM-judge at all, versus deterministic-only? This is an empirical question the Phase 3 calibration answers.
+- **Prompt-version storage.** File-based modules (versioned in Git) vs YAML/TOML files vs a DB table. Recommendation: start file-based in Git (simplest, reviewable, matches `rule_defaults.py`); revisit a DB-backed registry only if non-engineers need to edit prompts in a UI.
+- **CI cost/latency.** Per-PR runs must stay cheap (cheap tier + caching + a small smoke slice); the full LLM-judge set runs nightly, not per-PR.
+
+## First Slice (proposed concrete deliverable)
+
+`enrich_missing_bigo`, end-to-end: a `PromptSpec` for its prompt; a small versioned golden dataset drawn from approved cases; a deterministic amount-match + schema-conformance metric; a `pytest` gate via DeepEval; and a `run_eval.py` invocation that prints a premium-vs-cheap delta table. This proves the entire loop on the smallest, most deterministic surface and becomes the template the other enrichers copy.
+
+## References
+
+Prompt management & versioning: Braintrust — Best Prompt Versioning Tools (https://www.braintrust.dev/articles/best-prompt-versioning-tools-2025); LangWatch — What is Prompt Management (https://langwatch.ai/blog/what-is-prompt-management-and-how-to-version-control-deploy-prompts-in-productions); Agenta — Definitive Guide to Prompt Management Systems (https://agenta.ai/blog/the-definitive-guide-to-prompt-management-systems).
+Eval frameworks: TECHSY — 8 LLM Eval Tools Ranked (https://techsy.io/en/blog/best-llm-evaluation-tools); Comet — LLM Evaluation Frameworks Head-to-Head (https://www.comet.com/site/blog/llm-evaluation-frameworks/); helpmetest — RAGAS vs DeepEval vs PromptFoo vs Langfuse (https://helpmetest.com/blog/llm-evaluation-frameworks/).
+Golden sets & CI gating: TestQuality — LLM Regression Testing Pipeline (https://testquality.com/llm-regression-testing-pipeline/); Traceloop — Automated Prompt Regression Testing with LLM-as-a-Judge and CI/CD (https://www.traceloop.com/blog/automated-prompt-regression-testing-with-llm-as-a-judge-and-ci-cd); Medium — Evaluation-First AI Product Engineering (https://medium.com/@falvarezpinto/evaluation-first-ai-product-engineering-golden-sets-drift-monitoring-and-release-gates-for-llm-2c3bfb3f1e7b).
+Structured-extraction eval: arXiv — Real-Time Trustworthiness Scoring for LLM Structured Outputs (https://arxiv.org/pdf/2603.18014); MDPI — Benchmarking LLM-as-a-Judge for 5W1H Extraction (https://www.mdpi.com/2079-9292/15/3/659); arXiv — A Review of Faithfulness Metrics (https://arxiv.org/pdf/2501.00269).
+LLM-as-judge: Mervin Praison — LLM-as-a-Judge Best Practices (https://mer.vin/2025/11/llm-as-a-judge-best-practices-for-consistent-evaluation/); Weights & Biases — Exploring LLM-as-a-Judge (https://wandb.ai/site/articles/exploring-llm-as-a-judge/).
+Multilingual / low-resource: arXiv — Mitigating Translationese Bias in Multilingual LLM-as-a-Judge (https://arxiv.org/html/2603.10351); arXiv — Ready to Translate, Not to Represent? (https://arxiv.org/pdf/2510.07877).
+Prompt optimization: arXiv — Is It Time To Treat Prompts As Code? (DSPy) (https://arxiv.org/html/2507.03620v1); Towards Data Science — Systematic LLM Prompt Engineering Using DSPy (https://towardsdatascience.com/systematic-llm-prompt-engineering-using-dspy-optimization/).

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,0 +1,2 @@
+# Generated calibration run artifact (produced by `calibrate_judge --run`).
+datasets/judge_calibration/last_run.json

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,54 @@
+# LLM eval layer
+
+Model-independent evaluation for the Jawafdehi LLM pipelines. This is the first vertical slice (the BIGO enricher) of the plan in `../docs/llm-prompt-centralization-and-evals.md`. It is the template the other enrichers — and the sourcing scripts — copy.
+
+## What's here
+
+- `../llm/prompts/` — the prompt registry. Each prompt is a `PromptSpec` (key, immutable version, system + user templates, tier, output schema, golden examples). `enrich_missing_bigo.py` is the first entry; it is a *view* over the live enricher constants (single source of truth, drift-guarded), not a copy.
+- `metrics/deterministic.py` — cheap, language-agnostic field-level checks (exact bigo match + JSON-schema conformance). Reuses the production `_coerce_bigo_int`, so there is no second copy of that logic. Runs offline.
+- `judge_model.py` — a DeepEval `DeepEvalBaseLLM` that routes the judge through our own provider router (`llm/routing`) instead of OpenAI, so evals stay on our infra and the judge model is pinned independent of the graded model. DeepEval is optional; the import is guarded.
+- `calibrate_judge.py` — measures how well the LLM case-review judge agrees with human dispositions (Cohen's kappa + confusion matrix) on real cases. This is the gate-vs-advisory decision for the Nepali judge.
+- `datasets/` — real golden data (see "Real data" below).
+- `test_*.py` — the CI gate (deterministic + schema + drift guard + the kappa math; DeepEval test skips if not installed).
+- `run_eval.py` — live, read-only, end-to-end eval and model-migration comparison.
+
+## Run it
+
+Offline (no Django DB, no network, no LLM, no credentials — these are what CI runs):
+
+    poetry run python -m evals.metrics.deterministic          # real CIAA amount strings -> bigo, 7/7
+    poetry run python -m evals.calibrate_judge --demo         # kappa on the real label set (illustrative machine column)
+    poetry run pytest evals/test_enrich_missing_bigo_eval.py evals/test_calibrate_judge.py
+
+Live (read-only — never PATCHes; NOT run in CI). Defaults to the `claude_cli` provider (`claude -p`, subscription auth) — the same one the enrichers/pollers use — and needs the `bigo-enrichment` extras (`poetry install -E bigo-enrichment`) for source conversion. Reads cases over the API, so set a token (a systemwide read-only DRF token is enough):
+
+    export JAWAFDEHI_API_TOKEN=...        # read-only is sufficient
+    export JAWAFDEHI_API_BASE_URL=https://portal.jawafdehi.org
+    poetry run python -m evals.run_eval --limit 5                  # accuracy on real cases via claude -p
+    poetry run python -m evals.run_eval --compare                 # premium vs cheap migration verdict
+    poetry run python -m evals.calibrate_judge --run --limit 5    # real judge-vs-human agreement (each case = a full review)
+
+Verified working (`claude-opus-4-8`): `run_eval` extracts the correct bigo for the real cases; `calibrate_judge --run` ran the full review pipeline (likhit converts the Nepali PDFs) over all 7 cases and produced `n=7, accuracy=0.714, kappa=0.462` (saved to `datasets/judge_calibration/last_run.json`). That kappa is below the 0.6 gate threshold → on these labels the judge is ADVISORY, not a hard gate — which is the whole point of measuring it. The judge agrees on all four clear PASS cases and the clear REJECT, but over-rejects the two borderline cases (081-CR-0044 published, 081-CR-0136 in-review). Caveat: the labels are the publication-state PROXY, so those disagreements may mean the judge is over-strict OR genuinely catching issues; the definitive kappa needs the real 51 priority-review verdicts (swap them into `labels.json`, unchanged harness).
+
+### Converter OOM guard (a real bug this surfaced)
+
+081-CR-0022 has a 9.3 MB image-heavy procurement-bid PDF (`source:073dccea`) that is the only source on the case with no pre-converted MARKDOWN. The review converter runs pdfminer on it live and it OOM-SIGKILLs the whole review process (rc 137, ~9 min) — uncatchable in-process, even with 39 GB free. **The production review poller runs the same converter, so submitting this case (or any with a large RAW-only PDF) to the judge would OOM-kill the poller.** The harness now defends with `--skip-oversized-mb` (default 8): it drops un-converted PDFs above that size (loudly logged, never silent) before the review — faithful, because prod has no markdown for that source either. With the guard, 081-CR-0022 reviews cleanly (→ PASS). The real fix belongs in `sourcing/converter.py`: convert PDFs in a subprocess bounded by `RLIMIT_AS` + a wall-clock timeout (so an OOM/timeout becomes a caught per-source failure, not a dead poller), and/or pre-skip by size/page-count. That is a production change, pending approval.
+
+To light up the DeepEval judge metrics: `poetry add --group dev deepeval` (the harness already routes it through our providers).
+
+## Real data
+
+Every golden value is drawn from a real Jawafdehi case, with the cited court case number, and was cross-checked against the human-approved `bigo` on the published case. The amount-coercion set exercises the genuine CIAA formatting edges seen in production: danda `।` paisa (081-CR-0116, 081-CR-0136), dot `.` paisa (081-CR-0044), slash `/` paisa, arba-scale figures (081-CR-0095), and the "paisa digits must not merge into rupees" trap. The judge-calibration labels use each case's real publication state as a documented PROXY for the human disposition (PUBLISHED→PASS, IN_REVIEW→REVISE, DRAFT→REJECT); swap in the real reviewer dispositions (e.g. the 51 priority-review verdicts) and nothing else changes.
+
+## No prod changes
+
+This slice is entirely additive. It does not edit any production file: the enricher (`casework/enrich_missing_bigo.py`), the transport (`llm/invoke.py`), and the review pipeline are untouched. The registry reads the enricher's prompt constants; the `invoke_prompt` wrapper lives in `llm/prompts/runner.py` rather than in `llm/invoke.py`. The Phase-1 migration (separate change) inverts that — the enricher imports its prompt from the registry, and `invoke_prompt` folds into `llm/invoke.py`.
+
+## Adding the next pipeline
+
+1. Add a `PromptSpec` module under `llm/prompts/` and register its key (generalise from `enrich_missing_bigo.py`).
+2. Capture real golden cases under `datasets/<pipeline>/` from already-approved data.
+3. Write deterministic metrics first (free, language-agnostic — especially important for Nepali); add a DeepEval rubric metric only for genuinely open-ended fields.
+4. Add a `test_*_eval.py` gate and wire it into the CI job that blocks on per-cohort regression.
+
+The same treatment applies to the **sourcing scripts** (`sourcing/`, `scripts/ciaa_extraction/`, `cases/services/case_scraper.py`): centralise their prompts into the registry and add field-level golden checks where they extract structured data. They are explicitly in scope in the RFC migration order.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,7 @@
+"""Model-independent eval layer for the Jawafdehi LLM pipelines.
+
+See ``evals/README.md`` and ``docs/llm-prompt-centralization-and-evals.md``. The
+deterministic metrics + calibration harness run offline (no Django, no network, no LLM);
+the live model-comparison (``run_eval.py``) and judge calibration (``calibrate_judge.py
+--run``) call the in-house providers read-only and are not run in CI.
+"""

--- a/evals/calibrate_judge.py
+++ b/evals/calibrate_judge.py
@@ -1,0 +1,333 @@
+"""Judge calibration: how well does the LLM case-review judge agree with humans?
+
+The Nepali caveat in the RFC is the whole reason this exists: LLM-as-judge reliability
+collapses for low-resource languages (cross-lingual judge agreement around kappa 0.3,
+optimistic scoring). Before any judge score is allowed to GATE anything, measure its
+agreement with real human dispositions on real Nepali cases. If agreement is low, the
+judge is advisory, not a gate.
+
+This module is intentionally split:
+  * the math (cohen_kappa, confusion_matrix, report) and the offline ``--demo`` run with
+    no Django / network / LLM and are unit-tested;
+  * ``--run`` exercises the live judge READ-ONLY — it fetches each case over the HTTP API
+    and calls ``review.runner.process_case`` (DB-free; never PATCHes), then scores
+    agreement against the human labels in ``datasets/judge_calibration/labels.json``.
+
+    poetry run python -m evals.calibrate_judge --demo
+    poetry run python -m evals.calibrate_judge --run --limit 5   # live via claude -p; each case = a full review
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+DISPOSITIONS = ["PASS", "REVISE", "REJECT"]
+
+LABELS_PATH = (
+    Path(__file__).resolve().parent / "datasets" / "judge_calibration" / "labels.json"
+)
+
+# Illustrative machine column for the offline --demo ONLY. Replace with real `--run`
+# output. Aligned positionally with the cases in labels.json; here the judge disagrees on
+# one published case (calls it REVISE) to produce a non-trivial kappa.
+_ILLUSTRATIVE_MACHINE = ["PASS", "PASS", "REVISE", "PASS", "PASS", "REVISE", "REJECT"]
+
+
+def cohen_kappa(human: Sequence[str], machine: Sequence[str]) -> float:
+    """Cohen's kappa for two label sequences (dependency-free).
+
+    1.0 = perfect agreement, 0.0 = chance-level, < 0 = worse than chance.
+    """
+    n = len(human)
+    if n == 0:
+        return 0.0
+    labels = set(human) | set(machine)
+    po = sum(1 for a, b in zip(human, machine) if a == b) / n
+    pe = 0.0
+    for label in labels:
+        pa = sum(1 for a in human if a == label) / n
+        pb = sum(1 for b in machine if b == label) / n
+        pe += pa * pb
+    if pe >= 1.0:
+        # Only possible when both columns are a single identical label -> agreement is
+        # perfect by construction.
+        return 1.0 if po >= 1.0 else 0.0
+    return (po - pe) / (1 - pe)
+
+
+def confusion_matrix(
+    human: Sequence[str], machine: Sequence[str], labels: Sequence[str] = DISPOSITIONS
+) -> dict:
+    """Return a {human_label: {machine_label: count}} confusion matrix."""
+    matrix = {h: {m: 0 for m in labels} for h in labels}
+    for a, b in zip(human, machine):
+        if a in matrix and b in matrix[a]:
+            matrix[a][b] += 1
+    return matrix
+
+
+def report(human: Sequence[str], machine: Sequence[str]) -> dict:
+    """Agreement report: n, accuracy, kappa, confusion matrix."""
+    n = len(human)
+    accuracy = (sum(1 for a, b in zip(human, machine) if a == b) / n) if n else 0.0
+    return {
+        "n": n,
+        "accuracy": accuracy,
+        "kappa": cohen_kappa(human, machine),
+        "confusion": confusion_matrix(human, machine),
+    }
+
+
+def load_labels(path: Path | str = LABELS_PATH) -> list[dict]:
+    """Load the real human-labelled calibration cases."""
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)["cases"]
+
+
+def render_report(rep: dict, title: str) -> str:
+    """Format an agreement report as text."""
+    lines = [title, "-" * len(title)]
+    lines.append(
+        f"n = {rep['n']}   accuracy = {rep['accuracy']:.3f}   kappa = {rep['kappa']:.3f}"
+    )
+    lines.append("")
+    lines.append("confusion (rows = human, cols = machine):")
+    header = "          " + "".join(f"{m:>9}" for m in DISPOSITIONS)
+    lines.append(header)
+    for h in DISPOSITIONS:
+        row = rep["confusion"][h]
+        lines.append(f"  {h:<8}" + "".join(f"{row[m]:>9}" for m in DISPOSITIONS))
+    kappa = rep["kappa"]
+    verdict = (
+        "GATE-WORTHY (kappa >= 0.6)"
+        if kappa >= 0.6
+        else "ADVISORY ONLY — do not gate on judge score (kappa < 0.6)"
+    )
+    lines.append("")
+    lines.append(f"interpretation: {verdict}")
+    return "\n".join(lines)
+
+
+def _pdf_size_mb(url: str) -> Optional[float]:
+    """HEAD a URL and return its size in MB, or None if unknown.
+
+    Uses a curl User-Agent: the default ``Python-urllib`` UA is blocked by the Cloudflare
+    WAF in front of the asset host, which would otherwise make every probe silently fail.
+    """
+    try:
+        req = urllib.request.Request(
+            url, method="HEAD", headers={"User-Agent": "curl/8.4.0"}
+        )
+        with urllib.request.urlopen(
+            req, timeout=20
+        ) as resp:  # noqa: S310 - trusted s3 host
+            cl = resp.headers.get("Content-Length")
+            return int(cl) / 1048576 if cl else None
+    except Exception:  # noqa: BLE001 - best-effort size probe
+        return None
+
+
+def prune_oversized_sources(case: dict, max_mb: float) -> tuple[dict, list]:
+    """Drop evidence sources with no pre-converted MARKDOWN whose RAW PDF exceeds max_mb.
+
+    The review converter runs pdfminer live on any source lacking a MARKDOWN link, and a
+    large image-heavy PDF (e.g. a procurement bid document) makes pdfminer OOM and SIGKILL
+    the whole review — uncatchable in-process. Such a source has no markdown for prod
+    either (its conversion already failed), so dropping it keeps the review faithful while
+    preventing the kill. Returns (possibly-new case, dropped[{title, mb}]).
+    """
+    evidence = case.get("evidence") or []
+    kept = []
+    dropped = []
+    for entry in evidence:
+        src = entry.get("source") or {}
+        urls = src.get("urls") or []
+        has_md = any(
+            isinstance(u, dict) and u.get("role") == "MARKDOWN" and u.get("link")
+            for u in urls
+        )
+        if has_md:
+            kept.append(entry)
+            continue
+        pdfs = [
+            u["link"]
+            for u in urls
+            if isinstance(u, dict)
+            and str(u.get("link", "")).lower().endswith(".pdf")
+            and u.get("role") in ("RAW", "ALTERNATE", "SOURCE_PAGE")
+        ]
+        oversized = next(
+            (
+                mb
+                for link in pdfs
+                if (mb := _pdf_size_mb(link)) is not None and mb > max_mb
+            ),
+            None,
+        )
+        if oversized is not None:
+            dropped.append({"title": src.get("title", ""), "mb": round(oversized, 1)})
+        else:
+            kept.append(entry)
+    if dropped:
+        case = {**case, "evidence": kept}
+    return case, dropped
+
+
+def _default_judge(
+    provider: str,
+    model: str,
+    api_base_url: str = "",
+    api_token: str = "",
+    skip_oversized_mb: float = 8.0,
+) -> Callable[[str], Optional[str]]:
+    """Build a live judge_fn(slug) -> disposition. READ-ONLY (no DB writes, no PATCH).
+
+    Lazily bootstraps Django + LLM and fetches each case over the API, then runs the
+    DB-free review core. Requires LLM credentials and the bigo-enrichment extras (likhit);
+    not exercised in CI. ``skip_oversized_mb`` drops un-converted PDFs above that size so a
+    pathological source can't OOM-kill the review (0 disables the guard).
+    """
+    from casework.common import CaseworkApi, bootstrap
+
+    bootstrap(provider, model)
+    from review import runner  # imported after bootstrap
+
+    api = CaseworkApi(base_url=api_base_url, token=api_token)
+    cfg = {"pass_threshold": 80, "revise_threshold": 60, "llm_samples": 3}
+
+    def judge_fn(slug: str) -> Optional[str]:
+        case = api.get_case(slug)
+        if skip_oversized_mb:
+            case, dropped = prune_oversized_sources(case, skip_oversized_mb)
+            for d in dropped:
+                # Loud, never silent: report what was excluded and why.
+                print(
+                    f"    skip oversized source ({d['mb']} MB, no markdown): {d['title']}",
+                    flush=True,
+                )
+        payload = runner.process_case(case, cfg)
+        return (payload.get("result") or {}).get("disposition")
+
+    return judge_fn
+
+
+def run(cases: list[dict], judge_fn: Callable[[str], Optional[str]]) -> dict:
+    """Run judge_fn over each case and report agreement vs human_disposition.
+
+    Each case is a slow full review, so progress is printed (flushed) as it goes, and a
+    single failing case is recorded and skipped rather than aborting the whole run.
+    """
+    human: list[str] = []
+    machine: list[str] = []
+    per_case = []
+    n = len(cases)
+    for i, case in enumerate(cases, 1):
+        slug = case["slug"]
+        h = case["human_disposition"]
+        try:
+            m = judge_fn(slug)
+        except Exception as exc:  # noqa: BLE001 - one bad case must not lose the rest
+            print(f"  [{i}/{n}] {slug}: ERROR {exc}", flush=True)
+            per_case.append(
+                {"slug": slug, "human": h, "machine": None, "error": str(exc)}
+            )
+            continue
+        if m is None:
+            print(f"  [{i}/{n}] {slug}: human={h} machine=None (skip)", flush=True)
+            per_case.append(
+                {"slug": slug, "human": h, "machine": None, "skipped": True}
+            )
+            continue
+        print(f"  [{i}/{n}] {slug}: human={h} machine={m}", flush=True)
+        human.append(h)
+        machine.append(m)
+        per_case.append({"slug": slug, "human": h, "machine": m})
+    rep = report(human, machine)
+    rep["per_case"] = per_case
+    return rep
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Calibrate the LLM review judge vs humans."
+    )
+    ap.add_argument(
+        "--demo",
+        action="store_true",
+        help="offline demo on bundled illustrative predictions",
+    )
+    ap.add_argument(
+        "--run",
+        action="store_true",
+        help="live, read-only: run the judge over the real cases",
+    )
+    # Default to the claude -p CLI provider, which is what the review pollers use.
+    ap.add_argument("--provider", default="claude_cli")
+    ap.add_argument("--model", default="")
+    ap.add_argument("--api-base-url", default="")
+    ap.add_argument("--api-token", default="")
+    ap.add_argument(
+        "--limit", type=int, default=None, help="cap live cases (each is a full review)"
+    )
+    ap.add_argument(
+        "--skip-oversized-mb",
+        type=float,
+        default=8.0,
+        help="drop un-converted PDFs above this size so they can't OOM the review (0=off)",
+    )
+    args = ap.parse_args(argv)
+
+    cases = load_labels()
+    if args.limit:
+        cases = cases[: args.limit]
+
+    if args.run:
+        judge_fn = _default_judge(
+            args.provider,
+            args.model,
+            args.api_base_url,
+            args.api_token,
+            args.skip_oversized_mb,
+        )
+        print(
+            f"Running {len(cases)} live review(s) via provider={args.provider} ...",
+            flush=True,
+        )
+        rep = run(cases, judge_fn)
+        # Persist the result so it survives stdout buffering / long background runs.
+        out_path = LABELS_PATH.parent / "last_run.json"
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(rep, fh, ensure_ascii=False, indent=2)
+        print()
+        print(render_report(rep, "Judge calibration — LIVE"))
+        print(f"\nwrote {out_path}")
+        return 0
+
+    if args.demo:
+        human = [c["human_disposition"] for c in cases]
+        machine = _ILLUSTRATIVE_MACHINE[: len(human)]
+        rep = report(human, machine)
+        print(
+            render_report(
+                rep, "Judge calibration — OFFLINE DEMO (illustrative machine column)"
+            )
+        )
+        print(
+            "\nNOTE: machine column is illustrative. Use --run for real judge output."
+        )
+        return 0
+
+    print("Loaded real human-labelled calibration cases:")
+    for c in cases:
+        print(f"  {c['slug']:<40} [{c['state']:<10}] -> {c['human_disposition']}")
+    print("\nRun with --demo (offline) or --run (live, read-only).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/datasets/enrich_missing_bigo/golden.json
+++ b/evals/datasets/enrich_missing_bigo/golden.json
@@ -1,0 +1,107 @@
+{
+  "_about": "Golden set for the BIGO enricher. Every entry is drawn from a REAL published/known Jawafdehi case (court case number cited) — no synthetic data. 'amount_coercion' tests the deterministic post-processing (_coerce_bigo_int) that runs regardless of model; 'extraction' entries carry the human-approved bigo for the live end-to-end run_eval (which fetches each case's CIAA press release read-only at run time).",
+  "amount_coercion": [
+    {
+      "raw_amount": "रु.४,५८,९७,४०३। ८८",
+      "expected_bigo": 45897403,
+      "court_case": "special:081-CR-0116",
+      "edge": "danda '।' paisa with trailing space; Devanagari digits; lakh/crore grouping"
+    },
+    {
+      "raw_amount": "रु. १,१०,०१,१९९।७५",
+      "expected_bigo": 11001199,
+      "court_case": "special:081-CR-0136",
+      "edge": "danda '।' paisa; appears repeatedly in the charge sheet"
+    },
+    {
+      "raw_amount": "रु. ९,२२,४६,०३२.३३",
+      "expected_bigo": 92246032,
+      "court_case": "special:081-CR-0044",
+      "edge": "dot '.' paisa separator"
+    },
+    {
+      "raw_amount": "रु. १,८५,००,०००",
+      "expected_bigo": 18500000,
+      "court_case": "special:081-CR-0022",
+      "edge": "clean amount, no paisa"
+    },
+    {
+      "raw_amount": "रु. ३,२१,८३,७७,१८२",
+      "expected_bigo": 3218377182,
+      "court_case": "special:081-CR-0095",
+      "edge": "arba-scale (billions), no paisa"
+    },
+    {
+      "raw_amount": "१,४६,८१,२२५/९०",
+      "expected_bigo": 14681225,
+      "court_case": "CIAA-format (production prompt Rule 1 example)",
+      "edge": "slash '/' paisa separator — a CIAA formatting variant cited in the prompt"
+    },
+    {
+      "raw_amount": "२३,७५,४६,३२४।५७",
+      "expected_bigo": 237546324,
+      "court_case": "CIAA-format (production prompt Rule 2 example)",
+      "edge": "paisa digits must NOT merge into rupees (237546324, not 2375463245)"
+    }
+  ],
+  "extraction": [
+    {
+      "court_case": "special:081-CR-0116",
+      "slug": "case-99ca8d124afa-dbd7c3",
+      "title": "काठमाडौँ महानगरपालिका तत्कालीन इन्जिनियर रामबाबु महतो कोईरी — गैरकानूनी सम्पत्ति आर्जन",
+      "expected_bigo": 45897403,
+      "press_release_type": "charge_filing",
+      "note": "illegal-enrichment 'source apug' figure; danda paisa in source"
+    },
+    {
+      "court_case": "special:081-CR-0136",
+      "slug": "case-081-cr-0136-oxygen-plant",
+      "title": "थाहा नगरपालिका अक्सिजन जेनेरेसन प्लान्ट खरिदमा भ्रष्टाचार",
+      "expected_bigo": 11001199,
+      "press_release_type": "charge_filing",
+      "distractors": ["97,55,575 / 97,35,575 pre-VAT bid", "12,00,000 peshki/advance"],
+      "note": "HARD: multiple amounts present; only the labelled bigo (1,10,01,199।75) must be picked"
+    },
+    {
+      "court_case": "special:081-CR-0022",
+      "slug": "case-081-cr-0022-ec3412bb",
+      "title": "लुम्बिनी विकास कोष सरोज भट्टराई — घुस तथा सम्पत्ति शुद्धिकरण",
+      "expected_bigo": 18500000,
+      "press_release_type": "charge_filing",
+      "note": "money-laundering routed amount"
+    },
+    {
+      "court_case": "special:081-CR-0095",
+      "slug": "teramocs-081-cr-0095-32c84510",
+      "title": "टेरामक्स (TERAMOCS) खरिदमा भ्रष्टाचार",
+      "expected_bigo": 3218377182,
+      "press_release_type": "charge_filing",
+      "note": "large 'hani-noksani' (loss) figure stated in the press release"
+    },
+    {
+      "court_case": "special:081-CR-0044",
+      "slug": "case-081-cr-0044-a72c082d",
+      "title": "जगतगुरु कृपालु प्रतिष्ठान — नागार्जुन नगर प्रमुख भ्रष्टाचार",
+      "expected_bigo": 92246032,
+      "press_release_type": "charge_filing",
+      "distractors": ["6.82 crore land transfer", "13.12 crore laundered property"],
+      "note": "HARD: bribe/laundering figures present; bigo is the 9,22,46,032.33 ghus total"
+    },
+    {
+      "court_case": "special:080-CR-0087",
+      "slug": "case-080-cr-0087-080-cr-0087-f63627",
+      "title": "उदयपुर सिमेन्ट उद्योग — गैरकानूनी लाभ तथा हानी",
+      "expected_bigo": 2278305,
+      "press_release_type": "charge_filing",
+      "note": "DRAFT case; smaller bigo"
+    },
+    {
+      "court_case": "special:081-CR-0107",
+      "slug": "case-081-cr-0107-patanjali",
+      "title": "पतञ्जली योगपीठ — हदबन्दी उल्लङ्घन / जग्गा खिचोला",
+      "expected_bigo": 185850000,
+      "press_release_type": "charge_filing",
+      "note": "HARD: amount not stated as a single clean numeral in prose; land-valuation derived"
+    }
+  ]
+}

--- a/evals/datasets/judge_calibration/labels.json
+++ b/evals/datasets/judge_calibration/labels.json
@@ -1,0 +1,49 @@
+{
+  "_about": "Human-side labels for calibrating the LLM case-review judge. These are REAL Jawafdehi cases. The judge's machine disposition is filled in at run time by `calibrate_judge.py --run` (read-only: it never PATCHes), then agreement (Cohen's kappa + confusion) is computed against the human_disposition column here.",
+  "labeling_method": "human_disposition is derived from each case's REAL publication state as a documented PROXY: PUBLISHED -> PASS (a human reviewer approved and published it), IN_REVIEW -> REVISE (submitted, not yet approved), DRAFT -> REJECT (stub / not ready). This is a stand-in until the real per-case reviewer dispositions from the review queue (e.g. the 51 priority-review verdicts) are wired in; swap them in and the harness is unchanged.",
+  "disposition_labels": ["PASS", "REVISE", "REJECT"],
+  "cases": [
+    {
+      "slug": "case-99ca8d124afa-dbd7c3",
+      "court_case": "special:081-CR-0116",
+      "state": "PUBLISHED",
+      "human_disposition": "PASS"
+    },
+    {
+      "slug": "case-081-cr-0107-patanjali",
+      "court_case": "special:081-CR-0107",
+      "state": "PUBLISHED",
+      "human_disposition": "PASS"
+    },
+    {
+      "slug": "case-081-cr-0022-ec3412bb",
+      "court_case": "special:081-CR-0022",
+      "state": "PUBLISHED",
+      "human_disposition": "PASS"
+    },
+    {
+      "slug": "teramocs-081-cr-0095-32c84510",
+      "court_case": "special:081-CR-0095",
+      "state": "PUBLISHED",
+      "human_disposition": "PASS"
+    },
+    {
+      "slug": "case-081-cr-0044-a72c082d",
+      "court_case": "special:081-CR-0044",
+      "state": "PUBLISHED",
+      "human_disposition": "PASS"
+    },
+    {
+      "slug": "case-081-cr-0136-oxygen-plant",
+      "court_case": "special:081-CR-0136",
+      "state": "IN_REVIEW",
+      "human_disposition": "REVISE"
+    },
+    {
+      "slug": "case-080-cr-0087-080-cr-0087-f63627",
+      "court_case": "special:080-CR-0087",
+      "state": "DRAFT",
+      "human_disposition": "REJECT"
+    }
+  ]
+}

--- a/evals/judge_model.py
+++ b/evals/judge_model.py
@@ -1,0 +1,69 @@
+"""DeepEval judge wired through the in-house provider abstraction.
+
+DeepEval defaults its LLM-as-judge metrics (GEval, faithfulness, hallucination) to OpenAI.
+We don't want that: evals must run on our own infra (data residency) and the judge model
+must be pinnable independent of the model being graded (to avoid self-preference bias).
+``ProviderJudge`` is a ``DeepEvalBaseLLM`` that routes every judge call through
+``llm.invoke`` / ``llm.routing``, so the same Bedrock/proxy/CLI tiers grade the evals.
+
+DeepEval is an OPTIONAL dependency (not in pyproject yet). Import is guarded so the eval
+package stays importable without it; install with ``poetry add --group dev deepeval`` and
+the judge metrics light up. See ``evals/README.md``.
+"""
+
+from __future__ import annotations
+
+try:
+    from deepeval.models.base_model import DeepEvalBaseLLM
+
+    DEEPEVAL_AVAILABLE = True
+except Exception:  # noqa: BLE001 - deepeval is optional; absence must not break imports
+    DEEPEVAL_AVAILABLE = False
+    DeepEvalBaseLLM = object  # type: ignore[assignment,misc]
+
+
+_JUDGE_SYSTEM = (
+    "You are a meticulous, strict-but-fair evaluator for Jawafdehi. You understand "
+    "Nepali and English. Follow the rubric exactly and reply only as instructed."
+)
+
+
+class ProviderJudge(DeepEvalBaseLLM):
+    """A DeepEval judge backed by the Jawafdehi provider router.
+
+    Args:
+        tier: which routing tier grades the evals ("premium" by default — match rubric
+            complexity to judge capability, and keep it independent of the graded model).
+    """
+
+    def __init__(self, tier: str = "premium"):
+        if not DEEPEVAL_AVAILABLE:
+            raise RuntimeError(
+                "deepeval is not installed; run `poetry add --group dev deepeval`"
+            )
+        self.tier = tier
+
+    def load_model(self):  # DeepEvalBaseLLM hook
+        return None
+
+    def generate(self, prompt: str, schema=None) -> str:
+        # Imported here so the module imports without Django/transport configured.
+        from llm.invoke import invoke_text
+
+        return invoke_text(
+            system=_JUDGE_SYSTEM,
+            content=prompt,
+            max_tokens=1500,
+            tier=self.tier,
+        )
+
+    async def a_generate(self, prompt: str, schema=None) -> str:
+        return self.generate(prompt, schema)
+
+    def get_model_name(self) -> str:
+        from llm.routing import model_for_tier
+
+        try:
+            return f"jawafdehi:{self.tier}:{model_for_tier(self.tier)}"
+        except Exception:  # noqa: BLE001 - reporting must never crash
+            return f"jawafdehi:{self.tier}"

--- a/evals/metrics/__init__.py
+++ b/evals/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Eval metrics: deterministic (field-level, offline) and model-graded (DeepEval)."""

--- a/evals/metrics/deterministic.py
+++ b/evals/metrics/deterministic.py
@@ -1,0 +1,146 @@
+"""Deterministic, language-agnostic eval metrics for the BIGO enricher.
+
+These are the cheap, free, model-independent checks the RFC leans on (especially for
+Nepali, where LLM-judging is unreliable): exact field-level accuracy on the amount, and
+JSON-schema conformance of the model's output. They reuse the *production* normalisation
+(`_coerce_bigo_int`) and schema validator directly — there is no second copy of that logic.
+
+Runnable offline with no Django / network / LLM:
+
+    poetry run python evals/metrics/deterministic.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Production logic, imported directly (offline-safe: the enricher's top-level imports are
+# stdlib + requests, and the Django bootstrap is a function, not run on import).
+from casework.enrich_missing_bigo import _coerce_bigo_int
+from llm.prompts.spec import validate_output
+
+GOLDEN_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "datasets"
+    / "enrich_missing_bigo"
+    / "golden.json"
+)
+
+
+def load_golden(path: Path | str = GOLDEN_PATH) -> dict:
+    """Load the BIGO golden dataset."""
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def coerce_amount(raw: str) -> Optional[int]:
+    """Normalise a raw CIAA amount string to an NPR integer (production logic)."""
+    return _coerce_bigo_int(raw)
+
+
+def bigo_field_match(predicted: Optional[int], expected: Optional[int]) -> bool:
+    """Exact field-level match for the bigo amount (None == None counts as a match)."""
+    return predicted == expected
+
+
+def score_amount_coercion(entries: list[dict]) -> dict:
+    """Score the deterministic amount-coercion layer over golden entries.
+
+    Returns field_accuracy (= document_accuracy here, one field per entry), the count, and
+    a per-entry breakdown so a CI run can show exactly which string regressed.
+    """
+    results = []
+    correct = 0
+    for entry in entries:
+        raw = entry["raw_amount"]
+        expected = entry["expected_bigo"]
+        got = coerce_amount(raw)
+        ok = bigo_field_match(got, expected)
+        correct += int(ok)
+        results.append(
+            {
+                "raw_amount": raw,
+                "expected": expected,
+                "got": got,
+                "ok": ok,
+                "court_case": entry.get("court_case", ""),
+                "edge": entry.get("edge", ""),
+            }
+        )
+    total = len(entries)
+    return {
+        "field_accuracy": (correct / total) if total else 1.0,
+        "correct": correct,
+        "total": total,
+        "results": results,
+    }
+
+
+def score_model_output(
+    predicted_obj: dict, expected_bigo: Optional[int], schema: Optional[dict]
+) -> dict:
+    """Score one raw model output: schema conformance + bigo field match.
+
+    `predicted_obj` is the parsed JSON the model returned for an extraction case; the bigo
+    is read from it and coerced with the production logic before comparison.
+    """
+    schema_errors = validate_output(predicted_obj, schema)
+    raw_bigo = predicted_obj.get("bigo") if isinstance(predicted_obj, dict) else None
+    if isinstance(raw_bigo, str):
+        predicted_bigo = coerce_amount(raw_bigo)
+    else:
+        predicted_bigo = raw_bigo
+    return {
+        "schema_ok": not schema_errors,
+        "schema_errors": schema_errors,
+        "predicted_bigo": predicted_bigo,
+        "expected_bigo": expected_bigo,
+        "bigo_match": bigo_field_match(predicted_bigo, expected_bigo),
+    }
+
+
+def _selftest() -> int:
+    """Offline self-test: score the real golden coercion set; 0 = all pass."""
+    golden = load_golden()
+    report = score_amount_coercion(golden["amount_coercion"])
+
+    print("BIGO amount-coercion eval (real CIAA strings)\n" + "-" * 64)
+    for r in report["results"]:
+        flag = "OK  " if r["ok"] else "FAIL"
+        print(
+            f"  [{flag}] {r['raw_amount']!r} -> {r['got']} (expected {r['expected']})"
+        )
+    print("-" * 64)
+    print(
+        f"field_accuracy = {report['field_accuracy']:.3f} "
+        f"({report['correct']}/{report['total']})"
+    )
+
+    # Schema conformance: a well-formed output passes; a malformed one is rejected.
+    from llm.prompts import get
+
+    schema = get("enrich.missing_bigo").output_schema
+    good = {
+        "bigo": 11001199,
+        "confidence": "high",
+        "evidence_quote": "बिगो रु. १,१०,०१,१९९।७५ कायम",
+        "press_release_type": "charge_filing",
+    }
+    bad = {"bigo": "lots", "confidence": "definitely", "evidence_quote": 5}
+    good_errs = validate_output(good, schema)
+    bad_errs = validate_output(bad, schema)
+    print(
+        f"schema: good_output_errors={good_errs} "
+        f"bad_output_caught={len(bad_errs)} issue(s)"
+    )
+
+    ok = report["correct"] == report["total"] and not good_errs and bad_errs
+    print("\nRESULT:", "ALL PASS" if ok else "FAILURES PRESENT")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_selftest())

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -1,0 +1,180 @@
+"""Live, end-to-end BIGO eval + model-migration comparison (READ-ONLY).
+
+Runs the real extraction pipeline over the golden ``extraction`` cases and scores
+field-level accuracy against the human-approved bigo. Because it can run any tier/model,
+this is the model-migration tool: it answers "is the cheap tier (or a new model) safe to
+swap in for this enricher?" with a per-case delta, not a guess.
+
+It reuses the enricher's OWN input assembly (``_get_source_content``) and post-processing
+(``_parse_bigo_response``) so the only thing that varies is the model — the eval is
+faithful to production. It only reads (fetch case + call model); it never PATCHes.
+
+    poetry run python -m evals.run_eval --tier premium        # via claude -p (default provider)
+    poetry run python -m evals.run_eval --compare             # premium vs cheap migration verdict
+
+Needs the bigo-enrichment extras (likhit) + a read API token (JAWAFDEHI_API_TOKEN); not run in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+from evals.metrics import deterministic as det
+
+
+def evaluate(
+    tier: str,
+    provider: str,
+    model: str,
+    api_base_url: str = "",
+    api_token: str = "",
+    limit: Optional[int] = None,
+) -> dict:
+    """Run the BIGO pipeline at a given tier over the golden extraction cases."""
+    from casework.common import CaseworkApi, bootstrap, clamp, env_int
+
+    bootstrap(provider, model)
+    from casework.enrich_missing_bigo import _get_source_content, _parse_bigo_response
+    from llm.invoke import invoke_text
+    from llm.prompts import get
+    from llm.usage import UsageAccumulator
+
+    spec = get("enrich.missing_bigo")
+    api = CaseworkApi(base_url=api_base_url, token=api_token)
+    cases = det.load_golden()["extraction"]
+    if limit:
+        cases = cases[:limit]
+
+    usage = UsageAccumulator()
+    rows = []
+    correct = 0
+    scored = 0
+    for entry in cases:
+        slug = entry["slug"]
+        expected = entry["expected_bigo"]
+        detail = api.get_case(slug)
+        source_text, source_context = _get_source_content(detail)
+        if not source_text:
+            rows.append({"court_case": entry["court_case"], "skipped": "no source"})
+            continue
+        content = spec.render_user(
+            case_id=entry["court_case"],
+            case_title=entry["title"],
+            source_context=source_context,
+            markdown=clamp(
+                source_text, env_int("CASEWORK_BIGO_FEED_CHARS", 100000), "bigo"
+            ),
+        )
+        resp = invoke_text(
+            system=spec.system,
+            content=content,
+            max_tokens=spec.max_tokens,
+            tier=tier,
+            usage=usage,
+        )
+        predicted = _parse_bigo_response(resp)
+        match = det.bigo_field_match(predicted, expected)
+        scored += 1
+        correct += int(match)
+        rows.append(
+            {
+                "court_case": entry["court_case"],
+                "expected": expected,
+                "predicted": predicted,
+                "match": match,
+            }
+        )
+
+    return {
+        "tier": tier,
+        "field_accuracy": (correct / scored) if scored else 0.0,
+        "correct": correct,
+        "scored": scored,
+        "rows": rows,
+        "usage": usage.as_dict(),
+    }
+
+
+def _print_report(rep: dict) -> None:
+    from llm.usage import render_usage_table
+
+    print(f"\nBIGO extraction eval — tier={rep['tier']}")
+    print("-" * 72)
+    for r in rep["rows"]:
+        if r.get("skipped"):
+            print(f"  [skip] {r['court_case']}: {r['skipped']}")
+            continue
+        flag = "OK  " if r["match"] else "FAIL"
+        print(
+            f"  [{flag}] {r['court_case']}: predicted={r['predicted']} expected={r['expected']}"
+        )
+    print("-" * 72)
+    print(
+        f"field_accuracy = {rep['field_accuracy']:.3f} ({rep['correct']}/{rep['scored']})"
+    )
+    print(render_usage_table(rep["usage"]["by_provider"], title="eval usage"))
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Live BIGO eval / model-migration comparison."
+    )
+    ap.add_argument("--tier", default="premium", choices=["premium", "cheap"])
+    ap.add_argument(
+        "--compare", action="store_true", help="run premium AND cheap, show delta"
+    )
+    # Default to the claude -p CLI provider, which is what the enrichers/pollers use.
+    ap.add_argument("--provider", default="claude_cli")
+    ap.add_argument("--model", default="")
+    ap.add_argument("--api-base-url", default="")
+    ap.add_argument("--api-token", default="")
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args(argv)
+
+    if args.compare:
+        prem = evaluate(
+            "premium",
+            args.provider,
+            args.model,
+            args.api_base_url,
+            args.api_token,
+            args.limit,
+        )
+        cheap = evaluate(
+            "cheap",
+            args.provider,
+            args.model,
+            args.api_base_url,
+            args.api_token,
+            args.limit,
+        )
+        _print_report(prem)
+        _print_report(cheap)
+        delta = cheap["field_accuracy"] - prem["field_accuracy"]
+        print("\n=== MODEL-MIGRATION VERDICT ===")
+        print(f"premium accuracy = {prem['field_accuracy']:.3f}")
+        print(f"cheap   accuracy = {cheap['field_accuracy']:.3f}")
+        print(f"delta (cheap - premium) = {delta:+.3f}")
+        print(
+            "SAFE to swap to cheap"
+            if delta >= 0
+            else "NOT safe — cheap regresses on real cases"
+        )
+        return 0
+
+    rep = evaluate(
+        args.tier,
+        args.provider,
+        args.model,
+        args.api_base_url,
+        args.api_token,
+        args.limit,
+    )
+    _print_report(rep)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/test_calibrate_judge.py
+++ b/evals/test_calibrate_judge.py
@@ -1,0 +1,90 @@
+"""Unit tests for the judge-calibration math (offline, no LLM)."""
+
+from __future__ import annotations
+
+import pytest
+
+from evals import calibrate_judge as cj
+
+
+def test_kappa_perfect_agreement():
+    a = ["PASS", "PASS", "REVISE", "REJECT"]
+    assert cj.cohen_kappa(a, a) == pytest.approx(1.0)
+
+
+def test_kappa_known_value():
+    # n=3, observed agreement 2/3, expected 4/9 -> kappa = 0.4
+    human = ["PASS", "PASS", "REVISE"]
+    machine = ["PASS", "REVISE", "REVISE"]
+    assert cj.cohen_kappa(human, machine) == pytest.approx(0.4)
+
+
+def test_kappa_total_disagreement_is_non_positive():
+    human = ["PASS", "REJECT", "PASS", "REJECT"]
+    machine = ["REJECT", "PASS", "REJECT", "PASS"]
+    assert cj.cohen_kappa(human, machine) <= 0.0
+
+
+def test_kappa_empty_is_zero():
+    assert cj.cohen_kappa([], []) == 0.0
+
+
+def test_confusion_matrix_counts():
+    human = ["PASS", "PASS", "REVISE", "REJECT"]
+    machine = ["PASS", "REVISE", "REVISE", "REJECT"]
+    m = cj.confusion_matrix(human, machine)
+    assert m["PASS"]["PASS"] == 1
+    assert m["PASS"]["REVISE"] == 1
+    assert m["REVISE"]["REVISE"] == 1
+    assert m["REJECT"]["REJECT"] == 1
+
+
+def test_report_shape():
+    rep = cj.report(["PASS", "REVISE"], ["PASS", "REJECT"])
+    assert rep["n"] == 2
+    assert rep["accuracy"] == pytest.approx(0.5)
+    assert set(rep["confusion"]) == set(cj.DISPOSITIONS)
+
+
+def test_load_real_labels():
+    cases = cj.load_labels()
+    assert len(cases) >= 5
+    for c in cases:
+        assert c["human_disposition"] in cj.DISPOSITIONS
+        assert c["slug"]
+
+
+def test_prune_oversized_sources(monkeypatch):
+    case = {
+        "evidence": [
+            {
+                "source": {
+                    "title": "small RAW only",
+                    "urls": [{"role": "RAW", "link": "a.pdf"}],
+                }
+            },
+            {
+                "source": {
+                    "title": "big RAW only",
+                    "urls": [{"role": "RAW", "link": "big.pdf"}],
+                }
+            },
+            {
+                "source": {
+                    "title": "has markdown",
+                    "urls": [
+                        {"role": "RAW", "link": "c.pdf"},
+                        {"role": "MARKDOWN", "link": "c.md"},
+                    ],
+                }
+            },
+        ]
+    }
+    sizes = {"a.pdf": 1.0, "big.pdf": 20.0, "c.pdf": 50.0}
+    monkeypatch.setattr(cj, "_pdf_size_mb", lambda u: sizes.get(u))
+    pruned, dropped = cj.prune_oversized_sources(case, 8.0)
+    titles = [e["source"]["title"] for e in pruned["evidence"]]
+    # The big RAW-only PDF is dropped; the small one is kept; the one WITH markdown is kept
+    # even though its PDF is huge (it is never converted live, so it can't OOM).
+    assert titles == ["small RAW only", "has markdown"]
+    assert dropped == [{"title": "big RAW only", "mb": 20.0}]

--- a/evals/test_enrich_missing_bigo_eval.py
+++ b/evals/test_enrich_missing_bigo_eval.py
@@ -1,0 +1,99 @@
+"""Eval gate for the BIGO enricher — runs in CI, no LLM/network required.
+
+These are the deterministic, model-independent checks: real-data field-level accuracy,
+schema conformance, prompt-variable rendering, and a drift guard proving the prompt
+registry is byte-identical to the live enricher. The optional DeepEval judge test skips
+unless ``deepeval`` is installed.
+
+    poetry run pytest evals/test_enrich_missing_bigo_eval.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from casework.enrich_missing_bigo import (
+    EXTRACTION_SYSTEM_PROMPT,
+    EXTRACTION_USER_PROMPT,
+)
+from evals.metrics import deterministic as det
+from llm.prompts import get
+from llm.prompts.spec import validate_output
+
+GOLDEN = det.load_golden()
+
+
+@pytest.mark.parametrize(
+    "entry",
+    GOLDEN["amount_coercion"],
+    ids=[e["court_case"] for e in GOLDEN["amount_coercion"]],
+)
+def test_amount_coercion_matches_real_bigo(entry):
+    """Each real CIAA amount string normalises to the human-approved bigo integer."""
+    assert det.coerce_amount(entry["raw_amount"]) == entry["expected_bigo"]
+
+
+def test_amount_coercion_field_accuracy_is_perfect():
+    """The whole real coercion golden set scores 100% (regression gate)."""
+    rep = det.score_amount_coercion(GOLDEN["amount_coercion"])
+    assert rep["field_accuracy"] == 1.0, rep["results"]
+
+
+def test_schema_accepts_valid_and_rejects_malformed():
+    schema = get("enrich.missing_bigo").output_schema
+    valid = {
+        "bigo": 11001199,
+        "confidence": "high",
+        "evidence_quote": "बिगो रु. १,१०,०१,१९९।७५ कायम",
+        "press_release_type": "charge_filing",
+    }
+    malformed = {"bigo": "lots", "confidence": "definitely", "evidence_quote": 5}
+    assert validate_output(valid, schema) == []
+    assert validate_output(malformed, schema), "malformed output should be flagged"
+
+
+def test_null_bigo_is_schema_valid():
+    """A sting/appeal release yields bigo=null, which must conform (nullable integer)."""
+    schema = get("enrich.missing_bigo").output_schema
+    null_case = {
+        "bigo": None,
+        "confidence": "high",
+        "evidence_quote": "रंगेहात पक्राउ",
+        "press_release_type": "sting_operation",
+    }
+    assert validate_output(null_case, schema) == []
+
+
+def test_bigo_field_match_metric():
+    assert det.bigo_field_match(11001199, 11001199) is True
+    assert det.bigo_field_match(None, None) is True
+    assert det.bigo_field_match(123, 456) is False
+
+
+def test_registry_spec_matches_live_enricher():
+    """Drift guard: the registry prompt is a view over the enricher, never a stale copy."""
+    spec = get("enrich.missing_bigo")
+    assert spec.system == EXTRACTION_SYSTEM_PROMPT
+    assert spec.user_template == EXTRACTION_USER_PROMPT
+    assert spec.version == "1.0.0"
+
+
+def test_prompt_renders_declared_variables():
+    spec = get("enrich.missing_bigo")
+    rendered = spec.render_user(
+        case_id="case-081-cr-0136",
+        case_title="Oxygen plant",
+        source_context="title: ...",
+        markdown="बिगो रु. १,१०,०१,१९९।७५",
+    )
+    assert "case-081-cr-0136" in rendered
+    assert "१,१०,०१,१९९।७५" in rendered
+
+
+def test_deepeval_judge_routes_through_providers_when_installed():
+    """If deepeval is installed, the judge must be model-pinned to our own tiers."""
+    pytest.importorskip("deepeval")
+    from evals.judge_model import ProviderJudge
+
+    judge = ProviderJudge(tier="premium")
+    assert judge.get_model_name().startswith("jawafdehi:")

--- a/llm/prompts/__init__.py
+++ b/llm/prompts/__init__.py
@@ -1,0 +1,45 @@
+"""Central prompt registry.
+
+Prompts live here as ``PromptSpec`` data (see ``spec.py``) instead of inline string
+constants scattered across the enrichers. The registry is intentionally lazy: importing
+``llm.prompts`` is cheap and Django-free; the per-prompt modules are imported on demand by
+``get()`` because they pull the live prompt constants from their enricher (which is fine
+under Django, but we don't want to force it at package import).
+
+Each entry maps a stable key to the module that exposes a ``SPEC``. New prompts are added
+by writing a module next to ``enrich_missing_bigo.py`` and registering its key here.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from llm.prompts.spec import PromptSpec, validate_output
+
+# key -> dotted module path exposing a module-level ``SPEC``.
+REGISTRY: dict[str, str] = {
+    "enrich.missing_bigo": "llm.prompts.enrich_missing_bigo",
+}
+
+
+def get(key: str) -> PromptSpec:
+    """Return the ``PromptSpec`` registered under ``key``.
+
+    Raises KeyError for an unknown key.
+    """
+    try:
+        module_path = REGISTRY[key]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown prompt key {key!r}; known keys: {sorted(REGISTRY)}"
+        ) from exc
+    module = importlib.import_module(module_path)
+    return module.SPEC
+
+
+def all_keys() -> list[str]:
+    """List every registered prompt key."""
+    return sorted(REGISTRY)
+
+
+__all__ = ["PromptSpec", "validate_output", "get", "all_keys", "REGISTRY"]

--- a/llm/prompts/enrich_missing_bigo.py
+++ b/llm/prompts/enrich_missing_bigo.py
@@ -1,0 +1,50 @@
+"""Registry entry for the BIGO-extraction prompt.
+
+The prompt text is sourced live from ``casework.enrich_missing_bigo`` so there is exactly
+one copy in the tree: this spec is a *view* over the production constants, not a duplicate.
+A drift-guard test (``evals/test_enrich_missing_bigo_eval.py``) asserts the two stay
+byte-identical. The Phase-1 migration described in
+``docs/llm-prompt-centralization-and-evals.md`` inverts this dependency (the enricher
+imports from the registry); until then we keep the enricher untouched and read from it.
+"""
+
+from __future__ import annotations
+
+from casework.enrich_missing_bigo import (
+    EXTRACTION_SYSTEM_PROMPT,
+    EXTRACTION_USER_PROMPT,
+)
+from llm.prompts.spec import PromptSpec
+
+OUTPUT_SCHEMA = {
+    "type": "object",
+    "required": ["bigo", "confidence", "evidence_quote", "press_release_type"],
+    "properties": {
+        "bigo": {"type": "integer", "nullable": True},
+        "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+        "evidence_quote": {"type": "string"},
+        "press_release_type": {
+            "type": "string",
+            "enum": ["sting_operation", "appeal_review", "charge_filing", "other"],
+        },
+    },
+}
+
+SPEC = PromptSpec(
+    key="enrich.missing_bigo",
+    version="1.0.0",
+    system=EXTRACTION_SYSTEM_PROMPT,
+    user_template=EXTRACTION_USER_PROMPT,
+    tier="premium",
+    max_tokens=2000,
+    output_schema=OUTPUT_SCHEMA,
+    examples="evals/datasets/enrich_missing_bigo/golden.json",
+    source_ref="casework/enrich_missing_bigo.py::_extract_bigo_from_source",
+    variables=("case_id", "case_title", "source_context", "markdown"),
+    notes=(
+        "Extracts BIGO (बिगो, the damage-claim amount) from a CIAA press release. "
+        "The model returns the schema above; deterministic post-processing "
+        "(_coerce_bigo_int / _parse_bigo_response in the enricher) normalises Devanagari "
+        "digits, strips the paisa suffix, and gates on confidence + bigo-context keywords."
+    ),
+)

--- a/llm/prompts/runner.py
+++ b/llm/prompts/runner.py
@@ -1,0 +1,64 @@
+"""Thin call wrapper around a PromptSpec.
+
+``invoke_prompt`` renders a spec, calls the model through the existing ``llm.invoke``
+choke point (so all provider/tier routing is unchanged), validates the parsed JSON against
+the spec's schema, and returns the result plus a small metadata envelope carrying the
+prompt key + version for traceability.
+
+This lives in the prompts package rather than in ``llm/invoke.py`` so the production
+transport module is left untouched. The Phase-1 migration folds this into ``llm/invoke.py``
+and rewires the enrichers to call it; for now it is additive and opt-in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm.prompts.spec import PromptSpec, validate_output
+
+
+def invoke_prompt(
+    spec: PromptSpec,
+    *,
+    usage: Any = None,
+    strict: bool = False,
+    **values: Any,
+) -> dict:
+    """Render ``spec``, call the model, parse + validate JSON, return result + meta.
+
+    Args:
+        spec: the PromptSpec to run.
+        usage: optional UsageAccumulator passed through to the transport.
+        strict: when True, raise ValueError if the output violates the schema; when False
+            (default) the violations are returned under ``meta.schema_errors`` so callers
+            can decide.
+        **values: variables substituted into the spec's user template.
+
+    Returns:
+        ``{"output": <parsed dict>, "meta": {"prompt_key", "prompt_version",
+        "schema_errors": [...]}}``.
+    """
+    # Imported lazily: this keeps ``llm.prompts`` import-safe without Django/transport.
+    from llm.invoke import invoke_json
+
+    content = spec.render_user(**values)
+    output = invoke_json(
+        system=spec.system,
+        content=content,
+        max_tokens=spec.max_tokens,
+        tier=spec.tier,
+        usage=usage,
+    )
+
+    errors = validate_output(output, spec.output_schema)
+    if errors and strict:
+        raise ValueError(f"{spec.key} output failed schema: {errors}")
+
+    return {
+        "output": output,
+        "meta": {
+            "prompt_key": spec.key,
+            "prompt_version": spec.version,
+            "schema_errors": errors,
+        },
+    }

--- a/llm/prompts/spec.py
+++ b/llm/prompts/spec.py
@@ -1,0 +1,102 @@
+"""PromptSpec: a prompt as versioned data, not an inline string constant.
+
+This generalises the prompts-as-data pattern already used by ``review/rule_defaults.py``
+(rules carry title + description + good/bad examples + weight + gate) to the enricher
+prompts, so every prompt has a stable key, an immutable version, a declared variable
+surface, an output schema, and golden examples that double as eval seed data.
+
+The dataclass is deliberately dependency-free (stdlib only) so importing the registry
+never pulls Django or the LLM transport. Rendering is plain ``str.format`` to mirror how
+the enrichers already build their user prompts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class PromptSpec:
+    """A single prompt, captured as data.
+
+    Fields mirror what an enricher needs to make one LLM call plus what an eval needs to
+    score it. ``output_schema`` is a small JSON-Schema-ish dict (see ``validate_output``);
+    ``examples`` is a path to / list of golden reference cases.
+    """
+
+    key: str
+    version: str
+    system: str
+    user_template: str
+    tier: str = "premium"
+    max_tokens: int = 2000
+    output_schema: Optional[dict] = None
+    examples: str = ""
+    source_ref: str = ""
+    notes: str = ""
+    variables: tuple = field(default_factory=tuple)
+
+    def render_user(self, **values: Any) -> str:
+        """Render the user prompt by substituting declared variables."""
+        return self.user_template.format(**values)
+
+
+def validate_output(obj: Any, schema: Optional[dict]) -> list[str]:
+    """Validate ``obj`` against a tiny JSON-Schema subset; return a list of errors.
+
+    Supports the handful of constraints the enricher outputs actually use — ``type``,
+    ``required``, per-property ``type``/``enum``/``nullable`` — without taking a
+    jsonschema dependency. An empty list means the object conforms.
+    """
+    if not schema:
+        return []
+    errors: list[str] = []
+
+    expected_type = schema.get("type")
+    if expected_type == "object" and not isinstance(obj, dict):
+        return [f"expected object, got {type(obj).__name__}"]
+
+    if isinstance(obj, dict):
+        for key in schema.get("required", []):
+            if key not in obj:
+                errors.append(f"missing required field: {key}")
+
+        for prop, rule in schema.get("properties", {}).items():
+            if prop not in obj:
+                continue
+            value = obj[prop]
+            if value is None:
+                if not rule.get("nullable"):
+                    errors.append(f"field {prop} is null but not nullable")
+                continue
+            ptype = rule.get("type")
+            if ptype and not _matches_type(value, ptype):
+                errors.append(
+                    f"field {prop}: expected {ptype}, got {type(value).__name__}"
+                )
+            enum = rule.get("enum")
+            if enum and value not in enum:
+                errors.append(f"field {prop}: {value!r} not in {enum}")
+
+    return errors
+
+
+_TYPE_MAP = {
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def _matches_type(value: Any, ptype: str) -> bool:
+    py = _TYPE_MAP.get(ptype)
+    if py is None:
+        return True
+    # bool is a subclass of int; keep them distinct so a flag never satisfies integer.
+    if ptype == "integer" and isinstance(value, bool):
+        return False
+    return isinstance(value, py)


### PR DESCRIPTION
## What & why

Enricher prompts and the case-review LLM rules are fragmented as inline string constants across ~11 enrichers + the review judge — no registry, versioning, or evals — so we can't run regressions, gate prompt edits, or prove a model swap is safe. This PR adds the foundation: a **prompt registry** (prompts-as-data) and a **model-independent eval layer**, delivered as a complete first vertical slice (the BIGO enricher) that the other pipelines copy.

Full design + the Nepali low-resource-judging caveat that motivates the deterministic-first approach: `docs/llm-prompt-centralization-and-evals.md`.

## What's in it

**`llm/prompts/` — registry**
- `PromptSpec`: a prompt as versioned data (key, immutable version, system/user templates, tier, JSON output schema, golden examples), generalizing the existing `review/rule_defaults.py` prompts-as-data pattern.
- The `enrich_missing_bigo` spec is a **drift-guarded view** over the live enricher constants — no duplication; a test asserts byte-identity.
- `invoke_prompt` wrapper kept additive in `runner.py` (not folded into `llm/invoke.py`).

**`evals/` — eval layer**
- Deterministic, language-agnostic field metrics that reuse the production `_coerce_bigo_int` (no second copy).
- DeepEval judge routed through `llm/routing` (our own providers, **not OpenAI**; optional/guarded) so evals stay on our infra and the judge is model-pinned independent of the graded model.
- Judge **calibration harness** (Cohen's kappa + confusion matrix) with an oversized-PDF guard.
- Read-only `run_eval` / `calibrate_judge` CLIs (default to the `claude -p` provider, as the pollers use) for extraction accuracy and model-migration deltas.
- Golden datasets built from **real, human-approved cases**.

## Additive only
No existing production files are modified — the registry reads the enricher's constants and the eval reuses prod functions.

## Verified
- Offline pytest gate: **21 passed, 1 skipped** (the DeepEval test skips when `deepeval` isn't installed).
- Live via `claude -p` (`claude-opus-4-8`, read-only token): BIGO extraction **100%** on the real cases; full judge calibration over 7 real cases → **n=7, accuracy=0.714, kappa=0.462 (ADVISORY — below the 0.6 gate threshold)**. That low kappa is exactly the signal the calibration exists to produce for a low-resource (Nepali) judge.

## Bug surfaced (separate prod fix)
A 9.3 MB image-heavy procurement-bid PDF on one case OOM-SIGKILLs the review converter (`sourcing/converter.py` via pdfminer) — and the **production review poller runs the same converter**, so submitting such a case to the judge would OOM the poller. This PR guards the *eval* (`--skip-oversized-mb`, default 8, loudly logged). The real fix — convert PDFs in a subprocess bounded by `RLIMIT_AS` + a wall-clock timeout so an OOM/timeout becomes a caught per-source failure — is a production change left for a follow-up.

## Caveats / next
- The calibration labels are a **publication-state proxy**, not real reviewer verdicts; the definitive kappa needs the real 51 priority-review dispositions wired into `labels.json` (harness unchanged).
- Follow-ups: add `deepeval` as a dev dependency; wire the CI per-cohort gate; replicate the template to `enrich_tags` and the sourcing scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized prompt system with versioned prompt definitions and standardized prompt execution.
  * Introduced a new evaluation layer for comparing model output quality and running live, read-only checks.
  * Added judge calibration tools and model-tier comparison support.

* **Bug Fixes**
  * Improved output validation to catch malformed responses before they reach users.
  * Added safeguards for oversized source documents during evaluation runs.

* **Tests**
  * Added deterministic evaluation datasets and CI checks for extraction accuracy and judge agreement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->