### PR TITLE
Review follow-up: paginate grouped reviews at the DB level + harden dev-login body

### DIFF
--- a/review/views.py
+++ b/review/views.py
@@ -16,6 +16,7 @@ endpoint. We expose a small `me` view so the SPA can show who is signed in and
 gate the UI by role.
 """
 
+from django.db.models import Max
 from django.utils import timezone
 from rest_framework import generics, status
 from rest_framework.decorators import (
@@ -119,6 +120,13 @@ def dev_login_view(request):
     """
     if not settings.DEV_AUTH:
         return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+    # request.data is a list/scalar for a non-object body — guard so .get() can't
+    # raise AttributeError → 500.
+    if not isinstance(request.data, dict):
+        return Response(
+            {"detail": "Request body must be a JSON object."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     username = (request.data.get("username") or "").strip()
     password = request.data.get("password") or ""
     user = authenticate(request, username=username, password=password)
@@ -225,25 +233,32 @@ class GroupedReviewListView(generics.ListAPIView):
     permission_classes = [CanReadReview]
     serializer_class = CaseReviewListSerializer
 
-    def _grouped_cases(self):
-        # CaseReview.Meta.ordering is -created_at, so iterating in that order
-        # yields executions newest-first per group and cases in most-recent-first
-        # order (the first slug seen is the one with the newest execution).
-        groups: dict[str, list[CaseReview]] = {}
-        for review in CaseReview.objects.all():
-            groups.setdefault(review.slug, []).append(review)
-        return groups
-
     def list(self, request, *args, **kwargs):
-        groups = self._grouped_cases()
-        slugs = list(groups.keys())  # already ordered newest-case-first
+        # Paginate BY CASE at the DB level: rank slugs by their most-recent
+        # execution, then fetch only the current page's rows — instead of
+        # loading the whole CaseReview table into memory to group in Python.
+        slug_qs = (
+            CaseReview.objects.values("slug")
+            .annotate(latest_created_at=Max("created_at"))
+            .order_by("-latest_created_at")
+            .values_list("slug", flat=True)
+        )
 
-        page = self.paginate_queryset(slugs)
-        page_slugs = page if page is not None else slugs
+        page = self.paginate_queryset(slug_qs)
+        page_slugs = list(page) if page is not None else list(slug_qs)
+
+        # Fetch executions only for this page's slugs. Meta.ordering (-created_at)
+        # gives newest-first, so grouping in iteration order keeps each case's
+        # executions newest-first.
+        groups: dict[str, list[CaseReview]] = {}
+        for review in CaseReview.objects.filter(slug__in=page_slugs):
+            groups.setdefault(review.slug, []).append(review)
 
         results = []
-        for slug in page_slugs:
-            executions = groups[slug]
+        for slug in page_slugs:  # preserves the DB-ranked newest-case-first order
+            executions = groups.get(slug)
+            if not executions:  # defensive: a slug vanished between the two queries
+                continue
             items = CaseReviewListSerializer(executions, many=True).data
             latest = executions[0]
             results.append(

--- a/tests/api/test_dev_login.py
+++ b/tests/api/test_dev_login.py
@@ -44,6 +44,14 @@ def test_dev_login_bad_password(enable_dev_auth):
 
 
 @pytest.mark.django_db
+def test_dev_login_non_object_body_is_400_not_500(enable_dev_auth):
+    # A non-object JSON body (list/scalar) must not blow up request.data.get().
+    c = APIClient()
+    r = c.post("/api/casework/auth/dev-login/", ["not", "an", "object"], format="json")
+    assert r.status_code == 400
+
+
+@pytest.mark.django_db
 def test_dev_login_hard_404_when_flag_off(settings):
     # Routes are always mounted, but the view hard-404s at runtime when the flag
     # is off — the boundary that keeps the platform SSO-only in production.

--- a/tests/api/test_reviews_grouped.py
+++ b/tests/api/test_reviews_grouped.py
@@ -100,6 +100,31 @@ def test_grouped_paginates_by_case():
 
 
 @pytest.mark.django_db
+def test_grouped_pagination_ranks_cases_across_pages():
+    """DB-level slug pagination keeps the newest-case-first ranking across pages.
+
+    Cases are created oldest-first (case-00 … case-24), so the newest execution
+    belongs to case-24. Page 1 must start at case-24 and page 2 must continue the
+    descending ranking without gaps or repeats.
+    """
+    for i in range(25):
+        CaseReview.objects.create(slug=f"case-{i:02d}", case_title=f"Case {i}")
+
+    client = _reader_client()
+    page1 = client.get(URL)
+    page2 = client.get(URL, {"page": 2})
+
+    slugs1 = [g["slug"] for g in page1.data["results"]]
+    slugs2 = [g["slug"] for g in page2.data["results"]]
+
+    assert slugs1[0] == "case-24"  # newest execution first
+    assert len(slugs1) == 20 and len(slugs2) == 5
+    # Full descending sequence, no overlap between pages.
+    assert slugs1 + slugs2 == [f"case-{i:02d}" for i in range(24, -1, -1)]
+    assert set(slugs1).isdisjoint(slugs2)
+
+
+@pytest.mark.django_db
 def test_grouped_item_shape_matches_flat_list():
     """Each execution item carries the same fields the flat /reviews/ list emits."""
     CaseReview.objects.create(slug="case-shape", case_title="Shape")


### PR DESCRIPTION
Post-merge follow-up to #267, addressing the Gemini review.

## High — grouped reviews loaded the whole table into memory
`GroupedReviewListView` iterated **all** `CaseReview` rows to group + paginate in Python, so memory and latency grow unbounded with review volume. Now:
- Rank distinct slugs by their most-recent execution at the DB level — `values("slug").annotate(latest_created_at=Max("created_at")).order_by("-latest_created_at")` — and paginate *that*.
- Fetch executions only for the current page's slugs (`filter(slug__in=page_slugs)`).

Same response shape and ordering (cases newest-execution-first; each case's executions newest-first). Added a cross-page test asserting the descending ranking continues across pages with no overlap.

## Medium — dev-login 500 on a non-object body
A non-object JSON body (list/scalar) made `request.data.get()` raise `AttributeError` → 500. Added an `isinstance(request.data, dict)` guard → 400, plus a regression test.

## Verification
- **890 unit tests pass** (`pytest --ignore=integration-tests`); the existing grouped-review tests (grouping, latest, ordering, pagination-by-case, item shape) stay green, plus 2 new.
- `manage.py check` clean.