### PR TITLE
docs: reconcile api docs to main-trunk + flat /api contract (post-cutover)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ jawafdehi-api/
   search/                 unified OpenSearch query plane (all 4 types)
   discovery/              ResourceSync + Sitemaps off the @id envelope
   lakehouse/              DORMANT Iceberg/DuckDB seam (not a live path)
-  content/                headless Wagtail CMS (Newsroom) — NOTE: on `main`,
-                          being forward-ported to `v2`; see ARCHITECTURE §3.5
+  content/                headless Wagtail CMS (Newsroom) — Newsroom updates/news;
+                          served at /api/cms/v2/; see ARCHITECTURE §3.5
   docs/                   design docs + sourcing artifacts
 ```
 
@@ -54,12 +54,12 @@ docker build -t jawafdehi .                  # single image, context = repo root
 For the local dev stack (Postgres ×3, OpenSearch, MinIO) see `docker-compose.yml`.
 
 ## Working model
-Trunk is **`v2`**. `origin` = the org (`Jawafdehi/JawafdehiAPI`), `fork` = the
+Trunk is **`main`**. `origin` = the org (`Jawafdehi/JawafdehiAPI`), `fork` = the
 `damodaha` personal fork; PRs are filed on the org from the fork. New work goes on a
-feature branch → PR → `v2`. **Do local changes in git worktrees**
-(`git worktree add <path> v2`), not by checking out branches in the primary tree.
+feature branch → PR → `main`. **Do local changes in git worktrees**
+(`git worktree add <path> main`), not by checking out branches in the primary tree.
 Commits authored `oopsy <oopsy@claudy.com>`.
 
-_An older `main` line still exists on the org remotes and still carries the Wagtail
-`content/` app; `v2` is the active trunk and the CMS is being ported forward from
-`main` — see `docs/ARCHITECTURE.md` §3.5._
+_The deprecated `v2` branch still exists on the org remotes but is no longer the
+trunk; do not push to it. The Wagtail `content/` app was forward-ported onto the
+mainline (PR #270) and is now present on `main` — see `docs/ARCHITECTURE.md` §3.5._

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,14 +145,14 @@ services:
       VITE_API_PROXY_TARGET: "http://platform:8080"
       # SAME-ORIGIN relative API base URLs so requests go through the Vite proxy
       # above (to the local platform) instead of the production defaults baked into
-      # the API clients. Jawafdehi cases + unified search live under /api; NES
-      # entities under /api/nes (see config/urls.py).
+      # the API clients. The /api surface is FLAT — no /nes or /ngm prefix
+      # (config/urls.py HARD-CUT the prefixes 2026-07-01, no redirects). NES
+      # entities are at /api/entities, NGM materials at /api/materials/ and court
+      # cases at /api/courtcases; Jawafdehi cases + unified search also under /api.
       VITE_JDS_API_BASE_URL: "/api"
-      VITE_NES_API_BASE_URL: "/api/nes"
-      VITE_API_BASE_URL: "/api/nes"
-      # NGM materials + court cases live under /api/ngm on the same platform; a
-      # same-origin relative base keeps NGM detail-page fetches on the Vite proxy.
-      VITE_NGM_API_BASE_URL: "/api/ngm"
+      VITE_NES_API_BASE_URL: "/api"
+      VITE_API_BASE_URL: "/api"
+      VITE_NGM_API_BASE_URL: "/api"
     volumes:
       # Live source for hot reload; anonymous volume keeps the image's installed
       # node_modules from being shadowed by the host mount.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       # the API clients. The /api surface is FLAT — no /nes or /ngm prefix
       # (config/urls.py HARD-CUT the prefixes 2026-07-01, no redirects). NES
       # entities are at /api/entities, NGM materials at /api/materials/ and court
-      # cases at /api/courtcases; Jawafdehi cases + unified search also under /api.
+      # cases at /api/courtcases/; Jawafdehi cases + unified search also under /api.
       VITE_JDS_API_BASE_URL: "/api"
       VITE_NES_API_BASE_URL: "/api"
       VITE_API_BASE_URL: "/api"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ a monolith**; this doc describes the shipped result, not the journey.
 
 ## 1. Shape: one Django monolith, three databases
 
-- **One Django project** in the `jawafdehi-api` repo (trunk `v2`), one WSGI, one
+- **One Django project** in the `jawafdehi-api` repo (trunk `main`), one WSGI, one
   image, runs at **`:48000`**. (The R1 collapse flattened the earlier
   `monolith/` + `services/{nes,ngm,jawafdehi}/` layout into top-level apps.)
 - **Apps** (all top-level dirs, in `INSTALLED_APPS`): `entities` (NES), `courts`
@@ -163,7 +163,7 @@ held and which can be promoted, see
 
 ## 7. Working model
 
-Two repos, **both with `v2` as the working trunk**:
+Two repos, **both with `main` as the working trunk**:
 
 - **`jawafdehi-api`** (this repo — the Django backend). Local clone at
   `/damodaha-volunteer/think-big/jawafdehi-api`. `origin` = the org
@@ -173,12 +173,12 @@ Two repos, **both with `v2` as the working trunk**:
   `jawafdehi/jawafdehi` org so we can unify the frontend too). `origin` = our fork,
   `upstream` = the org for pull/sync.
 
-New work goes on a feature branch → PR → `v2`. **Do local changes in git worktrees**
-(`git worktree add <path> v2`), not by checking out branches in the primary tree (a
+New work goes on a feature branch → PR → `main`. **Do local changes in git worktrees**
+(`git worktree add <path> main`), not by checking out branches in the primary tree (a
 `git checkout` over unmerged/conflicted paths silently fails and tangles stashes).
 Commits authored `oopsy <oopsy@claudy.com>`. Planning/sourcing artifacts live in this
 repo's `docs/` tree.
 
-_Note: an older `main` line still exists on the org remotes (it still carries the
-Wagtail `content/` app — see §3.5). `v2` is the active trunk; `main` is not retired
-and is the source for the CMS forward-port._
+_Note: the deprecated `v2` branch still exists on the org remotes but is no longer the
+trunk (do not push to it). `main` is the active trunk and already carries the
+forward-ported Wagtail `content/` app (see §3.5)._

--- a/docs/DOC-STATUS.md
+++ b/docs/DOC-STATUS.md
@@ -1,6 +1,6 @@
 # DOC-STATUS — Documentation Audit & Orientation Index
 
-_Last audited: 2026-07-02 (docs reconciled to the R1-collapsed `v2` tree: flat top-level apps, `config/` glue, trunk `v2`; CMS forward-port + frontend `/v2`-drift items recorded)._
+_Last audited: 2026-07-02 (docs reconciled to the R1-collapsed `v2` tree: flat top-level apps, `config/` glue, trunk `main`; CMS forward-port + frontend `/v2`-drift items recorded)._
 
 **Read this first.** This file is the orientation index for the `docs/` tree: it says,
 doc by doc, what to trust and what to treat with caution. For *what the platform is now*
@@ -14,7 +14,7 @@ read [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
 ## What the platform ACTUALLY is now (the ground truth)
 
-- **Single Django MONOLITH** — one project, **trunk `v2`** (the R1 collapse flattened the
+- **Single Django MONOLITH** — one project, **trunk `main`** (the `v2` branch is deprecated; the R1 collapse flattened the
   old `monolith/` + `services/{nes,ngm,jawafdehi}/` layout into top-level apps). Apps (all
   top-level dirs): `entities` (NES), `courts` + `materials` (NGM), `cases` + `review`
   (Jawafdehi), plus platform `search`, `discovery`, `jobs`. _(`case_workflows` was dropped —
@@ -24,10 +24,7 @@ read [`ARCHITECTURE.md`](./ARCHITECTURE.md).
   HTTP client by design — `review/ngm_client.py`, `review/jds_client.py`)_. One image.
   **uv workspace** (NOT poetry — one top-level `pyproject.toml` + `uv.lock`). Cross-app libs
   in top-level `jawafdehi_shared/`. Runs at `:48000`.
-- **Headless Wagtail CMS** (`content/` app, "Newsroom") serves public updates/news at
-  `/api/cms/v2/…`; consumed by the SPA `/updates` routes. **It lives on `origin/main` but
-  is NOT yet on `v2`** (dropped in the collapse commit `4c39d8c`) — being forward-ported.
-  See ARCHITECTURE §3.5.
+- **Headless Wagtail CMS** (`content/` app, "Newsroom") serves public updates/news at `/api/cms/v2/…`; consumed by the SPA `/updates` routes. It was dropped from `v2` in the R1 collapse commit `4c39d8c`, then **forward-ported back into `v2`** (PR #270, adapted from `origin/main`) with the frontend contract preserved — so it now ships on trunk `main`. See ARCHITECTURE §3.5.
 - **schema.org JSON-LD is the canonical stored form** for NES entities AND NGM materials,
   keyed by **`@id` IRIs**: `https://jawafdehi.org/entity/<prefix>/<slug>`,
   `/material/<source>/<ident>`, `/case/<slug>`, `/courtcase/<court>/<case_number>`. **Clean
