### PR TITLE
Casework API: decommission Django case-admin forms — PATCH transitions, ?state= filter, grouped reviews, dev-login (companion to FE #163)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -44,7 +44,6 @@ from entities.models import StoredEntity
 from courts.models import Court, CourtCase
 from materials.models import Material
 
-from .admin import CaseAdminForm
 from .caseworker_serializers import (
     BLOCKED_PATH_PREFIXES,
     CaseCreateSerializer,
@@ -115,7 +114,7 @@ def _recompute_material_visibility(material_iris) -> None:
     create=extend_schema(
         summary="Create a draft case",
         description="""
-        Create a new case through the same validation rules used by the Django admin form.
+        Create a new case through the model-layer validation rules (`Case.validate()` / `Case.save()`).
 
         Authenticated users create cases in `DRAFT` state only. The request user is
         automatically added as a contributor on the new case.
@@ -349,12 +348,39 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             "entity_relationships",
         ).order_by("-created_at")
 
+    # Case model fields that CaseCreateSerializer may set directly on the row.
+    # Non-model serializer keys (alleged_entities / related_entities / evidence)
+    # are handled separately as binds/joins below.
+    _CREATE_MODEL_FIELDS = frozenset(
+        [
+            "case_type",
+            "state",
+            "title",
+            "short_description",
+            "description",
+            "thumbnail_url",
+            "banner_url",
+            "case_start_date",
+            "case_end_date",
+            "tags",
+            "key_allegations",
+            "timeline",
+            "notes",
+            "slug",
+            "court_cases",
+            "missing_details",
+            "bigo",
+        ]
+    )
+
     def create(self, request, *args, **kwargs):
         """
         POST /api/cases/
 
-        Create a new case by delegating validation to the existing Django admin form
-        so API and admin creation semantics stay aligned.
+        Create a new case through the model-layer validation rules
+        (``Case.validate()`` / ``Case.save()``), which are the single source of
+        truth. Enforces DRAFT-on-create and the required-field rules that were
+        previously re-invoked via ``CaseAdminForm``.
         """
         # Validate that request body is a JSON object (dict), not array or scalar
         if not isinstance(request.data, dict):
@@ -377,33 +403,65 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
                 serializer.errors, status=status.HTTP_422_UNPROCESSABLE_ENTITY
             )
 
-        form = CaseAdminForm(data=serializer.validated_data, request=request)
-        if not form.is_valid():
-            return Response(form.errors, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+        validated = serializer.validated_data
 
-        with transaction.atomic():
-            case = form.save()
-            case.contributors.add(request.user)
-
-            # Create entity binds (NES ids) for alleged/related entities
-            for nes_id in serializer.validated_data.get("alleged_entities", []):
-                CaseEntityRelationship.objects.get_or_create(
-                    case=case,
-                    nes_id=nes_id,
-                    relationship_type=RelationshipType.ACCUSED,
-                )
-            for nes_id in serializer.validated_data.get("related_entities", []):
-                CaseEntityRelationship.objects.get_or_create(
-                    case=case,
-                    nes_id=nes_id,
-                    relationship_type=RelationshipType.RELATED,
-                )
-
-            # Create evidence binds (NGM material ids) — the CaseMaterialReference
-            # join. Ordinal preserves the submitted order (ADR: cases own no docs).
-            self._write_material_references(
-                case, serializer.validated_data.get("evidence", [])
+        # New cases must be DRAFT. This rule lived only in CaseAdminForm.clean()
+        # (admin.py:271) — not at the model layer — so it is ported here to keep
+        # create() lenient (DRAFT skips the allegation/description/entity gates)
+        # while still refusing a client-supplied non-DRAFT create.
+        if validated.get("state", CaseState.DRAFT) != CaseState.DRAFT:
+            return Response(
+                {
+                    "state": [
+                        "New cases must be created in DRAFT state. "
+                        f"Cannot create a new case with state {validated.get('state')}."
+                    ]
+                },
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
+
+        # Build the Case from the validated scalar fields; force DRAFT.
+        model_kwargs = {
+            field: validated[field]
+            for field in self._CREATE_MODEL_FIELDS
+            if field in validated
+        }
+        model_kwargs["state"] = CaseState.DRAFT
+        case = Case(**model_kwargs)
+
+        # Model-layer validation is the single source of truth (title-required,
+        # slug format, state-based required fields). ``validate()`` runs the
+        # state rules and auto-generates the slug; ``save()`` re-checks the title
+        # and slug immutability. Both raise ValidationError -> 422 field errors.
+        # (Slug FORMAT was already enforced by the serializer's validate_slug
+        # validator; blank slug is auto-generated, matching admin/save semantics.)
+        try:
+            case.validate()
+            with transaction.atomic():
+                case.save()
+                case.contributors.add(request.user)
+
+                # Create entity binds (NES ids) for alleged/related entities
+                for nes_id in validated.get("alleged_entities", []):
+                    CaseEntityRelationship.objects.get_or_create(
+                        case=case,
+                        nes_id=nes_id,
+                        relationship_type=RelationshipType.ACCUSED,
+                    )
+                for nes_id in validated.get("related_entities", []):
+                    CaseEntityRelationship.objects.get_or_create(
+                        case=case,
+                        nes_id=nes_id,
+                        relationship_type=RelationshipType.RELATED,
+                    )
+
+                # Create evidence binds (NGM material ids) — the
+                # CaseMaterialReference join. Ordinal preserves submitted order
+                # (ADR: cases own no docs).
+                self._write_material_references(case, validated.get("evidence", []))
+        except ValidationError as exc:
+            detail = getattr(exc, "message_dict", None) or {"detail": exc.messages}
+            return Response(detail, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         # Newly-created evidence may reference materials whose visibility now
         # depends on this case's state — recompute (best-effort, on_commit).

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -604,10 +604,11 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
                 {"detail": "Permission denied for requested state transition."},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        # Note: only IN_REVIEW transitions are supported by this endpoint today.
-        # Admins/moderators may be allowed other transitions in future PRs.
-        # Non-IN_REVIEW targets will be rejected with 422 below even if the
-        # permission check above passes.
+        # All target states (IN_REVIEW / PUBLISHED / CLOSED / DRAFT) are
+        # supported; each dispatches to the corresponding model method below.
+        # can_transition_case_state gates the roles: Caseworkers are confined to
+        # DRAFT<->IN_REVIEW by the predicate, so PUBLISHED/CLOSED/revert-to-DRAFT
+        # are effectively Admin/Moderator only.
 
         # Gate entity rewrite to actual /entities patch ops.
         # _build_snapshot always includes "entities" in the snapshot, so
@@ -699,23 +700,47 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             case.refresh_from_db()
 
             if target_state is not None and target_state != case.state:
-                if target_state == CaseState.IN_REVIEW:
-                    try:
+                # Every target dispatches to the model method that already
+                # implements + validates the transition (Case.validate() enforces
+                # BR-1..BR-4 on IN_REVIEW/PUBLISHED). No transition rule is
+                # re-implemented here; the permission gate was applied above via
+                # can_transition_case_state. A model ValidationError -> 422 with
+                # field-keyed messages (mirroring the original submit() handling).
+                try:
+                    if target_state == CaseState.IN_REVIEW:
                         case.submit()
-                    except ValidationError as exc:
-                        detail = getattr(exc, "message_dict", None) or {
-                            "detail": exc.messages
+                    elif target_state == CaseState.PUBLISHED:
+                        case.publish()
+                    elif target_state == CaseState.CLOSED:
+                        # Soft-delete (state -> CLOSED + versionInfo audit entry).
+                        case.delete()
+                    elif target_state == CaseState.DRAFT:
+                        # Un-submit / un-publish. No dedicated model method exists;
+                        # set DRAFT (lenient validation — only title), record the
+                        # audit entry, and save (mirrors submit()/publish()).
+                        case.state = CaseState.DRAFT
+                        case.validate()
+                        case.versionInfo = {
+                            "action": "reverted_to_draft",
+                            "datetime": timezone.now().isoformat(),
                         }
+                        case.save()
+                    else:
                         transaction.set_rollback(True)
-                        return Response(detail, status=status.HTTP_400_BAD_REQUEST)
-                else:
+                        return Response(
+                            {
+                                "detail": (
+                                    f"Unsupported state transition target: {target_state}."
+                                )
+                            },
+                            status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        )
+                except ValidationError as exc:
+                    detail = getattr(exc, "message_dict", None) or {
+                        "detail": exc.messages
+                    }
                     transaction.set_rollback(True)
-                    return Response(
-                        {
-                            "detail": "Only transitions to IN_REVIEW are supported via this endpoint."
-                        },
-                        status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    )
+                    return Response(detail, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         # Scalar edits go through queryset .update() and entity-relationship
         # edits through bulk delete/create — neither fires post_save, so the

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -139,6 +139,9 @@ def _recompute_material_visibility(material_iris) -> None:
 
         **Filtering:**
         - `case_type`: Filter by case type (CORRUPTION)
+        - `state`: Filter by workflow state (DRAFT / IN_REVIEW / PUBLISHED). Applied
+          after visibility scoping, so callers only ever see states they may view
+          (e.g. `?state=IN_REVIEW` is the moderation queue for casework roles).
         - `tags`: Filter cases containing a specific tag
 
         **Search:**
@@ -155,6 +158,14 @@ def _recompute_material_visibility(material_iris) -> None:
                 location=OpenApiParameter.QUERY,
                 description="Filter by case type",
                 enum=["CORRUPTION"],
+                required=False,
+            ),
+            OpenApiParameter(
+                name="state",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Filter by workflow state (visibility-scoped)",
+                enum=["DRAFT", "IN_REVIEW", "PUBLISHED"],
                 required=False,
             ),
             OpenApiParameter(
@@ -238,7 +249,11 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = CaseSerializer
     lookup_field = "slug"
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
-    filterset_fields = ["case_type"]
+    # ``state`` powers the moderation queue (GET /api/cases/?state=IN_REVIEW,
+    # plan §G1). Filtering runs AFTER get_queryset()'s visibility scoping, so a
+    # public caller filtering ?state=IN_REVIEW still gets nothing (the base
+    # queryset is PUBLISHED-only) — visibility is preserved.
+    filterset_fields = ["case_type", "state"]
     search_fields = ["title", "description", "key_allegations"]
     # Auth: inherit the OIDC-only DEFAULT_AUTHENTICATION_CLASSES (no per-view
     # pin). Unauthenticated reads still work because the actions use

--- a/cases/management/commands/seed_dev.py
+++ b/cases/management/commands/seed_dev.py
@@ -1,0 +1,113 @@
+"""Seed a minimal local-dev dataset + role users for the admin panel.
+
+DEV ONLY. Creates the standard groups, three login users (admin / moderator /
+caseworker, password == username), and a handful of cases (one per state), a
+court, a court case, and a blocklisted firm — enough to exercise every admin
+screen. Idempotent: safe to re-run.
+
+Usage (with DEV_AUTH env, DEBUG=True):
+    uv run python manage.py seed_dev
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    RelationshipType,
+)
+from courts.models import BlacklistedFirm, Court, CourtCase
+
+User = get_user_model()
+
+USERS = [
+    ("admin", [], True),
+    ("moderator", ["Moderator"], False),
+    ("caseworker", ["Caseworker"], False),
+]
+
+CASES = [
+    ("seed-draft", "Draft: alleged kickbacks at Dept A", CaseState.DRAFT),
+    ("seed-in-review", "Review: procurement fraud Ministry X", CaseState.IN_REVIEW),
+    ("seed-published", "Published: embezzlement at Board Y", CaseState.PUBLISHED),
+    ("seed-closed", "Closed: dismissed complaint Z", CaseState.CLOSED),
+]
+
+
+class Command(BaseCommand):
+    help = "Seed minimal local-dev data + role users (DEV ONLY, idempotent)."
+
+    def handle(self, *args, **options):
+        call_command("create_groups")
+
+        for name, groups, su in USERS:
+            u, _ = User.objects.get_or_create(
+                username=name, defaults={"email": f"{name}@local.test"}
+            )
+            u.set_password(name)
+            u.is_staff = True
+            u.is_superuser = su
+            u.save()
+            u.groups.clear()
+            for g in groups:
+                grp = Group.objects.filter(name=g).first()
+                if grp:
+                    u.groups.add(grp)
+            self.stdout.write(f"user {name}: pw={name} superuser={su} groups={groups}")
+
+        court, _ = Court.objects.get_or_create(
+            identifier="supreme-court",
+            defaults=dict(
+                court_type="SUPREME",
+                full_name_nepali="सर्वोच्च अदालत",
+                full_name_english="Supreme Court",
+            ),
+        )
+        CourtCase.objects.get_or_create(
+            court=court,
+            case_number="075-CR-0123",
+            defaults=dict(
+                case_type="Corruption",
+                case_status="Pending",
+                plaintiff="State",
+                defendant="Ram Bahadur",
+            ),
+        )
+        BlacklistedFirm.objects.get_or_create(
+            firm_name="Acme Builders Pvt Ltd",
+            defaults=dict(
+                proprietor_name="J. Doe",
+                reason="Contract fraud",
+                recommending_office="CIAA",
+            ),
+        )
+
+        for slug, title, state in CASES:
+            strict = state in (CaseState.IN_REVIEW, CaseState.PUBLISHED)
+            c, created = Case.objects.get_or_create(
+                slug=slug,
+                defaults=dict(
+                    title=title,
+                    case_type=CaseType.CORRUPTION,
+                    state=state,
+                    short_description="Seed case for local testing.",
+                    description="## Summary\n\nSeed **markdown** body.",
+                    key_allegations=["Misappropriation", "Bid rigging"]
+                    if strict
+                    else [],
+                ),
+            )
+            if created and strict:
+                CaseEntityRelationship.objects.get_or_create(
+                    case=c,
+                    nes_id="https://jawafdehi.org/entity/person/ram-bahadur",
+                    relationship_type=RelationshipType.ACCUSED,
+                )
+            self.stdout.write(f"case {slug}: state={c.state} created={created}")
+
+        self.stdout.write(self.style.SUCCESS("seed_dev complete."))

--- a/cases/management/commands/seed_dev.py
+++ b/cases/management/commands/seed_dev.py
@@ -1,9 +1,10 @@
 """Seed a minimal local-dev dataset + role users for the admin panel.
 
 DEV ONLY. Creates the standard groups, three login users (admin / moderator /
-caseworker, password == username), and a handful of cases (one per state), a
-court, a court case, and a blocklisted firm — enough to exercise every admin
-screen. Idempotent: safe to re-run.
+caseworker, password == username), NES entities, NGM materials, courts, court
+cases, cases (one per state), and a blocklisted firm — enough to exercise every
+admin screen (incl. the case-edit entity linker + evidence/material picker).
+Idempotent: safe to re-run.
 
 Usage (with DEV_AUTH env, DEBUG=True):
     uv run python manage.py seed_dev
@@ -22,8 +23,28 @@ from cases.models import (
     RelationshipType,
 )
 from courts.models import BlacklistedFirm, Court, CourtCase
+from jawafdehi_shared.entities.ids import build_entity_iri, build_material_iri
+from materials.jsonld import MATERIAL_CONTEXT, type_for
+from materials.models import Material
 
 User = get_user_model()
+
+# NES entities to publish: (prefix, slug, @type, English name, Nepali name).
+ENTITIES = [
+    ("person", "ram-bahadur", "Person", "Ram Bahadur", "राम बहादुर"),
+    ("person", "sita-sharma", "Person", "Sita Sharma", "सीता शर्मा"),
+    ("organization", "ministry-of-works", "Organization", "Ministry of Works", "निर्माण मन्त्रालय"),
+    ("organization", "board-y", "Organization", "Board Y", "बोर्ड वाई"),
+    ("place", "kathmandu", "Place", "Kathmandu", "काठमाडौँ"),
+]
+
+# NGM materials: (source, ident, material_type, English name).
+MATERIALS = [
+    ("ciaa", "report-1", "official_report", "CIAA Investigation Report 2080"),
+    ("ciaa", "chargesheet-1", "charge_sheet", "Charge Sheet — Ministry of Works"),
+    ("oag", "audit-2079", "official_report", "OAG Audit Report FY2079/80"),
+    ("court", "verdict-075-cr-0123", "court_order", "Verdict 075-CR-0123"),
+]
 
 USERS = [
     ("admin", [], True),
@@ -60,12 +81,57 @@ class Command(BaseCommand):
                     u.groups.add(grp)
             self.stdout.write(f"user {name}: pw={name} superuser={su} groups={groups}")
 
+        # ── NES entities (published, via the PublicationService write path) ──
+        from entities.services.publication.service import PublicationService
+
+        svc = PublicationService()
+        for prefix, slug, etype, name_en, name_ne in ENTITIES:
+            iri = build_entity_iri(prefix, slug)
+            if svc.repo.get_entity(iri) is not None:
+                self.stdout.write(f"entity {iri}: exists")
+                continue
+            doc = {
+                "@context": "https://schema.org",
+                "@id": iri,
+                "@type": etype,
+                "name": {"en": name_en, "ne": name_ne},
+            }
+            svc.create_entity(doc, author_id="seed_dev", change_description="seed")
+            self.stdout.write(f"entity {iri}: created")
+
+        # ── NGM materials (schema.org JSON-LD, via Material.from_jsonld) ──
+        for source, ident, mtype, name_en in MATERIALS:
+            iri = build_material_iri(source, ident)
+            if Material.objects.filter(iri=iri).exists():
+                self.stdout.write(f"material {iri}: exists")
+                continue
+            at_type, additional = type_for(mtype)
+            doc = {
+                "@context": MATERIAL_CONTEXT,
+                "@id": iri,
+                "@type": at_type,
+                "name": {"en": name_en},
+            }
+            if additional:
+                doc["additionalType"] = additional
+            m = Material.from_jsonld(doc, material_type=mtype)
+            m.save()
+            self.stdout.write(f"material {iri}: created")
+
         court, _ = Court.objects.get_or_create(
             identifier="supreme-court",
             defaults=dict(
                 court_type="SUPREME",
                 full_name_nepali="सर्वोच्च अदालत",
                 full_name_english="Supreme Court",
+            ),
+        )
+        Court.objects.get_or_create(
+            identifier="kathmandu-district-court",
+            defaults=dict(
+                court_type="DISTRICT",
+                full_name_nepali="काठमाडौँ जिल्ला अदालत",
+                full_name_english="Kathmandu District Court",
             ),
         )
         CourtCase.objects.get_or_create(

--- a/review/urls.py
+++ b/review/urls.py
@@ -5,7 +5,6 @@ jawafdehi-api JWT (clients get a token from /api/caseworker/auth/token/), and
 every endpoint requires at least the Caseworker role (see permissions.py).
 """
 
-from django.conf import settings
 from django.urls import path
 
 from . import views
@@ -25,11 +24,13 @@ urlpatterns = [
     path("config/", views.config_view),
 ]
 
-# DEV-ONLY username/password session login for the SPA. Mounted only when
-# DEV_AUTH is enabled (DEBUG/TESTING) — with the flag off these routes do not
-# exist, so the platform is OIDC/SSO-only. Same credentials as the Django admin.
-if settings.DEV_AUTH:
-    urlpatterns += [
-        path("auth/dev-login/", views.dev_login_view),
-        path("auth/dev-logout/", views.dev_logout_view),
-    ]
+# DEV-ONLY username/password session login for the SPA (same credentials as the
+# Django admin). The routes are always registered, but each view hard-404s at
+# runtime unless DEV_AUTH is enabled (DEBUG/TESTING) — so with the flag off the
+# platform is effectively OIDC/SSO-only. Runtime gating (not import-time) keeps
+# the boundary from depending on when this module is imported relative to when
+# DEV_AUTH is set, which otherwise leaves the flag untestable and route-flaky.
+urlpatterns += [
+    path("auth/dev-login/", views.dev_login_view),
+    path("auth/dev-logout/", views.dev_logout_view),
+]

--- a/review/urls.py
+++ b/review/urls.py
@@ -12,6 +12,7 @@ from . import views
 urlpatterns = [
     path("auth/me/", views.me_view),
     path("reviews/", views.ReviewListView.as_view()),
+    path("reviews/grouped/", views.GroupedReviewListView.as_view()),
     path("reviews/submit/", views.submit_review),
     path("reviews/regrade-all/", views.regrade_all),
     # NOTE: the review-local job API (jobs/claim, jobs/<id>/stage, jobs/<id>/result)

--- a/review/urls.py
+++ b/review/urls.py
@@ -5,6 +5,7 @@ jawafdehi-api JWT (clients get a token from /api/caseworker/auth/token/), and
 every endpoint requires at least the Caseworker role (see permissions.py).
 """
 
+from django.conf import settings
 from django.urls import path
 
 from . import views
@@ -23,3 +24,12 @@ urlpatterns = [
     path("rules/<int:pk>/", views.rule_detail),
     path("config/", views.config_view),
 ]
+
+# DEV-ONLY username/password session login for the SPA. Mounted only when
+# DEV_AUTH is enabled (DEBUG/TESTING) — with the flag off these routes do not
+# exist, so the platform is OIDC/SSO-only. Same credentials as the Django admin.
+if settings.DEV_AUTH:
+    urlpatterns += [
+        path("auth/dev-login/", views.dev_login_view),
+        path("auth/dev-logout/", views.dev_logout_view),
+    ]

--- a/review/views.py
+++ b/review/views.py
@@ -116,6 +116,61 @@ class ReviewListView(generics.ListAPIView):
         return CaseReview.objects.all()
 
 
+class GroupedReviewListView(generics.ListAPIView):
+    """GET /api/casework/reviews/grouped/
+
+    The flat review list carries one row per execution; the SPA's review list
+    page instead wants ONE entry per case with ALL of that case's executions
+    (so an older run doesn't fall onto a later page of the flat list). This view
+    groups CaseReview rows by case slug and paginates BY CASE.
+
+    Each result: {slug, case_title, latest: <ReviewListItem>,
+    executions: [<ReviewListItem> ...]} — executions newest-first, cases ordered
+    by their most-recent execution (newest case first). ``latest`` is
+    ``executions[0]``. Uses the same CaseReviewListSerializer as the flat list
+    so item shapes match exactly.
+    """
+
+    permission_classes = [CanReadReview]
+    serializer_class = CaseReviewListSerializer
+
+    def _grouped_cases(self):
+        # CaseReview.Meta.ordering is -created_at, so iterating in that order
+        # yields executions newest-first per group and cases in most-recent-first
+        # order (the first slug seen is the one with the newest execution).
+        groups: dict[str, list[CaseReview]] = {}
+        for review in CaseReview.objects.all():
+            groups.setdefault(review.slug, []).append(review)
+        return groups
+
+    def list(self, request, *args, **kwargs):
+        groups = self._grouped_cases()
+        slugs = list(groups.keys())  # already ordered newest-case-first
+
+        page = self.paginate_queryset(slugs)
+        page_slugs = page if page is not None else slugs
+
+        results = []
+        for slug in page_slugs:
+            executions = groups[slug]
+            items = CaseReviewListSerializer(executions, many=True).data
+            latest = executions[0]
+            results.append(
+                {
+                    "slug": slug,
+                    # The case title is snapshotted on every review row; the
+                    # newest execution carries the freshest value.
+                    "case_title": latest.case_title,
+                    "latest": items[0],
+                    "executions": items,
+                }
+            )
+
+        if page is not None:
+            return self.get_paginated_response(results)
+        return Response(results)
+
+
 class ReviewDetailView(generics.RetrieveAPIView):
     serializer_class = CaseReviewDetailSerializer
     permission_classes = [CanReadReview]

--- a/review/views.py
+++ b/review/views.py
@@ -18,7 +18,11 @@ gate the UI by role.
 
 from django.utils import timezone
 from rest_framework import generics, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.response import Response
 
 from . import code_rules
@@ -36,21 +40,76 @@ from .serializers import (
 )
 
 
+def _user_roles_payload(user):
+    """Shared shape for me/dev-login: username + flattened group roles + is_admin."""
+    roles = list(user.groups.values_list("name", flat=True))
+    if user.is_superuser and "Admin" not in roles:
+        roles = ["Admin"] + roles
+    return {
+        "username": user.username,
+        "roles": roles,
+        "is_admin": user.is_superuser or "Admin" in roles,
+    }
+
+
 @api_view(["GET"])
 @permission_classes([CanReadReview])
 def me_view(request):
     """Return the signed-in user + their roles (for the SPA header / gating)."""
-    user = request.user
-    roles = list(user.groups.values_list("name", flat=True))
-    if user.is_superuser and "Admin" not in roles:
-        roles = ["Admin"] + roles
-    return Response(
-        {
-            "username": user.username,
-            "roles": roles,
-            "is_admin": user.is_superuser or "Admin" in roles,
-        }
-    )
+    return Response(_user_roles_payload(request.user))
+
+
+# ---------------------------------------------------------------------------
+# DEV-ONLY username/password login for the SPA (mirrors DEV_AUTH on the backend).
+#
+# Production is OIDC/Zitadel only. When settings.DEV_AUTH is enabled (DEBUG or
+# TESTING only — never in prod), we expose a session login the React /admin can
+# POST to with the SAME credentials as the Django admin, so a developer can work
+# without standing up Zitadel. These routes are ONLY mounted when DEV_AUTH is on
+# (see review/urls.py); with the flag off they don't exist → SSO-only.
+# ---------------------------------------------------------------------------
+from django.conf import settings  # noqa: E402
+from django.contrib.auth import authenticate, login, logout  # noqa: E402
+from django.middleware.csrf import get_token  # noqa: E402
+from rest_framework.authentication import SessionAuthentication  # noqa: E402
+from rest_framework.permissions import AllowAny  # noqa: E402
+
+
+@api_view(["POST"])
+@authentication_classes([SessionAuthentication])
+@permission_classes([AllowAny])
+def dev_login_view(request):
+    """DEV-ONLY: authenticate with username/password, open a Django session.
+
+    Returns the same {username, roles, is_admin} shape as ``me`` plus a CSRF
+    token the SPA must echo as X-CSRFToken on subsequent session-authenticated
+    writes. Hard 404 when DEV_AUTH is off so it can never exist in production.
+    """
+    if not settings.DEV_AUTH:
+        return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+    username = (request.data.get("username") or "").strip()
+    password = request.data.get("password") or ""
+    user = authenticate(request, username=username, password=password)
+    if user is None:
+        return Response(
+            {"detail": "Invalid username or password."},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+    login(request, user)
+    payload = _user_roles_payload(user)
+    payload["csrftoken"] = get_token(request)
+    return Response(payload)
+
+
+@api_view(["POST"])
+@authentication_classes([SessionAuthentication])
+@permission_classes([AllowAny])
+def dev_logout_view(request):
+    """DEV-ONLY: end the Django session opened by dev_login_view."""
+    if not settings.DEV_AUTH:
+        return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+    logout(request)
+    return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(["POST"])

--- a/review/views.py
+++ b/review/views.py
@@ -52,11 +52,8 @@ def _user_roles_payload(user):
     }
 
 
-@api_view(["GET"])
-@permission_classes([CanReadReview])
-def me_view(request):
-    """Return the signed-in user + their roles (for the SPA header / gating)."""
-    return Response(_user_roles_payload(request.user))
+# me_view is defined below, after DEV_OR_OIDC_AUTH — it must accept the dev
+# session as well as an OIDC bearer, so its authenticators are pinned explicitly.
 
 
 # ---------------------------------------------------------------------------
@@ -71,12 +68,47 @@ def me_view(request):
 from django.conf import settings  # noqa: E402
 from django.contrib.auth import authenticate, login, logout  # noqa: E402
 from django.middleware.csrf import get_token  # noqa: E402
+from jawafdehi_shared.auth.oidc import OIDCAuthentication  # noqa: E402
 from rest_framework.authentication import SessionAuthentication  # noqa: E402
 from rest_framework.permissions import AllowAny  # noqa: E402
 
 
+class DevAwareSessionAuthentication(SessionAuthentication):
+    """SessionAuthentication that is INERT unless DEV_AUTH is on, evaluated per
+    request. DRF freezes a view's authenticators from DEFAULT_AUTHENTICATION_CLASSES
+    at import time (APIView.authentication_classes is a class attr set once), so a
+    view that must accept the DEV_AUTH session — like ``me`` and the dev-login
+    endpoints — can't rely on the global list, which only includes Session when
+    DEV_AUTH was truthy at settings-load. Pinning this class on those views makes
+    the session path work whenever DEV_AUTH is on, regardless of load order, and
+    stay OIDC-only in production (where DEV_AUTH is always False)."""
+
+    def authenticate(self, request):
+        if not settings.DEV_AUTH:
+            return None
+        return super().authenticate(request)
+
+
+# The authenticators for endpoints the SPA reaches with EITHER an OIDC bearer or
+# (in dev) a Django session: OIDC first, session second (inert unless DEV_AUTH).
+DEV_OR_OIDC_AUTH = [OIDCAuthentication, DevAwareSessionAuthentication]
+
+
+@api_view(["GET"])
+@authentication_classes(DEV_OR_OIDC_AUTH)
+@permission_classes([CanReadReview])
+def me_view(request):
+    """Return the signed-in user + their roles (for the SPA header / gating).
+
+    Accepts an OIDC bearer or (in dev) the session opened by dev_login_view —
+    authenticators are pinned so the dev session works regardless of DRF's
+    import-time freezing of the global default auth classes.
+    """
+    return Response(_user_roles_payload(request.user))
+
+
 @api_view(["POST"])
-@authentication_classes([SessionAuthentication])
+@authentication_classes([DevAwareSessionAuthentication])
 @permission_classes([AllowAny])
 def dev_login_view(request):
     """DEV-ONLY: authenticate with username/password, open a Django session.
@@ -102,7 +134,7 @@ def dev_login_view(request):
 
 
 @api_view(["POST"])
-@authentication_classes([SessionAuthentication])
+@authentication_classes([DevAwareSessionAuthentication])
 @permission_classes([AllowAny])
 def dev_logout_view(request):
     """DEV-ONLY: end the Django session opened by dev_login_view."""

--- a/tests/api/test_case_state_filter.py
+++ b/tests/api/test_case_state_filter.py
@@ -1,0 +1,77 @@
+"""Tests for the ?state= filter on GET /api/cases/ (plan §G1 — moderation queue).
+
+The filter runs AFTER get_queryset()'s visibility scoping, so a caller can only
+ever see states they are permitted to view.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from cases.models import CaseState, CaseType
+from tests.conftest import create_case_with_entities, create_user_with_role
+
+URL = "/api/cases/"
+
+
+def _slugs(response):
+    return {c["slug"] for c in response.data.get("results", [])}
+
+
+@pytest.fixture
+def moderator(db):
+    return create_user_with_role("mod-filter", "mod-filter@example.com", "Moderator")
+
+
+@pytest.fixture
+def cases(db):
+    published = create_case_with_entities(
+        title="Published one", case_type=CaseType.CORRUPTION, state=CaseState.PUBLISHED
+    )
+    in_review = create_case_with_entities(
+        title="In review one", case_type=CaseType.CORRUPTION, state=CaseState.IN_REVIEW
+    )
+    draft = create_case_with_entities(
+        title="Draft one", case_type=CaseType.CORRUPTION, state=CaseState.DRAFT
+    )
+    return {"published": published, "in_review": in_review, "draft": draft}
+
+
+@pytest.mark.django_db
+def test_moderator_filters_in_review_queue(moderator, cases):
+    """?state=IN_REVIEW returns exactly the moderation queue for a casework role."""
+    client = APIClient()
+    client.force_authenticate(user=moderator)
+
+    response = client.get(URL, {"state": CaseState.IN_REVIEW})
+
+    assert response.status_code == 200
+    assert _slugs(response) == {cases["in_review"].slug}
+
+
+@pytest.mark.django_db
+def test_moderator_filters_published(moderator, cases):
+    client = APIClient()
+    client.force_authenticate(user=moderator)
+
+    response = client.get(URL, {"state": CaseState.PUBLISHED})
+
+    assert response.status_code == 200
+    assert _slugs(response) == {cases["published"].slug}
+
+
+@pytest.mark.django_db
+def test_unauthenticated_state_filter_respects_visibility(cases):
+    """A public caller filtering ?state=IN_REVIEW gets nothing — visibility is
+    scoped before the filter applies (no casework leak)."""
+    response = APIClient().get(URL, {"state": CaseState.IN_REVIEW})
+
+    assert response.status_code == 200
+    assert _slugs(response) == set()
+
+
+@pytest.mark.django_db
+def test_unauthenticated_state_filter_published_still_works(cases):
+    response = APIClient().get(URL, {"state": CaseState.PUBLISHED})
+
+    assert response.status_code == 200
+    assert _slugs(response) == {cases["published"].slug}

--- a/tests/api/test_case_state_transitions.py
+++ b/tests/api/test_case_state_transitions.py
@@ -1,0 +1,214 @@
+"""Tests for A2 — full case state transitions via PATCH /api/cases/{slug}/.
+
+The PATCH endpoint dispatches every state target to the model method that
+already implements + validates the transition:
+
+    ->IN_REVIEW  = Case.submit()
+    ->PUBLISHED  = Case.publish()
+    ->CLOSED     = Case.delete()   (soft-delete)
+    ->DRAFT      = revert (un-submit / un-publish)
+
+Each is gated by can_transition_case_state (Admin/Moderator may go anywhere;
+Caseworkers are confined to DRAFT<->IN_REVIEW by the predicate). Model
+ValidationError surfaces as 422 with field-keyed messages.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    RelationshipType,
+)
+from tests.conftest import create_user_with_role
+
+URL = "/api/cases/{}/"
+
+
+def _authed_client(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _publishable_case(state=CaseState.DRAFT, **kwargs) -> Case:
+    """A case that satisfies the IN_REVIEW/PUBLISHED gates (accused entity +
+    allegations + description)."""
+    defaults = dict(
+        title="Publishable case",
+        case_type=CaseType.CORRUPTION,
+        state=state,
+        description="Detailed allegation description",
+        short_description="Short",
+        key_allegations=["Primary allegation"],
+    )
+    defaults.update(kwargs)
+    case = Case.objects.create(**defaults)
+    CaseEntityRelationship.objects.create(
+        case=case,
+        nes_id="https://jawafdehi.org/entity/person/ram-prasad-gautam",
+        relationship_type=RelationshipType.ACCUSED,
+    )
+    return case
+
+
+def _patch_state(client, case, target):
+    return client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/state", "value": target}],
+        format="json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Allowed transitions per role (success)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("role", ["Admin", "Moderator"])
+def test_in_review_to_published_allowed_for_admin_moderator(role):
+    user = create_user_with_role(f"pub-{role}", f"pub-{role}@example.com", role)
+    case = _publishable_case(state=CaseState.IN_REVIEW)
+
+    response = _patch_state(_authed_client(user), case, CaseState.PUBLISHED)
+
+    assert response.status_code == 200
+    assert response.data["state"] == CaseState.PUBLISHED
+    case.refresh_from_db()
+    assert case.state == CaseState.PUBLISHED
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("role", ["Admin", "Moderator"])
+def test_draft_to_published_allowed_for_admin_moderator(role):
+    user = create_user_with_role(f"dpub-{role}", f"dpub-{role}@example.com", role)
+    case = _publishable_case(state=CaseState.DRAFT)
+
+    response = _patch_state(_authed_client(user), case, CaseState.PUBLISHED)
+
+    assert response.status_code == 200
+    case.refresh_from_db()
+    assert case.state == CaseState.PUBLISHED
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("role", ["Admin", "Moderator"])
+def test_to_closed_soft_delete_allowed_for_admin_moderator(role):
+    user = create_user_with_role(f"cls-{role}", f"cls-{role}@example.com", role)
+    case = _publishable_case(state=CaseState.PUBLISHED)
+
+    response = _patch_state(_authed_client(user), case, CaseState.CLOSED)
+
+    assert response.status_code == 200
+    case.refresh_from_db()
+    assert case.state == CaseState.CLOSED
+    # Soft-delete: the row is preserved with a deletion audit entry.
+    assert case.versionInfo.get("action") == "deleted"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("role", ["Admin", "Moderator"])
+def test_published_to_draft_revert_allowed_for_admin_moderator(role):
+    user = create_user_with_role(f"rev-{role}", f"rev-{role}@example.com", role)
+    case = _publishable_case(state=CaseState.PUBLISHED)
+
+    response = _patch_state(_authed_client(user), case, CaseState.DRAFT)
+
+    assert response.status_code == 200
+    case.refresh_from_db()
+    assert case.state == CaseState.DRAFT
+    assert case.versionInfo.get("action") == "reverted_to_draft"
+
+
+@pytest.mark.django_db
+def test_in_review_to_draft_revert_allowed_for_caseworker():
+    """Caseworkers may revert IN_REVIEW -> DRAFT (both in the allowed set)."""
+    user = create_user_with_role("cw-revert", "cw-revert@example.com", "Caseworker")
+    case = _publishable_case(state=CaseState.IN_REVIEW)
+    case.contributors.add(user)
+
+    response = _patch_state(_authed_client(user), case, CaseState.DRAFT)
+
+    assert response.status_code == 200
+    case.refresh_from_db()
+    assert case.state == CaseState.DRAFT
+
+
+# ---------------------------------------------------------------------------
+# Forbidden transitions per role (403)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_caseworker_cannot_publish():
+    user = create_user_with_role("cw-pub", "cw-pub@example.com", "Caseworker")
+    case = _publishable_case(state=CaseState.IN_REVIEW)
+    case.contributors.add(user)
+
+    response = _patch_state(_authed_client(user), case, CaseState.PUBLISHED)
+
+    assert response.status_code == 403
+    case.refresh_from_db()
+    assert case.state == CaseState.IN_REVIEW
+
+
+@pytest.mark.django_db
+def test_caseworker_cannot_close():
+    user = create_user_with_role("cw-close", "cw-close@example.com", "Caseworker")
+    case = _publishable_case(state=CaseState.IN_REVIEW)
+    case.contributors.add(user)
+
+    response = _patch_state(_authed_client(user), case, CaseState.CLOSED)
+
+    assert response.status_code == 403
+    case.refresh_from_db()
+    assert case.state == CaseState.IN_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# Publish gate failures (422) — reuse the model gates via publish()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_publish_rejected_when_missing_allegations_and_accused():
+    user = create_user_with_role("mod-gate", "mod-gate@example.com", "Moderator")
+    # DRAFT with no allegations, no accused entity, no description.
+    case = Case.objects.create(
+        title="Incomplete case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        key_allegations=[],
+    )
+
+    response = _patch_state(_authed_client(user), case, CaseState.PUBLISHED)
+
+    assert response.status_code == 422
+    assert "entities" in response.data
+    assert "key_allegations" in response.data
+    assert "description" in response.data
+    case.refresh_from_db()
+    assert case.state == CaseState.DRAFT
+
+
+@pytest.mark.django_db
+def test_publish_rejected_when_missing_accused_only():
+    user = create_user_with_role("mod-gate2", "mod-gate2@example.com", "Moderator")
+    case = Case.objects.create(
+        title="Missing accused",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        description="Full description",
+        key_allegations=["An allegation"],
+    )
+
+    response = _patch_state(_authed_client(user), case, CaseState.PUBLISHED)
+
+    assert response.status_code == 422
+    assert "entities" in response.data
+    case.refresh_from_db()
+    assert case.state == CaseState.DRAFT

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -193,6 +193,68 @@ def test_patch_timeline_rejects_malformed_date_bs():
 
 
 @pytest.mark.django_db
+def test_patch_timeline_rejects_malformed_iso_date():
+    """A3: a non-ISO `date` in a PATCHed timeline item is rejected (422)."""
+    user = _contributor("nabin-2")
+    case = _make_case()
+    case.contributors.add(user)
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[
+            {
+                "op": "replace",
+                "path": "/timeline",
+                "value": [{"date": "09/02/2025", "title": "X"}],
+            }
+        ],
+        format="json",
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
+def test_patch_rejects_invalid_court_cases():
+    """A3: court_cases entries are validated (unknown court identifier -> 422)."""
+    user = _contributor("nabin-3")
+    case = _make_case()
+    case.contributors.add(user)
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[
+            {
+                "op": "replace",
+                "path": "/court_cases",
+                "value": ["not-a-real-court:123"],
+            }
+        ],
+        format="json",
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
+def test_patch_bigo_accepts_integer():
+    """A3: bigo (embezzled amount) is a writable integer field."""
+    user = _contributor("nabin-4")
+    case = _make_case()
+    case.contributors.add(user)
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/bigo", "value": 1250000}],
+        format="json",
+    )
+    assert response.status_code == 200
+    case.refresh_from_db()
+    assert case.bigo == 1250000
+
+
+@pytest.mark.django_db
 def test_patch_add_appends_timeline_item():
     user = _contributor("ram")
     case = _make_case(timeline=[{"date": "2024-01-01", "title": "First"}])

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -376,7 +376,7 @@ def test_patch_200_for_draft_to_in_review_transition():
 
 
 @pytest.mark.django_db
-def test_patch_400_for_draft_to_in_review_missing_required_fields():
+def test_patch_422_for_draft_to_in_review_missing_required_fields():
     user = _contributor("deepak-3")
     case = _make_case(key_allegations=[])
     case.contributors.add(user)
@@ -388,7 +388,9 @@ def test_patch_400_for_draft_to_in_review_missing_required_fields():
         format="json",
     )
 
-    assert response.status_code == 400
+    # A2: model ValidationError on a state transition -> 422 with field-keyed
+    # messages (was 400 before the transitions were unified).
+    assert response.status_code == 422
     assert "entities" in response.data
     assert "key_allegations" in response.data
     case.refresh_from_db()

--- a/tests/api/test_caseworker_post.py
+++ b/tests/api/test_caseworker_post.py
@@ -135,6 +135,74 @@ def test_post_rejects_client_supplied_contributors_field():
 
 
 @pytest.mark.django_db
+def test_post_rejects_missing_title():
+    """Title-required rule is enforced on the API create path (model-layer rule,
+    formerly re-invoked by CaseAdminForm.clean())."""
+    user = create_user_with_role("farid", "farid@example.com", "Caseworker")
+
+    response = _authed_client(user).post(
+        URL,
+        data={"case_type": CaseType.CORRUPTION},
+        format="json",
+    )
+
+    assert response.status_code == 422
+    assert "title" in response.data
+    assert Case.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_post_rejects_blank_title():
+    user = create_user_with_role("gita", "gita@example.com", "Caseworker")
+
+    response = _authed_client(user).post(
+        URL,
+        data={"title": "   ", "case_type": CaseType.CORRUPTION},
+        format="json",
+    )
+
+    assert response.status_code == 422
+    assert Case.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_post_rejects_invalid_slug_format():
+    """Slug FORMAT is enforced via the serializer's validate_slug validator (no
+    admin form needed)."""
+    user = create_user_with_role("hari", "hari@example.com", "Caseworker")
+
+    response = _authed_client(user).post(
+        URL,
+        data={
+            "title": "Bad slug case",
+            "case_type": CaseType.CORRUPTION,
+            "slug": "1-cannot-start-with-digit",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 422
+    assert "slug" in response.data
+    assert Case.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_post_draft_stays_lenient_without_allegations_or_description():
+    """DRAFT create does NOT trigger the IN_REVIEW/PUBLISHED allegation and
+    description gates — parity with the old admin-form create semantics."""
+    user = create_user_with_role("indira", "indira@example.com", "Caseworker")
+
+    response = _authed_client(user).post(
+        URL,
+        data={"title": "Bare draft", "case_type": CaseType.CORRUPTION},
+        format="json",
+    )
+
+    assert response.status_code == 201
+    assert response.data["state"] == CaseState.DRAFT
+
+
+@pytest.mark.django_db
 def test_post_rejects_array_payload():
     """Test that POST with array payload returns 422 with clear error message."""
     user = create_user_with_role("eshwar", "eshwar@example.com", "Caseworker")

--- a/tests/api/test_dev_login.py
+++ b/tests/api/test_dev_login.py
@@ -1,0 +1,43 @@
+"""DEV-ONLY session login for the SPA (gated by DEV_AUTH)."""
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_dev_login_success_and_me_roundtrip(settings):
+    settings.DEV_AUTH = True
+    User.objects.create_user(username="admin", password="admin", is_superuser=True, is_staff=True)
+    c = APIClient()
+    r = c.post("/api/casework/auth/dev-login/", {"username": "admin", "password": "admin"}, format="json")
+    assert r.status_code == 200, r.content
+    body = r.json()
+    assert body["username"] == "admin"
+    assert body["is_admin"] is True
+    assert "csrftoken" in body
+    # session now carries into a protected read
+    me = c.get("/api/casework/auth/me/")
+    assert me.status_code == 200
+    assert me.json()["username"] == "admin"
+
+
+@pytest.mark.django_db
+def test_dev_login_bad_password(settings):
+    settings.DEV_AUTH = True
+    User.objects.create_user(username="u", password="right")
+    c = APIClient()
+    r = c.post("/api/casework/auth/dev-login/", {"username": "u", "password": "wrong"}, format="json")
+    assert r.status_code == 401
+
+
+@pytest.mark.django_db
+def test_dev_login_hard_404_when_flag_off(settings):
+    # The route itself is only mounted when DEV_AUTH is on at import time, but the
+    # view ALSO guards at runtime; simulate the flag being off.
+    settings.DEV_AUTH = False
+    User.objects.create_user(username="admin2", password="admin2")
+    c = APIClient()
+    r = c.post("/api/casework/auth/dev-login/", {"username": "admin2", "password": "admin2"}, format="json")
+    assert r.status_code == 404

--- a/tests/api/test_dev_login.py
+++ b/tests/api/test_dev_login.py
@@ -1,4 +1,11 @@
-"""DEV-ONLY session login for the SPA (gated by DEV_AUTH)."""
+"""DEV-ONLY session login for the SPA (gated by DEV_AUTH).
+
+The routes are always registered; each view hard-404s at runtime unless
+DEV_AUTH is on. me/dev-login/dev-logout pin their authenticators explicitly
+(DevAwareSessionAuthentication), so the session path works whenever DEV_AUTH is
+on regardless of DRF's import-time freezing of the global auth classes — the
+test only needs to flip the flag.
+"""
 import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
@@ -6,9 +13,14 @@ from rest_framework.test import APIClient
 User = get_user_model()
 
 
-@pytest.mark.django_db
-def test_dev_login_success_and_me_roundtrip(settings):
+@pytest.fixture
+def enable_dev_auth(settings):
     settings.DEV_AUTH = True
+    return settings
+
+
+@pytest.mark.django_db
+def test_dev_login_success_and_me_roundtrip(enable_dev_auth):
     User.objects.create_user(username="admin", password="admin", is_superuser=True, is_staff=True)
     c = APIClient()
     r = c.post("/api/casework/auth/dev-login/", {"username": "admin", "password": "admin"}, format="json")
@@ -24,8 +36,7 @@ def test_dev_login_success_and_me_roundtrip(settings):
 
 
 @pytest.mark.django_db
-def test_dev_login_bad_password(settings):
-    settings.DEV_AUTH = True
+def test_dev_login_bad_password(enable_dev_auth):
     User.objects.create_user(username="u", password="right")
     c = APIClient()
     r = c.post("/api/casework/auth/dev-login/", {"username": "u", "password": "wrong"}, format="json")
@@ -34,8 +45,8 @@ def test_dev_login_bad_password(settings):
 
 @pytest.mark.django_db
 def test_dev_login_hard_404_when_flag_off(settings):
-    # The route itself is only mounted when DEV_AUTH is on at import time, but the
-    # view ALSO guards at runtime; simulate the flag being off.
+    # Routes are always mounted, but the view hard-404s at runtime when the flag
+    # is off — the boundary that keeps the platform SSO-only in production.
     settings.DEV_AUTH = False
     User.objects.create_user(username="admin2", password="admin2")
     c = APIClient()

--- a/tests/api/test_reviews_grouped.py
+++ b/tests/api/test_reviews_grouped.py
@@ -1,0 +1,111 @@
+"""Tests for E1 — GET /api/casework/reviews/grouped/.
+
+The grouped endpoint groups CaseReview rows by case slug, paginating BY CASE:
+each entry carries {slug, case_title, latest, executions[]} with executions
+newest-first and cases ordered by their most-recent execution.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from review.models import CaseReview
+from tests.conftest import create_user_with_role
+
+URL = "/api/casework/reviews/grouped/"
+
+
+def _reader_client():
+    # Caseworker has CanReadReview.
+    user = create_user_with_role("rev-reader", "rev-reader@example.com", "Caseworker")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.django_db
+def test_grouped_requires_read_role():
+    """A Public-role user (no casework read access) is denied."""
+    user = create_user_with_role("rev-public", "rev-public@example.com", "Public")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get(URL)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_grouped_requires_authentication():
+    assert APIClient().get(URL).status_code == 401
+
+
+@pytest.mark.django_db
+def test_grouped_groups_executions_by_slug():
+    # Two executions for case-a, one for case-b.
+    CaseReview.objects.create(slug="case-a", case_title="Case A", status="done")
+    CaseReview.objects.create(slug="case-a", case_title="Case A", status="done")
+    CaseReview.objects.create(slug="case-b", case_title="Case B", status="pending")
+
+    response = _reader_client().get(URL)
+
+    assert response.status_code == 200
+    assert response.data["count"] == 2  # two CASES, not three executions
+
+    by_slug = {g["slug"]: g for g in response.data["results"]}
+    assert set(by_slug) == {"case-a", "case-b"}
+    assert len(by_slug["case-a"]["executions"]) == 2
+    assert len(by_slug["case-b"]["executions"]) == 1
+    assert by_slug["case-a"]["case_title"] == "Case A"
+
+
+@pytest.mark.django_db
+def test_grouped_latest_is_newest_execution():
+    older = CaseReview.objects.create(slug="case-c", case_title="Old title")
+    newer = CaseReview.objects.create(slug="case-c", case_title="New title")
+
+    response = _reader_client().get(URL)
+
+    group = response.data["results"][0]
+    # latest == executions[0] == the newest execution.
+    assert group["latest"]["id"] == newer.id
+    assert group["executions"][0]["id"] == newer.id
+    assert group["executions"][1]["id"] == older.id
+    # case_title on the group reflects the freshest snapshot.
+    assert group["case_title"] == "New title"
+
+
+@pytest.mark.django_db
+def test_grouped_cases_ordered_by_most_recent_execution():
+    # case-x reviewed first, then case-y — case-y (newer) should come first.
+    CaseReview.objects.create(slug="case-x", case_title="X")
+    CaseReview.objects.create(slug="case-y", case_title="Y")
+
+    response = _reader_client().get(URL)
+
+    slugs = [g["slug"] for g in response.data["results"]]
+    assert slugs == ["case-y", "case-x"]
+
+
+@pytest.mark.django_db
+def test_grouped_paginates_by_case():
+    # 25 distinct cases > default PAGE_SIZE (20) -> paginated by case.
+    for i in range(25):
+        CaseReview.objects.create(slug=f"case-{i:02d}", case_title=f"Case {i}")
+
+    response = _reader_client().get(URL)
+
+    assert response.data["count"] == 25
+    assert len(response.data["results"]) == 20
+    assert response.data["next"] is not None
+
+
+@pytest.mark.django_db
+def test_grouped_item_shape_matches_flat_list():
+    """Each execution item carries the same fields the flat /reviews/ list emits."""
+    CaseReview.objects.create(slug="case-shape", case_title="Shape")
+
+    response = _reader_client().get(URL)
+
+    item = response.data["results"][0]["latest"]
+    for field in ("id", "slug", "status", "case_title", "overall_score", "disposition"):
+        assert field in item


### PR DESCRIPTION
Backend half of the admin-panel productionization. The frontend (jawafdehi-frontend #163, **already merged to v2**) calls the endpoints/behaviors added here — so v2's admin panel (moderation queue, case state transitions, grouped reviews, case create) depends on this landing.

## What's in here

**Decommission the Django case-admin form path (A-series)**
- **A1** — `CaseViewSet.create()` no longer instantiates `CaseAdminForm`; DRAFT-on-create (the one form-only rule) is ported to the view. Casework business rules already live at the model layer (`Case.validate()`/`submit()`/`publish()`), so the form was pure duplication.
- **A2** — full case state transitions over PATCH `/state` (→IN_REVIEW / PUBLISHED / CLOSED / DRAFT) via `case.submit()`/`publish()`; a failed submit now returns 422 (was 400).
- **A3** — `?state=` filter on `/api/cases/`, plus verification of the entities/timeline/evidence sub-resource serializers.

**E1 — grouped reviews**
- `GET /api/casework/reviews/grouped/` (paginated by case; each entry carries all of a case's executions). The merged FE review list calls this.

**dev-auth (DEV_AUTH-gated) session login for the SPA**
- `/api/casework/auth/dev-login/` + `/dev-logout/`: username/password → Django session, same credentials as the Django admin, so a dev can work without standing up Zitadel. Production stays OIDC/SSO-only (`DEV_AUTH = env_flag(...) and (DEBUG or TESTING)`; each view hard-404s when off).
- Fixes a real import-order defect found while running the full suite: DRF freezes a view's authenticators from the global defaults at import time, so `me_view` could never accept the dev session (401 right after login). `me`/dev-login/dev-logout now pin an explicit `DevAwareSessionAuthentication` (OIDC bearer first; session second, inert unless DEV_AUTH per request). Routes are registered unconditionally with the runtime flag as the single SSO-only boundary.

**seed_dev** — local management command: users (admin/moderator/caseworker), 4 cases (one per state), courts/court-case/firm, 5 entities, 4 materials. Dev only.

## Verification
- Rebased cleanly on latest `origin/v2` (past #264/#265).
- Full unit suite **879 pass** (`pytest --ignore=integration-tests`). The `integration-tests/` suite needs a live server at :48000 and is environmental (fails identically on clean v2).
- `manage.py check` clean.