### PR TITLE
docs: index data-plane-design in DOC-STATUS; mark lakehouse research deferred

### DIFF
--- a/docs/DOC-STATUS.md
+++ b/docs/DOC-STATUS.md
@@ -1,6 +1,6 @@
 # DOC-STATUS — Documentation Audit & Orientation Index
 
-_Last audited: 2026-06-30._
+_Last audited: 2026-07-01 (data-plane consolidation: #262 jobs queue, #263 cases-own-no-documents, #264 material_convert FTS feed all merged to `v2`)._
 
 **Read this first.** This file is the orientation index for the `docs/` tree: it says,
 doc by doc, what to trust and what to treat with caution. For *what the platform is now*
@@ -60,9 +60,10 @@ A `>` status banner has been added in-place to the most-misleading STALE docs (m
 | Doc | Class | Notes | Disposition |
 |---|---|---|---|
 | `README.md` | CURRENT | Docs front door; points at ARCHITECTURE.md + here | Keep. |
-| `ARCHITECTURE.md` | CURRENT | **Single source of truth** for the current platform (monolith, 3 DBs/router, schema.org/IRI, unified OpenSearch, OIDC) | Keep. |
+| `ARCHITECTURE.md` | CURRENT | **Single source of truth** for the current platform (monolith, 3 DBs/router, schema.org/IRI, unified OpenSearch, OIDC); §5 = data plane (Postgres-SoR, lakehouse-lite) | Keep. |
 | `DOC-STATUS.md` (this file) | CURRENT | The orientation index / per-doc audit | Keep. |
-| `unified-search-plan.md` | CURRENT (BUILT & LIVE) | §0 = pre-build starting point (marked as such); §1-§8 reconciled to the live build (hard-fail no-fallback, four index constants, case_id done, no "internal" role, no `visibility` field) | Keep. |
+| `data-plane-design.md` | CURRENT (BUILT) | Data-plane consolidation: Postgres-SoR + R2 archive + OpenSearch; **no live Iceberg** (`lakehouse/` dormant seam); `material_convert` FTS feed shipped (#264). Reconciles ARCHITECTURE §5; incorporates the jobs queue + cases-own-no-documents ADR | Keep (load-bearing). |
+| `unified-search-plan.md` | CURRENT (BUILT & LIVE) | §0 = pre-build starting point (marked as such); §1-§8 reconciled to the live build (hard-fail no-fallback, four index constants, case_id done, no "internal" role). NOTE: `Material.visibility` now EXISTS (added by #263) and gates material indexing — supersedes the old "no `visibility` field" caveat | Keep. |
 | `case-workflows-retirement-plan.md` | CURRENT | Live/actionable plan to retire `case_workflows` + drop the langchain/langgraph/deepagents stack; uses live monolith + uv-workspace paths | Keep; execute. |
 
 ### `shared/`
@@ -77,8 +78,8 @@ A `>` status banner has been added in-place to the most-misleading STALE docs (m
 | Doc | Class | Notes | Disposition |
 |---|---|---|---|
 | `shared/research/COST-AUDIT.md` | CURRENT | Free-OSS-only audit binding; FastAPI/"database-per-service" rows footnoted as pre-monolith framing (only license verdicts load-bearing) | Keep. |
-| `shared/research/iceberg-catalog-options.md` | CURRENT | Lakekeeper + R2 + DuckDB recommendation, topology-agnostic | Keep. |
-| `shared/research/duckdb-iceberg-r2-wiring.md` | CURRENT | DuckDB↔Iceberg↔R2 wiring; load-bearing for the lakehouse module | Keep. |
+| `shared/research/iceberg-catalog-options.md` | CURRENT (DEFERRED) | Lakekeeper + R2 + DuckDB recommendation, topology-agnostic. Applies to the **dormant** `lakehouse/` seam only — there is no live Iceberg lake now (`data-plane-design.md` §6) | Keep for if/when a lake is stood up. |
+| `shared/research/duckdb-iceberg-r2-wiring.md` | CURRENT (DEFERRED) | DuckDB↔Iceberg↔R2 wiring; blueprint for the **dormant** `lakehouse/` module (not a live serving path — `data-plane-design.md` §6) | Keep for if/when a lake is stood up. |
 | `shared/research/entity-resolution-tech.md` | CURRENT | Splink + Fellegi-Sunter + DuckDB + bilingual normalization; topology-agnostic | Keep. |
 | `shared/research/nes-sourcing-feasibility.md` | CURRENT | 1M-not-reachable, ~250k-450k realistic ceiling | Keep. |
 | `shared/research/opensearch-bilingual-nepali.md` | CURRENT | analysis-icu + icu_transform + indic-transliteration — the adopted unified-search approach | Keep (load-bearing). |

--- a/docs/data-plane-design.md
+++ b/docs/data-plane-design.md
@@ -1,8 +1,9 @@
 # Data Plane Design — Consolidation (Postgres-SoR, lakehouse-lite)
 
-**Status:** DRAFT for review · **Date:** 2026-07-01 · **Branch:** off `v2`. Foundations all
-merged: control-plane `80e2462`; jobs queue #262 `7458cbd`; **ADR cases-own-no-documents
-merged in PR #263** (`712dc2b`) — Materials is the sole document store on `v2` today.
+**Status:** ACCEPTED & BUILT · **Date:** 2026-07-01 · **Branch:** merged on `v2`. All
+foundations merged: control-plane `80e2462`; jobs queue #262; **ADR cases-own-no-documents
+#263** (`712dc2b`) — Materials is the sole document store; **material_convert FTS feed #264**
+(`fd13c35`). Remaining work is the provenance sidecar + governance tables (§8).
 
 **Goal.** One coherent data plane serving three domains (NES entities, NGM
 courts/governance, Jawafdehi cases) at target scale, read-heavy via the website,
@@ -46,7 +47,7 @@ another's critical path**:
   ┌──────────────────────────────────────────────────────────────┐
   │ ARCHIVE PLANE (R2)  — the object bytes (the bulk of storage)   │
   │   raw capture bytes                       [EXISTS: upload→R2]  │
-  │   OCR/likhit markdown  (linkRole=MARKDOWN) [GAP: extraction]   │
+  │   OCR/likhit markdown  (linkRole=MARKDOWN) [BUILT: #264]       │
   │   provenance sidecar   (source_url, ocr_*, sha256, …) [GAP]    │
   │   → immutable; system of record for RAW EVIDENCE               │
   └───────────────┬───────────────────────────────┬──────────────┘
@@ -56,7 +57,7 @@ another's critical path**:
   │ SERVING PLANE — Postgres   │        │ SEARCH PLANE — OpenSearch       │
   │  SoR. 3 DBs + router:      │───────►│  4 indices, bilingual.          │
   │   nes: entities            │ index  │  materials `body` = full text   │
-  │   ngm: courts, materials   │        │   [MACHINERY EXISTS; needs feed]│
+  │   ngm: courts, materials   │        │   [MACHINERY EXISTS; fed #264] │
   │   default: cases, JOBS     │        │  visibility-gated (draft≠public)│
   │  point + list reads (hot)  │        │  point + faceted + FTS (hot)    │
   └───────────────────────────┘        └───────────────────────────────┘
@@ -64,7 +65,7 @@ another's critical path**:
         website reads hit Postgres + OpenSearch ONLY (never the archive engine)
 
   JOBS QUEUE (default DB) — async plane cutting across ingestion→archive→search:
-    kind=material_convert: bytes → OCR markdown → data["text"] → reindex   [GAP: handler]
+    kind=material_convert: bytes → OCR markdown → data["text"] → reindex   [BUILT: #264]
     kind=case_review (ported), reindex/enrich (opportunistic)         [BUILT]
 ```
 


### PR DESCRIPTION
Doc-only housekeeping after the data-plane consolidation merges (#262 jobs queue, #263 cases-own-no-documents, #264 material_convert FTS feed).

Keeps the DOC-STATUS orientation index truthful against `v2`:
- **Add a row for `data-plane-design.md`** (CURRENT/BUILT, load-bearing) — it was merged in #264 but not indexed.
- **Note ARCHITECTURE §5** is now the data plane (Postgres-SoR, lakehouse-lite).
- **Mark `iceberg-catalog-options.md` + `duckdb-iceberg-r2-wiring.md` as CURRENT (DEFERRED)** — they describe the **dormant** `lakehouse/` seam, not a live serving path, so a reader doesn't mistake Iceberg for shipped infra.
- **Correct the stale "no `visibility` field" caveat** on `unified-search-plan.md` — `Material.visibility` exists since #263 and gates material indexing.
- Bump the audit date to 2026-07-01.

No code changes.