@@ -74,6 +71,7 @@ A `>` status banner has been added in-place to the most-misleading STALE docs (m
 | `data-plane-design.md` | CURRENT (BUILT) | Data-plane consolidation: Postgres-SoR + R2 archive + OpenSearch; **no live Iceberg** (`lakehouse/` dormant seam); `material_convert` FTS feed shipped (#264). Reconciles ARCHITECTURE §5; incorporates the jobs queue + cases-own-no-documents ADR | Keep (load-bearing). |
 | `unified-search-plan.md` | CURRENT (BUILT & LIVE) | §0 = pre-build starting point (marked as such); §1-§8 reconciled to the live build (hard-fail no-fallback, four index constants, case_id done, no "internal" role). NOTE: `Material.visibility` now EXISTS (added by #263) and gates material indexing — supersedes the old "no `visibility` field" caveat | Keep. |
 | `case-workflows-retirement-plan.md` | HISTORICAL (DONE) | Plan to retire `case_workflows` + drop the langchain/langgraph/deepagents stack. **Executed:** app removed, tables dropped by migration `cases/migrations/0040`, no langchain/langgraph/deepagents deps remain in `pyproject.toml`. Its cited `monolith/config` + `services/jawafdehi/pyproject.toml` paths predate the R1 collapse (single top-level `pyproject.toml` now) | Keep as record; mark done. |
+| `control-plane-api-design.md` **[bannered]** | HISTORICAL (superseded) | Dated 2026-06-30 control-plane design/audit. §1 "target" largely shipped, but §2 "current surface (audited)" + §2.3 describe the PRE-hard-cut world (`/nes`+`/ngm` prefixes, `services/{nes,ngm,jawafdehi}`+`monolith/` layout) and propose "301 aliases". **Superseded by the 2026-07-01 hard cut: FLAT `/api/*` surface, prefixes removed with NO aliases, flat apps + `config/`, trunk `main`.** Banner added at top scoping §2/§2.3 as pre-cut record | Keep as pre-cut record. |
 
 ### `shared/`
 

--- a/docs/control-plane-api-design.md
+++ b/docs/control-plane-api-design.md
@@ -7,6 +7,13 @@
 > store. Where this doc still describes `/api/sources` or a distinct Jawafdehi source
 > resource, defer to the ADR.
 
+> **HISTORICAL for current-state purposes (as of the 2026-07-01 hard cut).** The public
+> API surface is now FLAT `/api/*`: the `/nes` and `/ngm` prefixes were **removed with NO
+> 301 aliases** (`config/urls.py`), superseding §2's audited "as-shipped" surface and
+> §2.3's alias/redirect plan. The `services/{nes,ngm,jawafdehi}` + `monolith/` layout was
+> collapsed to flat Django apps + `config/`, and the trunk is now `main` (not `v2`). Read
+> §2 and §2.3 as a pre-cut record, not current state.
+
 **Status:** DRAFT for review · **Date:** 2026-06-30 · **Branch:** `feat/control-plane-design` (off monolith `v2` @ `734b401`)
 
 **Goal:** a fully-RESTful control plane for NES and NGM on the monolith, including **material file uploads** (the one genuinely-missing capability). Everything else — MCP, casework, integration tests, frontend — rewires into these endpoints.


### PR DESCRIPTION
Reconciles the repo's docs to post-cutover reality (from a cross-repo consistency sweep):

- Trunk is **`main`** (the `v2` branch is deprecated) — fixed README "Working model", ARCHITECTURE §1/§7, DOC-STATUS ground-truth + status table.
- API surface is **flat `/api/*`** — the `/api/nes` + `/api/ngm` prefixes were hard-cut 2026-07-01 (no 301 aliases). Fixed `docker-compose.yml` `VITE_*_API_BASE_URL` block.
- Wagtail CMS (`content/`) is **forward-ported** (PR #270), not "in progress".
- Added a HISTORICAL banner to `docs/control-plane-api-design.md` (its §2 "as-shipped" audit + §2.3 alias plan predate the hard cut) + a DOC-STATUS row.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)