### PR TITLE
feat(db): read-replica routing for anonymous public reads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,5 +60,6 @@ RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org \
 EXPOSE 8080
 CMD ["uv", "run", \
      "gunicorn", "config.wsgi:application", \
+     "--config", "config/gunicorn.py", \
      "--bind", "0.0.0.0:8080", "--workers", "2", "--threads", "4", \
      "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-"]

--- a/config/db_router.py
+++ b/config/db_router.py
@@ -30,6 +30,26 @@ dotted ``name``).
 
 from __future__ import annotations
 
+import threading
+
+# Per-thread read-routing flag, set by config.middleware.ReadReplicaRoutingMiddleware
+# for the duration of a request: True → this request's reads may use the read
+# replica; False (default, and outside any request — mgmt commands, shell, tasks)
+# → reads use the primary. Kept here (next to the router that consumes it) so the
+# router has no import-time dependency on the middleware.
+_routing_state = threading.local()
+
+
+def route_reads_to_replica(enabled: bool) -> None:
+    """Mark the current thread's reads as replica-eligible (True) or primary-only
+    (False). The middleware sets it per request and always resets it afterwards."""
+    _routing_state.use_replica = enabled
+
+
+def _reads_use_replica() -> bool:
+    return getattr(_routing_state, "use_replica", False)
+
+
 # App labels owned by each service database. Anything not listed routes to
 # "default" (the Jawafdehi database, which also owns django.contrib.* — auth,
 # admin, sessions, contenttypes — since that is the only app that uses Users).
@@ -80,7 +100,17 @@ class ServiceDatabaseRouter:
     """Route each service-app's models to that service's database."""
 
     def db_for_read(self, model, **hints):
-        return _db_for_label(model._meta.app_label)
+        primary = _db_for_label(model._meta.app_label)
+        # Anonymous public reads (flagged by the middleware) may use the read
+        # replica if one is configured for this service; everything else — writes,
+        # admin/casework, mgmt commands (no flag) — reads from the primary so it
+        # always sees its own writes. Import settings lazily to avoid an
+        # import-time cycle (settings imports this module as DATABASE_ROUTERS).
+        if _reads_use_replica():
+            from django.conf import settings
+
+            return settings.REPLICA_ALIASES.get(primary, primary)
+        return primary
 
     def db_for_write(self, model, **hints):
         return _db_for_label(model._meta.app_label)

--- a/config/db_router.py
+++ b/config/db_router.py
@@ -30,24 +30,29 @@ dotted ``name``).
 
 from __future__ import annotations
 
-import threading
+import contextvars
 
-# Per-thread read-routing flag, set by config.middleware.ReadReplicaRoutingMiddleware
-# for the duration of a request: True → this request's reads may use the read
-# replica; False (default, and outside any request — mgmt commands, shell, tasks)
-# → reads use the primary. Kept here (next to the router that consumes it) so the
+# Read-routing flag, set by config.middleware.ReadReplicaRoutingMiddleware for the
+# duration of a request: True → this request's reads may use the read replica;
+# False (default, and outside any request — mgmt commands, shell, tasks) → reads
+# use the primary. A ContextVar (not threading.local) so it is correct under BOTH
+# sync gunicorn worker threads AND async views/tasks: each thread has its own
+# top-level context and each async task copies it, so the flag never leaks across
+# concurrent requests. Kept here (next to the router that consumes it) so the
 # router has no import-time dependency on the middleware.
-_routing_state = threading.local()
+_use_replica_var: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "use_replica_for_reads", default=False
+)
 
 
 def route_reads_to_replica(enabled: bool) -> None:
