### PR TITLE
fix(entities): route raw tags SQL to the nes DB alias

### DIFF
--- a/entities/persistence.py
+++ b/entities/persistence.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from django.db import connection
+from django.db import connections, router
 from django.db.models import Q, QuerySet
 from jawafdehi_shared.entities.ids import canonicalize_entity_iri, parse_entity_iri
 
@@ -48,9 +48,19 @@ def _clamp_offset(offset: int) -> int:
     return max(0, offset)
 
 
+def _entities_connection():
+    """The connection the router pins entities models to (``nes`` in prod).
+
+    Raw SQL against the ``entities`` table must use this connection, NOT the
+    ``default`` one — after the platform collapse ``default`` is the Jawafdehi
+    DB, which owns no entities tables (``relation "entities" does not exist``).
+    """
+    return connections[router.db_for_read(StoredEntity)]
+
+
 def _supports_jsonb_containment() -> bool:
     """Postgres supports ``@>`` containment lookups; sqlite (tests) does not."""
-    return connection.vendor == "postgresql"
+    return _entities_connection().vendor == "postgresql"
 
 
 def _canonicalize_doc_id(doc: Dict[str, Any]) -> str:
@@ -304,6 +314,7 @@ class EntityRepository:
 
     def all_keywords(self) -> List[str]:
         """Distinct schema.org ``keywords`` across all entities (for /api/entities/tags)."""
+        connection = _entities_connection()
         if connection.vendor == "postgresql":
             with connection.cursor() as cursor:
                 cursor.execute(


### PR DESCRIPTION
## Problem

`GET /api/entities/tags` returns 500 in production: `ProgrammingError: relation "entities" does not exist`.

`EntityRepository.all_keywords()` runs its raw keywords SQL on the **default** connection (the Jawafdehi DB). Post-collapse the entities tables live in the `nes` database — the ORM paths work because the router pins `entities` models there, but the raw cursor bypassed the router. This breaks the `get_nes_tags` MCP tool in the chat assistant on every call.

## Fix

Resolve the connection via `router.db_for_read(StoredEntity)` (same pattern as the courts raw query plane, `courts/views.py`), and use the same routed connection for the `_supports_jsonb_containment()` vendor check (same latent bug — coincidentally right today because both DBs are Postgres in prod and both sqlite in tests).

## Verify

- Full suite: **923 passed**, `ruff` clean.
- Trigger/traceback confirmed against prod logs before the fix (request_id `b8c9b980`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)