### PR TITLE
fix(review): resolve case/court-case IRIs at submit; drop stale seed message

### DIFF
--- a/review/case_provider.py
+++ b/review/case_provider.py
@@ -38,10 +38,11 @@ def _serialize_local_case(slug):
     try:
         case = Case.objects.get(slug=slug)
     except Case.DoesNotExist:
-        raise CaseNotFound(
-            f"Case '{slug}' is not in the local database. "
-            f"Seed it first with: python manage.py seed_jawafdehi --slug {slug}"
-        )
+        # Submissions are resolved to a canonical slug at submit time
+        # (review.serializers.SubmitSerializer), so reaching here means the case
+        # was removed/renamed between submit and grade — not a "needs seeding"
+        # condition (the review DB IS the live case DB in the monolith).
+        raise CaseNotFound(f"No Jawafdehi case found with slug '{slug}'.")
     # context=None is fine: get_url builds relative URLs when there is no request.
     data = CaseDetailSerializer(case, context={}).data
     # Normalize to plain dict and ensure slug present.

--- a/review/serializers.py
+++ b/review/serializers.py
@@ -1,5 +1,12 @@
 from rest_framework import serializers
 
+from jawafdehi_shared.entities.ids import (
+    canonicalize_courtcase_iri,
+    is_valid_case_iri,
+    is_valid_courtcase_iri,
+    parse_case_iri,
+)
+
 from .models import CaseReview, ReviewConfig
 
 
@@ -63,11 +70,100 @@ class ReviewConfigSerializer(serializers.ModelSerializer):
         read_only_fields = ["updated_at"]
 
 
-class SubmitSerializer(serializers.Serializer):
-    slug = serializers.CharField(max_length=255)
+def _require_case_slug(slug, *, source_label):
+    """Return ``slug`` iff a Case row has it; else raise a 400 naming the input.
 
-    def validate_slug(self, value):
-        return value.strip().strip("/")
+    ``source_label`` is the field the caseworker actually submitted (``iri`` or
+    ``slug``) so the error attaches to it in the DRF response.
+    """
+    from cases.models import Case
+
+    if not Case.objects.filter(slug=slug).exists():
+        raise serializers.ValidationError(
+            {source_label: f"No Jawafdehi case found for slug '{slug}'."}
+        )
+    return slug
+
+
+def _resolve_iri_to_slug(iri):
+    """Resolve a canonical @id IRI to the slug of the Jawafdehi case it names.
+
+    Accepts either form (host is not anchored — the DB lookup is the authority):
+
+      * a Jawafdehi case IRI ``https://<base>/case/<slug>`` — the slug is the
+        case's external id, used directly.
+      * a court-case IRI ``https://<base>/courtcase/<court>/<case_number>`` —
+        resolved to the single Jawafdehi case that references it (via the
+        ``CaseCourtCaseReference`` join). Ambiguous (>1 case) or unreferenced
+        court cases are rejected with a 400.
+    """
+    from cases.models import Case
+
+    if is_valid_case_iri(iri, any_host=True):
+        return _require_case_slug(parse_case_iri(iri).slug, source_label="iri")
+
+    if is_valid_courtcase_iri(iri, any_host=True):
+        canonical = canonicalize_courtcase_iri(iri)
+        slugs = list(
+            Case.objects.filter(courtcase_references__courtcase_iri=canonical)
+            .order_by("id")
+            .values_list("slug", flat=True)
+            .distinct()
+        )
+        if not slugs:
+            raise serializers.ValidationError(
+                {"iri": f"No Jawafdehi case references court-case IRI '{canonical}'."}
+            )
+        if len(slugs) > 1:
+            raise serializers.ValidationError(
+                {
+                    "iri": (
+                        f"Court-case IRI '{canonical}' is referenced by multiple cases "
+                        f"({', '.join(slugs)}); submit the specific case IRI instead."
+                    )
+                }
+            )
+        return slugs[0]
+
+    raise serializers.ValidationError(
+        {
+            "iri": (
+                "Submit a canonical @id IRI: a Jawafdehi case IRI "
+                "('https://<base>/case/<slug>') or a court-case IRI "
+                "('https://<base>/courtcase/<court>/<case-number>')."
+            )
+        }
+    )
+
+
+class SubmitSerializer(serializers.Serializer):
+    """Resolve a submitted identifier to a canonical Jawafdehi case slug.
+
+    Caseworkers submit an ``iri`` — either the Jawafdehi case IRI or a
+    court-case IRI (see :func:`_resolve_iri_to_slug`). A bare ``slug`` (an exact
+    canonical case slug) is also accepted for the internal re-run / regrade
+    paths, which already hold the resolved slug. Exactly one must be given.
+    ``validated_data['slug']`` is always the canonical case slug on success.
+    """
+
+    iri = serializers.CharField(max_length=255, required=False, allow_blank=True)
+    slug = serializers.CharField(max_length=255, required=False, allow_blank=True)
+
+    def validate(self, attrs):
+        iri = (attrs.get("iri") or "").strip()
+        slug = (attrs.get("slug") or "").strip().strip("/")
+        if bool(iri) == bool(slug):
+            raise serializers.ValidationError(
+                "Submit exactly one of 'iri' (a Jawafdehi case or court-case @id IRI) "
+                "or 'slug'."
+            )
+        attrs.pop("iri", None)
+        attrs["slug"] = (
+            _resolve_iri_to_slug(iri)
+            if iri
+            else _require_case_slug(slug, source_label="slug")
+        )
+        return attrs
 
 
 class JobResultSerializer(serializers.Serializer):

