### PR TITLE
fix(entities): gate entity writes on platform content roles, drop NES groups

### DIFF
--- a/cases/management/commands/create_groups.py
+++ b/cases/management/commands/create_groups.py
@@ -134,7 +134,8 @@ class Command(BaseCommand):
             self.stdout.write("Caseworker group already exists")
 
         # Caseworkers get view, add, and change permissions (limited by assignment for cases)
-        # Entities: caseworkers can view and add, but cannot change or delete
+        # (NES entity writes are authorized in entities.permissions by Group membership
+        # — Caseworker/Moderator/Admin — not by these model permissions.)
         caseworker_group.permissions.set(
             [
                 case_permissions["view"],

--- a/docs/control-plane-api-design.md
+++ b/docs/control-plane-api-design.md
@@ -82,7 +82,7 @@ This doc is **grounded in the code on `v2` as it stands today** (audited 2026-06
 - **Upload mechanism:** **multipart through the API** (decided). Client POSTs the
   file to `/api/materials/.../file`; the monolith streams it to R2 and upserts the
   Material JSON-LD in one call. Mirrors the proven case-evidence upload path.
-- **Auth:** one OIDC/Zitadel gate. Writes to `/api/entities` need `nes_contributor`;
+- **Auth:** one OIDC/Zitadel gate. Writes to `/api/entities` need a content role (Caseworker/Moderator/Admin);
   writes to `/api/materials` + `/api/courtcases` need the NGM role; `/api/cases`
   (corruption cases) keeps its existing caseworker gate. (Role *names* may converge
   later; the gate stays per-resource.)
@@ -102,9 +102,9 @@ This doc is **grounded in the code on `v2` as it stands today** (audited 2026-06
 | `/entities/{ref}` | GET | public | ✅ detail; `ref` = url-encoded IRI **or** `prefix/slug` |
 | `/entities/{ref}/versions` | GET | public | ✅ |
 | `/entities/tags`, `/entity_prefixes` | GET | public | ✅ |
-| `/entities` | POST | `nes_contributor` | ✅ create (JSON-LD or authoring shape) → 201 |
-| `/entities/{ref}` | PATCH | `nes_contributor` | ✅ RFC-6902; blocks `/@id /@type /@context /jawafdehi:version` |
-| `/admin/reindex` | POST | `nes_admin` | ⚠️ no-op stub (no search backend on this plane) |
+| `/entities` | POST | content role | ✅ create (JSON-LD or authoring shape) → 201 |
+| `/entities/{ref}` | PATCH | content role | ✅ RFC-6902; blocks `/@id /@type /@context /jawafdehi:version` |
+| `/admin/reindex` | POST | Moderator/Admin | ⚠️ no-op stub (no search backend on this plane) |
 
 ### 2.2 NGM `/api/ngm/*`
 | Route | Method | Auth | Status |

--- a/docs/unified-api-refactor-plan.md
+++ b/docs/unified-api-refactor-plan.md
@@ -51,7 +51,7 @@ ngm/                                       was services/jawafdehi/ngm (proxy app
 **Public API (R3):**
 | Path | Resource | Backing app | Auth |
 |---|---|---|---|
-| `/api/entities` | things (people, orgs, **courts**, **firms**, locations) | entities | `nes_contributor` write |
+| `/api/entities` | things (people, orgs, **courts**, **firms**, locations) | entities | content-role write |
 | `/api/materials` | documents (file-bearing CreativeWork) | materials | NGM role write |
 | `/api/courtcases` | court-case records (composite key) + hearings/parties | courts | NGM role write |
 | `/api/cases` | Jawafdehi **corruption** cases (unchanged) | cases | caseworker |

--- a/entities/permissions.py
+++ b/entities/permissions.py
@@ -1,40 +1,43 @@
-"""NES permission classes.
+"""Entity API permission classes.
 
 The shared :class:`jawafdehi_shared.auth.oidc.OIDCAuthentication` validates the
 Zitadel JWT and syncs the token's project roles into Django Groups on every
 request. So role checks here are just Django Group-membership checks — no token
 re-parsing — exactly like NGM's ``HasNgmRole``.
 
-NES write surface (create / patch / add-name / bulk-ingest) requires the
-``nes_contributor`` role; admin reindex requires ``nes_admin``. These map to the
-``NES_Contributor`` / ``NES_Admin`` Django Groups via the shared authenticator's
-``DEFAULT_ROLE_TO_GROUP`` (entries added when this regression was fixed).
+Entity writes (create / patch / delete) require any platform *content* role —
+``Caseworker`` / ``Moderator`` / ``Admin`` (the same set as
+``cases.rules.predicates.has_role``) — plus Django superuser. Admin-only
+operations (reindex) require ``Moderator`` / ``Admin``. The read-only roles
+(``ReadOnly`` / ``Public``) are intentionally excluded from writes.
 
-DECISION (match FastAPI semantics): the FastAPI NES service gated writes on the
-*NES-specific* ``nes_contributor`` role only — the platform-wide ``Contributor``
-/ ``Moderator`` roles could NOT write NES entities. We therefore DELIBERATELY do
-NOT include the generic platform groups in the NES write-allow set; granting
-them would be a privilege expansion over the ported behaviour. The write set is
-``NES_Contributor`` + ``NES_Admin`` (admins can also write) + Django superuser.
-Admin reindex is ``NES_Admin`` + superuser. Unauthenticated → 401 (the
-authenticator sets WWW-Authenticate); authenticated-without-role → 403.
+History: entity writes used to be gated on the NES-specific ``NES_Contributor``
+/ ``NES_Admin`` groups — a carry-over from the standalone FastAPI NES service.
+Post-monolith (all services in one Django project) that separate role namespace
+is dropped in favour of the platform content roles, so a Caseworker/Moderator
+who can author and moderate cases can also write the entities those cases
+reference — no separate ``nes_contributor`` grant required.
+
+Unauthenticated → 401 (the authenticator sets WWW-Authenticate);
+authenticated-without-a-write-role → 403.
 """
 
 from __future__ import annotations
 
 from rest_framework import permissions
 
-# Groups that grant the NES write surface (create/patch/add-name/bulk-ingest).
-# NES_Admin is included because an NES admin is a superset of a contributor.
-NES_CONTRIBUTOR_GROUPS = frozenset({"NES_Contributor", "NES_Admin"})
+# Platform content roles that may write entities (create / patch / delete).
+# Mirrors ``cases.rules.predicates.has_role``; superuser is short-circuited in
+# ``_RequireGroups`` below.
+ENTITY_WRITE_GROUPS = frozenset({"Caseworker", "Moderator", "Admin"})
 
-# Groups that grant the NES admin surface (reindex).
-NES_ADMIN_GROUPS = frozenset({"NES_Admin"})
+# Elevated roles for admin-only entity operations (reindex).
+ENTITY_ADMIN_GROUPS = frozenset({"Moderator", "Admin"})
 
 
 class _RequireGroups(permissions.BasePermission):
     groups: frozenset = frozenset()
-    message = "An NES role is required."
+    message = "A content role is required."
 
     def has_permission(self, request, view) -> bool:
         user = getattr(request, "user", None)
@@ -46,15 +49,15 @@ class _RequireGroups(permissions.BasePermission):
         return bool(user_groups & self.groups)
 
 
-class HasNesContributorRole(_RequireGroups):
-    """Require the ``nes_contributor`` role (or an elevated platform role)."""
+class HasEntityWriteRole(_RequireGroups):
+    """Require a platform content role (Caseworker / Moderator / Admin) to write entities."""
 
-    groups = NES_CONTRIBUTOR_GROUPS
-    message = "The 'nes_contributor' role is required to write entities."
+    groups = ENTITY_WRITE_GROUPS
+    message = "A content role (Caseworker, Moderator, or Admin) is required to write entities."
 
 
-class HasNesAdminRole(_RequireGroups):
-    """Require the ``nes_admin`` role (or platform Admin)."""
+class HasEntityAdminRole(_RequireGroups):
+    """Require Moderator / Admin for admin-only entity operations (reindex)."""
 
-    groups = NES_ADMIN_GROUPS
-    message = "The 'nes_admin' role is required."
+    groups = ENTITY_ADMIN_GROUPS
+    message = "Moderator or Admin is required."

--- a/entities/tests/test_api.py
+++ b/entities/tests/test_api.py
@@ -177,7 +177,7 @@ class SearchAndCountTests(_DbAPITestCase):
 class WritePlaneAuthTests(_DbAPITestCase):
     @classmethod
     def setUpTestData(cls):
-        g, _ = Group.objects.get_or_create(name="NES_Contributor")
+        g, _ = Group.objects.get_or_create(name="Caseworker")
         cls.contributor = User.objects.create(username="oidc-sub-writer")
         cls.contributor.groups.add(g)
         cls.norole = User.objects.create(username="oidc-sub-norole")
@@ -196,12 +196,20 @@ class WritePlaneAuthTests(_DbAPITestCase):
         resp = self.client.post("/api/entities", _person_payload("c-norole"), format="json")
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_platform_contributor_is_403(self):
-        platform = User.objects.create(username="oidc-sub-platform")
-        g, _ = Group.objects.get_or_create(name="Contributor")
-        platform.groups.add(g)
-        self.client.force_authenticate(user=platform)
-        resp = self.client.post("/api/entities", _person_payload("d-platform"), format="json")
+    def test_moderator_can_write(self):
+        moderator = User.objects.create(username="oidc-sub-moderator")
+        g, _ = Group.objects.get_or_create(name="Moderator")
+        moderator.groups.add(g)
+        self.client.force_authenticate(user=moderator)
+        resp = self.client.post("/api/entities", _person_payload("d-moderator"), format="json")
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED, msg=resp.data)
+
+    def test_readonly_cannot_write(self):
+        readonly = User.objects.create(username="oidc-sub-readonly")
+        g, _ = Group.objects.get_or_create(name="ReadOnly")
+        readonly.groups.add(g)
+        self.client.force_authenticate(user=readonly)
+        resp = self.client.post("/api/entities", _person_payload("e-readonly"), format="json")
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_create_then_get_round_trip(self):
@@ -391,3 +399,29 @@ def _now():
     from datetime import datetime, timezone
 
     return datetime.now(timezone.utc)
+
+
+class AdminPlaneAuthTests(_DbAPITestCase):
+    """Reindex (admin plane) is gated on Moderator/Admin — NOT the write role."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.caseworker = User.objects.create(username="oidc-sub-cw")
+        cls.caseworker.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+        cls.moderator = User.objects.create(username="oidc-sub-mod")
+        cls.moderator.groups.add(Group.objects.get_or_create(name="Moderator")[0])
+
+    def test_reindex_unauth_is_401(self):
+        resp = self.client.post("/api/admin/reindex")
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_reindex_write_role_is_403(self):
+        # A content/write role (Caseworker) must NOT reach the admin plane.
+        self.client.force_authenticate(user=self.caseworker)
+        resp = self.client.post("/api/admin/reindex")
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_reindex_moderator_ok(self):
+        self.client.force_authenticate(user=self.moderator)
+        resp = self.client.post("/api/admin/reindex")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/entities/tests/test_delete_api.py
+++ b/entities/tests/test_delete_api.py
@@ -3,8 +3,8 @@
 ``DELETE /api/entities/{ref}`` flips ``is_deleted=True`` (never hard-deletes —
 this is an accountability/audit platform): the entity vanishes from list /
 detail / search but the row (and version history) survive. Auth mirrors the
-write plane (``HasNesContributorRole`` -> the ``NES_Contributor`` Django Group);
-unauthenticated / authenticated-without-role assert the 401 / 403 contract.
+write plane (``HasEntityWriteRole`` -> the ``Caseworker`` / ``Moderator`` / ``Admin``
+Django Groups); unauthenticated / authenticated-without-role assert the 401 / 403 contract.
 
 Run under the platform settings (DB-less: sqlite fallback) from the repo root::
 
@@ -53,7 +53,7 @@ class EntityDeleteTests(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
-        g, _ = Group.objects.get_or_create(name="NES_Contributor")
+        g, _ = Group.objects.get_or_create(name="Caseworker")
         cls.contributor = User.objects.create(username="oidc-sub-writer")
         cls.contributor.groups.add(g)
         cls.norole = User.objects.create(username="oidc-sub-norole")

--- a/entities/views.py
+++ b/entities/views.py
@@ -15,10 +15,11 @@ paths shown are relative to that prefix.
     GET /api/entity_prefixes
   List shape: ``{entities, total, limit, offset}``; detail: the stored JSON-LD doc.
   (Batch-by-ids returns ``{entities, total, requested, not_found}`` instead.)
-- Write plane (OIDC + ``nes_contributor`` via ``HasNesContributorRole``):
-    POST  /api/entities           — create (JSON-LD or authoring shape)
-    PATCH /api/entities/{ref}     — RFC-6902 jsonpatch (immutable @id/@type guarded)
-- Admin plane (OIDC + ``nes_admin`` via ``HasNesAdminRole``):
+- Write plane (OIDC + a content role via ``HasEntityWriteRole`` — Caseworker/Moderator/Admin):
+    POST   /api/entities          — create (JSON-LD or authoring shape)
+    PATCH  /api/entities/{ref}    — RFC-6902 jsonpatch (immutable @id/@type guarded)
+    DELETE /api/entities/{ref}    — soft delete (is_deleted=True)
+- Admin plane (OIDC + Moderator/Admin via ``HasEntityAdminRole``):
     POST  /api/admin/reindex      — reindex stub (no-op until search backend wired)
 
 The detail ``{ref}`` is resolved to the canonical @id IRI by ``_resolve_ref``:
@@ -45,7 +46,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from entities.permissions import HasNesAdminRole, HasNesContributorRole
+from entities.permissions import HasEntityAdminRole, HasEntityWriteRole
 from entities.persistence import (
     EntityRepository,
     _clamp_limit,
@@ -118,7 +119,7 @@ class EntityListCreateView(AuditlogActorMixin, APIView):
 
     def get_permissions(self):
         if self.request.method == "POST":
-            return [HasNesContributorRole()]
+            return [HasEntityWriteRole()]
         return [AllowAny()]
 
     # --- GET: list / search / batch -----------------------------------
@@ -239,7 +240,7 @@ class EntityDetailView(AuditlogActorMixin, APIView):
 
     def get_permissions(self):
         if self.request.method in ("PATCH", "DELETE"):
-            return [HasNesContributorRole()]
+            return [HasEntityWriteRole()]
         return [AllowAny()]
 
     def get(self, request, ref: str):
@@ -374,9 +375,9 @@ def list_entity_prefixes(request):
 
 
 class ReindexView(APIView):
-    """POST /api/admin/reindex — OIDC + ``nes_admin`` gated stub."""
+    """POST /api/admin/reindex — OIDC + Moderator/Admin gated stub."""
 
-    permission_classes = [HasNesAdminRole]
+    permission_classes = [HasEntityAdminRole]
 
     def post(self, request):
         return Response(

--- a/jawafdehi_shared/auth/oidc.py
+++ b/jawafdehi_shared/auth/oidc.py
@@ -108,14 +108,6 @@ DEFAULT_ROLE_TO_GROUP = {
     "ngm_silver": "NGM_SilverTier",
     "ngm_gold": "NGM_GoldTier",
     "ngm_platinum": "NGM_PlatinumTier",
-    # NES-specific roles. The FastAPI NES service gated its write surface on the
-    # NES-specific ``nes_contributor`` role (admin reindex on ``nes_admin``), NOT
-    # the platform-wide contributor/moderator roles. Without these entries a
-    # valid ``nes_contributor`` token mapped to zero Groups and was denied. This
-    # addition is purely additive (other services ignore Groups they don't gate
-    # on), so it is safe for ngm/jawafdehi.
-    "nes_contributor": "NES_Contributor",
-    "nes_admin": "NES_Admin",
 }
 
 


### PR DESCRIPTION
## What

Entity write/admin API permissions were gated on the NES-specific `NES_Contributor` / `NES_Admin` Django groups — a carry-over from the standalone FastAPI NES service. This PR gates them on the **platform content roles** instead:

- **Write** (`POST /api/entities`, `PATCH`/`DELETE /api/entities/{ref}`) → `Caseworker` / `Moderator` / `Admin` (the same set as `cases.rules.predicates.has_role`), plus Django superuser.
- **Admin** (`POST /api/admin/reindex`) → `Moderator` / `Admin`.

The `nes_contributor` / `nes_admin` → `NES_*` entries are removed from `DEFAULT_ROLE_TO_GROUP` (those groups are now unused). Permission classes renamed `HasNesContributorRole → HasEntityWriteRole`, `HasNesAdminRole → HasEntityAdminRole`. The entity docstrings and the two design docs that stated the old role are refreshed.

## Why

Post-monolith (NES/NGM/Jawafdehi in one Django project) the separate NES role namespace is friction: a Caseworker/Moderator who can author and moderate cases could not create the entities those cases reference without a separate `nes_contributor` grant that was easy to miss — surfaced during the bug bash (writers hit "The 'nes_contributor' role is required to write entities"). This unifies entity writes with the rest of the platform's role model; no separate grant needed.

## Tests

- `entities/tests/test_api.py`: caseworker **and moderator** can write; **readonly** and unauthenticated cannot; new `AdminPlaneAuthTests` asserts the write-vs-admin split (a write-role user is **denied** reindex → 403).
- `entities/tests/test_delete_api.py`: the soft-delete plane now grants on the content roles.
- 46 entity + 27 oidc tests pass locally (sqlite fallback). `ruff check` clean; `ruff format` is not CI-gated (tree predates it).

## Reviewer notes / decisions (from a pre-PR code review)

1. **Rollout precondition.** Any Zitadel principal that had **only** `nes_contributor`/`nes_admin` (no platform content role) loses entity write once this merges. Grant such users `caseworker`/`moderator` first; the `NES_Contributor`/`NES_Admin` Zitadel roles + groups can then be retired.
2. **Privilege expansion — chat service account.** The chat/MCP service account is provisioned into the `Caseworker` group (`cases/management/commands/setup_chat_service_account.py`), so it now **can** create/patch/soft-delete entities via the API. The MCP tools are read-only in practice, but the capability is new — consider moving that service account to `ReadOnly` if it should not write entities. (Not changed here — flagging for a decision.)
3. **Caseworker write breadth.** Caseworkers now get full entity write **including PATCH/DELETE** (soft-delete is reversible, and it provides the delete-and-recreate path to fix mis-typed entities). If create-only for caseworkers is preferred, gate `PATCH`/`DELETE` on `HasEntityAdminRole` instead — a one-line change.

## Out of scope
- The shared entity data-quality gap (a mis-typed `@type` is still immutable via the API) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity write access now follows unified content roles, with `Caseworker` and `Moderator` permissions replacing older NES-specific access.
  * Admin reindex access now uses updated role-based authorization.

* **Bug Fixes**
  * Updated entity API authorization so write, delete, and admin actions are checked against the correct user groups.
  * Aligned delete behavior and API tests with the new role mapping.

* **Documentation**
  * Refreshed API docs to reflect the new authorization requirements for entity and admin endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->