### PR TITLE
ci: build the platform image on main too (v2->mainline transition)

### DIFF
--- a/.github/workflows/docker-publish-platform.yml
+++ b/.github/workflows/docker-publish-platform.yml
@@ -1,16 +1,19 @@
 # SPDX-License-Identifier: Hippocratic-3.0
 
-# Builds the v2 platform image docker.io/jawafdehi/jawafdehi-platform from this branch (the repo IS
-# the platform after the wholesale port). Keel watches the mutable :v2 tag and rolls it onto the
-# jawafdehi-platform Deployment (api.jawafdehi.org). Mirrors the legacy docker-publish.yml's pinned
-# actions + DockerHub secrets.
+# Builds the platform image docker.io/jawafdehi/jawafdehi-platform (the repo IS the platform after
+# the wholesale monolith port). Produces :<branch>, :<short-sha>, and :vX.Y semver tags. Keel rolls
+# the mutable branch tag onto the jawafdehi-platform Deployment (api.jawafdehi.org).
+#
+# Builds on BOTH main and v2 during the v2->mainline transition: v2 is fast-forward-merged into main,
+# after which main is the monolith and produces :main. v2 stays here so the current deploy (tracking
+# :v2) keeps building until it's cut over to :main; drop 'v2' once that cutover is done.
 name: Docker Publish (platform)
 on:
   push:
-    branches: ['v2']
+    branches: ['main', 'v2']
     tags: ['v*']
   pull_request:
-    branches: ['v2']
+    branches: ['main', 'v2']
   workflow_dispatch: {}
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
First step of CI reconciliation ahead of the `v2 → main` fast-forward merge.

**Problem:** `docker-publish-platform.yml` only triggers on branch `v2`. After v2 fast-forwards into `main`, a push to `main` would build **nothing** — `jawafdehi/jawafdehi-platform:main` would never exist, and the deploy cutover would have no image to point at.

**Fix:** trigger on both `main` and `v2` during the transition (push + PR). `main` so the merged monolith publishes `:main` (+ `:<short-sha>`, the same scheme used to pin the legacy portal); `v2` so the current `jawafdehi-platform` deploy — which still tracks `:v2` — keeps building until it's cut over to `:main`. Drop `'v2'` once that cutover is done.

Lands on `v2` so `main` inherits it via the fast-forward.

### Not in this PR (follow-up — flagged during investigation)
The monolith has **no test/lint/SPDX CI** (v2 dropped the legacy Poetry-based workflows in the wholesale port). Restoring a green gate isn't a no-op:
- **`ruff check .`** → 12 errors (7 auto-fixable).
- **`pytest` on sqlite (`settings_test`)** → 8+ failures — `DatabaseOperationForbidden` on the `ngm` alias in `TestCase` subclasses that don't declare `databases='__all__'` (the conftest auto-enroll hook only covers pytest-marker tests). Pre-existing test-infra debt, **not** postgres-required and not code bugs — but they'd red-fail a naive gate.
- **SPDX per-file header check** → all 387 `.py` files lack headers (the monolith dropped that convention); restoring it would fail immediately, so it should stay dropped.

Recommend a second PR that fixes the ruff errors + adds `databases='__all__'` to the offending `TestCase` classes, then adds a `uv`-based `ci.yml` (`ruff check` + `ruff format --check` + `pytest` on sqlite, no external services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)