### PR TITLE
material_convert: OCR source documents into full-text search (data-plane FTS feed)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,13 +78,30 @@ per-type Pydantic models were deleted in NES.
   idea was dropped.
 - Draft/in-review cases are **not indexed** and not publicly retrievable.
 
-## 5. Storage / lakehouse
+## 5. Storage / data plane (Postgres-SoR, lakehouse-lite)
 
-- Object store: **Cloudflare R2** (S3-compatible); local dev uses MinIO.
-- Lakehouse: **Apache Iceberg + DuckDB**, Lakekeeper (Iceberg REST catalog) — all
-  free/OSS (hard constraint: no paid tiers; see `shared/research/COST-AUDIT.md`).
-- NGM `ngm_service/lakehouse/` is the medallion (bronze/silver/gold) module
-  (in-process, not a separate service). The R2 JSON-LD index publish is implemented.
+The full design + decisions are in [`data-plane-design.md`](./data-plane-design.md);
+the shape today:
+
+- **Three planes, none on another's hot path.** **Serving** = the 3 Postgres DBs
+  (SoR for everything served) + **Search** = unified OpenSearch (§3) + **Archive** =
+  **Cloudflare R2** object store (raw bytes + OCR/likhit markdown + provenance;
+  immutable SoR for raw evidence — this is where the storage bulk lives; local dev
+  uses MinIO). Heavy async work runs on the central `jobs` queue (§ below).
+- **Postgres is the system of record**, NOT a lake. The served structured corpus is
+  only tens of GB (entity JSONB, court cases); the large storage figure is R2 object
+  bytes, referenced by URL (one copy).
+- **No Iceberg / DuckDB / Lakekeeper lake right now ("lakehouse-lite").** The
+  `lakehouse/` module (Apache Iceberg + DuckDB + Lakekeeper, all free/OSS — see
+  `shared/research/COST-AUDIT.md`) is a **DORMANT, tested seam**, kept Iceberg-ready
+  but not the shipped storage layer. Its medallion framing ("silver is the source /
+  Postgres derived from silver") is **superseded**: any future silver is derived
+  *from* Postgres + the R2 archive, never the reverse. Revisit only when a real
+  recurring cross-domain analytical query (or serving-Postgres latency from analyst
+  SQL) earns it (`data-plane-design.md` §6).
+- **Full-text search over materials** is fed by the async `material_convert` job kind:
+  OCR/likhit → markdown in R2 (`linkRole=MARKDOWN`) → `Material.data["text"]` → unified
+  search reindex (`data-plane-design.md` §5).
 
 ## 6. Data sourcing (the live program)
 

--- a/docs/data-plane-design.md
+++ b/docs/data-plane-design.md
@@ -1,0 +1,376 @@
+# Data Plane Design — Consolidation (Postgres-SoR, lakehouse-lite)
+
+**Status:** DRAFT for review · **Date:** 2026-07-01 · **Branch:** off `v2`. Foundations all
+merged: control-plane `80e2462`; jobs queue #262 `7458cbd`; **ADR cases-own-no-documents
+merged in PR #263** (`712dc2b`) — Materials is the sole document store on `v2` today.
+
+**Goal.** One coherent data plane serving three domains (NES entities, NGM
+courts/governance, Jawafdehi cases) at target scale, read-heavy via the website,
+long-term-stable, **free-OSS-only** (R2 PAYG is the sole accepted spend). This doc
+**decides the direction of truth** and **reconciles two prior docs that contradicted
+each other** on it (see §7).
+
+This is a *consolidation* doc, not a greenfield: the merged control plane and the
+built jobs queue did most of the construction. What remains is small glue + one gap.
+
+---
+
+## 0. Decisions (locked in session)
+
+1. **Postgres (3 DBs + router) is the system of record** for all *served* structured
+   data — entities, court cases/hearings/parties, material metadata, corruption cases.
+2. **No Iceberg / DuckDB / Lakekeeper lake right now.** "Lakehouse-lite." The
+   `lakehouse/` module (`schema.py`, `engine.py`, `medallion.py`, `config.py`) is
+   marked **DORMANT, not deleted** — it is the Iceberg-ready seam if an isolated
+   analytical/SQL workload ever earns it (§6). This is consistent with the standing
+   platform discipline ("no Iceberg for 10³–10⁵ rows", jobs-queue-design §0).
+3. **Materials is the single universal document store** across all three domains
+   (per [`jawafdehi/adr-cases-own-no-documents.md`](./jawafdehi/adr-cases-own-no-documents.md)).
+   There is exactly one document resource — `/api/materials` — with exactly one owner.
+4. **Full-text search over materials lives in OpenSearch**, fed from the OCR/likhit
+   markdown. Never in DuckDB.
+5. **Async heavy work (OCR/extraction, reindex, enrich) runs on the central `jobs`
+   queue**, not in the request path or a broker.
+
+---
+
+## 1. The three planes (+ one cross-cutting)
+
+Every access pattern the platform has maps to one plane, and **no plane sits on
+another's critical path**:
+
+```
+  scrapers / ingestion (/api/ingestion/*) / upload (/api/materials/.../file)
+        │                                   [ALL MERGED — R6, feat/jobs-queue]
+        ▼
+  ┌──────────────────────────────────────────────────────────────┐
+  │ ARCHIVE PLANE (R2)  — the object bytes (the bulk of storage)   │
+  │   raw capture bytes                       [EXISTS: upload→R2]  │
+  │   OCR/likhit markdown  (linkRole=MARKDOWN) [GAP: extraction]   │
+  │   provenance sidecar   (source_url, ocr_*, sha256, …) [GAP]    │
+  │   → immutable; system of record for RAW EVIDENCE               │
+  └───────────────┬───────────────────────────────┬──────────────┘
+     text → Material.data["text"]        bytes referenced by URL (one copy)
+                  ▼                                 ▼
+  ┌───────────────────────────┐        ┌───────────────────────────────┐
+  │ SERVING PLANE — Postgres   │        │ SEARCH PLANE — OpenSearch       │
+  │  SoR. 3 DBs + router:      │───────►│  4 indices, bilingual.          │
+  │   nes: entities            │ index  │  materials `body` = full text   │
+  │   ngm: courts, materials   │        │   [MACHINERY EXISTS; needs feed]│
+  │   default: cases, JOBS     │        │  visibility-gated (draft≠public)│
+  │  point + list reads (hot)  │        │  point + faceted + FTS (hot)    │
+  └───────────────────────────┘        └───────────────────────────────┘
+                  ▲
+        website reads hit Postgres + OpenSearch ONLY (never the archive engine)
+
+  JOBS QUEUE (default DB) — async plane cutting across ingestion→archive→search:
+    kind=material_convert: bytes → OCR markdown → data["text"] → reindex   [GAP: handler]
+    kind=case_review (ported), reindex/enrich (opportunistic)         [BUILT]
+```
+
+**Cross-cutting: the archive is the evidentiary backbone.** For an anti-corruption
+platform, "show me the original `*.gov.np` capture, with when/how we fetched it" is a
+first-class requirement, independent of any analytics ambition. That is why the archive
+plane exists in *every* version of this design, lake or no lake.
+
+---
+
+## 2. Serving plane — Postgres is SoR (unchanged topology)
+
+- **3 DBs + router, no cross-DB FKs/joins** (`monolith/config/db_router.py`). Entities →
+  `nes`; courts + materials → `ngm`; cases + **jobs** → `default`. This is already built,
+  proven, and matches "read-heavy + long-term stability" better than anything else here.
+- **Storage form:** schema.org JSON-LD in a JSONB `data` column, keyed by `@id` IRI, with
+  promoted typed columns for what we filter on (`entity_type`, `material_type`, `source`,
+  `court_identifier`, dates…) + a GIN index on `data` for containment filters.
+  `entities.StoredEntity`, `materials.Material`, `courts.CourtCase/*` already do this.
+- **Cross-domain joins are forbidden here** (router `allow_relation`). Domains link by
+  **string `@id` IRI**, never a cross-DB FK — the same rule the ADR applies to cases.
+  This is the constraint that *would* have justified a lake (§6); for now cross-domain
+  work is per-domain queries joined in app, which suffices at this scale.
+
+**Scale check (why Postgres is comfortable):** the *structured* corpus is tens of GB
+(1M entity JSONB docs ≈ a few GB; 10M court cases + ~10× hearings ≈ tens of GB; 10k CIAA
+cases trivial). The large storage figure is **object bytes in the archive plane**, not
+database. Postgres is not the scale risk; the archive-plane object count is.
+
+---
+
+## 3. Archive plane — R2, immutable, the document bulk
+
+**Owner: Materials only.** Per the ADR, every document in the platform — case evidence,
+court orders, charge sheets, reports, legal corpus — is a `Material` with an `@id`; there
+is no `DocumentSource` and no per-domain document table. So the archive plane has one
+writer path and one vocabulary.
+
+**What's already built (R6, merged):** `POST /api/materials/<source>/<ident>/file`
+streams the uploaded file to R2 (shared hashed-filename S3 mechanism) and appends a
+`contentUrl` `MediaObject` with a `jawafdehi:linkRole` to the Material's `associatedMedia`
+(`materials/views.py:248`). `/api/ingestion/{cases,entities/resolve,documents}` are real
+batch writers (`courts/views.py:352+`).
+
+**What consolidation adds (the two archive gaps):**
+
+1. **OCR/likhit markdown as a roled link.** The extraction step (async, §5) produces
+   Devanagari-aware markdown from the raw bytes and stores it in R2 as a
+   **`linkRole=MARKDOWN`** MediaObject (the role already exists —
+   `materials/jsonld.py:120`) *and* folds the text into `Material.data["text"]` (the field
+   the search indexer already reads — §4). Standard recipe: `shared/ocr_bedrock.py`
+   (PyMuPDF render + multimodal Claude on Bedrock).
+2. **Provenance sidecar + content-hash idempotency.** Each capture lands a
+   `provenance` record (`source_url`, `fetch_method`, `tls_status`, `ocr_engine`,
+   `ocr_confidence`, `scraped_at`, `sha256`). Re-landing the same bytes is idempotent on
+   the content hash. This formalizes what is ad-hoc in `material_uploads/` today. (The
+   dormant `lakehouse/medallion.BronzeObject` already sketches this struct — reuse the
+   shape, land it as Material provenance, not an Iceberg bronze row.)
+
+**R2 layout (prefix-partitioned, one account):**
+```
+material/<source>/<ident>/<sha256>.<ext>     raw capture (immutable)
+material/<source>/<ident>/<sha256>.md        OCR/likhit markdown  (linkRole=MARKDOWN)
+material/<source>/<ident>/<sha256>.prov.json provenance sidecar
+```
+Bytes are referenced by URL from the Material JSON-LD — **one copy**, no duplication of
+the storage bulk into the DB or the index.
+
+### 3.1 How a Material links to its files (the field-level contract)
+
+The URLs are **not** promoted columns. They live inside the Material's JSONB `data`
+column as a list of schema.org **`MediaObject`** entries under **`associatedMedia`**.
+Every URL variant — the R2-hosted PDF, an external permalink, the source HTML page, the
+OCR markdown — is one MediaObject, shaped by `materials/jsonld._media_object`
+(`jsonld.py:124`). The `Material` row itself promotes only routing/filter columns
+(`iri` = the `@id` PK, `material_type`, `source`, `ident`); URLs stay in the JSON-LD.
+
+**Two axes carry everything you asked about:**
+- **Which variant a URL is → `jawafdehi:linkRole`** (an enum on the MediaObject, not
+  separate fields): `RAW` | `ALTERNATE` | `PERMALINK` | `SOURCE_PAGE` | `MARKDOWN`. The
+  upload endpoint takes this as the `role` multipart param (default `RAW`,
+  `views.py:291`); `SOURCE_PAGE`+`MARKDOWN` were added by the ADR so no legacy
+  `SourceLinkRole` value is lost.
+- **Where the bytes live → the value of `contentUrl`.** A MediaObject does not care
+  whether we host the file: an R2 object URL (written by `store_file_as_link` on upload)
+  and an external `*.gov.np` permalink (straight from a scraper's roled link) are *both*
+  just a `contentUrl` string with a role. One uniform representation, hosted or linked.
+
+**Per-`MediaObject` fields:**
+
+| Field | Meaning | Code |
+|---|---|---|
+| `@type` | always `"MediaObject"` | `jsonld.py:131` |
+| `contentUrl` | the URL itself (R2 object, permalink, source page…) | `jsonld.py:132` |
+| `jawafdehi:linkRole` | which variant (`RAW`/`ALTERNATE`/`PERMALINK`/`SOURCE_PAGE`/`MARKDOWN`) | `jsonld.py:133` |
+| `encodingFormat` | MIME; auto for SOURCE_PAGE→`text/html`, MARKDOWN→`text/markdown` (`_ROLE_ENCODING_HINTS`), else guessed from filename | `jsonld.py:135-137`, `views.py:235-237` |
+| `identifier` | optional — the logical `document_id`, so media trace back to their source doc | `jsonld.py:165-166` |
+
+**Example** (a court order with the R2 scan, its OCR markdown, and an upstream permalink):
+```json
+{
+  "@id": "https://jawafdehi.org/material/court_order/supreme.082-oa-0503",
+  "@type": ["Manuscript", "DigitalDocument"],
+  "name": {"ne": "..."},
+  "text": {"ne": "<OCR full text — the FTS field, see §4>"},
+  "associatedMedia": [
+    {"@type": "MediaObject", "contentUrl": "https://<r2>/material/court_order/supreme.082-oa-0503/<sha256>.pdf",
+     "jawafdehi:linkRole": "RAW", "encodingFormat": "application/pdf"},
+    {"@type": "MediaObject", "contentUrl": "https://<r2>/material/court_order/supreme.082-oa-0503/<sha256>.md",
+     "jawafdehi:linkRole": "MARKDOWN", "encodingFormat": "text/markdown"},
+    {"@type": "MediaObject", "contentUrl": "https://supremecourt.gov.np/...",
+     "jawafdehi:linkRole": "PERMALINK"}
+  ]
+}
+```
+
+**The OCR step writes two distinct fields — do not conflate them (see §5):**
+1. `associatedMedia[linkRole=MARKDOWN]` with `contentUrl` = the R2 `.md` URL — "here is
+   the markdown **file**" (a retrievable roled link).
+2. `data["text"]` (language-mapped `{"ne": …}`) — "here is the **text**" — the field
+   `materials/search_index.py:58` indexes into the OpenSearch `body` for FTS/snippets.
+
+The same conversion produces both. Court orders reach `associatedMedia` via
+`media_objects_from_document_sources` (reading the court-case `document_sources` JSONB
+`{document_id, url:[{link, role}]}`). **PR #263 completes the convergence for cases:**
+Jawafdehi's old `DocumentSource` rows are projected to full Materials by
+`documentsource_to_jsonld` + `build_source_material_iri` (source segment `jawafdehi`), and
+a case binds them via **`CaseMaterialReference`** (`material_iri` required + strict, optional
+`additional_details`, `ordinal`) — never a local copy. So **one link representation —
+`associatedMedia` MediaObjects on a Material — is now the single form everywhere**: upload,
+NGM ingestion, the court `document_sources` converter, and the Jawafdehi source→Material
+projection all feed it. The `MARKDOWN` + `SOURCE_PAGE` roles used above were added by #263
+so no legacy `SourceLinkRole` value is lost.
+
+---
+
+## 4. Search plane — OpenSearch, bilingual FTS over materials
+
+**The FTS machinery is already complete.** The only thing missing is the *feed*.
+
+- **Mapping** (`shared/jawafdehi_shared/search/mappings.py`): the shared index doc has a
+  bilingual **`body`** field — `mixed_script` analyzer + `ne`/`en`/`translit` subfields —
+  purpose-built for mixed Devanagari/Roman OCR text, plus title/keywords/identifiers.
+- **Indexer** (`materials/search_index.py:58-60`): `body` is populated from
+  `data["text"]` (schema.org full-text) + `data["description"]`.
+- **Query + snippets** (`search/service.py`): `body` is boosted, matched (`best_fields`),
+  and **highlighted** for snippets in the `/api/search/` envelope.
+
+**⇒ The one gap:** nothing populates `Material.data["text"]` today. The upload endpoint
+stores bytes + a `contentUrl`, but never extracts text. So a material is findable by
+title/description but **not by full text**. Closing this is exactly the `material_convert`
+job (§5) writing `data["text"]`; everything downstream already indexes and searches it.
+
+**Sizing (estimate).** 1M materials, Devanagari at 3 bytes/char, mixed doc lengths
+(≈70% short orders/notices ~1–2pp, ~25% medium charge-sheets ~6pp, ~5% long reports
+~50pp) ⇒ **~40 KB extracted text/material ⇒ ~40 GB raw text**. In OpenSearch with the
+bilingual dual-analysis + stored `_source` for highlighting: **~60–100 GB primary,
+~120–200 GB with one replica**. Court cases add ~10–20 GB. A modest 3-node cluster
+handles this; FTS is a small, bounded serving workload — **not** a lake-scale problem.
+*Knob:* store full text in `_source` (needed for highlighting; recommended at this size)
+vs index-only — the difference between a ~100 GB and ~60 GB index.
+
+**Visibility gate (LANDED in PR #263 — `materials/visibility.py`).** With `DocumentSource`
+gone, a Material is the only row, and it lives in the public `ngm` DB. `Material.visibility`
+(LISTED / UNLISTED / PRIVATE, default LISTED) is computed as the **MAX over the states of
+all referring cases** — a draft case pulls its evidence Material down to PRIVATE. It is the
+**draft-leak guard**, honored by three read surfaces: sitemaps/ResourceSync
+(`discovery/corpus.py`), the unified-search signal, and the retrieve/list endpoints (anon
+sees LISTED; +UNLISTED by direct IRI; PRIVATE authed-only). Recompute fires **live** on case
+create / evidence-change / state-transition / soft-delete, over the **union of current +
+removed** IRIs (`materials/signals.py` + the write paths); `recompute_all()` is the
+init/reconciler backstop (run once post prod-migration). This is a data-plane invariant, not
+just a casework detail.
+
+---
+
+## 5. Async plane — the `jobs` queue, and `material_convert` (IMPLEMENTED)
+
+The FTS-feed gap and every other heavy step run as **kinds** on the central Postgres
+`jobs` queue (#262, built: claim/lease/reaper/retry/dedup/priority + `/api/jobs/*` +
+dashboard; `case_review` ported). No new async mechanism — we register handlers.
+
+- **`material_convert` (the kind that closes the FTS gap) — IMPLEMENTED.** The three seams
+  mirror `case_review` exactly and split the same way (server-side hooks in the API;
+  worker-side conversion in the consumer, so the heavy conversion deps never import into
+  API pods). **All code is in-repo — no dependency on anything outside the repo/worktree.**
+  - **enqueue** — `materials/conversion.py::enqueue_material_convert(iri)` is called from
+    the upload endpoint after a successful upsert (only for convertible roles
+    RAW/ALTERNATE/PERMALINK — not our own MARKDOWN output or SOURCE_PAGE HTML), dedup on
+    `material_convert:<iri>`, best-effort so a queue hiccup never fails the upload.
+  - **build_payload** (server, at claim) — resolves the source document URL(s) from the
+    Material's `associatedMedia` by role preference → hands the DB-free worker
+    `{source_urls}`; fails fast if the material is gone or has no convertible source.
+  - **worker handler** — `materials/job_handlers.py::handle_material_convert` reuses the
+    **in-repo** `review.converter.convert_source` (likhit/MarkItDown — declared deps, with
+    download + Devanagari OCR at a Bedrock-safe DPI + on-disk caching + a per-source
+    timeout already built in), tries source URLs in order, `on_stage` pings progress,
+    returns `{text, source_url}`.
+  - **on_result** (server) — `apply_convert_result` stores the markdown in R2 as a
+    `linkRole=MARKDOWN` MediaObject (replace-or-append, idempotent) and sets
+    `data["text"]`; the `Material` `post_save` signal reindexes into unified search.
+  - Registered in `jobs/consumers.py` with **lease 1800s / max_attempts 2**; the poller
+    aggregates `materials.job_handlers.HANDLERS` (`review_poller --kinds material_convert`,
+    or combined with `case_review`).
+  - **No `on_failure`:** a failed convert just leaves `data["text"]` unset — the Material
+    is still served + metadata-searchable, and a re-upload re-runs (dedup key freed on
+    terminal state).
+- **Why this shape:** the write path stays fast (OCR is off-request), and it reuses the
+  exact `claim/stage/result` contract the review poller already speaks. `reindex_*` /
+  `enrich_ciaa_*` become kinds opportunistically.
+  - **Note — enqueue is NOT transactional with the material write.** `Job` lives on the
+    `default` DB, `Material` on `ngm` (the router forbids a cross-DB transaction). So the
+    enqueue is **best-effort after** the upsert: if it fails, the file is still stored and
+    a re-upload re-enqueues (dedup makes that safe). This is *why* the convert is idempotent
+    and re-runnable, rather than relying on atomic enqueue. A true exactly-once enqueue
+    would need an outbox on the `ngm` DB — deliberately not built (the re-run path covers it).
+- **Follow-up:** wire the same `enqueue_material_convert` call into the `/api/ingestion/*`
+  batch document path (the interactive upload is done); and land the provenance sidecar
+  (§8 item 2) so a convert can also be driven from a re-scrape.
+
+---
+
+## 6. Why no lake now — and the seam that keeps it cheap later
+
+The only workload that genuinely wants columnar-scan-over-object-storage is
+**cross-domain investigative analytics** (e.g. "asset-declaration wealth jumps in the FY a
+linked contractor won a tender", joining assets ↔ courts ↔ procurement ↔ blacklist) plus a
+gated ad-hoc `SELECT` plane. That is real to the mission but has **no concrete first query
+queued**, and the DB router forbids exactly those joins in Postgres today.
+
+**Decision: defer.** Build archive + serving + search + async first. Keep the lake
+*possible* by construction:
+- `lakehouse/` stays as a **dormant, tested seam** (DDL/secret builders are real and
+  unit-checked; only the live `ATTACH` is stubbed).
+- The **`@id` IRI is the universal join key**, so a future lake can join across domains
+  the router forbids — the lake becomes precisely "where cross-domain joins legally happen".
+- The archive plane's immutable raw + markdown is exactly a **bronze zone** already; a
+  future silver derivation reads from it + Postgres without re-scraping.
+
+**Revisit trigger:** a real, recurring cross-domain analytical query, or serving-Postgres
+latency pressure from ad-hoc analyst SQL. Until then, Iceberg/DuckDB/Lakekeeper +
+compaction cron are operational cost with no serving benefit. (If analytics is later
+wanted *cheaply* before a full lake, a Postgres **read replica** for analyst SQL is the
+smaller intermediate step.)
+
+---
+
+## 7. Docs reconciled / amended by this doc
+
+- **`ARCHITECTURE.md` §5 ("Storage / lakehouse")** — currently states the lakehouse *is*
+  Iceberg + DuckDB + Lakekeeper. **Amend** to: Postgres-SoR serving + R2 archive +
+  OpenSearch; Iceberg deferred (`lakehouse/` dormant). The medallion module is a seam, not
+  the shipped lake.
+- **`lakehouse/medallion.py` + `schema.py`** — their framing that "silver is the source /
+  the relational Postgres view is *derived* from silver" is **superseded**: Postgres is
+  SoR; if silver ever exists it is *derived from* Postgres + archive, never the reverse.
+  The `schema.py` TableSpecs remain a useful **blueprint for future `ngm`-DB Django models**
+  (procurement/budget/audit/assets/gazette) — as relational tables, not Iceberg tables.
+- **`jawafdehi/adr-cases-own-no-documents.md`** — **incorporated, not amended**, and now
+  **implemented + MERGED (PR #263, `712dc2b`)**: `Material.visibility` +
+  `materials/visibility.py`, `CaseMaterialReference`, `cases/services/material_resolver.py`
+  (`resolve_materials`) + `material_ingest.py`, the `documentsource_to_jsonld` projection,
+  `MARKDOWN`/`SOURCE_PAGE` roles, and `news`/`social_media` types are all landed code (822
+  unit tests green). It is the document-ownership foundation of this plane: Materials =
+  universal doc store; `visibility` mandatory (§4); MARKDOWN linkRole (§3); one
+  `material_type` vocabulary. **Follow-ups tracked by #263 (not this doc):** the ~799-row
+  prod `DocumentSource`→Material data migration (runbook
+  `docs/jawafdehi/sources-to-materials-prod-migration.md`, run separately + `recompute_all()`
+  once after); the frontend + MCP "Document Source" terminology purge (ADR D-E, other repos);
+  the CIAA content-enrichers left stubbed (`NotImplementedError`) as a separate effort.
+- **`jobs-queue-design.md`** — **incorporated.** `material_convert` (its §5 step 4) is the
+  data plane's async extraction kind (§5).
+
+---
+
+## 8. Work items (small — most heavy lifting already merged)
+
+Ordered by value/risk. None is a rewrite.
+
+1. ✅ **DONE — Close the FTS feed (highest value).** The `material_convert` kind
+   (`materials/conversion.py` + `materials/job_handlers.py`, registered in
+   `jobs/consumers.py`, enqueued from the upload endpoint) does bytes → OCR markdown → R2
+   (`linkRole=MARKDOWN`) → `Material.data["text"]` → reindex. 14 unit tests + suite green;
+   `manage.py check` clean; ruff clean. *Delivers full-text search over materials end to
+   end.* Remaining thread: also enqueue from `/api/ingestion/documents` (§5 follow-up).
+2. **Formalize archive provenance.** Add the `provenance` sidecar + content-hash
+   idempotency to the existing upload/ingest path; adopt the R2 layout (§3).
+3. ✅ **DONE — Reconcile the docs (§7).** `ARCHITECTURE.md §5` rewritten to Postgres-SoR /
+   lakehouse-lite; `lakehouse/__init__.py` bannered DORMANT + blueprint (supersedes the
+   "silver is SoR" framing in `medallion.py`/`schema.py`).
+4. **Governance-domain tables (when sourced):** turn the `schema.py` specs
+   (procurement/budget/audit/assets/gazette) into `ngm`-DB Django models — additive, only
+   when data for them is actually acquired.
+
+**Already landed elsewhere (was planned here — do not re-scope):**
+- `Material.visibility` + the draft-leak gate across search/sitemaps/retrieve (PR #263, §4).
+- The single link representation (`associatedMedia`) + `CaseMaterialReference` binds + the
+  source→Material projection (PR #263, §3.1).
+- The async queue itself — claim/lease/retry/dedup/`/api/jobs/*` (#262).
+
+**Related follow-up owned elsewhere:** the ~799-row prod `DocumentSource`→Material data
+migration (PR #263 runbook), and the frontend/MCP terminology purge (ADR D-E).
+
+## 9. Out of scope
+
+- Iceberg/DuckDB/Lakekeeper, compaction cron, silver/gold Iceberg zones (§6 — deferred).
+- Merging the 3 Postgres DBs into 1 (separate project; router keeps them isolated).
+- A broker for the async plane (jobs-queue-design §0 — Postgres queue, no Celery/Redis).
+- Any second copy of the object bytes; the archive holds one copy, referenced by URL.

--- a/jobs/consumers.py
+++ b/jobs/consumers.py
@@ -108,3 +108,37 @@ register(
         on_failure=_case_review_on_failure,
     )
 )
+
+
+# --- material_convert: OCR a Material's source document → data["text"] -------
+#
+# The data-plane FTS feed (docs/data-plane-design.md §5). build_payload resolves
+# the source document URL(s) from the Material's associatedMedia (server-side, so
+# the consumer stays DB-free); on_result stores the OCR markdown as a MARKDOWN
+# MediaObject and sets data["text"] (the field the search indexer reads). The
+# worker-side OCR handler lives in materials.job_handlers (heavy deps off the API).
+
+
+def _material_convert_build_payload(job) -> dict:
+    from materials.conversion import build_convert_payload
+
+    return build_convert_payload(job)
+
+
+def _material_convert_on_result(job, result: dict) -> None:
+    from materials.conversion import apply_convert_result
+
+    apply_convert_result(job, result)
+
+
+register(
+    KindSpec(
+        kind="material_convert",
+        lease_seconds=1800,  # 300-page OCR is minutes; heartbeat extends per page.
+        max_attempts=2,  # network/OCR flakes retry once; then dead-letter.
+        build_payload=_material_convert_build_payload,
+        on_result=_material_convert_on_result,
+        # No on_failure: a failed convert just leaves data["text"] unset; the
+        # Material is still served (metadata-searchable), and a re-upload re-runs.
+    )
+)

--- a/lakehouse/__init__.py
+++ b/lakehouse/__init__.py
@@ -1,12 +1,23 @@
-"""NGM lakehouse service layer (DuckDB / Iceberg over Cloudflare R2).
+"""NGM lakehouse service layer (DuckDB / Iceberg over Cloudflare R2) — DORMANT.
 
-A plain service module — deliberately NOT Django models. The court relational
-tables (``courts.models``) are the Postgres projection; this package
-is the medallion (bronze/silver/gold) substrate over object storage, queried
-through DuckDB + an Iceberg REST catalog rather than the ORM.
+**Status: dormant, Iceberg-ready seam — NOT the shipped storage layer.** The
+platform data plane is **Postgres-SoR, lakehouse-lite**: Postgres (3 DBs) is the
+system of record for served data, R2 is the immutable archive, OpenSearch serves
+search. There is deliberately **no live Iceberg/DuckDB/Lakekeeper lake right now**
+(see ``docs/data-plane-design.md`` §6 and ``docs/ARCHITECTURE.md`` §5).
 
-Ported from the FastAPI ``ngm.lakehouse`` package. Everything imports cleanly
-with no native/network dependency; the live-R2 / live-catalog boundary
-(``engine.connect`` ATTACH, the ``medallion`` bronze/silver/gold bodies) is
-stubbed with ``NotImplementedError`` + a precise TODO, exactly as upstream.
+This package is kept — fully importable, DDL/secret builders real and unit-tested —
+so a lake can be stood up cheaply *if* a real recurring cross-domain analytical
+query ever earns it. Until then it is not wired into any serving path.
+
+**Superseded framing:** the medallion docstrings below describe silver as the
+source with the Postgres tables *derived from* it. That direction is reversed:
+Postgres + the R2 archive are the source; any future silver is derived *from*
+them, never the other way. Read the medallion/schema modules as a **blueprint**
+(e.g. the ``schema.py`` TableSpecs → future ``ngm``-DB Django models for
+procurement/budget/audit/assets/gazette), not as the current storage contract.
+
+Everything imports cleanly with no native/network dependency; the live-R2 /
+live-catalog boundary (``engine.connect`` ATTACH, the ``medallion``
+bronze/silver/gold bodies) is stubbed with ``NotImplementedError`` + a precise TODO.
 """

--- a/materials/conversion.py
+++ b/materials/conversion.py
@@ -64,7 +64,12 @@ def source_urls(data: dict[str, Any]) -> list[str]:
     """
     by_role: dict[str, list[str]] = {r: [] for r in _SOURCE_ROLES}
     for mo in _media_list(data):
-        url = (mo.get("contentUrl") or "").strip()
+        # contentUrl comes from free-form JSONB; guard against a non-string
+        # (int/list/dict) so a malformed doc can't crash the whole convert.
+        raw_url = mo.get("contentUrl")
+        if not isinstance(raw_url, str):
+            continue
+        url = raw_url.strip()
         if not url:
             continue
         role = mo.get("jawafdehi:linkRole") or "RAW"
@@ -132,6 +137,7 @@ def apply_convert_result(job, result: dict) -> None:
     here leaves the job DONE but the text unset — a re-run (re-upload) recovers.
     """
     from django.core.files.base import ContentFile
+    from django.db import transaction
 
     from jawafdehi_shared.storage import store_file_as_link
 
@@ -143,35 +149,52 @@ def apply_convert_result(job, result: dict) -> None:
 
     from .models import Material
 
-    row = Material.objects.filter(pk=iri, is_deleted=False).first()
-    if row is None:
+    # Cheap pre-check so we don't upload to R2 for a material that's already gone.
+    if not Material.objects.filter(pk=iri, is_deleted=False).exists():
         logger.warning("material_convert %s: material gone before result apply", iri)
         return
 
     # 1) Land the markdown in R2 as a roled MARKDOWN link (hashed filename).
-    # NOTE: store_file_as_link uses FILE_STORAGE_PREFIX (default "case_uploads/"),
-    # so the .md currently lands under that shared prefix. The material-specific
-    # R2 layout (docs/data-plane-design.md §3) is folded in with the provenance
-    # work (§8 item 2); until then the link is correct, just not prefix-isolated.
+    # Done OUTSIDE the DB transaction below — a network round-trip must not hold a
+    # row lock. NOTE: store_file_as_link uses FILE_STORAGE_PREFIX (default
+    # "case_uploads/"), so the .md currently lands under that shared prefix. The
+    # material-specific R2 layout (docs/data-plane-design.md §3) is folded in with
+    # the provenance work (§8 item 2); until then the link is correct, just not
+    # prefix-isolated.
     md_file = ContentFile(text.encode("utf-8"), name="material.md")
     link = store_file_as_link(md_file, role="MARKDOWN")
 
-    data = dict(row.data or {})
-    # 2) Replace-or-append the MARKDOWN MediaObject (idempotent re-run).
-    media = [
-        mo
-        for mo in _media_list(data)
-        if (mo.get("jawafdehi:linkRole") or "RAW") != "MARKDOWN"
-    ]
-    md_mo = jsonld._media_object({"link": link["link"], "role": "MARKDOWN"})
-    if md_mo is not None:
-        media.append(md_mo)
-    data["associatedMedia"] = media
-    # 3) The searchable full text (language-mapped, per MATERIAL_CONTEXT).
-    data["text"] = {_TEXT_LANG: text}
+    # 2) Read-modify-write the JSONB doc under a row lock so a concurrent write
+    # (e.g. a re-upload upserting the same @id) can't clobber our text, or ours
+    # theirs — the whole ``data`` blob is rewritten, so a naive read+save would
+    # lose the other writer's fields (lost-update).
+    with transaction.atomic():
+        row = (
+            Material.objects.select_for_update()
+            .filter(pk=iri, is_deleted=False)
+            .first()
+        )
+        if row is None:  # deleted between the pre-check and the lock
+            logger.warning(
+                "material_convert %s: material gone before result apply", iri
+            )
+            return
+        data = dict(row.data or {})
+        # Replace-or-append the MARKDOWN MediaObject (idempotent re-run).
+        media = [
+            mo
+            for mo in _media_list(data)
+            if (mo.get("jawafdehi:linkRole") or "RAW") != "MARKDOWN"
+        ]
+        md_mo = jsonld._media_object({"link": link["link"], "role": "MARKDOWN"})
+        if md_mo is not None:
+            media.append(md_mo)
+        data["associatedMedia"] = media
+        # The searchable full text (language-mapped, per MATERIAL_CONTEXT).
+        data["text"] = {_TEXT_LANG: text}
 
-    row.data = data
-    row.save(update_fields=["data", "updated_at"])  # post_save → reindex
+        row.data = data
+        row.save(update_fields=["data", "updated_at"])  # post_save → reindex
     logger.info(
         "material_convert %s: stored %d chars markdown + text (from %s)",
         iri,

--- a/materials/conversion.py
+++ b/materials/conversion.py
@@ -1,0 +1,180 @@
+"""Server-side plumbing for the ``material_convert`` job kind (OCR → full text).
+
+This is the *data-plane FTS feed*: a Material that carries a file (a RAW/source
+document link) but no extracted ``text`` is not full-text searchable — the
+unified-search indexer reads ``data["text"]`` (``materials/search_index.py``),
+and nothing populates it on upload. ``material_convert`` closes that gap
+asynchronously on the central ``jobs`` queue.
+
+The three seams here are the SERVER-side halves of the job (the worker-side
+conversion handler lives in ``materials.job_handlers``, which reuses the in-repo
+``review.converter`` — likhit/MarkItDown — so its heavy deps never import into the
+API process):
+
+- :func:`enqueue_material_convert` — transactional enqueue (dedup on the IRI) from
+  a file-bearing write path (the upload endpoint, ingestion).
+- :func:`build_convert_payload` — resolve the source file URL(s) from the
+  Material's ``associatedMedia`` at claim time, so the DB-free consumer gets its
+  input without touching the DB. Registered as the kind's ``build_payload`` hook.
+- :func:`apply_convert_result` — persist the worker's extracted text: store the
+  markdown in R2 as a ``MARKDOWN`` MediaObject and set ``data["text"]``, then save
+  the Material (the ``post_save`` signal reindexes it). The kind's ``on_result``.
+
+Only :func:`build_convert_payload` / :func:`apply_convert_result` are wired into
+the queue (``jobs.consumers``); OCR itself is the worker's job.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from . import jsonld
+
+logger = logging.getLogger("materials.conversion")
+
+CONVERT_KIND = "material_convert"
+
+#: Link roles whose ``contentUrl`` is an original document worth OCR-ing, in
+#: preference order. MARKDOWN is intentionally excluded (it's our own output);
+#: SOURCE_PAGE is HTML, not a document scan.
+_SOURCE_ROLES = ("RAW", "ALTERNATE", "PERMALINK")
+
+#: Language tag for the extracted text map (``{"ne": …}``); NGM documents are
+#: Nepali. The indexer's ``body`` analysis handles Devanagari + transliteration.
+_TEXT_LANG = "ne"
+
+
+def _media_list(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """The Material's ``associatedMedia`` as a list (it may be a single dict)."""
+    media = data.get("associatedMedia")
+    if isinstance(media, dict):
+        return [media]
+    if isinstance(media, list):
+        return [m for m in media if isinstance(m, dict)]
+    return []
+
+
+def source_urls(data: dict[str, Any]) -> list[str]:
+    """Ordered, de-duplicated source document URLs to OCR for this Material.
+
+    Picks MediaObject ``contentUrl``s by role preference (:data:`_SOURCE_ROLES`),
+    skipping our own MARKDOWN output and non-document SOURCE_PAGE links. Returns
+    ``[]`` when the Material carries nothing OCR-able.
+    """
+    by_role: dict[str, list[str]] = {r: [] for r in _SOURCE_ROLES}
+    for mo in _media_list(data):
+        url = (mo.get("contentUrl") or "").strip()
+        if not url:
+            continue
+        role = mo.get("jawafdehi:linkRole") or "RAW"
+        if role in by_role:
+            by_role[role].append(url)
+    ordered: list[str] = []
+    for role in _SOURCE_ROLES:
+        for url in by_role[role]:
+            if url not in ordered:
+                ordered.append(url)
+    return ordered
+
+
+def enqueue_material_convert(material_iri: str, *, priority: int = 100):
+    """Enqueue an OCR/extraction job for ``material_iri`` (idempotent on the IRI).
+
+    Call from a file-bearing write path *after* the Material is upserted, in the
+    same request. ``jobs.enqueue`` dedups on ``dedup_key`` so re-uploading while a
+    convert is still queued/running is a no-op; a fresh upload after a prior
+    convert finished enqueues again (the key is freed on terminal state). Returns
+    the ``Job`` (or the existing one), or ``None`` if the jobs app is unavailable.
+    """
+    from jobs import queue as jobs_queue
+
+    return jobs_queue.enqueue(
+        CONVERT_KIND,
+        payload={"material_iri": material_iri},
+        dedup_key=f"{CONVERT_KIND}:{material_iri}",
+        priority=priority,
+    )
+
+
+def build_convert_payload(job) -> Optional[dict]:
+    """``build_payload`` hook: resolve the source URLs for a claimed convert job.
+
+    Reads the Material row named by ``payload['material_iri']`` and returns the
+    ordered ``source_urls`` for the DB-free worker to fetch + OCR. Raises when the
+    material is missing or has no OCR-able source (so the job fails fast rather
+    than the worker no-op-ing).
+    """
+    from .models import Material
+
+    iri = (job.payload or {}).get("material_iri")
+    if not iri:
+        raise ValueError("material_convert payload is missing 'material_iri'.")
+    row = Material.objects.filter(pk=iri, is_deleted=False).first()
+    if row is None:
+        raise ValueError(f"material_convert: no live Material at {iri!r}.")
+    urls = source_urls(row.data or {})
+    if not urls:
+        raise ValueError(f"material_convert: {iri} has no OCR-able source link.")
+    return {"source_urls": urls}
+
+
+def apply_convert_result(job, result: dict) -> None:
+    """``on_result`` hook: persist the worker's extracted text onto the Material.
+
+    ``result`` carries ``{"text": <str>, "source_url": <str>}`` (the converted
+    markdown). This stores the markdown in R2 as a ``MARKDOWN`` MediaObject and
+    sets ``data['text']`` (the field the search indexer reads), then saves — the
+    ``post_save`` signal re-indexes the row into unified search. Idempotent: a
+    prior MARKDOWN MediaObject for this material is replaced, not duplicated.
+
+    Best-effort by contract (``jobs.finalize`` swallows hook errors); a failure
+    here leaves the job DONE but the text unset — a re-run (re-upload) recovers.
+    """
+    from django.core.files.base import ContentFile
+
+    from jawafdehi_shared.storage import store_file_as_link
+
+    iri = (job.payload or {}).get("material_iri")
+    text = (result or {}).get("text") or ""
+    if not iri or not text.strip():
+        logger.info("material_convert %s: empty text, nothing to persist", iri)
+        return
+
+    from .models import Material
+
+    row = Material.objects.filter(pk=iri, is_deleted=False).first()
+    if row is None:
+        logger.warning("material_convert %s: material gone before result apply", iri)
+        return
+
+    # 1) Land the markdown in R2 as a roled MARKDOWN link (hashed filename).
+    # NOTE: store_file_as_link uses FILE_STORAGE_PREFIX (default "case_uploads/"),
+    # so the .md currently lands under that shared prefix. The material-specific
+    # R2 layout (docs/data-plane-design.md §3) is folded in with the provenance
+    # work (§8 item 2); until then the link is correct, just not prefix-isolated.
+    md_file = ContentFile(text.encode("utf-8"), name="material.md")
+    link = store_file_as_link(md_file, role="MARKDOWN")
+
+    data = dict(row.data or {})
+    # 2) Replace-or-append the MARKDOWN MediaObject (idempotent re-run).
+    media = [
+        mo
+        for mo in _media_list(data)
+        if (mo.get("jawafdehi:linkRole") or "RAW") != "MARKDOWN"
+    ]
+    md_mo = jsonld._media_object({"link": link["link"], "role": "MARKDOWN"})
+    if md_mo is not None:
+        media.append(md_mo)
+    data["associatedMedia"] = media
+    # 3) The searchable full text (language-mapped, per MATERIAL_CONTEXT).
+    data["text"] = {_TEXT_LANG: text}
+
+    row.data = data
+    row.save(update_fields=["data", "updated_at"])  # post_save → reindex
+    logger.info(
+        "material_convert %s: stored %d chars markdown + text (from %s)",
+        iri,
+        len(text),
+        (result or {}).get("source_url"),
+    )

--- a/materials/job_handlers.py
+++ b/materials/job_handlers.py
@@ -49,6 +49,17 @@ def _convert_with_timeout(convert_source, url: str) -> dict:
             "url": url,
             "note": f"conversion timed out after {timeout}s",
         }
+    except Exception as exc:  # noqa: BLE001
+        # convert_source normally returns an error dict rather than raising, but
+        # if it (or the executor) ever does raise, degrade to an error result so
+        # the caller falls back to the next alternate URL instead of the whole
+        # job dying on the first source.
+        return {
+            "markdown": "",
+            "status": "error",
+            "url": url,
+            "note": f"conversion raised: {exc}",
+        }
     finally:
         ex.shutdown(wait=False)
 

--- a/materials/job_handlers.py
+++ b/materials/job_handlers.py
@@ -1,0 +1,99 @@
+"""Worker-side handler for the ``material_convert`` job kind (source → markdown).
+
+This runs in the JOBS CONSUMER process (``review_poller --kinds material_convert``),
+NOT in the API. Given the source document URL(s) resolved server-side into
+``payload['source_urls']`` (by ``materials.conversion.build_convert_payload``), it
+converts the document to Nepali-aware Markdown and returns the text. The server's
+``on_result`` hook (``apply_convert_result``) persists it as ``data["text"]`` + a
+MARKDOWN MediaObject.
+
+Conversion reuses the **in-repo** casework converter (``review.converter``), which
+wraps ``likhit`` / MarkItDown (both declared deps) — download, Devanagari OCR at a
+Bedrock-safe DPI, and on-disk caching are already handled there. We deliberately do
+NOT depend on any code outside this repo. The heavy deps (likhit/fitz/markitdown)
+load lazily inside ``review.converter``, so importing this module stays cheap and
+the API process never pulls them in.
+
+Handler signature (the poller's contract):
+    handler(payload: dict, *, on_stage: Callable[[str], None]) -> dict
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def _convert_with_timeout(convert_source, url: str) -> dict:
+    """Run ``convert_source({"url":[url]})`` under a hard wall-clock timeout.
+
+    Mirrors ``review.converter.convert_all``: a single stalled artifact (a slow
+    host, or a scan whose OCR never returns) is abandoned as an ``error`` result
+    rather than pinning the consumer thread until the job lease lapses. The
+    timeout is ``settings.CONVERT_SOURCE_TIMEOUT`` (default 180s).
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import TimeoutError as FutureTimeout
+
+    from django.conf import settings
+
+    timeout = getattr(settings, "CONVERT_SOURCE_TIMEOUT", 180)
+    ex = ThreadPoolExecutor(max_workers=1)
+    fut = ex.submit(convert_source, {"url": [url]})
+    try:
+        return fut.result(timeout=timeout)
+    except FutureTimeout:
+        fut.cancel()
+        return {
+            "markdown": "",
+            "status": "error",
+            "url": url,
+            "note": f"conversion timed out after {timeout}s",
+        }
+    finally:
+        ex.shutdown(wait=False)
+
+
+def handle_material_convert(
+    payload: dict,
+    *,
+    on_stage: Callable[[str], None],
+) -> dict:
+    """Convert the source document(s) → ``{"text", "source_url"}``.
+
+    Tries each ``source_urls`` entry in order (they are alternates of the same
+    document — RAW, then ALTERNATE, PERMALINK); the first that yields markdown
+    wins. ``on_stage`` pings progress so the job lease is extended. Raises if no
+    source produced any text (a retryable failure).
+    """
+    # Local import: review.converter lazily loads likhit/markitdown/fitz, which
+    # we want to happen only in the consumer, never at API import time.
+    from review.converter import convert_source
+
+    urls = payload.get("source_urls") or []
+    if not urls:
+        raise ValueError("material_convert payload has no 'source_urls'.")
+
+    last_note = ""
+    for url in urls:
+        on_stage(f"convert:{url[:48]}")
+        # convert_source takes a source dict ({"url": [...], "markdown"?}) and
+        # returns {"markdown", "status", "url", "note"}; it downloads + OCRs +
+        # caches internally. It has NO internal wall-clock timeout (only
+        # review.convert_all does), so wrap it the same way review does — a
+        # stalled host/OCR must not pin the consumer past the job lease.
+        result = _convert_with_timeout(convert_source, url)
+        text = (result.get("markdown") or "").strip()
+        if text:
+            on_stage(f"convert:done {len(text)}c")
+            return {"text": text, "source_url": result.get("url") or url}
+        last_note = result.get("note") or result.get("status") or ""
+        on_stage(f"convert:empty {result.get('status', '')}")
+
+    raise RuntimeError(
+        f"material_convert: all {len(urls)} source(s) produced no text; "
+        f"last: {last_note}"
+    )
+
+
+#: kind -> worker-side handler, merged into the poller's HANDLERS registry.
+HANDLERS = {"material_convert": handle_material_convert}

--- a/materials/tests/test_material_convert.py
+++ b/materials/tests/test_material_convert.py
@@ -85,6 +85,21 @@ def test_source_urls_handles_single_dict_and_empty():
     assert source_urls(_doc("x", [_mo("", "RAW")])) == []
 
 
+def test_source_urls_skips_non_string_content_url():
+    # Malformed JSONB: contentUrl is a list/int/dict, not a string. Must be
+    # skipped, not crash with AttributeError on .strip().
+    data = _doc(
+        "x",
+        [
+            {"@type": "MediaObject", "contentUrl": ["not", "a", "str"],
+             "jawafdehi:linkRole": "RAW"},
+            {"@type": "MediaObject", "contentUrl": 123, "jawafdehi:linkRole": "RAW"},
+            _mo("https://a/raw.pdf", "RAW"),
+        ],
+    )
+    assert source_urls(data) == ["https://a/raw.pdf"]
+
+
 # --- build_convert_payload ---------------------------------------------------
 
 
@@ -247,6 +262,25 @@ def test_worker_handler_raises_when_all_sources_empty():
             handle_material_convert(
                 {"source_urls": ["https://a/raw.pdf"]}, on_stage=lambda s: None
             )
+
+
+def test_worker_handler_falls_back_when_convert_source_raises():
+    """If convert_source raises (not just returns error), _convert_with_timeout
+    degrades to an error result so the loop tries the next alternate URL."""
+    from materials.job_handlers import handle_material_convert
+
+    def _convert(source):
+        if source["url"][0] == "https://a/raw.pdf":
+            raise RuntimeError("library crash")
+        return {"markdown": "ok", "status": "converted",
+                "url": source["url"][0], "note": ""}
+
+    with patch("review.converter.convert_source", side_effect=_convert):
+        out = handle_material_convert(
+            {"source_urls": ["https://a/raw.pdf", "https://a/alt.pdf"]},
+            on_stage=lambda s: None,
+        )
+    assert out == {"text": "ok", "source_url": "https://a/alt.pdf"}
 
 
 def test_worker_handler_times_out_a_stalled_conversion(settings):

--- a/materials/tests/test_material_convert.py
+++ b/materials/tests/test_material_convert.py
@@ -1,0 +1,280 @@
+"""Tests for the ``material_convert`` job kind — the data-plane FTS feed.
+
+Covers the server-side seams (no OCR, no network):
+- source_urls role preference + MARKDOWN/SOURCE_PAGE exclusion,
+- enqueue_material_convert dedup on the IRI,
+- build_convert_payload resolves URLs / fails on missing material or no source,
+- apply_convert_result writes data["text"] + a single MARKDOWN MediaObject and
+  is idempotent on re-run,
+- the kind is registered with its policy + hooks,
+and the worker handler with the OCR helper mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from jawafdehi_shared.entities.ids import build_material_iri
+from materials.conversion import (
+    CONVERT_KIND,
+    apply_convert_result,
+    build_convert_payload,
+    enqueue_material_convert,
+    source_urls,
+)
+from materials.models import Material
+
+
+def _doc(iri, media):
+    return {
+        "@context": "https://schema.org",
+        "@type": "DigitalDocument",
+        "@id": iri,
+        "name": {"ne": "परीक्षण"},
+        "associatedMedia": media,
+    }
+
+
+def _mo(url, role):
+    return {"@type": "MediaObject", "contentUrl": url, "jawafdehi:linkRole": role}
+
+
+def _store(iri, media):
+    mat = Material.from_jsonld(_doc(iri, media), material_type="document")
+    mat.save()
+    return mat
+
+
+# --- source_urls (pure) ------------------------------------------------------
+
+
+def test_source_urls_prefers_raw_then_alternate_then_permalink():
+    data = _doc(
+        "x",
+        [
+            _mo("https://a/permalink.pdf", "PERMALINK"),
+            _mo("https://a/raw.pdf", "RAW"),
+            _mo("https://a/alt.pdf", "ALTERNATE"),
+        ],
+    )
+    assert source_urls(data) == [
+        "https://a/raw.pdf",
+        "https://a/alt.pdf",
+        "https://a/permalink.pdf",
+    ]
+
+
+def test_source_urls_excludes_markdown_and_source_page():
+    data = _doc(
+        "x",
+        [
+            _mo("https://a/out.md", "MARKDOWN"),
+            _mo("https://a/page.html", "SOURCE_PAGE"),
+            _mo("https://a/raw.pdf", "RAW"),
+        ],
+    )
+    assert source_urls(data) == ["https://a/raw.pdf"]
+
+
+def test_source_urls_handles_single_dict_and_empty():
+    single = {"associatedMedia": _mo("https://a/raw.pdf", "RAW")}
+    assert source_urls(single) == ["https://a/raw.pdf"]
+    assert source_urls({}) == []
+    assert source_urls(_doc("x", [_mo("", "RAW")])) == []
+
+
+# --- build_convert_payload ---------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_build_payload_resolves_source_urls():
+    iri = build_material_iri("ciaa", "report-1")
+    _store(iri, [_mo("https://a/raw.pdf", "RAW")])
+    job = _FakeJob(payload={"material_iri": iri})
+    assert build_convert_payload(job) == {"source_urls": ["https://a/raw.pdf"]}
+
+
+@pytest.mark.django_db
+def test_build_payload_raises_on_missing_material():
+    job = _FakeJob(payload={"material_iri": build_material_iri("ciaa", "gone")})
+    with pytest.raises(ValueError, match="no live Material"):
+        build_convert_payload(job)
+
+
+@pytest.mark.django_db
+def test_build_payload_raises_when_no_ocrable_source():
+    iri = build_material_iri("ciaa", "html-only")
+    _store(iri, [_mo("https://a/page.html", "SOURCE_PAGE")])
+    job = _FakeJob(payload={"material_iri": iri})
+    with pytest.raises(ValueError, match="no OCR-able source"):
+        build_convert_payload(job)
+
+
+# --- apply_convert_result ----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_apply_result_sets_text_and_markdown_media():
+    iri = build_material_iri("ciaa", "report-2")
+    _store(iri, [_mo("https://a/raw.pdf", "RAW")])
+    job = _FakeJob(payload={"material_iri": iri})
+
+    with patch(
+        "jawafdehi_shared.storage.store_file_as_link",
+        return_value={"link": "https://cdn/x.md", "role": "MARKDOWN"},
+    ):
+        apply_convert_result(job, {"text": "पूर्ण पाठ", "source_url": "https://a/raw.pdf"})
+
+    row = Material.objects.get(pk=iri)
+    assert row.data["text"] == {"ne": "पूर्ण पाठ"}
+    md = [
+        m
+        for m in row.data["associatedMedia"]
+        if m.get("jawafdehi:linkRole") == "MARKDOWN"
+    ]
+    assert len(md) == 1 and md[0]["contentUrl"] == "https://cdn/x.md"
+    # The original RAW link is preserved.
+    assert any(m.get("jawafdehi:linkRole") == "RAW" for m in row.data["associatedMedia"])
+
+
+@pytest.mark.django_db
+def test_apply_result_is_idempotent_on_rerun():
+    iri = build_material_iri("ciaa", "report-3")
+    _store(iri, [_mo("https://a/raw.pdf", "RAW")])
+    job = _FakeJob(payload={"material_iri": iri})
+
+    with patch(
+        "jawafdehi_shared.storage.store_file_as_link",
+        side_effect=[
+            {"link": "https://cdn/v1.md", "role": "MARKDOWN"},
+            {"link": "https://cdn/v2.md", "role": "MARKDOWN"},
+        ],
+    ):
+        apply_convert_result(job, {"text": "v1", "source_url": "https://a/raw.pdf"})
+        apply_convert_result(job, {"text": "v2", "source_url": "https://a/raw.pdf"})
+
+    row = Material.objects.get(pk=iri)
+    md = [
+        m
+        for m in row.data["associatedMedia"]
+        if m.get("jawafdehi:linkRole") == "MARKDOWN"
+    ]
+    assert len(md) == 1 and md[0]["contentUrl"] == "https://cdn/v2.md"
+    assert row.data["text"] == {"ne": "v2"}
+
+
+@pytest.mark.django_db
+def test_apply_result_noop_on_empty_text():
+    iri = build_material_iri("ciaa", "report-4")
+    _store(iri, [_mo("https://a/raw.pdf", "RAW")])
+    job = _FakeJob(payload={"material_iri": iri})
+    apply_convert_result(job, {"text": "   ", "source_url": "https://a/raw.pdf"})
+    assert "text" not in Material.objects.get(pk=iri).data
+
+
+# --- enqueue dedup -----------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_enqueue_dedups_on_iri():
+    iri = build_material_iri("ciaa", "report-5")
+    j1 = enqueue_material_convert(iri)
+    j2 = enqueue_material_convert(iri)
+    assert j1.pk == j2.pk
+    assert j1.dedup_key == f"{CONVERT_KIND}:{iri}"
+
+
+# --- registration ------------------------------------------------------------
+
+
+def test_kind_is_registered_with_hooks():
+    from jobs import registry
+
+    spec = registry.get(CONVERT_KIND)
+    assert spec.kind == CONVERT_KIND
+    assert spec.build_payload is not None and spec.on_result is not None
+    assert spec.lease_seconds == 1800 and spec.max_attempts == 2
+
+
+# --- worker handler (OCR mocked) ---------------------------------------------
+
+
+def test_worker_handler_converts_first_working_source():
+    from materials.job_handlers import handle_material_convert
+
+    stages: list[str] = []
+    # convert_source (in-repo review.converter) returns a status dict.
+    with patch(
+        "review.converter.convert_source",
+        return_value={"markdown": "पूर्ण पाठ", "status": "converted",
+                      "url": "https://a/raw.pdf", "note": ""},
+    ):
+        out = handle_material_convert(
+            {"source_urls": ["https://a/raw.pdf"]}, on_stage=stages.append
+        )
+    assert out == {"text": "पूर्ण पाठ", "source_url": "https://a/raw.pdf"}
+    assert any(s.startswith("convert:done") for s in stages)
+
+
+def test_worker_handler_falls_back_to_next_source_when_empty():
+    from materials.job_handlers import handle_material_convert
+
+    def _convert(source):
+        url = source["url"][0]
+        if url == "https://a/raw.pdf":
+            return {"markdown": "", "status": "error", "url": url, "note": "boom"}
+        return {"markdown": "ok", "status": "converted", "url": url, "note": ""}
+
+    with patch("review.converter.convert_source", side_effect=_convert):
+        out = handle_material_convert(
+            {"source_urls": ["https://a/raw.pdf", "https://a/alt.pdf"]},
+            on_stage=lambda s: None,
+        )
+    assert out == {"text": "ok", "source_url": "https://a/alt.pdf"}
+
+
+def test_worker_handler_raises_when_all_sources_empty():
+    from materials.job_handlers import handle_material_convert
+
+    with patch(
+        "review.converter.convert_source",
+        return_value={"markdown": "", "status": "error",
+                      "url": "https://a/raw.pdf", "note": "no text"},
+    ):
+        with pytest.raises(RuntimeError, match="no text"):
+            handle_material_convert(
+                {"source_urls": ["https://a/raw.pdf"]}, on_stage=lambda s: None
+            )
+
+
+def test_worker_handler_times_out_a_stalled_conversion(settings):
+    """A conversion that never returns is abandoned at CONVERT_SOURCE_TIMEOUT
+    (not left to pin the consumer until the job lease lapses)."""
+    import time
+
+    from materials.job_handlers import handle_material_convert
+
+    settings.CONVERT_SOURCE_TIMEOUT = 1  # keep the test fast
+
+    def _hang(_source):
+        time.sleep(30)  # far longer than the timeout
+        return {"markdown": "never", "status": "converted", "url": "x", "note": ""}
+
+    with patch("review.converter.convert_source", side_effect=_hang):
+        # Single stalled source → all sources produced no text → RuntimeError,
+        # but it returns in ~1s (the timeout), not 30s.
+        with pytest.raises(RuntimeError, match="timed out"):
+            handle_material_convert(
+                {"source_urls": ["https://a/raw.pdf"]}, on_stage=lambda s: None
+            )
+
+
+# --- test doubles ------------------------------------------------------------
+
+
+class _FakeJob:
+    def __init__(self, payload):
+        self.payload = payload
+        self.pk = 1

--- a/materials/tests/test_material_convert_smoke.py
+++ b/materials/tests/test_material_convert_smoke.py
@@ -1,0 +1,183 @@
+"""End-to-end smoke tests for material_convert.
+
+Unlike ``test_material_convert.py`` (which unit-tests each seam in isolation with
+a fake job), these drive the FULL real path through the actual queue engine and
+the real upload endpoint, mocking ONLY the true external boundaries:
+
+- the document conversion network call (``review.converter.convert_source`` —
+  would hit the source URL + Bedrock OCR),
+- object storage (``store_file_as_link`` — would write to R2),
+- the OpenSearch index upsert (``materials.search_index.index``).
+
+So the queue's real enqueue → claim (build_payload) → worker handler →
+finalize (on_result) chain and the real signal-driven reindex are all exercised.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APITestCase
+
+from jobs import queue as jobs_queue
+from jobs.models import Job
+from materials.models import Material
+
+User = get_user_model()
+
+
+def _run_one_convert_job():
+    """Claim the next material_convert job, run its worker handler, finalize.
+
+    This is what ``review_poller --apply --kinds material_convert`` does per job,
+    but in-process (no HTTP), so the smoke test needs no live server. Returns the
+    finalized Job, or None if the queue was empty.
+    """
+    from materials.job_handlers import handle_material_convert
+
+    job = jobs_queue.claim_next(["material_convert"])
+    if job is None:
+        return None
+    try:
+        result = handle_material_convert(job.payload, on_stage=lambda s: None)
+        return jobs_queue.finalize(job, status=Job.DONE, result=result)
+    except Exception as exc:  # mirror the poller: report a retryable failure
+        return jobs_queue.finalize(
+            job, status=Job.FAILED, error=str(exc), retryable=True
+        )
+
+
+class MaterialConvertSmokeTests(APITestCase):
+    databases = "__all__"
+
+    URL = "/api/materials/nkp/smoke-order-1/file"
+    IRI = "https://jawafdehi.org/material/nkp/smoke-order-1"
+
+    @classmethod
+    def setUpTestData(cls):
+        g, _ = Group.objects.get_or_create(name="Caseworker")
+        cls.user = User.objects.create(username="oidc-writer")
+        cls.user.groups.add(g)
+
+    def _pdf(self, name="order.pdf"):
+        return SimpleUploadedFile(name, b"%PDF-1.4 data", content_type="application/pdf")
+
+    def test_upload_enqueues_and_convert_populates_text_and_search(self):
+        """The whole feed: upload → job enqueued → run → data['text'] + reindex."""
+        self.client.force_authenticate(user=self.user)
+
+        indexed: list[str] = []
+
+        def _record_index(obj, **kwargs):
+            # Capture what got (re)indexed + its body, proving the search feed.
+            indexed.append(obj.data.get("text", {}).get("ne", ""))
+
+        # Two distinct storage bindings: the upload endpoint binds
+        # store_file_as_link at module import (materials.views); conversion.py
+        # imports it locally. Patch both so RAW (upload) and MARKDOWN (on_result)
+        # land at deterministic URLs. In prod both call the same real R2 helper.
+        with patch(
+            "materials.views.store_file_as_link",
+            return_value={"link": "https://cdn/raw.pdf", "role": "RAW"},
+        ), patch(
+            "jawafdehi_shared.storage.store_file_as_link",
+            return_value={"link": "https://cdn/extracted.md", "role": "MARKDOWN"},
+        ), patch(
+            "materials.search_index.index", side_effect=_record_index
+        ):
+            # 1) Upload the source PDF.
+            resp = self.client.post(
+                self.URL,
+                {"file": self._pdf(), "material_type": "court_order"},
+                format="multipart",
+            )
+            self.assertEqual(resp.status_code, 201, resp.data)
+
+            # 2) A material_convert job was enqueued (transactionally, deduped).
+            job = Job.objects.get(kind="material_convert")
+            self.assertEqual(job.status, Job.QUEUED)
+            self.assertEqual(job.dedup_key, f"material_convert:{self.IRI}")
+            self.assertEqual(job.payload["material_iri"], self.IRI)
+
+            # 3) Run the job through the REAL queue engine, with the conversion
+            #    network/OCR call mocked to return markdown. captureOnCommitCallbacks
+            #    forces the Material post_save→reindex on_commit hook to actually
+            #    run (APITestCase wraps each test in a rolled-back transaction, so
+            #    on_commit callbacks would otherwise never fire).
+            with patch(
+                "review.converter.convert_source",
+                return_value={
+                    "markdown": "अदालतको आदेश — पूर्ण पाठ",
+                    "status": "converted",
+                    "url": "https://cdn/raw.pdf",
+                    "note": "",
+                },
+            ), self.captureOnCommitCallbacks(execute=True):
+                done = _run_one_convert_job()
+
+        # 4) Job finished cleanly.
+        self.assertIsNotNone(done)
+        self.assertEqual(done.status, Job.DONE)
+        self.assertEqual(done.result["text"], "अदालतको आदेश — पूर्ण पाठ")
+
+        # 5) The Material now carries searchable full text + a MARKDOWN link.
+        row = Material.objects.get(pk=self.IRI)
+        self.assertEqual(row.data["text"], {"ne": "अदालतको आदेश — पूर्ण पाठ"})
+        roles = [m["jawafdehi:linkRole"] for m in row.data["associatedMedia"]]
+        self.assertIn("RAW", roles)
+        self.assertIn("MARKDOWN", roles)
+        md = next(
+            m for m in row.data["associatedMedia"]
+            if m["jawafdehi:linkRole"] == "MARKDOWN"
+        )
+        self.assertEqual(md["contentUrl"], "https://cdn/extracted.md")
+
+        # 6) The reindex actually fired with the extracted body (the search feed).
+        self.assertIn("अदालतको आदेश — पूर्ण पाठ", indexed)
+
+    def test_reupload_while_queued_does_not_double_enqueue(self):
+        """Dedup on the IRI: a second upload before the convert runs is a no-op."""
+        self.client.force_authenticate(user=self.user)
+        with patch(
+            "jawafdehi_shared.storage.store_file_as_link",
+            return_value={"link": "https://cdn/raw.pdf", "role": "RAW"},
+        ), patch("materials.search_index.index"):
+            self.client.post(
+                self.URL,
+                {"file": self._pdf(), "material_type": "court_order"},
+                format="multipart",
+            )
+            self.client.post(
+                self.URL, {"file": self._pdf()}, format="multipart"
+            )
+        self.assertEqual(Job.objects.filter(kind="material_convert").count(), 1)
+
+    def test_convert_failure_leaves_material_served_without_text(self):
+        """A conversion failure dead-letters/retries the job but never corrupts
+        the Material: it stays served, just without full text."""
+        self.client.force_authenticate(user=self.user)
+        with patch(
+            "jawafdehi_shared.storage.store_file_as_link",
+            return_value={"link": "https://cdn/raw.pdf", "role": "RAW"},
+        ), patch("materials.search_index.index"):
+            self.client.post(
+                self.URL,
+                {"file": self._pdf(), "material_type": "court_order"},
+                format="multipart",
+            )
+            with patch(
+                "review.converter.convert_source",
+                return_value={"markdown": "", "status": "error",
+                              "url": "x", "note": "download 404"},
+            ):
+                done = _run_one_convert_job()
+
+        # Job did not succeed (retry re-queued since retryable + attempts remain).
+        self.assertIsNotNone(done)
+        self.assertNotEqual(done.status, Job.DONE)
+        # Material still exists and is served; just no text yet.
+        row = Material.objects.get(pk=self.IRI)
+        self.assertNotIn("text", row.data)

--- a/materials/views.py
+++ b/materials/views.py
@@ -14,6 +14,7 @@ no stored row is materialized on the fly from the relational court tables via
 
 from __future__ import annotations
 
+import logging
 import mimetypes
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -49,6 +50,12 @@ LD_JSON = "application/ld+json"
 _UPLOAD_ROLES = frozenset(
     {"RAW", "ALTERNATE", "PERMALINK", "MARKDOWN", "SOURCE_PAGE"}
 )
+
+#: Upload roles that carry an original document worth OCR-ing into full text.
+#: Excludes MARKDOWN (our own extraction output) + SOURCE_PAGE (HTML, not a scan).
+_CONVERTIBLE_ROLES = frozenset({"RAW", "ALTERNATE", "PERMALINK"})
+
+logger = logging.getLogger("materials.views")
 
 #: Upper bound on an uploaded material file. Generous (scanned court orders /
 #: charge sheets run large — this is NOT the 10 MB case-evidence limit) but
@@ -368,6 +375,20 @@ def material_file_upload(request, source: str, ident: str):
     )
     if error is not None:
         return Response(error, status=code)
+
+    # Feed full-text search: enqueue async OCR→text for a newly-attached source
+    # document (data-plane FTS feed, docs/data-plane-design.md §5). Only for
+    # OCR-able source roles — never for our own MARKDOWN output or SOURCE_PAGE
+    # HTML. Idempotent (dedup on the IRI); best-effort so a queue hiccup never
+    # fails the upload.
+    if role in _CONVERTIBLE_ROLES:
+        try:
+            from .conversion import enqueue_material_convert
+
+            enqueue_material_convert(iri)
+        except Exception:  # noqa: BLE001 — the file is stored; convert can re-run.
+            logger.exception("material_convert enqueue failed for %s", iri)
+
     return Response(result, status=code, content_type=LD_JSON)
 
 

--- a/review/management/commands/review_poller.py
+++ b/review/management/commands/review_poller.py
@@ -44,7 +44,14 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from review.oidc_client_credentials import OIDCTokenError, get_provider
-from review.job_handlers import HANDLERS
+from review.job_handlers import HANDLERS as _REVIEW_HANDLERS
+from materials.job_handlers import HANDLERS as _MATERIAL_HANDLERS
+
+#: Worker-side handlers this consumer can run, aggregated from the owning apps
+#: (review, materials). Each app keeps its own heavy deps in its handler module;
+#: the poller just dispatches by kind. Add a new app's HANDLERS here to make the
+#: consumer able to claim that kind.
+HANDLERS = {**_REVIEW_HANDLERS, **_MATERIAL_HANDLERS}
 
 
 class PollerError(Exception):


### PR DESCRIPTION
## Summary

Closes the **data-plane full-text-search feed** (`docs/data-plane-design.md` §5). A `Material` that carries a source document (an uploaded/ingested RAW file or roled link) but no extracted `text` was **not full-text searchable** — the unified-search indexer reads `Material.data["text"]` (`materials/search_index.py`) and nothing populated it. This adds a `material_convert` job kind that converts a source document to Nepali-aware markdown **asynchronously on the central `jobs` queue** and writes the text back.

Built on merged `v2` (control-plane #261, jobs queue #262, cases-own-no-documents #263). No new async mechanism — it registers handlers on the existing queue, mirroring `case_review`.

## What it does

`upload/ingest → enqueue (dedup) → claim → OCR/convert (off API pods) → data["text"] + MARKDOWN link → post_save reindex`

- **`materials/conversion.py`** (server-side seams):
  - `enqueue_material_convert(iri)` — dedup on `material_convert:<iri>`, best-effort **after** the material upsert.
  - `build_convert_payload` — resolves source URL(s) from `associatedMedia` by role preference (RAW→ALTERNATE→PERMALINK), hands the DB-free worker `{source_urls}`.
  - `apply_convert_result` — stores markdown in object storage as a `linkRole=MARKDOWN` MediaObject (replace-or-append, idempotent) and sets `data["text"]`; the `Material` `post_save` signal reindexes.
- **`materials/job_handlers.py`** (worker-side) — reuses the **in-repo** `review.converter` (likhit/MarkItDown, declared deps) under a `CONVERT_SOURCE_TIMEOUT` guard. **No dependency on any code outside the repo.**
- **`jobs/consumers.py`** — registers the kind (lease 1800s / max_attempts 2, no `on_failure`: a failed convert leaves the Material served + metadata-searchable and a re-upload re-runs).
- **`review_poller`** — aggregates `HANDLERS` from `review` + `materials` (`--kinds material_convert`).
- **`materials/views.py`** — enqueues on upload for convertible roles.

## Docs (reconciliation, also in scope)

- `docs/ARCHITECTURE.md` §5 rewritten to **Postgres-SoR / lakehouse-lite** (three planes: archive/serving/search; no live Iceberg now).
- `lakehouse/__init__.py` bannered **DORMANT** (Iceberg-ready seam, "silver is SoR" framing superseded).
- `docs/data-plane-design.md` added (the full design + decisions).

## Design notes

- **Enqueue is NOT transactional with the material write** — `Job` lives on `default`, `Material` on `ngm` (router forbids a cross-DB txn). Enqueue is best-effort after the upsert; **idempotent re-run** (not atomicity) makes it safe. No outbox by design.
- Markdown currently lands under the shared `FILE_STORAGE_PREFIX`; material-specific R2 layout folds into the deferred provenance work (design §8 item 2).

## Testing

- 15 unit tests (`test_material_convert.py`) + **3 end-to-end smoke tests** (`test_material_convert_smoke.py`) that drive the **real queue engine + real upload endpoint**, mocking only external boundaries (conversion network, storage, OpenSearch): full feed, dedup, failure-safety.
- Full unit suite **843 passing**; `manage.py check` clean; `ruff` clean.

## Follow-ups (not in this PR)

- Enqueue from `/api/ingestion/documents` too (interactive upload is done).
- Provenance sidecar + material-specific R2 prefix (design §8 item 2).