### PR TITLE
fix(auditlog): log content PATCHes and attribute the actor

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -32,6 +32,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
+from jawafdehi_shared.drf.auditlog import AuditlogActorMixin, log_bulk_update
 from jawafdehi_shared.identity import (
     JAWAFDEHI_USER_ID_HEADER,
     resolve_or_create_identity,
@@ -223,7 +224,7 @@ def _recompute_material_visibility(material_iris) -> None:
         tags=["cases"],
     ),
 )
-class CaseViewSet(viewsets.ReadOnlyModelViewSet):
+class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
     """
     Public read-only API for Cases (with PATCH support for authenticated users).
 
@@ -683,6 +684,18 @@ class CaseViewSet(viewsets.ReadOnlyModelViewSet):
             if scalar_updates:
                 case = self.get_object()
                 Case.objects.filter(pk=case.pk).update(**scalar_updates)
+                # ``QuerySet.update()`` bypasses ``post_save``, so auditlog's UPDATE
+                # receiver never fires for scalar content edits — the same bypass the
+                # explicit search re-index below compensates for. Record the diff
+                # explicitly so content changes (description, timeline, allegations, …)
+                # are attributable, not just workflow/state saves. ``case`` still holds
+                # the pre-update values here (``update()`` doesn't touch the in-memory
+                # instance); it is refreshed to the new values on the next line.
+                log_bulk_update(
+                    case,
+                    Case.objects.get(pk=case.pk),
+                    fields=list(scalar_updates.keys()),
+                )
 
             # Persist entity relationship changes only when a /entities op
             # was explicitly included — avoids unnecessary delete/recreate on

--- a/courts/views.py
+++ b/courts/views.py
@@ -27,6 +27,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import connections, router, transaction
 from rest_framework import mixins, status, viewsets
 
+from jawafdehi_shared.drf.auditlog import AuditlogActorMixin
 from jawafdehi_shared.entities.ids import is_valid_entity_iri
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -60,11 +61,16 @@ def health(request):
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
-class _PublicReadNgmWriteMixin:
+class _PublicReadNgmWriteMixin(AuditlogActorMixin):
     """Per-method permissions: public reads, NGM-role-gated writes.
 
     Mirrors ``entities.views.EntityListCreateView.get_permissions``:
     write methods require ``HasNgmRole``, everything else is ``AllowAny``.
