### PR TITLE
fix(content): drop the dead case_id field from article case payloads

### DIFF
--- a/content/blocks.py
+++ b/content/blocks.py
@@ -66,7 +66,6 @@ class CaseChooserBlock(BaseCaseChooserBlock):
             return None
         return {
             "id": value.pk,
-            "case_id": value.case_id,
             "title": value.title,
             "slug": value.slug,
         }

--- a/content/serializers.py
+++ b/content/serializers.py
@@ -5,6 +5,5 @@ class RelatedCaseSerializer(serializers.Serializer):
     """Minimal case payload embedded in the article API for cross-linking."""
 
     id = serializers.IntegerField(source="pk")
-    case_id = serializers.CharField()
     title = serializers.CharField()
     slug = serializers.CharField()

--- a/tests/content/test_article_api.py
+++ b/tests/content/test_article_api.py
@@ -1,0 +1,74 @@
+"""Tests for the published-article API (`/api/cms/v2/pages/`).
+
+Focused on the case cross-links: the `related_cases` M2M and the inline
+`case` StreamField block. Both serialize a minimal case payload; the Case
+model has no `case_id` column (the slug is the public identifier), so these
+also guard against reintroducing dropped columns into the payload.
+"""
+
+import datetime
+
+import pytest
+
+from cases.models import Case, CaseState, CaseType
+from content.models import ArticleCategory, ArticleIndexPage, ArticlePage
+
+PAGES_URL = "/api/cms/v2/pages/"
+JSON = {"HTTP_ACCEPT": "application/json"}
+
+
+@pytest.fixture
+def case(db):
+    return Case.objects.create(
+        title="एनसेल कर विवाद परीक्षण मुद्दा",
+        slug="ncell-tax-test-case",
+        state=CaseState.PUBLISHED,
+        case_type=CaseType.CORRUPTION,
+    )
+
+
+@pytest.fixture
+def article_with_case_links(case):
+    index = ArticleIndexPage.objects.first()
+    assert index is not None, "ArticleIndexPage missing — content.0002 not applied"
+
+    article = ArticlePage(
+        title="Update with case links",
+        slug="update-with-case-links",
+        category=ArticleCategory.UPDATE,
+        date=datetime.date(2026, 7, 6),
+        excerpt="Cross-linked update",
+        body=[
+            ("paragraph", "<p>Context</p>"),
+            ("case", {"case": case, "note": "How this case relates"}),
+        ],
+    )
+    index.add_child(instance=article)
+    article.related_cases.add(case)
+    article.save_revision().publish()
+    return article
+
+
+@pytest.mark.django_db
+def test_article_serializes_related_cases(client, case, article_with_case_links):
+    resp = client.get(
+        PAGES_URL,
+        {"type": "content.ArticlePage", "slug": article_with_case_links.slug, "fields": "*"},
+        **JSON,
+    )
+
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    data = items[0]
+
+    assert data["related_cases"] == [
+        {"id": case.pk, "title": case.title, "slug": case.slug}
+    ]
+
+    case_blocks = [block for block in data["body"] if block["type"] == "case"]
+    assert len(case_blocks) == 1
+    assert case_blocks[0]["value"] == {
+        "case": {"id": case.pk, "title": case.title, "slug": case.slug},
+        "note": "How this case relates",
+    }


### PR DESCRIPTION
## Why

The `Case` model dropped its `case_id` column in favor of `slug`, but two CMS serialization paths still read `value.case_id`:

- `RelatedCaseSerializer` (`content/serializers.py`) — serializes the `related_cases` M2M on `ArticlePage`
- `CaseChooserBlock.get_api_representation` (`content/blocks.py`) — serializes inline `case` StreamField blocks

The first article to actually carry a case link would raise `AttributeError` and 500 the public CMS API (`/api/cms/v2/pages/`). It has never surfaced only because no article currently has case links — the updates were seeded without them, which is why e.g. `/updates/case-ncell-tax-dispute` lost the related-case links it had on the old portal. Restoring that data is blocked on this fix.

## What

- Drop `case_id` from both payloads; the SPA renders only `id`/`title`/`slug` (`ArticleView.tsx`, `StreamField.tsx`).
- Add the first published-article API test (`tests/content/test_article_api.py`) exercising both link paths end-to-end through `/api/cms/v2/pages/?fields=*`. Verified it fails with `AttributeError` on the pre-fix code.

A companion frontend PR removes `case_id` from the CMS TypeScript types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)