### PR TITLE
fix(metrics): exempt /metrics from the HTTPS redirect (vmagent scrape)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -762,6 +762,11 @@ if not DEBUG:
     # runner without being redirected to https. TESTING is only true under the
     # test runner (settings.py: pytest / TESTING=true), so prod is unaffected.
     SECURE_SSL_REDIRECT = env_flag("SECURE_SSL_REDIRECT", True) and not TESTING
+    # Exempt /metrics from the HTTPS redirect: vmagent scrapes the pod IP over
+    # plain HTTP (no Traefik, so no X-Forwarded-Proto=https), which SECURE_SSL_
+    # REDIRECT would otherwise 301 to an https:// URL the pod doesn't serve. The
+    # ingress still blocks /metrics from the public internet (metrics-deny-public).
+    SECURE_REDIRECT_EXEMPT = [r"^metrics$"]
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_HTTPONLY = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -751,6 +751,13 @@ if not CSRF_TRUSTED_ORIGINS:
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 X_FRAME_OPTIONS = "DENY"
+# Exempt /metrics from the HTTPS redirect: vmagent scrapes the pod IP over plain
+# HTTP (no Traefik, so no X-Forwarded-Proto=https), which SECURE_SSL_REDIRECT would
+# otherwise 301 to an https:// URL the pod doesn't serve. Defined unconditionally —
+# harmless when the redirect is off (DEBUG/tests) — so it always applies when the
+# redirect is on, and is testable without being overridden. Trailing slash optional.
+# The ingress still blocks /metrics from the public internet (metrics-deny-public).
+SECURE_REDIRECT_EXEMPT = [r"^metrics/?$"]
 
 if not DEBUG:
     SECURE_HSTS_SECONDS = int(os.getenv("SECURE_HSTS_SECONDS", "300"))
@@ -762,11 +769,6 @@ if not DEBUG:
     # runner without being redirected to https. TESTING is only true under the
     # test runner (settings.py: pytest / TESTING=true), so prod is unaffected.
     SECURE_SSL_REDIRECT = env_flag("SECURE_SSL_REDIRECT", True) and not TESTING
-    # Exempt /metrics from the HTTPS redirect: vmagent scrapes the pod IP over
-    # plain HTTP (no Traefik, so no X-Forwarded-Proto=https), which SECURE_SSL_
-    # REDIRECT would otherwise 301 to an https:// URL the pod doesn't serve. The
-    # ingress still blocks /metrics from the public internet (metrics-deny-public).
-    SECURE_REDIRECT_EXEMPT = [r"^metrics$"]
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_HTTPONLY = True

--- a/tests/test_metrics_ssl_exempt.py
+++ b/tests/test_metrics_ssl_exempt.py
@@ -5,14 +5,20 @@ redirects. SECURE_SSL_REDIRECT is off under TESTING, so force it on here.
 
 from django.test import Client, override_settings
 
+# Only force SECURE_SSL_REDIRECT on (it's disabled under TESTING); the exempt list
+# under test is the REAL SECURE_REDIRECT_EXEMPT from config.settings, not an
+# override — so removing it there would fail these tests.
 
-@override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=[r"^metrics$"])
+
+@override_settings(SECURE_SSL_REDIRECT=True)
 def test_metrics_is_exempt_from_ssl_redirect():
     # Plain-HTTP GET (secure=False) is NOT redirected — the scrape reaches /metrics.
+    # Trailing slash is also exempt (r"^metrics/?$").
     assert Client().get("/metrics", secure=False).status_code == 200
+    assert Client().get("/metrics/", secure=False).status_code in (200, 404)
 
 
-@override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=[r"^metrics$"])
+@override_settings(SECURE_SSL_REDIRECT=True)
 def test_non_metrics_paths_still_redirect_to_https():
     resp = Client().get("/api/cases/", secure=False)
     assert resp.status_code == 301

--- a/tests/test_metrics_ssl_exempt.py
+++ b/tests/test_metrics_ssl_exempt.py
@@ -13,9 +13,9 @@ from django.test import Client, override_settings
 @override_settings(SECURE_SSL_REDIRECT=True)
 def test_metrics_is_exempt_from_ssl_redirect():
     # Plain-HTTP GET (secure=False) is NOT redirected — the scrape reaches /metrics.
-    # Trailing slash is also exempt (r"^metrics/?$").
-    assert Client().get("/metrics", secure=False).status_code == 200
-    assert Client().get("/metrics/", secure=False).status_code in (200, 404)
+    # (The route is /metrics with no trailing slash; the regex just tolerates one.)
+    resp = Client().get("/metrics", secure=False)
+    assert resp.status_code == 200
 
 
 @override_settings(SECURE_SSL_REDIRECT=True)

--- a/tests/test_metrics_ssl_exempt.py
+++ b/tests/test_metrics_ssl_exempt.py
@@ -1,0 +1,19 @@
+"""/metrics must be exempt from the HTTPS redirect so vmagent can scrape the pod
+over plain HTTP (no Traefik → no X-Forwarded-Proto). Everything else still
+redirects. SECURE_SSL_REDIRECT is off under TESTING, so force it on here.
+"""
+
+from django.test import Client, override_settings
+
+
+@override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=[r"^metrics$"])
+def test_metrics_is_exempt_from_ssl_redirect():
+    # Plain-HTTP GET (secure=False) is NOT redirected — the scrape reaches /metrics.
+    assert Client().get("/metrics", secure=False).status_code == 200
+
+
+@override_settings(SECURE_SSL_REDIRECT=True, SECURE_REDIRECT_EXEMPT=[r"^metrics$"])
+def test_non_metrics_paths_still_redirect_to_https():
+    resp = Client().get("/api/cases/", secure=False)
+    assert resp.status_code == 301
+    assert resp["Location"].startswith("https://")


### PR DESCRIPTION
Follow-up to #275. `SECURE_SSL_REDIRECT` 301s plain-HTTP requests to https; vmagent scrapes the pod IP directly over HTTP (no Traefik → no `X-Forwarded-Proto=https`), so `/metrics` was **301'd to an https:// URL the pod doesn't serve** → scrape failed (verified live: 301 → `https://<podIP>:8080/metrics`).

Add `SECURE_REDIRECT_EXEMPT=[r"^metrics$"]` so `/metrics` is served over HTTP for in-cluster scraping; the ingress still blocks public `/metrics` (`metrics-deny-public`, verified 403). Regression tests: `/metrics` → 200 (exempt), other paths → 301→https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)