--- a/review/serializers.py
+++ b/review/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from jawafdehi_shared.entities.ids import (
+    MAX_IRI_LENGTH,
     canonicalize_courtcase_iri,
     is_valid_case_iri,
     is_valid_courtcase_iri,
@@ -104,9 +105,13 @@ def _resolve_iri_to_slug(iri):
 
     if is_valid_courtcase_iri(iri, any_host=True):
         canonical = canonicalize_courtcase_iri(iri)
+        # Order by slug (not id): with values_list(...).distinct(), any ORDER BY
+        # column is folded into the SELECT DISTINCT, so ordering by the unique id
+        # would defeat the de-dup. slug is the projected column, so this stays a
+        # distinct-on-slug and gives a deterministic multi-case message.
         slugs = list(
             Case.objects.filter(courtcase_references__courtcase_iri=canonical)
-            .order_by("id")
+            .order_by("slug")
             .values_list("slug", flat=True)
             .distinct()
         )
@@ -146,7 +151,9 @@ class SubmitSerializer(serializers.Serializer):
     ``validated_data['slug']`` is always the canonical case slug on success.
     """
 
-    iri = serializers.CharField(max_length=255, required=False, allow_blank=True)
+    iri = serializers.CharField(
+        max_length=MAX_IRI_LENGTH, required=False, allow_blank=True
+    )
     slug = serializers.CharField(max_length=255, required=False, allow_blank=True)
 
     def validate(self, attrs):

--- a/tests/api/test_review_submit.py
+++ b/tests/api/test_review_submit.py
@@ -104,6 +104,24 @@ def test_courtcase_iri_with_no_referencing_case_is_rejected(caseworker):
 
 
 @pytest.mark.django_db
+def test_ambiguous_courtcase_iri_is_rejected(caseworker, case):
+    # A second case referencing the same court-case IRI makes it ambiguous:
+    # the endpoint refuses to guess and lists the candidates.
+    other = Case.objects.create(
+        slug="case-080-cr-0111-beta-revenue",
+        title="Beta revenue",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.IN_REVIEW,
+        court_cases=[COURTCASE_IRI],
+    )
+    resp = _authed_client(caseworker).post(URL, {"iri": COURTCASE_IRI}, format="json")
+    assert resp.status_code == 400
+    body = str(resp.data)
+    assert case.slug in body and other.slug in body
+    assert not CaseReview.objects.exists()
+
+
+@pytest.mark.django_db
 def test_slug_path_still_accepted_for_rerun(caseworker, case):
     # The re-run / regrade path submits the already-resolved canonical slug.
     resp = _authed_client(caseworker).post(URL, {"slug": CASE_SLUG}, format="json")
@@ -130,7 +148,8 @@ def test_requires_exactly_one_identifier(caseworker, case, payload):
 
 @pytest.mark.django_db
 def test_requires_contributor_role(case):
+    # Authenticated but under-privileged (ReadOnly) -> 403 Forbidden, not 401.
     reader = create_user_with_role("ro", "ro@example.com", "ReadOnly")
     resp = _authed_client(reader).post(URL, {"iri": CASE_IRI}, format="json")
-    assert resp.status_code in (401, 403)
+    assert resp.status_code == 403
     assert not CaseReview.objects.exists()

--- a/tests/api/test_review_submit.py
+++ b/tests/api/test_review_submit.py
@@ -1,0 +1,136 @@
+"""Tests for POST /api/casework/reviews/submit/ identifier resolution.
+
+Caseworkers submit a canonical @id IRI — a Jawafdehi case IRI
+(``https://<base>/case/<slug>``) or a court-case IRI
+(``https://<base>/courtcase/<court>/<case_number>``) bound to one case. The
+endpoint resolves that IRI to the case's canonical slug and enqueues the review
+on it. A bare ``slug`` is still accepted for the internal re-run / regrade path.
+A non-IRI (a case number, a case name, a stray URL) is rejected at submit time
+with a clear 400 — NOT silently enqueued to die later at payload-build.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from cases.models import Case, CaseState, CaseType
+from review.models import CaseReview
+from tests.conftest import create_user_with_role
+
+URL = "/api/casework/reviews/submit/"
+
+CASE_SLUG = "case-080-cr-0111-alpha-land-fraud"
+CASE_IRI = f"https://jawafdehi.org/case/{CASE_SLUG}"
+COURTCASE_IRI = "https://jawafdehi.org/courtcase/special/080-cr-0111"
+
+
+def _authed_client(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def caseworker(db):
+    return create_user_with_role("cw", "cw@example.com", "Caseworker")
+
+
+@pytest.fixture
+def case(db):
+    return Case.objects.create(
+        slug=CASE_SLUG,
+        title="Alpha land fraud",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.IN_REVIEW,
+        court_cases=[COURTCASE_IRI],
+    )
+
+
+@pytest.mark.django_db
+def test_case_iri_resolves_to_slug(caseworker, case):
+    resp = _authed_client(caseworker).post(URL, {"iri": CASE_IRI}, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["slug"] == CASE_SLUG
+    assert CaseReview.objects.filter(slug=CASE_SLUG).exists()
+
+
+@pytest.mark.django_db
+def test_courtcase_iri_resolves_to_the_referencing_case(caseworker, case):
+    resp = _authed_client(caseworker).post(URL, {"iri": COURTCASE_IRI}, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["slug"] == CASE_SLUG
+
+
+@pytest.mark.django_db
+def test_courtcase_iri_is_canonicalized_before_lookup(caseworker, case):
+    # A court-case IRI on a non-canonical host still resolves: it is re-based to
+    # the canonical authority before the join lookup. (The path grammar itself
+    # is lowercase-only, matching the stored references.)
+    resp = _authed_client(caseworker).post(
+        URL,
+        {"iri": "http://api.jawafdehi.org/courtcase/special/080-cr-0111"},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["slug"] == CASE_SLUG
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("bad", ["080-CR-0111", "Giribandhu", "special:081-CR-0136"])
+def test_non_iri_is_rejected(caseworker, case, bad):
+    resp = _authed_client(caseworker).post(URL, {"iri": bad}, format="json")
+    assert resp.status_code == 400
+    assert not CaseReview.objects.exists()
+
+
+@pytest.mark.django_db
+def test_case_iri_for_unknown_case_is_rejected(caseworker):
+    resp = _authed_client(caseworker).post(
+        URL, {"iri": "https://jawafdehi.org/case/does-not-exist"}, format="json"
+    )
+    assert resp.status_code == 400
+    assert "does-not-exist" in str(resp.data)
+    assert not CaseReview.objects.exists()
+
+
+@pytest.mark.django_db
+def test_courtcase_iri_with_no_referencing_case_is_rejected(caseworker):
+    resp = _authed_client(caseworker).post(
+        URL,
+        {"iri": "https://jawafdehi.org/courtcase/special/080-cr-9999"},
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert not CaseReview.objects.exists()
+
+
+@pytest.mark.django_db
+def test_slug_path_still_accepted_for_rerun(caseworker, case):
+    # The re-run / regrade path submits the already-resolved canonical slug.
+    resp = _authed_client(caseworker).post(URL, {"slug": CASE_SLUG}, format="json")
+    assert resp.status_code == 201, resp.data
+    assert resp.data["slug"] == CASE_SLUG
+
+
+@pytest.mark.django_db
+def test_slug_path_for_unknown_case_is_rejected(caseworker):
+    resp = _authed_client(caseworker).post(URL, {"slug": "no-such-case"}, format="json")
+    assert resp.status_code == 400
+    assert not CaseReview.objects.exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "payload",
+    [{}, {"iri": CASE_IRI, "slug": CASE_SLUG}, {"iri": "", "slug": ""}],
+)
+def test_requires_exactly_one_identifier(caseworker, case, payload):
+    resp = _authed_client(caseworker).post(URL, payload, format="json")
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_requires_contributor_role(case):
+    reader = create_user_with_role("ro", "ro@example.com", "ReadOnly")
+    resp = _authed_client(reader).post(URL, {"iri": CASE_IRI}, format="json")
+    assert resp.status_code in (401, 403)
+    assert not CaseReview.objects.exists()


### PR DESCRIPTION
## Why

Recent case reviews were failing at the **payload-build** step with:

> `payload build failed: Case 'giribandhu' is not in the local database. Seed it first with: python manage.py seed_jawafdehi --slug giribandhu`

Two problems:

1. **Misleading error.** "Seed it first / `seed_jawafdehi`" is a relic of the standalone review-poller (which had its own DB). In the monolith the review DB **is** the live case DB — the case is already there; nothing needs seeding. The message just reused old wording for any missed lookup.
2. **Real cause — no identifier resolution.** `submit_review`/`SubmitSerializer` accepted a free-text `slug`, `.strip()`'d it, and exact-matched `cases.Case` at grade time. A friendly identifier (case name `giribandhu`, court-case number `080-CR-0111`, a URL) was accepted, enqueued, and only failed ~5 min later. The SPA even advertised "case slug, court case number, or case URL", none of which the backend actually resolved.

## What

- `SubmitSerializer` now resolves an **`iri`** to the canonical case slug:
  - Jawafdehi case IRI `https://<base>/case/<slug>` → the slug directly.
  - Court-case IRI `https://<base>/courtcase/<court>/<case-number>` → the single case referencing it (via `CaseCourtCaseReference`); ambiguous/unreferenced → 400.
- Validation happens **at submit time** → a clear 400 (`No Jawafdehi case found…` / `Submit a canonical @id IRI…`) instead of a silently-doomed job.
- A bare **`slug`** is still accepted for the internal **re-run/regrade** path (already-resolved canonical slug).
- The `court_case_number` (`special:…`) submission path is dropped (never implemented server-side).
- `CaseNotFound` message no longer points at the dead `seed_jawafdehi` command.

## Tests

New `tests/api/test_review_submit.py` (14 cases): case-IRI and court-case-IRI resolution, host canonicalization, non-IRI rejection, unknown case, ambiguous/unreferenced court case, slug re-run path, exactly-one-identifier, role gating. `jobs/tests/` + `cases/tests/test_courtcase_references.py` green.

Paired SPA change: Jawafdehi/Jawafdehi#(fix/review-submit-iri-resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case review submission now accepts either a case IRI or an exact case slug.
  * Court-case IRIs are now resolved to the correct canonical case slug automatically.

* **Bug Fixes**
  * Submission errors now give clearer guidance when a case has been removed or renamed.
  * Invalid, unknown, or ambiguous identifiers are rejected consistently, preventing invalid review creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->