### PR TITLE
feat(metrics): add django-prometheus /metrics (multiprocess-aware)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,5 +60,6 @@ RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org \
 EXPOSE 8080
 CMD ["uv", "run", \
      "gunicorn", "config.wsgi:application", \
+     "--config", "config/gunicorn.py", \
      "--bind", "0.0.0.0:8080", "--workers", "2", "--threads", "4", \
      "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-"]

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,0 +1,38 @@
+"""Gunicorn config — django-prometheus multiprocess support.
+
+With >1 gunicorn worker, django-prometheus must run in prometheus_client
+*multiprocess* mode: each worker writes per-pid metric files under
+``PROMETHEUS_MULTIPROC_DIR`` and the ``/metrics`` view aggregates across them.
+This config provides the two lifecycle hooks that mode needs so the aggregate
+stays correct as gunicorn forks and recycles workers:
+
+* ``on_starting``  — clear stale ``*.db`` files from a previous run (belt-and-
+  suspenders; the deploy also mounts a fresh emptyDir per pod).
+* ``child_exit``   — mark a dead worker's pid so its gauge files stop being
+  counted, otherwise recycled workers double-count.
+
+Only meaningful when ``PROMETHEUS_MULTIPROC_DIR`` is set (prod). If it is unset
+(local/dev, tests) both hooks are no-ops.
+"""
+
+import glob
+import os
+
+
+def on_starting(server):
+    d = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if not d or not os.path.isdir(d):
+        return
+    for f in glob.glob(os.path.join(d, "*.db")):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
+
+
+def child_exit(server, worker):
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        return
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)

--- a/config/settings.py
+++ b/config/settings.py
@@ -172,6 +172,11 @@ if not ALLOWED_HOSTS:
             "Set it to a comma-separated list of allowed hostnames "
             "(e.g. ALLOWED_HOSTS=portal.jawafdehi.org)."
         )
+# The pod's own IP (injected via the downward API), so Prometheus scraping of
+# /metrics by pod IP isn't rejected as a DisallowedHost. No-op when unset (dev).
+_pod_ip = os.getenv("POD_IP")
+if _pod_ip and _pod_ip not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append(_pod_ip)
 
 CSRF_TRUSTED_ORIGINS = get_env_list("CSRF_TRUSTED_ORIGINS")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -224,6 +224,8 @@ LOGGING = {
 # INSTALLED_APPS — the UNION of all three former projects' apps.
 # ---------------------------------------------------------------------------
 INSTALLED_APPS = [
+    # Prometheus /metrics (HTTP request metrics via the Before/After middleware).
+    "django_prometheus",
     # Jazzmin must precede django.contrib.admin (admin theme).
     "jazzmin",
     "django.contrib.admin",
@@ -292,6 +294,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # django-prometheus: Before must be FIRST and After LAST so the request timer
+    # spans the whole middleware chain.
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "jawafdehi_shared.middleware.RequestIdMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -306,6 +311,8 @@ MIDDLEWARE = [
     # Wagtail's editor-managed redirects (wagtail.contrib.redirects). Last so it
     # only runs on responses no earlier middleware/view produced (e.g. 404s).
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    # django-prometheus After must be the LAST middleware (see the Before entry).
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/config/urls.py
+++ b/config/urls.py
@@ -38,6 +38,10 @@ from cases.views import docs, index
 from content.api import api_router as wagtail_api_router
 
 urlpatterns = [
+    # Prometheus /metrics (django-prometheus). Not public — the ingress denies
+    # external access to /metrics (metrics-deny-public middleware); scraped
+    # in-cluster only.
+    path("", include("django_prometheus.urls")),
     # ── Jawafdehi (default DB) — keeps the original /api/ paths ─────────────
     path("", index, name="index"),
     path("docs/", docs, name="docs"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "drf-spectacular>=0.29",
     "gunicorn>=23.0",
     "whitenoise>=6.11",
+    # Prometheus /metrics (multiprocess-aware for the gunicorn workers).
+    "django-prometheus>=2.3",
     # --- auth (OIDC/Zitadel in prod; the single OIDCAuthentication impl lives in
     # jawafdehi_shared) ---
     "pyjwt[crypto]>=2.10",

--- a/uv.lock
+++ b/uv.lock
@@ -487,6 +487,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/c7/dc39c4c19f7b35e827a486d08376de1fad31c50decb26c56e32668314f13/django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e", size = 26465, upload-time = "2026-05-26T19:04:00.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5d/6ec3083ba69545696c962ae505a0e52e280e7592d4c278c2f3803cabb688/django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134", size = 31801, upload-time = "2026-05-26T19:03:59.505Z" },
+]
+
+[[package]]
 name = "django-storages"
 version = "1.14.6"
 source = { registry = "https://pypi.org/simple" }
@@ -921,6 +934,7 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-filter" },
     { name = "django-jazzmin" },
+    { name = "django-prometheus" },
     { name = "django-storages" },
     { name = "django-tinymce" },
     { name = "djangorestframework" },
@@ -974,6 +988,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.9" },
     { name = "django-filter", specifier = ">=25.2" },
     { name = "django-jazzmin", specifier = "==3.0.1" },
+    { name = "django-prometheus", specifier = ">=2.3" },
     { name = "django-storages", specifier = ">=1.14.3" },
     { name = "django-tinymce", specifier = ">=5.0" },
     { name = "djangorestframework", specifier = ">=3.16" },
@@ -1774,6 +1789,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the Prometheus gap between `api.jawafdehi.org` (had none) and the legacy portal.

## Changes
- **`django-prometheus`** dep (+ `prometheus-client`), `uv.lock` updated.
- **INSTALLED_APPS** `django_prometheus`; **MIDDLEWARE** `PrometheusBeforeMiddleware` first + `PrometheusAfterMiddleware` last (request timer spans the whole chain).
- **`/metrics`** via `django_prometheus.urls` — **not public**: the ingress denies external access (`metrics-deny-public`), scraped in-cluster only.
- **`config/gunicorn.py`** — multiprocess hooks: `on_starting` clears stale `*.db`, `child_exit` marks dead workers so the **2 gunicorn workers** aggregate correctly under `PROMETHEUS_MULTIPROC_DIR`. `Dockerfile` CMD adds `--config config/gunicorn.py`. Both hooks are no-ops when the env is unset (dev/tests).

## Verification
- `GET /metrics` → 200 with `django_http_requests_*` + `process_*`/`python_*` metrics.
- `ruff check` clean; `uv sync --frozen` resolves.

## Infra (separate, in services/infra)
The deploy needs `PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus` + an emptyDir volume + the `/metrics` IngressRoute with `metrics-deny-public`. Applied alongside this; without `PROMETHEUS_MULTIPROC_DIR` set, django-prometheus falls back to single-process mode (still works, just per-worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)