+
+    Also mixes in ``AuditlogActorMixin`` so any audit entry produced by a courts
+    write is attributed to the authenticated user. (Courts models aren't
+    auditlog-registered today, so this is inert until they are — it's here so the
+    actor-capture seam is uniform across the platform's write viewsets.)
     """
 
     def get_permissions(self):
@@ -356,8 +362,12 @@ class QueryView(APIView):
 # aggregate counts so a scraper can safely re-run a batch.
 
 
-class _IngestionView(APIView):
-    """Shared base for the OIDC + NGM-role gated ingestion writers."""
+class _IngestionView(AuditlogActorMixin, APIView):
+    """Shared base for the OIDC + NGM-role gated ingestion writers.
+
+    ``AuditlogActorMixin`` attributes any audit entry to the authenticated user
+    (inert until courts models are auditlog-registered; see
+    ``_PublicReadNgmWriteMixin``)."""
 
     permission_classes = [HasNgmRole]
 

--- a/entities/views.py
+++ b/entities/views.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import unquote
 
 import jsonpatch
+from jawafdehi_shared.drf.auditlog import AuditlogActorMixin
 from jawafdehi_shared.entities.ids import (
     build_entity_iri,
     canonicalize_entity_iri,
@@ -108,8 +109,12 @@ def health(request):
 # ---------------------------------------------------------------------------
 
 
-class EntityListCreateView(APIView):
-    """GET /api/entities (public list/search/batch) + POST /api/entities (create)."""
+class EntityListCreateView(AuditlogActorMixin, APIView):
+    """GET /api/entities (public list/search/batch) + POST /api/entities (create).
+
+    ``AuditlogActorMixin`` attributes any audit entry to the authenticated user
+    (inert until entities models are auditlog-registered; the seam is kept
+    uniform across the platform's write views)."""
 
     def get_permissions(self):
         if self.request.method == "POST":
@@ -224,7 +229,7 @@ class EntityListCreateView(APIView):
         return Response(created, status=status.HTTP_201_CREATED)
 
 
-class EntityDetailView(APIView):
+class EntityDetailView(AuditlogActorMixin, APIView):
     """GET /api/entities/{ref} (public) + PATCH/DELETE /api/entities/{ref} (write).
 
     DELETE is a SOFT delete: it flips ``is_deleted=True`` so the entity vanishes

--- a/jawafdehi_shared/drf/auditlog.py
+++ b/jawafdehi_shared/drf/auditlog.py
@@ -1,0 +1,108 @@
+"""DRF ↔ django-auditlog glue.
+
+Closes two gaps in the platform's audit trail:
+
+1. **Actor is NULL on every API-driven audit entry.** ``auditlog.middleware.AuditlogMiddleware``
+   captures ``request.user`` at the Django-middleware layer, which runs *before* DRF
+   authentication resolves the user in the view (the platform authenticates with
+   ``jawafdehi_shared.auth.oidc.OIDCAuthentication``). For token/OIDC clients the middleware
+   therefore only ever sees ``AnonymousUser``, so every ``LogEntry`` is written with
+   ``actor=NULL``. :class:`AuditlogActorMixin` re-binds the actor once DRF has authenticated,
+   reusing the request context the middleware already established so the ``remote_addr`` /
+   ``remote_port`` / ``cid`` it captured are preserved.
+
+2. **Writes made with ``QuerySet.update()`` / bulk ops are never logged.** auditlog hooks
+   ``post_save`` / ``post_delete``; a bulk ``update()`` emits neither, so those edits vanish
+   from the trail (this is why content PATCHes on cases were invisible while workflow saves
+   were not). :func:`log_bulk_update` writes the equivalent UPDATE entry explicitly — call it
+   right after the bulk write.
+
+The mixin lives here (not in a single app) so any DRF write endpoint touching an
+auditlog-registered model can opt in by inheritance.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from auditlog import get_logentry_model
+from auditlog.context import auditlog_value
+from auditlog.diff import model_instance_diff
+
+
+def _authenticated_actor(request):
+    """Return the request's authenticated user model instance, or ``None``."""
+    user = getattr(request, "user", None)
+    if isinstance(user, get_user_model()) and user.is_authenticated:
+        return user
+    return None
+
+
+def bind_actor_to_auditlog(request) -> None:
+    """Inject the DRF-authenticated user into auditlog's ambient request context.
+
+    ``AuditlogMiddleware`` establishes the context (with ``actor=None`` for API clients,
+    since DRF auth hasn't run yet) and connects the ``pre_save`` receiver that reads it when
+    a ``LogEntry`` is saved. We mutate that same context dict in place, so the actor is
+    resolved at *save* time and ``remote_addr`` / ``remote_port`` / ``cid`` survive.
+
+    Safe no-op when there is no authenticated user (anonymous public reads), when no auditlog
+    context is active (e.g. the middleware isn't installed, as in some unit tests), or when an
+    actor is already bound (don't clobber a value the middleware managed to capture, e.g. a
+    session-authenticated admin request).
+    """
+    actor = _authenticated_actor(request)
+    if actor is None:
+        return
+    try:
+        context = auditlog_value.get()
+    except LookupError:
+        return
+    if context.get("actor") is None:
+        context["actor"] = actor
+
+
+class AuditlogActorMixin:
+    """DRF view mixin that attributes audit entries to the authenticated user.
+
+    Mix into any ``APIView`` / ``ViewSet`` whose writes touch auditlog-registered models.
+    ``initial()`` runs after DRF authentication, so ``request.user`` is the real OIDC/token
+    user rather than the middleware's ``AnonymousUser``.
+    """
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+        bind_actor_to_auditlog(request)
+
+
+def log_bulk_update(old_instance, new_instance, *, fields=None, force_log=False):
+    """Write an auditlog UPDATE entry for a change that bypassed ``post_save``.
+
+    auditlog only logs saves that emit ``post_save``; ``QuerySet.update()`` and other bulk
+    writes don't, so those edits leave no trail. Capture a clean instance *before* the write
+    (``old_instance``) and *after* (``new_instance``) and call this to record the diff, in the
+    same format and with the same actor attribution as a signal-generated entry (the ambient
+    context — see :class:`AuditlogActorMixin` / ``AuditlogMiddleware`` — supplies actor and
+    ``remote_addr`` via the ``pre_save`` receiver on ``LogEntry``).
+
+    :param fields: restrict the diff to these field names (typically the ``update()`` keys),
+        mirroring how the signal path passes ``save(update_fields=...)``.
+    :returns: the created ``LogEntry``, or ``None`` when nothing changed and ``force_log`` is
+        false.
+    """
+    changes = model_instance_diff(
+        old_instance,
+        new_instance,
+        fields_to_check=fields,
+        use_json_for_changes=settings.AUDITLOG_STORE_JSON_CHANGES,
+    )
+    if not (changes or force_log):
+        return None
+    log_entry_model = get_logentry_model()
+    return log_entry_model.objects.log_create(
+        new_instance,
+        action=log_entry_model.Action.UPDATE,
+        changes=changes,
+        force_log=force_log,
+    )

--- a/tests/api/test_auditlog_actor.py
+++ b/tests/api/test_auditlog_actor.py
@@ -1,0 +1,175 @@
+"""
+Audit-trail coverage for the cases write API.
+
+Regression tests for two defects on ``CaseViewSet.partial_update``:
+
+1. Scalar content edits are persisted with ``Case.objects.update()``, which bypasses
+   ``post_save`` — so auditlog never logged content changes (only workflow/state saves,
+   which go through ``Case.save()``). See ``log_bulk_update``.
+2. ``AuditlogMiddleware`` reads ``request.user`` before DRF authentication runs, so every
+   API-driven ``LogEntry`` was written with ``actor=NULL``. See ``AuditlogActorMixin``.
+"""
+
+import pytest
+from auditlog.models import LogEntry
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    RelationshipType,
+)
+from tests.conftest import create_user_with_role
+
+User = get_user_model()
+
+URL = "/api/cases/{}/"
+
+
+def _make_case(**kwargs) -> Case:
+    defaults = dict(
+        title="Test case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        description="Some description",
+        short_description="Short",
+        timeline=[{"date": "2024-01-01", "title": "Event one"}],
+    )
+    defaults.update(kwargs)
+    return Case.objects.create(**defaults)
+
+
+def _contributor(name="rishi") -> User:
+    return create_user_with_role(name, f"{name}@example.com", "Caseworker")
+
+
+def _authed_client(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _case_updates(case):
+    """UPDATE log entries for a given Case, newest first."""
+    return LogEntry.objects.get_for_object(case).filter(action=LogEntry.Action.UPDATE)
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — content PATCHes must be audit-logged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_content_patch_creates_audit_entry():
+    """A scalar content edit (persisted via QuerySet.update) is logged."""
+    user = _contributor("hari")
+    case = _make_case(description="Original description")
+    case.contributors.add(user)
+
+    before = _case_updates(case).count()
+    response = _authed_client(user).patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/description", "value": "Amended description"}],
+        format="json",
+    )
+    assert response.status_code == 200
+
+    entries = _case_updates(case)
+    assert entries.count() == before + 1
+    changes = entries.first().changes
+    # auditlog stores changes as {field: [old, new]}; only the changed field appears.
+    assert "description" in changes
+    assert changes["description"][0] == "Original description"
+    assert changes["description"][1] == "Amended description"
+
+
+@pytest.mark.django_db
+def test_content_patch_logs_only_changed_fields():
+    """The diff is scoped to the fields the patch actually touched."""
+    user = _contributor("gita")
+    case = _make_case(title="Keep me", description="Change me")
+    case.contributors.add(user)
+
+    response = _authed_client(user).patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/description", "value": "Changed"}],
+        format="json",
+    )
+    assert response.status_code == 200
+
+    changes = _case_updates(case).first().changes
+    # The write rewrites every scalar column, but the diff only carries genuinely
+    # changed fields: description is in, the untouched title is not.
+    assert "description" in changes
+    assert "title" not in changes
+
+
+@pytest.mark.django_db
+def test_scalar_only_patch_does_not_log_when_unchanged():
+    """A no-op replace (same value) must not manufacture a spurious log entry."""
+    user = _contributor("mina")
+    # court_cases defaults to NULL but the endpoint normalizes it to [] on write,
+    # which is itself a real (loggable) column change. Pre-set it so the patch is a
+    # genuine no-op and we can assert the "no diff -> no entry" guarantee.
+    case = _make_case(description="Same", court_cases=[])
+    case.contributors.add(user)
+
+    before = _case_updates(case).count()
+    response = _authed_client(user).patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/description", "value": "Same"}],
+        format="json",
+    )
+    assert response.status_code == 200
+    assert _case_updates(case).count() == before  # no diff -> no entry
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — the actor must be attributed (not NULL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_content_patch_entry_attributes_actor():
+    user = _contributor("bikash")
+    case = _make_case(description="Original")
+    case.contributors.add(user)
+
+    response = _authed_client(user).patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/description", "value": "Edited"}],
+        format="json",
+    )
+    assert response.status_code == 200
+
+    entry = _case_updates(case).first()
+    assert entry.actor_id == user.id
+
+
+@pytest.mark.django_db
+def test_state_transition_entry_attributes_actor():
+    """The workflow-save path (Case.save) must also capture the actor."""
+    user = _contributor("puja")
+    # DRAFT->IN_REVIEW enforces the publish gate (accused entity + allegations +
+    # description), so build a case that satisfies it.
+    case = _make_case(description="Ready for review", key_allegations=["Primary allegation"])
+    CaseEntityRelationship.objects.create(
+        case=case,
+        nes_id="https://jawafdehi.org/entity/person/ram-prasad-gautam",
+        relationship_type=RelationshipType.ACCUSED,
+    )
+    case.contributors.add(user)
+
+    response = _authed_client(user).patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/state", "value": CaseState.IN_REVIEW}],
+        format="json",
+    )
+    assert response.status_code == 200, response.data
+
+    state_entries = [e for e in _case_updates(case) if "state" in (e.changes or {})]
+    assert state_entries, "expected a LogEntry recording the state change"
+    assert all(e.actor_id == user.id for e in state_entries)


