### PR TITLE
feat(search): colloquial romanization for indexing + stronger case boost

### DIFF
--- a/jawafdehi_shared/search/indexing.py
+++ b/jawafdehi_shared/search/indexing.py
@@ -22,7 +22,11 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Iterable
 
-from jawafdehi_shared.search.transliterate import to_devanagari, to_roman
+from jawafdehi_shared.search.transliterate import (
+    to_devanagari,
+    to_roman,
+    to_roman_colloquial,
+)
 
 logger = logging.getLogger("jawafdehi.search.index")
 
@@ -85,12 +89,19 @@ def title_translit(title_ne: str | None, title_en: str | None) -> str | None:
     Devanagari-ization of the Roman title, joined, so a query in either script
     has an ingest-side bridge in addition to the in-engine ICU one. Returns
     ``None`` when both sides are empty.
+
+    The Devanagari side contributes BOTH the scholarly IAST form ("bharata") and a
+    colloquial, schwa-deleted, ASCII form ("bharat") so that both a diacritic-exact
+    query and the way people actually type Nepali names in Latin ("Bharat") match.
     """
     parts: list[str] = []
     if title_ne:
         roman = to_roman(title_ne)
         if roman:
             parts.append(roman)
+        colloquial = to_roman_colloquial(title_ne)
+        if colloquial:
+            parts.append(colloquial)
     if title_en:
         deva = to_devanagari(title_en)
         if deva:

--- a/jawafdehi_shared/search/tests/test_transliterate.py
+++ b/jawafdehi_shared/search/tests/test_transliterate.py
@@ -52,3 +52,43 @@ def test_round_trip_or_fallback():
 def test_latin_to_devanagari_produces_devanagari():
     out = transliterate.to_devanagari("nepāla")
     assert any("ऀ" <= ch <= "ॿ" for ch in out)
+
+
+# ── Colloquial romanization (the Latin-query recall fix) ─────────────────────────
+# The fold/schwa helpers operate on IAST strings, so they are deterministic and run
+# WITHOUT the transliteration backend; only the end-to-end Devanagari test is gated.
+
+
+def test_fold_diacritics_strips_to_ascii():
+    assert transliterate._fold_diacritics("tāla") == "tala"
+    assert transliterate._fold_diacritics("nirmāṇamā") == "nirmanama"
+    assert transliterate._fold_diacritics("bharata") == "bharata"
+
+
+def test_colloquial_fold_applies_sound_map():
+    # ś/ṣ → sh, ṛ → ri, then the generic fold handles the rest.
+    assert transliterate._colloquial_fold("śarmā") == "sharma"
+    assert transliterate._colloquial_fold("kṛṣṇa") == "krishna"
+
+
+def test_delete_inherent_schwa_keeps_long_vowels():
+    assert transliterate._delete_inherent_schwa("bharata") == "bharat"
+    assert transliterate._delete_inherent_schwa("rāma") == "rām"
+    assert transliterate._delete_inherent_schwa("sītā") == "sītā"  # long ā, not a schwa
+    assert transliterate._delete_inherent_schwa("na") == "na"  # single syllable kept
+
+
+@pytest.mark.skipif(
+    not transliterate.backend_available(), reason="indic-transliteration not installed"
+)
+def test_to_roman_colloquial_emits_both_schwa_forms():
+    # The reported case: "Bharat" must be reachable from the Devanagari title.
+    out = transliterate.to_roman_colloquial("भरत ताल")  # "Bharat Tal"
+    tokens = out.split()
+    assert "bharat" in tokens and "tal" in tokens  # schwa-deleted spelling present
+    assert "bharata" in tokens  # schwa-kept spelling also present
+    assert all(ch.isascii() for ch in out)  # fully folded to ASCII
+
+
+def test_to_roman_colloquial_empty_passthrough():
+    assert transliterate.to_roman_colloquial("") == ""

--- a/jawafdehi_shared/search/transliterate.py
+++ b/jawafdehi_shared/search/transliterate.py
@@ -21,12 +21,26 @@ output as a recall booster, never an exact key.
 
 from __future__ import annotations
 
+import unicodedata
+
 # Romanization scheme used on the Latin side. IAST is the standard lossless
 # Latin-with-diacritics scheme; the index's roman/translit analyzers fold
 # diacritics (icu_folding / lowercase), so IAST round-trips through the index as
 # plain ASCII for matching while staying reversible here.
 _ROMAN_SCHEME = "iast"
 _DEVANAGARI_SCHEME = "devanagari"
+
+# Colloquial letter substitutions applied to IAST *before* the generic NFKD
+# diacritic fold, for the glyphs whose bare-ASCII fold does not match how people
+# actually spell the sound in Latin: vocalic ṛ is written "ri" (kṛṣṇa → krishna),
+# the sibilants ś/ṣ are "sh" (śarmā → sharma), etc. Everything else (ā ī ū ṭ ḍ ṇ …)
+# is handled by the NFKD combining-mark strip in :func:`_fold_diacritics`.
+_COLLOQUIAL_MAP = {
+    "ṛ": "ri", "ṝ": "ri",
+    "ś": "sh", "ṣ": "sh",
+    "ñ": "ny", "ṅ": "n",
+    "ṃ": "n", "ḥ": "h",
+}
 
 try:  # pragma: no cover - exercised by backend_available()
     from indic_transliteration import sanscript as _sanscript
@@ -71,3 +85,54 @@ def to_devanagari(text: str) -> str:
     if _sanscript is None:
         return text
     return _sanscript.transliterate(text, _ROMAN_SCHEME, _DEVANAGARI_SCHEME)
+
+
+def _fold_diacritics(text: str) -> str:
+    """Strip combining diacritics via NFKD (ā→a, ṇ→n, ī→i, ṭ→t, ḍ→d, …) to ASCII."""
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in nfkd if not unicodedata.combining(ch))
+
+
+def _colloquial_fold(iast: str) -> str:
+    """IAST → plain-ASCII colloquial spelling: apply the sound-spelling map
+    (ś→sh, ṛ→ri, …) then strip the remaining combining diacritics, lowercased."""
+    for src, dst in _COLLOQUIAL_MAP.items():
+        iast = iast.replace(src, dst)
+    return _fold_diacritics(iast).lower()
+
+
+def _delete_inherent_schwa(iast_token: str) -> str:
+    """Delete a single word-final inherent short 'a' (schwa) from an IAST token.
+
+    Runs on IAST (pre-fold) so the long vowel 'ā' — a real vowel, not a schwa — is
+    kept: "bharata"→"bharat", "rāma"→"rām", but "sītā" stays "sītā". Tokens of ≤2
+    chars (single syllables like "na") are left intact. Only word-final schwa is
+    handled; medial-schwa deletion (kāṭhamāḍauṃ→kathmandu) is out of scope for v1.
+    """
+    if len(iast_token) > 2 and iast_token.endswith("a"):
+        return iast_token[:-1]
+    return iast_token
+
+
+def to_roman_colloquial(text: str) -> str:
+    """Colloquial, search-friendly romanization of Devanagari ``text``.
+
+    IAST is scholarly ("भरत"→"bharata", with diacritics) and does not match how
+    people type Nepali names in Latin ("Bharat"). This folds diacritics to plain
+    ASCII and emits BOTH the schwa-kept and word-final-schwa-deleted spellings,
+    because word-final schwa deletion is word-dependent — "भरत"→"bharat" (deleted)
+    but "कृष्ण"→"krishna" (kept after a cluster). Indexing both forms lets either
+    spelling match: "भरत ताल" → "bharata tala bharat tal", "कृष्ण" → "krishna
+    krishn". Schwa deletion runs on IAST (before folding) so long 'ā' vowels
+    survive. Falls back to ``to_roman`` (identity) when the backend is unavailable.
+    """
+    roman = to_roman(text)
+    if not roman:
+        return roman
+    # NFC so precomposed 'ā' (U+0101) is one glyph for the schwa endswith("a") check.
+    tokens = unicodedata.normalize("NFC", roman).split()
+    kept = " ".join(_colloquial_fold(tok) for tok in tokens)
+    stripped = " ".join(_colloquial_fold(_delete_inherent_schwa(tok)) for tok in tokens)
+    if not stripped or stripped == kept:
+        return kept
+    return f"{kept} {stripped}"

--- a/search/service.py
+++ b/search/service.py
@@ -76,13 +76,16 @@ PHRASE_BOOST = 5.0
 # recall via the translit bridge is preserved — this is a re-rank, not a filter).
 _LANG_TITLE_MULTIPLIER = 2.0
 
-# Per-type (per-index) weighting: published editorial records (cases) and curated
-# entities are the primary answers; raw archive materials and court-case stubs
-# rank slightly lower at equal textual score. Applied via OpenSearch
-# ``indices_boost``. Tuned conservatively (within ~1.5x) so text relevance still
-# dominates — this only breaks near-ties.
+# Per-type (per-index) weighting: published editorial records (cases) are the
+# flagship, human-curated answers and are boosted hardest so a matching case
+# floats above the far larger pool of entities/court-case stubs/archive materials
+# at comparable textual score; curated entities come next. Applied via OpenSearch
+# ``indices_boost``. Text relevance still dominates within an index — this
+# re-ranks ACROSS indices, and (unlike a filter) a case must still MATCH the query
+# to benefit, so the colloquial ``title_translit`` recall fix is what lets a
+# Devanagari-titled case match a Latin query in the first place.
 TYPE_BOOSTS: dict[str, float] = {
-    "case": 1.3,
+    "case": 2.0,
     "entity": 1.2,
     "courtcase": 1.0,
     "material": 0.9,


### PR DESCRIPTION
## Problem

Searching the Latin **"Bharat"** does not surface the Devanagari-titled *Bharat Taal* case (`case-081-cr-0097`, title *भरत ताल निर्माणमा…*).

Root cause (traced against the live index): the ingest `title_translit` field **already exists**, but it emits scholarly **IAST** — `"bharata tāla nirmāṇamā"` — which fails Latin input two ways:
1. **Diacritics** aren't matched: `tala` ≠ indexed `tāla`.
2. **Inherent schwa**: IAST renders भरत as `"bharata"`, but people type `"Bharat"` — `bharat` ≠ `bharata`.

Devanagari-only cases have no `title_en`, so they depend entirely on this broken translit path. (Entities match "Bharat" fine — they carry an English `title_en`.)

## Fix

- **`to_roman_colloquial()`** — folds IAST diacritics to plain ASCII (NFKD + a small sound map `ś/ṣ→sh`, `ṛ→ri`) and emits **both** the schwa-kept and word-final-schwa-deleted spellings, because final-schwa deletion is word-dependent: `भरत→bharat` (deleted) but `कृष्ण→krishna` (kept after a cluster). Indexing both lets either spelling match. Schwa deletion runs on IAST *before* folding so long `ā` vowels survive (`sītā` stays `sita`, not `sit`).
- **`title_translit()`** — the Devanagari side now contributes the colloquial form alongside IAST (superset, non-breaking). E.g. `भरत ताल … →` `bharata tāla … bharata tala … bharat tal …`.
- **Case boost** — `indices_boost` for cases `1.3 → 2.0`, so a matching case (the flagship curated record) floats above the far larger entity/court-case/material pool.

## Verification (run in the api pod, real `indic-transliteration` backend)
- `to_roman_colloquial("भरत ताल")` → `"bharata tala bharat tal"` · `("कृष्ण")` → `"krishna krishn"` · `("शर्मा")` → `"sharma"`
- Reindexed cases with the patched code → **`type=case&q=Bharat` now returns the case** (was 0); `q="bharat tal"` surfaces it in the top results (was absent).
- Tests: **82 passed** (transliterate + indexing-helpers + search-service + indexers). New tests cover the fold/schwa helpers (backend-independent) and the both-forms colloquial output (backend-gated).

## Rollout (post-merge)
1. Deploy the image.
2. **Reindex all four indices** so every doc carries the colloquial `title_translit`: `reindex_cases`, `reindex_entities`, `reindex_courtcases`, `reindex_materials` (or `reindex_all`). *(cases already reindexed live during verification.)*

## Follow-ups (out of scope)
- Medial-schwa deletion (`kāṭhamāḍauṃ→kathmandu`) is not handled — v1 does word-final only.
- The live index's `translit_bridge` analyzer isn't folding diacritics despite the mapping (stale index mapping); the colloquial-at-ingest approach sidesteps it, but a `--rebuild` reindex would refresh the mapping too.
- For maximally-ambiguous single terms ("Bharat" alone matches 349 real entities), the long `title_translit` field's low per-token norm limits how far the boost lifts a case; a dedicated short colloquial-title field could help if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)