-    """Mark the current thread's reads as replica-eligible (True) or primary-only
+    """Mark the current context's reads as replica-eligible (True) or primary-only
     (False). The middleware sets it per request and always resets it afterwards."""
-    _routing_state.use_replica = enabled
+    _use_replica_var.set(enabled)
 
 
 def _reads_use_replica() -> bool:
-    return getattr(_routing_state, "use_replica", False)
+    return _use_replica_var.get()
 
 
 # App labels owned by each service database. Anything not listed routes to

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,0 +1,38 @@
+"""Gunicorn config — django-prometheus multiprocess support.
+
+With >1 gunicorn worker, django-prometheus must run in prometheus_client
+*multiprocess* mode: each worker writes per-pid metric files under
+``PROMETHEUS_MULTIPROC_DIR`` and the ``/metrics`` view aggregates across them.
+This config provides the two lifecycle hooks that mode needs so the aggregate
+stays correct as gunicorn forks and recycles workers:
+
+* ``on_starting``  — clear stale ``*.db`` files from a previous run (belt-and-
+  suspenders; the deploy also mounts a fresh emptyDir per pod).
+* ``child_exit``   — mark a dead worker's pid so its gauge files stop being
+  counted, otherwise recycled workers double-count.
+
+Only meaningful when ``PROMETHEUS_MULTIPROC_DIR`` is set (prod). If it is unset
+(local/dev, tests) both hooks are no-ops.
+"""
+
+import glob
+import os
+
+
+def on_starting(server):
+    d = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if not d or not os.path.isdir(d):
+        return
+    for f in glob.glob(os.path.join(d, "*.db")):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
+
+
+def child_exit(server, worker):
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        return
+    from prometheus_client import multiprocess
+
+    multiprocess.mark_process_dead(worker.pid)

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -25,10 +25,14 @@ _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 # Paths that must always read from the primary (they either write, or are editor
 # surfaces where stale replica reads would be confusing).
+# Every prefix ends with "/" so it matches a whole path segment and can't
+# accidentally catch a sibling (e.g. "/api/casework/" won't match some future
+# "/api/caseworkers"). Both /api/casework/ (review) and /api/caseworker/ (the
+# caseworker "me" endpoint) are listed explicitly.
 _PRIMARY_ONLY_PREFIXES = (
     "/django-admin/",
-    "/api/casework",
-    "/api/caseworker",
+    "/api/casework/",
+    "/api/caseworker/",
     "/api/jobs/",
     "/api/ingestion/",
     "/newsroom/",
@@ -41,7 +45,9 @@ class ReadReplicaRoutingMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        use_replica = request.method in _SAFE_METHODS and not request.path.startswith(
+        # Use path_info (path relative to the app), not path, so prefix matching is
+        # correct even if the app is ever mounted under a SCRIPT_NAME subpath.
+        use_replica = request.method in _SAFE_METHODS and not request.path_info.startswith(
             _PRIMARY_ONLY_PREFIXES
         )
         route_reads_to_replica(use_replica)

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,0 +1,51 @@
+"""Request middleware that steers anonymous public reads to the DB read replica.
+
+The DB router (config.db_router) can send reads to a per-service read replica, but
+only when this middleware flags the request as replica-eligible. The decision is
+made from the request PATH and METHOD, deliberately NOT from the authenticated
+user: DRF/OIDC resolves the user inside the view, which is too late for a
+middleware auth check. So:
+
+* unsafe methods (writes) → primary (read-your-write within the request), and
+* admin / casework / ingestion / OIDC surfaces → primary (editors must always see
+  their own just-saved data),
+* everything else — anonymous public GETs (cases, entities, court cases, materials,
+  search, sitemaps) — → replica.
+
+The flag is always reset in ``finally`` so a pooled worker thread never leaks it
+into the next request. A no-op when no replica is configured (REPLICA_ALIASES
+empty) since the router then falls back to the primary regardless.
+"""
+
+from __future__ import annotations
+
+from config.db_router import route_reads_to_replica
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+# Paths that must always read from the primary (they either write, or are editor
+# surfaces where stale replica reads would be confusing).
+_PRIMARY_ONLY_PREFIXES = (
+    "/django-admin/",
+    "/api/casework",
+    "/api/caseworker",
+    "/api/jobs/",
+    "/api/ingestion/",
+    "/newsroom/",
+    "/oidc/",
+)
+
+
+class ReadReplicaRoutingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        use_replica = request.method in _SAFE_METHODS and not request.path.startswith(
+            _PRIMARY_ONLY_PREFIXES
+        )
+        route_reads_to_replica(use_replica)
+        try:
+            return self.get_response(request)
+        finally:
+            route_reads_to_replica(False)

--- a/config/settings.py
+++ b/config/settings.py
@@ -310,6 +310,9 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # After auth so session/user reads use the primary; steers the VIEW's
+    # anonymous public reads to the DB read replica (config.db_router).
+    "config.middleware.ReadReplicaRoutingMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "auditlog.middleware.AuditlogMiddleware",
@@ -462,6 +465,27 @@ if db_password:
         if db_url and "${DATABASE_PASSWORD}" in db_url:
             new_url = db_url.replace("${DATABASE_PASSWORD}", db_password)
             DATABASES[db_key] = dj_database_url.parse(new_url)
+
+# Read replicas (optional). When a "*_READ_URL" is set, register a "<alias>_ro"
+# connection to the read-only replica endpoint. The DB router (config.db_router)
+# sends anonymous public reads there, while writes + admin/casework traffic stay
+# on the primary (read-your-write). REPLICA_ALIASES maps primary alias -> replica
+# alias; it is EMPTY when no replica is configured (dev/tests), so the router
+# transparently falls back to the primary and behaviour is unchanged.
+REPLICA_ALIASES: dict[str, str] = {}
+_replica_url_env = {
+    "default": "DATABASE_READ_URL",
+    "nes": "NES_DB_READ_URL",
+    "ngm": "NGM_DATABASE_READ_URL",
+}
+for _primary_alias, _read_env in _replica_url_env.items():
+    _read_url = os.getenv(_read_env)
+    if _read_url:
+        if db_password and "${DATABASE_PASSWORD}" in _read_url:
+            _read_url = _read_url.replace("${DATABASE_PASSWORD}", db_password)
+        _ro_alias = f"{_primary_alias}_ro"
+        DATABASES[_ro_alias] = dj_database_url.parse(_read_url)
+        REPLICA_ALIASES[_primary_alias] = _ro_alias
 
 # Apply SSL options + connection pooling to every Postgres database.
 for db_key in DATABASES:

--- a/config/settings.py
+++ b/config/settings.py
@@ -172,6 +172,11 @@ if not ALLOWED_HOSTS:
             "Set it to a comma-separated list of allowed hostnames "
             "(e.g. ALLOWED_HOSTS=portal.jawafdehi.org)."
         )
+# The pod's own IP (injected via the downward API), so Prometheus scraping of
+# /metrics by pod IP isn't rejected as a DisallowedHost. No-op when unset (dev).
+_pod_ip = os.getenv("POD_IP")
+if _pod_ip and _pod_ip not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append(_pod_ip)
 
 CSRF_TRUSTED_ORIGINS = get_env_list("CSRF_TRUSTED_ORIGINS")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -224,6 +224,8 @@ LOGGING = {
 # INSTALLED_APPS — the UNION of all three former projects' apps.
 # ---------------------------------------------------------------------------
 INSTALLED_APPS = [
+    # Prometheus /metrics (HTTP request metrics via the Before/After middleware).
+    "django_prometheus",
     # Jazzmin must precede django.contrib.admin (admin theme).
     "jazzmin",
     "django.contrib.admin",
@@ -292,6 +294,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # django-prometheus: Before must be FIRST and After LAST so the request timer
+    # spans the whole middleware chain.
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "jawafdehi_shared.middleware.RequestIdMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -306,6 +311,8 @@ MIDDLEWARE = [
     # Wagtail's editor-managed redirects (wagtail.contrib.redirects). Last so it
     # only runs on responses no earlier middleware/view produced (e.g. 404s).
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    # django-prometheus After must be the LAST middleware (see the Before entry).
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/config/settings_test.py
+++ b/config/settings_test.py
@@ -58,3 +58,8 @@ DATABASES = {
         "TEST": {"NAME": "file:test_ngm?mode=memory&cache=shared"},
     },
 }
+
+# No read replicas under tests: this DATABASES override drops any "_ro" alias the
+# base settings may have built from a stray *_READ_URL env, so clear the mapping
+# too or the router could route a read to an alias that no longer exists.
+REPLICA_ALIASES = {}

--- a/config/urls.py
+++ b/config/urls.py
@@ -38,6 +38,10 @@ from cases.views import docs, index
 from content.api import api_router as wagtail_api_router
 
 urlpatterns = [
+    # Prometheus /metrics (django-prometheus). Not public — the ingress denies
+    # external access to /metrics (metrics-deny-public middleware); scraped
+    # in-cluster only.
+    path("", include("django_prometheus.urls")),
     # ── Jawafdehi (default DB) — keeps the original /api/ paths ─────────────
     path("", index, name="index"),
     path("docs/", docs, name="docs"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "drf-spectacular>=0.29",
     "gunicorn>=23.0",
     "whitenoise>=6.11",
+    # Prometheus /metrics (multiprocess-aware for the gunicorn workers).
+    "django-prometheus>=2.3",
     # --- auth (OIDC/Zitadel in prod; the single OIDCAuthentication impl lives in
     # jawafdehi_shared) ---
     "pyjwt[crypto]>=2.10",

--- a/tests/test_read_replica_routing.py
+++ b/tests/test_read_replica_routing.py
@@ -76,7 +76,8 @@ def _flag_during(method, path):
         captured["flag"] = _reads_use_replica()
         return "response"
 
-    request = type("R", (), {"method": method, "path": path})()
+    # The middleware matches on path_info (not path).
+    request = type("R", (), {"method": method, "path_info": path})()
     ReadReplicaRoutingMiddleware(get_response)(request)
     return captured["flag"]
 

--- a/tests/test_read_replica_routing.py
+++ b/tests/test_read_replica_routing.py
@@ -1,0 +1,102 @@
+"""Read-replica routing: the DB router sends flagged anonymous reads to a
+per-service replica, and the middleware sets that flag only for public GETs.
+
+Pure logic — no database is touched (fake models expose only ``_meta.app_label``),
+so these run without the ``django_db`` fixture.
+"""
+
+from django.test import override_settings
+
+from config.db_router import (
+    ServiceDatabaseRouter,
+    _reads_use_replica,
+    route_reads_to_replica,
+)
+from config.middleware import ReadReplicaRoutingMiddleware
+
+router = ServiceDatabaseRouter()
+
+_ALL_RO = {"default": "default_ro", "nes": "nes_ro", "ngm": "ngm_ro"}
+
+
+def _model(app_label):
+    return type("M", (), {"_meta": type("Meta", (), {"app_label": app_label})})
+
+
+def teardown_function():
+    # Never leak the per-thread flag into another test.
+    route_reads_to_replica(False)
+
+
+def test_writes_always_go_to_the_primary():
+    route_reads_to_replica(True)  # even when reads are replica-eligible
+    assert router.db_for_write(_model("cases")) == "default"
+    assert router.db_for_write(_model("entities")) == "nes"
+    assert router.db_for_write(_model("courts")) == "ngm"
+
+
+def test_reads_use_primary_when_not_flagged():
+    with override_settings(REPLICA_ALIASES=_ALL_RO):
+        assert router.db_for_read(_model("cases")) == "default"
+        assert router.db_for_read(_model("entities")) == "nes"
+
+
+def test_reads_use_replica_only_when_flagged():
+    with override_settings(REPLICA_ALIASES=_ALL_RO):
+        route_reads_to_replica(True)
+        assert router.db_for_read(_model("cases")) == "default_ro"
+        assert router.db_for_read(_model("entities")) == "nes_ro"
+        assert router.db_for_read(_model("courts")) == "ngm_ro"
+
+
+def test_reads_fall_back_to_primary_for_a_service_without_a_replica():
+    with override_settings(REPLICA_ALIASES={"default": "default_ro"}):
+        route_reads_to_replica(True)
+        assert router.db_for_read(_model("cases")) == "default_ro"  # configured
+        assert router.db_for_read(_model("entities")) == "nes"  # no replica → primary
+
+
+def test_no_replicas_configured_is_a_noop():
+    with override_settings(REPLICA_ALIASES={}):
+        route_reads_to_replica(True)
+        assert router.db_for_read(_model("cases")) == "default"
+
+
+def test_allow_migrate_never_targets_a_replica():
+    assert router.allow_migrate("default", "cases") is True
+    assert router.allow_migrate("default_ro", "cases") is False
+    assert router.allow_migrate("nes_ro", "entities") is False
+
+
+# ── middleware ───────────────────────────────────────────────────────────────
+def _flag_during(method, path):
+    captured = {}
+
+    def get_response(_request):
+        captured["flag"] = _reads_use_replica()
+        return "response"
+
+    request = type("R", (), {"method": method, "path": path})()
+    ReadReplicaRoutingMiddleware(get_response)(request)
+    return captured["flag"]
+
+
+def test_anon_public_get_is_replica_eligible():
+    assert _flag_during("GET", "/api/cases/") is True
+    assert _flag_during("GET", "/api/entities/foo") is True
+    assert _flag_during("GET", "/sitemap.xml") is True
+    assert _flag_during("HEAD", "/api/courtcases/") is True
+
+
+def test_writes_and_editor_surfaces_stay_on_primary():
+    assert _flag_during("POST", "/api/cases/") is False
+    assert _flag_during("PATCH", "/api/cases/x/") is False
+    assert _flag_during("GET", "/django-admin/") is False
+    assert _flag_during("GET", "/api/casework/reviews") is False
+    assert _flag_during("GET", "/api/jobs/status") is False
+    assert _flag_during("GET", "/newsroom/pages/") is False
+
+
+def test_flag_is_reset_after_the_request():
+    _flag_during("GET", "/api/cases/")
+    assert _reads_use_replica() is False

--- a/uv.lock
+++ b/uv.lock
@@ -487,6 +487,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/c7/dc39c4c19f7b35e827a486d08376de1fad31c50decb26c56e32668314f13/django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e", size = 26465, upload-time = "2026-05-26T19:04:00.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5d/6ec3083ba69545696c962ae505a0e52e280e7592d4c278c2f3803cabb688/django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134", size = 31801, upload-time = "2026-05-26T19:03:59.505Z" },
+]
+
+[[package]]
 name = "django-storages"
 version = "1.14.6"
 source = { registry = "https://pypi.org/simple" }
@@ -921,6 +934,7 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-filter" },
     { name = "django-jazzmin" },
+    { name = "django-prometheus" },
     { name = "django-storages" },
     { name = "django-tinymce" },
     { name = "djangorestframework" },
@@ -974,6 +988,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.9" },
     { name = "django-filter", specifier = ">=25.2" },
     { name = "django-jazzmin", specifier = "==3.0.1" },
+    { name = "django-prometheus", specifier = ">=2.3" },
     { name = "django-storages", specifier = ">=1.14.3" },
     { name = "django-tinymce", specifier = ">=5.0" },
     { name = "djangorestframework", specifier = ">=3.16" },
@@ -1774,6 +1789,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the last of the three portal→api config gaps: the monolith sent **every** read to the primary, while the legacy portal had a read/write split.

## Design (per the agreed choice)
**Anonymous public reads → replica; admin/casework + all writes → primary** (read-your-write correctness).

- **settings** — when a `*_READ_URL` env is set (`DATABASE_READ_URL`, `NES_DB_READ_URL`, `NGM_DATABASE_READ_URL`), register a `<alias>_ro` connection and record it in `REPLICA_ALIASES`. Empty when unset → dev/tests unchanged; `settings_test` also clears it as a safety net. A service with no read URL transparently uses its primary.
- **db_router** — `db_for_read` returns the `_ro` alias **only** when the request is flagged replica-eligible; writes, admin/casework, and non-request code (mgmt commands/shell/tasks — no flag) always read the primary. `allow_migrate` never targets a `_ro` alias.
- **`config.middleware.ReadReplicaRoutingMiddleware`** — flags anonymous public GETs by **path + method**, *not* auth state (DRF/OIDC resolve the user in the view, too late for a middleware auth check). Editor surfaces (`/django-admin/`, `/api/casework`, `/api/jobs/`, `/api/ingestion/`, `/newsroom/`, `/oidc/`) and unsafe methods stay on the primary. The flag is reset in `finally` so it never leaks across pooled worker threads.

## Verification
- New tests: router (primary / replica-when-flagged / per-service fallback / `allow_migrate` skips `_ro`) + middleware (public GET → replica; POST/PATCH, admin, casework, jobs, newsroom → primary; flag reset). 
- Settings build verified: read URLs → `REPLICA_ALIASES={default,ngm}` pointing at `pg-r`, `nes` (no read URL) → primary.
- `ruff` clean; **full suite 921 passed**.

## Infra (separate, in services/infra)
Add `DATABASE_READ_URL` / `NES_DB_READ_URL` / `NGM_DATABASE_READ_URL` to `platform-env` (OpenBao) pointing at the CNPG `pg-r` read service (2-instance cluster: primary + 1 replica). Applied alongside; inert until this ships (no `*_READ_URL` → primary-only, no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics endpoints for service monitoring.
  * Enabled read-replica routing for safe public requests to improve read performance.
  * Added support for database read replicas when configured.

* **Bug Fixes**
  * Prevented host validation errors during metrics scraping in clustered environments.
  * Ensured request routing resets correctly after each request.
  * Improved Gunicorn startup and worker shutdown handling for metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->