### PR TITLE
fix(jobs): consumer must nest the handler result under "result"

### DIFF
--- a/jobs/tests/test_review_integration.py
+++ b/jobs/tests/test_review_integration.py
@@ -108,3 +108,55 @@ def test_regrade_reenqueues_after_prior_job_terminal():
     j2 = _enqueue_review_job(review)
     assert j2.id != j1.id
     assert j2.status == Job.QUEUED
+
+
+@pytest.mark.django_db
+def test_consumer_result_body_through_the_view_finalizes_the_review():
+    """The seam that broke in prod: the consumer's HTTP body -> view ->
+    JobResultSerializer -> finalize -> on_result. The handler's whole return
+    value must arrive nested under "result" (the serializer stores that field
+    verbatim as job.result); submitted flat, the hook read wrapper fields off
+    the inner scored dict and died on case_type (a dict) overflowing varchar.
+    """
+    from django.contrib.auth.models import Group, User
+    from rest_framework.test import APIClient
+
+    from review.views import _enqueue_review_job
+
+    Group.objects.get_or_create(name="Caseworker")
+    user = User.objects.create_user("seamworker", password="x")
+    user.groups.add(Group.objects.get(name="Caseworker"))
+    api = APIClient()
+    api.force_authenticate(user=user)
+
+    review = CaseReview.objects.create(slug="case-seam")
+    _enqueue_review_job(review)
+    with mock.patch("review.case_provider.get_case", return_value={"title": "Seam"}):
+        job = queue.claim_next(["case_review"])
+
+    # Exactly what review_poller._process_job submits: the handler wrapper
+    # nested under "result".
+    wrapper = {
+        "case_title": "Seam",
+        "case_state": "IN_REVIEW",
+        "case_type": "CIAA_BASIC",
+        "source_count": 3,
+        "sources_converted": 2,
+        "result": {"disposition": "PASS", "case_type": {"type": "CIAA_BASIC"}},
+        "duration_seconds": 12.5,
+    }
+    r = api.post(
+        f"/api/jobs/{job.pk}/result/",
+        {"status": "done", "result": wrapper, "duration_seconds": 12.5},
+        format="json",
+    )
+    assert r.status_code == 200
+
+    review.refresh_from_db()
+    assert review.status == CaseReview.STATUS_DONE
+    assert review.stage == "complete"
+    assert review.case_type == "CIAA_BASIC"  # the STRING, not the scored dict
+    assert review.case_title == "Seam"
+    assert review.source_count == 3
+    assert review.result == {"disposition": "PASS", "case_type": {"type": "CIAA_BASIC"}}
+    assert review.duration_seconds == 12.5

--- a/review/management/commands/review_poller.py
+++ b/review/management/commands/review_poller.py
@@ -190,8 +190,21 @@ class Command(BaseCommand):
                 payload,
                 on_stage=lambda s: self._report_stage(job_id, s),
             )
-            out["status"] = "done"
-            self._submit(job_id, out)
+            # The handler's ENTIRE return value is the job result — nest it
+            # under "result" (the JobResultSerializer field the server stores
+            # verbatim as job.result and hands to the kind's on_result hook).
+            # Submitted flat, the serializer keeps only the body's inner
+            # "result" key, and the case_review hook then reads
+            # case_title/case_type off the wrong (scored) dict — where
+            # case_type is a dict that overflows the varchar column.
+            self._submit(
+                job_id,
+                {
+                    "status": "done",
+                    "result": out,
+                    "duration_seconds": out.get("duration_seconds"),
+                },
+            )
             self.stdout.write(self.style.SUCCESS(f"  finished job {job_id}"))
         except Exception as e:  # noqa: BLE001 - report failure to the queue
             import traceback


### PR DESCRIPTION
## What broke

The first live `case_review` run after #286 completed its grading, but the CaseReview rows stayed `pending` forever: `on_result failed for case_review#390 [done]: value too long for type character varying(32)`.

## Why

`review_poller` submitted the handler's wrapper (`case_title`, `case_state`, `case_type`, `result: <scored dict>`, …) **flat** as the request body. `JobResultSerializer` stores only the body's `result` field — i.e. the inner scored dict — as `job.result`. The `case_review` `on_result` hook then read the wrapper fields off the scored dict, where `case_type` is a *dict* (`{"type", "label", …}`), overflowing the varchar(32) column and killing the hook. Jobs finished `done`; reviews dangled `pending`.

The integration tests missed it because they called `queue.finalize()` directly with the wrapper — bypassing the view/serializer seam that drops the wrapper.

## Fix

- The consumer now submits `{"status": "done", "result": <handler return>, "duration_seconds": …}`, so `job.result` is the wrapper the hook was written against.
- New test drives the consumer's **exact HTTP body** through `POST /api/jobs/<id>/result/` (view → serializer → finalize → hook) and asserts the CaseReview finalizes with the string `case_type`, counts, and scored result.

Suite: 991 passed. The two prod reviews stuck by this (470/471) are being repaired from their jobs' stored results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for submitting review job results through the web API.

* **Bug Fixes**
  * Job results are now sent in a structured format that preserves review details more reliably.
  * Review outcomes now store the expected values for status, stage, case type, title, source count, result data, and duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->