### PR DESCRIPTION
## Problem

Two defects on the cases write path left the monolith's audit trail incomplete — surfaced while auditing the giribandhu old-portal → v2 drift. Confirmed against prod `jawafdehi_v2`: **all 853** `auditlog_logentry` rows had `actor_id IS NULL`, and content edits (e.g. an 18.7KB description paste) left **no** entry at all.

1. **Content PATCHes weren't logged.** `CaseViewSet.partial_update` persists scalar fields via `Case.objects.filter(pk=…).update(**scalar_updates)`. `QuerySet.update()` bypasses `post_save` — the signal django-auditlog hooks — so content changes (description, timeline, key_allegations, …) were never recorded, while workflow/state saves (via `Case.save()`) logged fine. The endpoint already compensates for this same bypass for the search index (explicit re-index) but never did for auditlog.
2. **Actor was always NULL.** `auditlog.middleware.AuditlogMiddleware` reads `request.user` at the Django-middleware layer, but the platform authenticates with `jawafdehi_shared.auth.oidc.OIDCAuthentication` — a DRF auth class that runs later, in the view. So the middleware only ever saw `AnonymousUser`. (`remote_addr` was captured fine — it comes from `request.META` at middleware time.)

## Fix

New shared module `jawafdehi_shared/drf/auditlog.py`:

- **`AuditlogActorMixin`** — a DRF view mixin whose `initial()` runs after authentication and injects the real `request.user` into auditlog's ambient request context **in place**, preserving `remote_addr`/`remote_port`/`cid` the middleware already set. Both signal-generated and explicit entries now attribute correctly.
- **`log_bulk_update(old, new, *, fields=…)`** — writes the UPDATE entry that `QuerySet.update()` skips, using auditlog's own `model_instance_diff` + `LogEntry.objects.log_create`, so it matches the signal-generated format.

Applied to `CaseViewSet` (real effect — only the `cases` app registers models with auditlog) plus the `courts`/`entities` write viewsets for a uniform actor-capture seam. **Note:** the mixin is inert on courts/entities today since those apps register no models with auditlog; it's wired for uniformity/future-proofing and can be dropped from those files if you'd rather keep the diff to the cases path only.

## Tests

`tests/api/test_auditlog_actor.py` (5, green): content-PATCH logging, scoped diff, no-op → no entry, and actor attribution on both content and state entries. Full suites green — cases API + permissions + shared (300), courts + entities (143). `ruff check` clean.

## Scope / caveats

- Fixes attribution **going forward only** — the 853 existing NULL-actor rows and pre-fix unlogged content edits (e.g. the giribandhu SPA description paste) are unchanged; VictoriaLogs access logs remain the only forensic source for those.
- Incidental behavior the audit log now surfaces: `partial_update` rewrites all scalar columns each PATCH, and `court_cases` normalizes `null`→`[]`, so a legacy case's first edit legitimately logs a `court_cases: null→[]` change. Truthful, mildly noisy on first touch; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)