### PR TITLE
Capture provenance on file-bearing material MediaObjects (archive-plane record)

### DIFF
--- a/docs/data-plane-design.md
+++ b/docs/data-plane-design.md
@@ -3,7 +3,8 @@
 **Status:** ACCEPTED & BUILT · **Date:** 2026-07-01 · **Branch:** merged on `v2`. All
 foundations merged: control-plane `80e2462`; jobs queue #262; **ADR cases-own-no-documents
 #263** (`712dc2b`) — Materials is the sole document store; **material_convert FTS feed #264**
-(`fd13c35`). Remaining work is the provenance sidecar + governance tables (§8).
+(`fd13c35`); **provenance on file-bearing MediaObjects #266**. Remaining work is the
+material-specific R2 prefix + governance tables (§8).
 
 **Goal.** One coherent data plane serving three domains (NES entities, NGM
 courts/governance, Jawafdehi cases) at target scale, read-heavy via the website,
@@ -48,7 +49,7 @@ another's critical path**:
   │ ARCHIVE PLANE (R2)  — the object bytes (the bulk of storage)   │
   │   raw capture bytes                       [EXISTS: upload→R2]  │
   │   OCR/likhit markdown  (linkRole=MARKDOWN) [BUILT: #264]       │
-  │   provenance sidecar   (source_url, ocr_*, sha256, …) [GAP]    │
+  │   provenance on MediaObject (sha256, fetch_method, …) [BUILT]  │
   │   → immutable; system of record for RAW EVIDENCE               │
   └───────────────┬───────────────────────────────┬──────────────┘
      text → Material.data["text"]        bytes referenced by URL (one copy)
@@ -118,21 +119,29 @@ batch writers (`courts/views.py:352+`).
    `materials/jsonld.py:120`) *and* folds the text into `Material.data["text"]` (the field
    the search indexer already reads — §4). Standard recipe: `shared/ocr_bedrock.py`
    (PyMuPDF render + multimodal Claude on Bedrock).
-2. **Provenance sidecar + content-hash idempotency.** Each capture lands a
-   `provenance` record (`source_url`, `fetch_method`, `tls_status`, `ocr_engine`,
-   `ocr_confidence`, `scraped_at`, `sha256`). Re-landing the same bytes is idempotent on
-   the content hash. This formalizes what is ad-hoc in `material_uploads/` today. (The
-   dormant `lakehouse/medallion.BronzeObject` already sketches this struct — reuse the
-   shape, land it as Material provenance, not an Iceberg bronze row.)
+2. **Provenance + content-hash idempotency — BUILT (`materials/provenance.py`).** Each
+   file-bearing MediaObject carries a `jawafdehi:provenance` struct (`sha256`,
+   `captured_at`, `fetch_method` [`upload`|`ocr`|`scrape`], `source_url`, `content_length`,
+   `tls_status`, `ocr_engine`, `ocr_confidence` — `None`s dropped). Provenance is
+   **embedded on the MediaObject in the JSON-LD**, NOT a separate `.prov.json` R2 object:
+   the Postgres material row IS the record, it's queryable via the JSONB GIN index, and it
+   travels with the material (the design's own guidance — "land it as Material provenance,
+   not an Iceberg bronze row"; the dormant `lakehouse/medallion.BronzeObject` sketched the
+   field shape). `attach_media_object` dedups on **`(role, sha256)`** — re-uploading the
+   same bytes replaces that MediaObject instead of appending a duplicate. The upload
+   endpoint sets `fetch_method=upload`; `material_convert`'s `on_result` sets
+   `fetch_method=ocr`, `ocr_engine=likhit` on the MARKDOWN link.
 
-**R2 layout (prefix-partitioned, one account):**
+**R2 object layout (bytes only — provenance rides in the JSON-LD, not on disk):**
 ```
-material/<source>/<ident>/<sha256>.<ext>     raw capture (immutable)
-material/<source>/<ident>/<sha256>.md        OCR/likhit markdown  (linkRole=MARKDOWN)
-material/<source>/<ident>/<sha256>.prov.json provenance sidecar
+<FILE_STORAGE_PREFIX><sha256-of-filename>.<ext>   raw capture + the .md markdown blob
 ```
 Bytes are referenced by URL from the Material JSON-LD — **one copy**, no duplication of
