### PR TITLE
fix(review): lift concise timelines (recalibrate timeline count credit)

### DIFF
--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -12,6 +12,11 @@ import re
 
 GOLD_DESC_CHARS = 12000
 GOLD_TIMELINE = 20
+# Event count at which the timeline COUNT component reaches full credit: a case
+# with this many material, dated, ordered events is "complete enough" and must
+# not be docked for not reaching the gold length — concise timelines are the
+# editorial standard, not 20-event ones.
+ENOUGH_TIMELINE = 6
 GOLD_SOURCES = 7
 SUBSTANTIAL_DESC_CHARS = 600
 
@@ -395,8 +400,10 @@ def timeline(case):
     # is deliberately NO per-event character-length reward/penalty: a concise
     # "date + brief event" entry is the editorial standard, so the old <60-char
     # "thin" check punished correct timelines and rewarded verbose
-    # mini-paragraphs. Its 25 points are redistributed to the real signals.
-    pts += min(n / GOLD_TIMELINE, 1.0) * 45
+    # mini-paragraphs. The count reaches full credit at ENOUGH_TIMELINE events
+    # (not the gold length), so a complete-but-concise timeline scores ~100
+    # instead of being docked for not having ~20 events.
+    pts += min(n / ENOUGH_TIMELINE, 1.0) * 45
     pts += (with_ad / n) * 20
     pts += (with_bs / n) * 20
     pts += 15 if ordered else 0


### PR DESCRIPTION
## Summary
Resolves the second "tune before deploy" benchmark item. #256's `timeline_completeness` change removed the verbose-event reward but redistributed those points into the event **count**, scaled to the 20-event gold length — so a complete-but-concise timeline re-baselined ~6 **below** the old scoring instead of lifting (the opposite of the intent).

**Fix:** add `ENOUGH_TIMELINE = 6` — the count component reaches full credit at 6 material (dated, ordered) events instead of 20, so a complete concise timeline scores ~100.

## Validation (51 priority cases, deployed #256 → recalibrated)
- The 6 over-flagged timelines **lift to 100**: 0047 91→100, 0060 82→100, 0064 86→100, 0070 82→100, 0093 89→100, 0172 100→100.
- Mean **+20.2** across the 51; **50 up / 1 same / 0 down** (no regressions).

This completes the two benchmark tunables (3Q note-only in #259; 3E here). Ready for the poller image bump + full re-grade after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline reviews now award full credit after fewer events, making concise but complete timelines score appropriately.
  * Adjusted timeline scoring so shorter timelines are no longer penalized when they still meet the completeness threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->