-the storage bulk into the DB or the index.
+the storage bulk into the DB or the index. NOTE: `HashedFilenameS3Boto3Storage` hashes the
+*filename* (salted), and everything currently shares one `FILE_STORAGE_PREFIX`
+(default `case_uploads/`); the material-specific `material/<source>/<ident>/…` prefix
+layout is a remaining follow-up (it needs a storage-backend prefix override, orthogonal to
+the provenance record which is done).
 
 ### 3.1 How a Material links to its files (the field-level contract)
 
@@ -283,8 +292,8 @@ dashboard; `case_review` ported). No new async mechanism — we register handler
     and re-runnable, rather than relying on atomic enqueue. A true exactly-once enqueue
     would need an outbox on the `ngm` DB — deliberately not built (the re-run path covers it).
 - **Follow-up:** wire the same `enqueue_material_convert` call into the `/api/ingestion/*`
-  batch document path (the interactive upload is done); and land the provenance sidecar
-  (§8 item 2) so a convert can also be driven from a re-scrape.
+  batch document path (the interactive upload is done). Provenance on file-bearing
+  Materials is now recorded (§3 item 2 / §8 item 2).
 
 ---
 
@@ -351,8 +360,13 @@ Ordered by value/risk. None is a rewrite.
    (`linkRole=MARKDOWN`) → `Material.data["text"]` → reindex. 14 unit tests + suite green;
    `manage.py check` clean; ruff clean. *Delivers full-text search over materials end to
    end.* Remaining thread: also enqueue from `/api/ingestion/documents` (§5 follow-up).
-2. **Formalize archive provenance.** Add the `provenance` sidecar + content-hash
-   idempotency to the existing upload/ingest path; adopt the R2 layout (§3).
+2. ✅ **DONE — Formalize archive provenance.** `materials/provenance.py` — a
+   `jawafdehi:provenance` struct embedded on each file-bearing MediaObject +
+   content-hash idempotency (`attach_media_object` dedups on `(role, sha256)`).
+   Wired into the upload endpoint (`fetch_method=upload`) and `material_convert`
+   `on_result` (`fetch_method=ocr`, `ocr_engine=likhit`). *Remaining thread:*
+   material-specific R2 prefix (needs a storage-backend prefix override) + provenance
+   on the `/api/ingestion/documents` court `document_sources` path (scraper-supplied).
 3. ✅ **DONE — Reconcile the docs (§7).** `ARCHITECTURE.md §5` rewritten to Postgres-SoR /
    lakehouse-lite; `lakehouse/__init__.py` bannered DORMANT + blueprint (supersedes the
    "silver is SoR" framing in `medallion.py`/`schema.py`).

--- a/materials/conversion.py
+++ b/materials/conversion.py
@@ -26,10 +26,12 @@ the queue (``jobs.consumers``); OCR itself is the worker's job.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Any, Optional
 
 from . import jsonld
+from . import provenance
 
 logger = logging.getLogger("materials.conversion")
 
@@ -180,7 +182,9 @@ def apply_convert_result(job, result: dict) -> None:
             )
             return
         data = dict(row.data or {})
-        # Replace-or-append the MARKDOWN MediaObject (idempotent re-run).
+        # Replace-or-append the MARKDOWN MediaObject (idempotent re-run). MARKDOWN
+        # is our own singular derived output, so dedup is by role (drop any prior
+        # MARKDOWN, add the fresh one) — not by content hash.
         media = [
             mo
             for mo in _media_list(data)
@@ -188,6 +192,16 @@ def apply_convert_result(job, result: dict) -> None:
         ]
         md_mo = jsonld._media_object({"link": link["link"], "role": "MARKDOWN"})
         if md_mo is not None:
+            # Provenance: this markdown was produced by OCR/likhit conversion from
+            # the source doc (data-plane §3 — provenance rides on the MediaObject).
+            md_mo["encodingFormat"] = "text/markdown"
+            md_mo[provenance.PROVENANCE_KEY] = provenance.build_provenance(
+                sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                fetch_method="ocr",
+                source_url=(result or {}).get("source_url"),
+                content_length=len(text.encode("utf-8")),
+                ocr_engine="likhit",
+            )
             media.append(md_mo)
         data["associatedMedia"] = media
         # The searchable full text (language-mapped, per MATERIAL_CONTEXT).

--- a/materials/provenance.py
+++ b/materials/provenance.py
@@ -1,0 +1,157 @@
+"""Capture provenance for material MediaObjects (the archive-plane record).
+
+Every file-bearing MediaObject on a Material records **how that byte-stream was
+captured** — the evidentiary backbone of an accountability platform ("show me the
+original, and when/how we got it"). Per the data-plane design (§3), provenance is
+**Material provenance** — it rides on the MediaObject in the JSON-LD (queryable via
+the JSONB GIN index, travels with the material), NOT a separate Iceberg bronze row
+or a redundant R2 sidecar file: the material row in Postgres IS the record.
+
+The provenance struct (schema.org has no faithful term, so the ``jawafdehi:``
+extension namespace, consistent with ``jawafdehi:linkRole``) mirrors the fields the
+dormant ``lakehouse.medallion.BronzeObject`` sketched:
+
+    {
+      "sha256":         <hex>,          # content hash of the captured bytes
+      "captured_at":    <iso8601>,      # when we captured/stored it
+      "fetch_method":   "upload" | "scrape" | "ocr" | ...,
+      "source_url":     <str|None>,     # origin URL (None for a direct upload)
+      "content_length": <int|None>,     # bytes, when known
+      "tls_status":     <str|None>,     # for scrapes (GoN certs are often broken)
+      "ocr_engine":     <str|None>,     # set by material_convert on the MARKDOWN link
+      "ocr_confidence": <float|None>,
+    }
+
+**Content-hash idempotency:** ``attach_media_object`` dedups on ``(role, sha256)`` —
+re-uploading the same bytes for the same role replaces the existing MediaObject
+instead of appending a duplicate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Optional
+
+from django.utils import timezone
+
+from . import jsonld
+
+#: The extension key the provenance struct hangs off, on a MediaObject.
+PROVENANCE_KEY = "jawafdehi:provenance"
+
+#: Read uploads in bounded chunks so hashing a large scan never loads it all.
+_HASH_CHUNK = 1024 * 1024  # 1 MiB
+
+
+def content_sha256(uploaded_file: Any) -> str:
+    """SHA-256 of an uploaded file's bytes, streamed in chunks.
+
+    Resets the file pointer to 0 afterwards so the caller can still stream the
+    same object into storage. Works with Django ``UploadedFile`` and any file-like
+    object exposing ``chunks()`` or ``read()``.
+    """
+    h = hashlib.sha256()
+    if hasattr(uploaded_file, "chunks"):
+        for chunk in uploaded_file.chunks(chunk_size=_HASH_CHUNK):
+            h.update(chunk)
+    else:
+        while True:
+            chunk = uploaded_file.read(_HASH_CHUNK)
+            if not chunk:
+                break
+            h.update(chunk)
+    if hasattr(uploaded_file, "seek"):
+        uploaded_file.seek(0)
+    return h.hexdigest()
+
+
+def build_provenance(
+    *,
+    sha256: Optional[str] = None,
+    fetch_method: str,
+    source_url: Optional[str] = None,
+    content_length: Optional[int] = None,
+    tls_status: Optional[str] = None,
+    ocr_engine: Optional[str] = None,
+    ocr_confidence: Optional[float] = None,
+    captured_at: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a provenance struct, dropping keys that are ``None``.
+
+    ``captured_at`` defaults to ``timezone.now()`` ISO-8601 when not supplied.
+    ``fetch_method`` is the one required field (there is always a how).
+    """
+    prov: dict[str, Any] = {
+        "fetch_method": fetch_method,
+        "captured_at": captured_at or timezone.now().isoformat(),
+    }
+    optional = {
+        "sha256": sha256,
+        "source_url": source_url,
+        "content_length": content_length,
+        "tls_status": tls_status,
+        "ocr_engine": ocr_engine,
+        "ocr_confidence": ocr_confidence,
+    }
+    prov.update({k: v for k, v in optional.items() if v is not None})
+    return prov
+
+
+def _media_list(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """``associatedMedia`` as a list (it may be a single dict or absent)."""
+    media = doc.get("associatedMedia")
+    if isinstance(media, dict):
+        return [media]
+    if isinstance(media, list):
+        return [m for m in media if isinstance(m, dict)]
+    return []
+
+
+def _same_capture(mo: dict[str, Any], *, role: str, sha256: Optional[str]) -> bool:
+    """True when ``mo`` is the same capture — matched by ``(role, sha256)``.
+
+    Falls back to ``contentUrl`` identity when no ``sha256`` is available on
+    either side (so a URL-only re-register still dedups).
+    """
+    mo_role = mo.get("jawafdehi:linkRole") or "RAW"
+    if mo_role != role:
+        return False
+    mo_sha = (mo.get(PROVENANCE_KEY) or {}).get("sha256")
+    if sha256 and mo_sha:
+        return mo_sha == sha256
+    return False
+
+
+def attach_media_object(
+    doc: dict[str, Any],
+    *,
+    content_url: str,
+    role: str,
+    encoding_format: Optional[str] = None,
+    provenance: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Attach a roled MediaObject (with provenance) to ``doc.associatedMedia``.
+
+    Idempotent: if a MediaObject for the same ``(role, sha256)`` capture already
+    exists it is **replaced in place** (preserving list order) rather than
+    duplicated — content-hash idempotency. Otherwise the new one is appended.
+    Mutates + returns ``doc``.
+    """
+    mo = jsonld._media_object({"link": content_url, "role": role})
+    if mo is None:
+        return doc
+    if encoding_format and "encodingFormat" not in mo:
+        mo["encodingFormat"] = encoding_format
+    if provenance:
+        mo[PROVENANCE_KEY] = provenance
+
+    sha256 = (provenance or {}).get("sha256")
+    media = _media_list(doc)
+    for i, existing in enumerate(media):
+        if _same_capture(existing, role=role, sha256=sha256):
+            media[i] = mo  # replace the same capture (idempotent re-upload)
+            break
+    else:
+        media.append(mo)
+    doc["associatedMedia"] = media
+    return doc

--- a/materials/tests/test_file_upload_api.py
+++ b/materials/tests/test_file_upload_api.py
@@ -69,6 +69,41 @@ class MaterialFileUploadTests(_DbAPITestCase):
         row = Material.objects.get(pk=self.IRI)
         self.assertEqual(row.material_type, "court_order")
 
+    def test_upload_records_provenance_on_media_object(self):
+        self.client.force_authenticate(user=self.user)
+        resp = self.client.post(
+            self.URL,
+            {"file": self._pdf(), "material_type": "court_order",
+             "source_url": "https://supremecourt.gov.np/x.pdf"},
+            format="multipart",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
+        prov = resp.data["associatedMedia"][0]["jawafdehi:provenance"]
+        self.assertEqual(prov["fetch_method"], "upload")
+        self.assertEqual(prov["source_url"], "https://supremecourt.gov.np/x.pdf")
+        self.assertEqual(len(prov["sha256"]), 64)  # sha256 hex
+        self.assertIn("captured_at", prov)
+        self.assertEqual(prov["content_length"], len(b"%PDF-1.4 data"))
+
+    def test_reupload_identical_bytes_same_role_dedups(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(
+            self.URL,
+            {"file": self._pdf(), "material_type": "court_order"},
+            format="multipart",
+        )
+        # Re-upload the SAME bytes at the SAME role → content-hash idempotency:
+        # the MediaObject is replaced, not duplicated.
+        resp = self.client.post(
+            self.URL, {"file": self._pdf()}, format="multipart"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, resp.data)
+        raw_media = [
+            m for m in resp.data["associatedMedia"]
+            if m["jawafdehi:linkRole"] == "RAW"
+        ]
+        self.assertEqual(len(raw_media), 1)
+
     def test_upload_updates_existing_material_appends_media(self):
         self.client.force_authenticate(user=self.user)
         # First upload creates the material.

--- a/materials/tests/test_material_convert_smoke.py
+++ b/materials/tests/test_material_convert_smoke.py
@@ -134,6 +134,11 @@ class MaterialConvertSmokeTests(APITestCase):
             if m["jawafdehi:linkRole"] == "MARKDOWN"
         )
         self.assertEqual(md["contentUrl"], "https://cdn/extracted.md")
+        # The MARKDOWN link carries OCR provenance (archive-plane record).
+        md_prov = md["jawafdehi:provenance"]
+        self.assertEqual(md_prov["fetch_method"], "ocr")
+        self.assertEqual(md_prov["ocr_engine"], "likhit")
+        self.assertEqual(len(md_prov["sha256"]), 64)
 
         # 6) The reindex actually fired with the extracted body (the search feed).
         self.assertIn("अदालतको आदेश — पूर्ण पाठ", indexed)

--- a/materials/tests/test_provenance.py
+++ b/materials/tests/test_provenance.py
@@ -1,0 +1,124 @@
+"""Tests for material MediaObject provenance + content-hash idempotency."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+
+from materials.provenance import (
+    PROVENANCE_KEY,
+    attach_media_object,
+    build_provenance,
+    content_sha256,
+)
+
+
+class _Uploaded:
+    """Minimal UploadedFile stand-in exposing chunks()/seek()."""
+
+    def __init__(self, data: bytes):
+        self._buf = io.BytesIO(data)
+        self.size = len(data)
+        self._data = data
+
+    def chunks(self, chunk_size=None):
+        size = chunk_size or 1024
+        for i in range(0, len(self._data), size):
+            yield self._data[i : i + size]
+
+    def seek(self, pos):
+        self._buf.seek(pos)
+
+
+# --- content_sha256 ----------------------------------------------------------
+
+
+def test_content_sha256_matches_hashlib_and_rewinds():
+    data = b"%PDF-1.4 nepali scan bytes" * 1000
+    up = _Uploaded(data)
+    got = content_sha256(up)
+    assert got == hashlib.sha256(data).hexdigest()
+    # Pointer rewound so the caller can still stream the file into storage.
+    assert up._buf.tell() == 0
+
+
+# --- build_provenance --------------------------------------------------------
+
+
+def test_build_provenance_drops_none_keeps_required():
+    prov = build_provenance(fetch_method="upload", sha256="abc", source_url=None)
+    assert prov["fetch_method"] == "upload"
+    assert prov["sha256"] == "abc"
+    assert "source_url" not in prov  # None dropped
+    assert "captured_at" in prov  # defaulted
+
+
+def test_build_provenance_honors_explicit_captured_at():
+    prov = build_provenance(fetch_method="ocr", captured_at="2026-07-01T00:00:00")
+    assert prov["captured_at"] == "2026-07-01T00:00:00"
+
+
+# --- attach_media_object -----------------------------------------------------
+
+
+def _doc():
+    return {"@id": "https://jawafdehi.org/material/ciaa/x", "@type": "DigitalDocument"}
+
+
+def test_attach_appends_media_with_provenance():
+    doc = _doc()
+    prov = build_provenance(sha256="h1", fetch_method="upload")
+    attach_media_object(
+        doc, content_url="https://cdn/a.pdf", role="RAW",
+        encoding_format="application/pdf", provenance=prov,
+    )
+    media = doc["associatedMedia"]
+    assert len(media) == 1
+    assert media[0]["contentUrl"] == "https://cdn/a.pdf"
+    assert media[0]["jawafdehi:linkRole"] == "RAW"
+    assert media[0]["encodingFormat"] == "application/pdf"
+    assert media[0][PROVENANCE_KEY]["sha256"] == "h1"
+
+
+def test_attach_dedups_same_role_and_sha256():
+    doc = _doc()
+    p = build_provenance(sha256="same", fetch_method="upload")
+    attach_media_object(doc, content_url="https://cdn/v1.pdf", role="RAW", provenance=p)
+    # Re-upload identical bytes (same sha256, same role) → replaced, not doubled.
+    attach_media_object(doc, content_url="https://cdn/v2.pdf", role="RAW", provenance=p)
+    media = doc["associatedMedia"]
+    assert len(media) == 1
+    assert media[0]["contentUrl"] == "https://cdn/v2.pdf"
+
+
+def test_attach_keeps_distinct_hashes_and_roles():
+    doc = _doc()
+    attach_media_object(
+        doc, content_url="https://cdn/a.pdf", role="RAW",
+        provenance=build_provenance(sha256="h1", fetch_method="upload"),
+    )
+    # Different bytes, same role → distinct capture, kept.
+    attach_media_object(
+        doc, content_url="https://cdn/b.pdf", role="RAW",
+        provenance=build_provenance(sha256="h2", fetch_method="upload"),
+    )
+    # Same-ish but different role → kept.
+    attach_media_object(
+        doc, content_url="https://cdn/c.pdf", role="ALTERNATE",
+        provenance=build_provenance(sha256="h1", fetch_method="upload"),
+    )
+    assert len(doc["associatedMedia"]) == 3
+
+
+def test_attach_handles_preexisting_single_dict_media():
+    doc = _doc()
+    doc["associatedMedia"] = {
+        "@type": "MediaObject", "contentUrl": "https://cdn/old.pdf",
+        "jawafdehi:linkRole": "RAW",
+    }
+    attach_media_object(
+        doc, content_url="https://cdn/new.pdf", role="MARKDOWN",
+        provenance=build_provenance(sha256="m", fetch_method="ocr"),
+    )
+    media = doc["associatedMedia"]
+    assert isinstance(media, list) and len(media) == 2

--- a/materials/views.py
+++ b/materials/views.py
@@ -38,6 +38,7 @@ from jawafdehi_shared.storage import store_file_as_link
 from courts.permissions import HasNgmRole
 
 from . import jsonld
+from . import provenance
 from .bulk_ingest import _infer_material_type
 from .models import Material
 
@@ -263,30 +264,6 @@ def material_detail(request, source: str, ident: str):
     return Response(data, content_type=LD_JSON)
 
 
-def _append_media_object(doc: dict, *, content_url: str, role: str, filename: str) -> dict:
-    """Append a schema.org ``MediaObject`` for an uploaded file to ``associatedMedia``.
-
-    Reuses the ``jsonld._media_object`` shaping (``contentUrl`` /
-    ``jawafdehi:linkRole`` / ``encodingFormat``) so an uploaded file is one more
-    roled link on the material — identical to the DocumentSource modality. The
-    ``encodingFormat`` is guessed from the filename extension (the roled-link
-    hint has no format for RAW/ALTERNATE/PERMALINK). Mutates + returns ``doc``.
-    """
-    mo = jsonld._media_object({"link": content_url, "role": role})
-    if mo is not None:
-        encoding, _ = mimetypes.guess_type(filename)
-        if encoding and "encodingFormat" not in mo:
-            mo["encodingFormat"] = encoding
-        media = doc.get("associatedMedia")
-        if isinstance(media, dict):
-            media = [media]
-        elif not isinstance(media, list):
-            media = []
-        media.append(mo)
-        doc["associatedMedia"] = media
-    return doc
-
-
 @api_view(["POST"])
 @permission_classes([AllowAny])
 @parser_classes([MultiPartParser, FormParser])
@@ -363,11 +340,25 @@ def material_file_upload(request, source: str, ident: str):
         material_type = existing.material_type
         doc = dict(existing.data)
 
-    # Stream the file to storage (shared hashed-filename S3 mechanism) and append
-    # its permanent URL as a roled MediaObject on the material.
+    # Capture provenance BEFORE storing (hashing rewinds the file pointer), then
+    # stream to storage and attach a roled MediaObject carrying that provenance.
+    # attach_media_object dedups on (role, sha256) so re-uploading the same bytes
+    # replaces the link instead of appending a duplicate (content-hash idempotency).
+    sha256 = provenance.content_sha256(uploaded)
+    prov = provenance.build_provenance(
+        sha256=sha256,
+        fetch_method="upload",
+        content_length=uploaded.size,
+        source_url=(request.data.get("source_url") or None),
+    )
     link = store_file_as_link(uploaded, role=role)
-    _append_media_object(
-        doc, content_url=link["link"], role=link["role"], filename=uploaded.name
+    encoding, _ = mimetypes.guess_type(uploaded.name)
+    provenance.attach_media_object(
+        doc,
+        content_url=link["link"],
+        role=link["role"],
+        encoding_format=encoding or None,
+        provenance=prov,
     )
 
     result, code, error = _upsert_material(


### PR DESCRIPTION
## Summary

Implements the **provenance** archive-plane record from `docs/data-plane-design.md` §3 item 2 (the remaining piece after #264's FTS feed). Every file-bearing MediaObject on a Material now records **how/when the bytes were captured** — the evidentiary backbone for an accountability platform.

## What it does

- **`materials/provenance.py`** (new):
  - `content_sha256(uploaded_file)` — streamed SHA-256, rewinds the pointer so the caller can still stream to storage.
  - `build_provenance(...)` — the `jawafdehi:provenance` struct: `sha256`, `captured_at`, `fetch_method` (`upload`|`ocr`|`scrape`), `source_url`, `content_length`, `tls_status`, `ocr_engine`, `ocr_confidence` (Nones dropped; `fetch_method` required).
  - `attach_media_object(...)` — attaches a roled MediaObject with provenance, **deduped on `(role, sha256)`** = content-hash idempotency.
- **Provenance rides ON the MediaObject in the JSON-LD**, not a separate `.prov.json` R2 object — the Postgres material row *is* the record, it's queryable via the JSONB GIN index, and it travels with the material (the design doc's own guidance: "land it as Material provenance, not an Iceberg bronze row").
- **Upload endpoint**: hashes before storing, attaches `fetch_method=upload` provenance; **re-uploading identical bytes at the same role now replaces the link instead of appending a duplicate** (previously always appended). Removed the now-dead `_append_media_object`.
- **`material_convert` `on_result`**: the MARKDOWN link gets `fetch_method=ocr` / `ocr_engine=likhit`.

## Design notes

- **No schema change** — provenance is JSONB inside `Material.data`; `makemigrations --check` clean.
- **Content-hash idempotency is at the MediaObject level**, not storage: `HashedFilenameS3Boto3Storage` hashes the *filename* (salted), not content, so dedup has to live in the JSON-LD.
- Doc updated: §3/§8 mark provenance **BUILT (embedded, not a sidecar file)**; the material-specific R2 prefix (needs a storage-backend prefix override) and provenance on the scraper-fed `/api/ingestion/documents` path remain follow-ups.

## Testing

- 7 provenance unit tests (hash/rewind, build, dedup, distinct-hash/role, single-dict normalization).
- Upload API: provenance-recorded + identical-reupload-dedups.
- Convert smoke: MARKDOWN link carries `fetch_method=ocr` provenance.
- Full unit suite **854 passing**; `manage.py check` clean; no migration drift; ruff clean on changed files (4 pre-existing `materials/` errors in untouched files remain).