### PR TITLE
feat(search): enrich jawafdehi-cases index to render cards from search

### DIFF
--- a/cases/management/commands/reindex_cases.py
+++ b/cases/management/commands/reindex_cases.py
@@ -30,15 +30,18 @@ class Command(BaseCommand):
         # Only PUBLISHED cases are indexed. (build_doc also yields no iri for a
         # non-published case, so the reindex driver would skip it anyway — the
         # filter just avoids streaming the whole table.)
-        # build_doc reads the court_cases property (the reference join), so
-        # prefetch it; chunk_size is REQUIRED for prefetch to apply under
-        # .iterator() (ValueError without it on Django 5.x).
+        # build_indexed_doc reads the court_cases property (the reference join) and
+        # the entity_relationships (to resolve + denormalize entity names into the
+        # card), so prefetch both; chunk_size is REQUIRED for prefetch to apply
+        # under .iterator() (ValueError without it on Django 5.x). Using
+        # build_indexed_doc (not the pure build_doc) is what makes a rebuild REFRESH
+        # entity names rather than blanking the card.
         result = reindex(
             index=CASE_INDEX,
             records=Case.objects.filter(state=CaseState.PUBLISHED)
-            .prefetch_related("courtcase_references")
+            .prefetch_related("courtcase_references", "entity_relationships")
             .iterator(chunk_size=200),
-            build_doc=search_index.build_doc,
+            build_doc=search_index.build_indexed_doc,
             rebuild=options["rebuild"],
         )
         self.stdout.write(

--- a/cases/search_index.py
+++ b/cases/search_index.py
@@ -16,7 +16,19 @@ Field mapping:
 * ``keywords``       ← ``tags`` (+ ``case_type``),
 * ``identifiers``    ← the IRI, the slug, and the ``court_cases`` references,
 * ``date``           ← ``case_start_date`` (else created date),
-* ``raw``            ← a light serialized record (return-only).
+* ``case_status``    ← coarse ongoing/closed/others (mirrors the SPA rule); a
+  dedicated keyword (NOT the generic ``status``, which NGM uses for its scraper
+  enrichment flag) so the unified search can facet/filter cases without collision,
+* ``raw``            ← a light record PLUS a ``card`` payload (return-only): every
+  field the SPA case list/card renders — ``short_description``, ``key_allegations``,
+  ``tags``, dates, ``bigo``, thumbnail/banner, the ``timeline`` (major events), and
+  the resolved entity binds — denormalized so a search hit renders WITHOUT a
+  second fetch to ``/api/cases/{slug}/``.
+
+Denormalized entity names come from NES at index time, so a case must be
+re-indexed when a referenced entity is renamed (a scheduled ``reindex_cases``
+reconcile covers this — see the plan's WS3); the write-time signals only fire on
+``Case`` itself.
 
 Best-effort: an OpenSearch error is logged and swallowed.
 """
@@ -52,11 +64,59 @@ def _case_iri(case: Any) -> str | None:
     return getattr(case, "public_iri", None)
 
 
-def build_doc(case: Any) -> dict[str, Any]:
+def _iso(value: Any) -> str | None:
+    """ISO-8601 string for a date/datetime value (or ``None``)."""
+    if value is None:
+        return None
+    return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+
+def _derive_status(case: Any) -> str:
+    """Coarse case lifecycle for the ``case_status`` facet, mirroring the SPA rule.
+
+    ``ongoing`` = a start date but no end date; ``closed`` = both dates present;
+    ``others`` = neither (or only an end date). Kept in lockstep with the frontend
+    ``getCaseStatus`` so the server facet and the client badge agree."""
+    has_start = getattr(case, "case_start_date", None) is not None
+    has_end = getattr(case, "case_end_date", None) is not None
+    if has_start and not has_end:
+        return "ongoing"
+    if has_start and has_end:
+        return "closed"
+    return "others"
+
+
+def _safe_resolve_entities(case: Any) -> list[dict[str, Any]]:
+    """Resolve the case's entity binds to card display details (best-effort).
+
+    Uses the same shaper as ``CaseSerializer.get_entities``
+    (``nes_resolver.build_entity_binds``) so the card and the API can't drift.
+    Any failure — no relation manager (e.g. a bare test object) or NES unreachable
+    — yields ``[]`` (or ``None`` names), so the case is still indexed and a later
+    ``reindex_cases`` reconciles the names."""
+    try:
+        relationships = list(case.entity_relationships.all())
+    except (AttributeError, TypeError):
+        return []
+    if not relationships:
+        return []
+    from cases.services.nes_resolver import build_entity_binds, resolve_entities
+
+    try:
+        resolved = resolve_entities(rel.nes_id for rel in relationships)
+    except Exception:  # noqa: BLE001 — best-effort; index without names on failure.
+        resolved = {}
+    return build_entity_binds(relationships, resolved)
+
+
+def build_doc(case: Any, *, entities: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     """Map a published ``Case`` to the common index doc. Pure: no OpenSearch.
 
     The caller is responsible for the published gate; this shapes whatever it is
-    given (used directly by tests for the doc shape)."""
+    given (used directly by tests for the doc shape). ``entities`` is the resolved
+    entity-bind list for the ``card`` payload — ``index()`` resolves it via
+    :func:`_safe_resolve_entities`; passing ``None`` (the default) omits names so
+    the doc-shape tests stay pure/DB-free."""
     iri = _case_iri(case)
     title = getattr(case, "title", "") or ""
     title_ne, title_en = name_to_titles(title)
@@ -124,15 +184,63 @@ def build_doc(case: Any) -> dict[str, Any]:
     start = getattr(case, "case_start_date", None)
     created = getattr(case, "created_at", None)
     if start is not None:
-        doc["date"] = start.isoformat() if hasattr(start, "isoformat") else str(start)
+        doc["date"] = _iso(start)
     elif created is not None and hasattr(created, "date"):
         doc["date"] = created.date().isoformat()
     if created is not None:
-        doc["created_at"] = created.isoformat() if hasattr(created, "isoformat") else created
+        doc["created_at"] = _iso(created)
     updated = getattr(case, "updated_at", None)
     if updated is not None:
-        doc["updated_at"] = updated.isoformat() if hasattr(updated, "isoformat") else updated
+        doc["updated_at"] = _iso(updated)
+
+    # Coarse lifecycle as a dedicated indexed keyword so the unified search can
+    # facet/filter cases on it. Deliberately NOT the generic ``status`` field —
+    # NGM courtcases write their scraper enrichment flag (pending/enriched/failed)
+    # there, which must not blend into a case lifecycle facet.
+    case_status = _derive_status(case)
+    doc["case_status"] = case_status
+
+    # Card payload: everything the SPA case card/list renders, denormalized so a
+    # search hit needs no follow-up call to /api/cases/{slug}/. Lives under ``raw``
+    # (mapping ``enabled: false``) — stored + returned, never searched or faceted.
+    # Deliberately self-contained: the SPA reads the whole card off one hit.
+    doc["raw"]["card"] = {
+        "slug": slug,
+        "title": title,
+        "short_description": short.strip() if short and short.strip() else None,
+        "key_allegations": [
+            a.strip()
+            for a in (getattr(case, "key_allegations", None) or [])
+            if isinstance(a, str) and a.strip()
+        ],
+        "tags": tags,
+        "case_type": case_type,
+        "status": case_status,
+        "case_start_date": _iso(getattr(case, "case_start_date", None)),
+        "case_end_date": _iso(getattr(case, "case_end_date", None)),
+        "bigo": getattr(case, "bigo", None),
+        "thumbnail_url": getattr(case, "thumbnail_url", None),
+        "banner_url": getattr(case, "banner_url", None),
+        "timeline": [
+            entry
+            for entry in (getattr(case, "timeline", None) or [])
+            if isinstance(entry, dict)
+        ],
+        "entities": list(entities or []),
+    }
     return doc
+
+
+def build_indexed_doc(case: Any) -> dict[str, Any]:
+    """``build_doc`` for the real index paths: resolves entity names first.
+
+    ``build_doc`` stays pure (entities injected) so the shape tests need no DB;
+    this resolving wrapper is what BOTH the live ``index()`` signal path AND the
+    bulk ``reindex_cases`` driver call, so a rebuild REFRESHES the denormalized
+    entity names rather than blanking them (the driver calls ``build_doc``
+    positionally with no ``entities`` kwarg — see ``jawafdehi_shared/search/
+    reindex.py``)."""
+    return build_doc(case, entities=_safe_resolve_entities(case))
 
 
 @best_effort("index case")
@@ -143,7 +251,7 @@ def index(case: Any, *, client=None) -> None:
     (draft/in-review/closed) deletes the doc so it never appears in search."""
     cl = client or make_client()
     if should_index(case):
-        upsert_doc(cl, CASE_INDEX, build_doc(case))
+        upsert_doc(cl, CASE_INDEX, build_indexed_doc(case))
     else:
         delete(case, client=cl)
 

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -156,25 +156,20 @@ class CaseSerializer(serializers.ModelSerializer):
         ``type`` is the relationship type. ``display_name``/``entity_type`` come
         from the NES resolver (``None`` when NES can't resolve the id).
         """
-        from cases.services.nes_resolver import resolve_entities
+        from cases.services.nes_resolver import build_entity_binds, resolve_entities
 
         try:
             relationships = list(obj.entity_relationships.all())
             resolved = resolve_entities(rel.nes_id for rel in relationships)
             # Per-entity relationship notes are internal-only, same as the
             # case-level notes field (BB-04): expose them to casework roles only.
+            # The shared shaper (build_entity_binds) defaults notes to "" so the
+            # public search-card path can't leak them; we pass include_notes for
+            # casework viewers here.
             notes_visible = _viewer_has_casework_access(self.context)
-            return [
-                {
-                    "nes_id": rel.nes_id,
-                    "display_name": resolved[rel.nes_id]["display_name"],
-                    "entity_type": resolved[rel.nes_id]["entity_type"],
-                    "type": rel.relationship_type,
-                    "outcome": rel.outcome,
-                    "notes": rel.notes if notes_visible else "",
-                }
-                for rel in relationships
-            ]
+            return build_entity_binds(
+                relationships, resolved, include_notes=notes_visible
+            )
         except (ValueError, TypeError, AttributeError) as e:
             logger.error(
                 f"Error serializing entities for case {obj.slug}: {e}",

--- a/cases/services/nes_resolver.py
+++ b/cases/services/nes_resolver.py
@@ -130,3 +130,32 @@ def resolve_entities(nes_ids) -> dict[str, ResolvedEntity]:
         )
 
     return resolved
+
+
+def build_entity_binds(
+    relationships, resolved, *, include_notes: bool = False
+) -> list[dict]:
+    """Shape ``CaseEntityRelationship`` rows + resolved NES details into the entity
+    binds used by BOTH the API (``CaseSerializer.get_entities``) and the search
+    index card. One definition so the two consumers can't drift.
+
+    ``resolved`` is a :func:`resolve_entities` result (``nes_id -> ResolvedEntity``);
+    a missing/unresolved id yields ``None`` name/type rather than raising, so this
+    is safe on the best-effort indexing path as well as the API path.
+
+    Per-entity ``notes`` are internal casework content (BB-04): they must NOT reach
+    public/anonymous callers. The ``notes`` key is always present for schema
+    stability, but its value is ``""`` unless ``include_notes`` is set. The API
+    passes ``include_notes`` only for casework-role viewers; the public search-card
+    path leaves it ``False`` so the denormalized card never leaks internal notes."""
+    return [
+        {
+            "nes_id": rel.nes_id,
+            "display_name": (resolved.get(rel.nes_id) or {}).get("display_name"),
+            "entity_type": (resolved.get(rel.nes_id) or {}).get("entity_type"),
+            "type": rel.relationship_type,
+            "outcome": rel.outcome,
+            "notes": rel.notes if include_notes else "",
+        }
+        for rel in relationships
+    ]

--- a/jawafdehi_shared/search/mappings.py
+++ b/jawafdehi_shared/search/mappings.py
@@ -207,6 +207,12 @@ def common_mappings() -> dict[str, Any]:
                 "verdict_date": {"type": "date"},
                 "verdict_type": {"type": "keyword"},
                 "status": {"type": "keyword"},
+                # Coarse Jawafdehi-case lifecycle (ongoing/closed/others). A dedicated
+                # keyword so the unified search can facet/filter cases WITHOUT
+                # colliding with the generic ``status`` above (which NGM uses for its
+                # internal scraper enrichment flag pending/enriched/failed). Only
+                # Jawafdehi cases set this; other doc types leave it absent.
+                "case_status": {"type": "keyword"},
                 # Full serialized JSON-LD / record, return-only (not searchable).
                 "raw": {"type": "object", "enabled": False},
             }

--- a/search/service.py
+++ b/search/service.py
@@ -137,12 +137,15 @@ def _sort_spec(sort: str) -> list[dict[str, Any]]:
 
 # Facet/filter fields: the request param name -> the keyword index field it filters
 # and aggregates over. ``entity_type`` reuses the schema.org ``type`` token; ``tags``
-# reuses the shared ``keywords`` field. These are exact-match (``terms``) facets,
-# distinct from the per-type ``counts`` (which come from the ``_index`` agg).
+# reuses the shared ``keywords`` field; the ``status`` param filters the coarse
+# case lifecycle, backed by the dedicated ``case_status`` field (NOT the generic
+# ``status``, which holds NGM's scraper enrichment flag). These are exact-match
+# (``terms``) facets, distinct from the per-type ``counts`` (from the ``_index`` agg).
 FACET_FIELDS: dict[str, str] = {
     "entity_type": "type",
     "case_type": "case_type",
     "tags": "keywords",
+    "status": "case_status",
 }
 
 
@@ -341,6 +344,7 @@ def build_query(
             "entity_type": {"terms": {"field": "type", "size": 50}},
             "case_type": {"terms": {"field": "case_type", "size": 50}},
             "tags": {"terms": {"field": "keywords", "size": 50}},
+            "status": {"terms": {"field": "case_status", "size": 50}},
         },
     }
 
@@ -471,7 +475,7 @@ def _serialize_hit(hit: dict[str, Any]) -> dict[str, Any]:
         if raw.get(key) is not None:
             extra[key] = raw[key]
 
-    return {
+    envelope: dict[str, Any] = {
         "type": result_type,
         "id": source.get("iri"),
         "source_app": source.get("source_app"),
@@ -486,6 +490,17 @@ def _serialize_hit(hit: dict[str, Any]) -> dict[str, Any]:
         "matched_fields": sorted(highlight.keys()),
         "extra": extra,
     }
+
+    # Case hits carry a denormalized ``card`` payload (indexed under ``raw.card``)
+    # so the SPA renders the result card without a follow-up /api/cases/{slug}/
+    # fetch. Only cases have it; older docs indexed before this field simply omit
+    # it, so the key is absent rather than null.
+    if result_type == "case":
+        card = raw.get("card")
+        if card is not None:
+            envelope["card"] = card
+
+    return envelope
 
 
 def _facets_from_aggs(aggs: dict[str, Any]) -> dict[str, int]:

--- a/search/tests/test_indexer_index_calls.py
+++ b/search/tests/test_indexer_index_calls.py
@@ -90,3 +90,61 @@ def test_case_index_non_published_deletes():
         _, kwargs = client.delete.call_args
         # Falls back to building the IRI from the slug since public_iri is None.
         assert kwargs["id"] == "https://jawafdehi.org/case/x"
+
+
+def test_case_index_resolves_and_denormalizes_entities(monkeypatch):
+    """index() resolves NES display names at index time and stores them in the card."""
+    rel = SimpleNamespace(
+        nes_id="https://jawafdehi.org/entity/person/x",
+        relationship_type="accused",
+        outcome="convicted",
+        notes="",
+    )
+    case = _case("PUBLISHED")
+    case.entity_relationships = SimpleNamespace(all=lambda: [rel])
+
+    monkeypatch.setattr(
+        "cases.services.nes_resolver.resolve_entities",
+        lambda ids: {rel.nes_id: {"display_name": "Person X", "entity_type": "Person"}},
+    )
+
+    client = MagicMock()
+    case_index.index(case, client=client)
+    _, kwargs = client.index.call_args
+    entities = kwargs["body"]["raw"]["card"]["entities"]
+    assert entities == [
+        {
+            "nes_id": rel.nes_id,
+            "display_name": "Person X",
+            "entity_type": "Person",
+            "type": "accused",
+            "outcome": "convicted",
+            "notes": "",
+        }
+    ]
+
+
+def test_case_index_survives_entity_resolution_failure(monkeypatch):
+    """A NES resolution error must not stop the case from being indexed."""
+    rel = SimpleNamespace(
+        nes_id="https://jawafdehi.org/entity/person/x",
+        relationship_type="accused",
+        outcome="charged",
+        notes="",
+    )
+    case = _case("PUBLISHED")
+    case.entity_relationships = SimpleNamespace(all=lambda: [rel])
+
+    def _boom(ids):
+        raise RuntimeError("NES down")
+
+    monkeypatch.setattr("cases.services.nes_resolver.resolve_entities", _boom)
+
+    client = MagicMock()
+    case_index.index(case, client=client)
+    client.index.assert_called_once()
+    _, kwargs = client.index.call_args
+    # Still indexed, with the bind present but names left null for the reconcile.
+    entity = kwargs["body"]["raw"]["card"]["entities"][0]
+    assert entity["display_name"] is None
+    assert entity["type"] == "accused"

--- a/search/tests/test_indexers.py
+++ b/search/tests/test_indexers.py
@@ -211,3 +211,102 @@ def test_case_should_index_only_published():
         case = _published_case()
         case.state = state
         assert case_index.should_index(case) is False
+
+
+def _card_case(**overrides):
+    """A published case with the full render-payload attributes set."""
+    from datetime import date
+
+    base = dict(
+        state="PUBLISHED",
+        public_iri="https://jawafdehi.org/case/land-grab-2081",
+        slug="land-grab-2081",
+        title="Land grab",
+        description="desc",
+        short_description="<b>Short</b> summary.",
+        key_allegations=["Encroachment", ""],
+        tags=["land", "corruption"],
+        case_type="CORRUPTION",
+        court_cases=[],
+        case_start_date=date(2024, 1, 1),
+        case_end_date=None,
+        thumbnail_url="https://cdn/thumb.png",
+        banner_url="https://cdn/banner.png",
+        bigo=12345678,
+        timeline=[{"date": "2024-01-01", "title": "Filed"}, "not-a-dict"],
+        created_at=None,
+        updated_at=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_case_build_doc_status_ongoing_closed_others():
+    from datetime import date
+
+    # Coarse lifecycle rides on the dedicated ``case_status`` keyword (NOT the
+    # generic ``status``, which NGM courtcases use for their enrichment flag).
+    assert case_index.build_doc(_card_case())["case_status"] == "ongoing"
+    assert "status" not in case_index.build_doc(_card_case())
+    closed = case_index.build_doc(_card_case(case_end_date=date(2024, 6, 1)))
+    assert closed["case_status"] == "closed"
+    others = case_index.build_doc(_card_case(case_start_date=None))
+    assert others["case_status"] == "others"
+
+
+def test_build_indexed_doc_resolves_entities_for_bulk_path(monkeypatch):
+    """The bulk/live wrapper resolves NES names so a rebuild refreshes (not blanks)
+    the card entities — the pure build_doc alone would leave them empty."""
+    rel = SimpleNamespace(
+        nes_id="https://jawafdehi.org/entity/person/x",
+        relationship_type="accused",
+        outcome="convicted",
+        notes="",
+    )
+    case = _card_case()
+    case.entity_relationships = SimpleNamespace(all=lambda: [rel])
+    monkeypatch.setattr(
+        "cases.services.nes_resolver.resolve_entities",
+        lambda ids: {rel.nes_id: {"display_name": "Person X", "entity_type": "Person"}},
+    )
+    doc = case_index.build_indexed_doc(case)
+    assert doc["raw"]["card"]["entities"][0]["display_name"] == "Person X"
+    # Pure build_doc (what the driver would call without the wrapper) leaves it empty.
+    assert case_index.build_doc(case)["raw"]["card"]["entities"] == []
+
+
+def test_case_build_doc_card_payload():
+    entities = [
+        {
+            "nes_id": "https://jawafdehi.org/entity/person/x",
+            "display_name": "Person X",
+            "entity_type": "Person",
+            "type": "accused",
+            "outcome": "convicted",
+            "notes": "",
+        }
+    ]
+    doc = case_index.build_doc(_card_case(), entities=entities)
+    card = doc["raw"]["card"]
+    # Render fields the SPA card needs, denormalized into the doc.
+    assert card["slug"] == "land-grab-2081"
+    assert card["short_description"] == "<b>Short</b> summary."
+    assert card["key_allegations"] == ["Encroachment"]  # blank dropped
+    assert card["tags"] == ["land", "corruption"]
+    assert card["case_type"] == "CORRUPTION"
+    assert card["status"] == "ongoing"
+    assert card["case_start_date"] == "2024-01-01"
+    assert card["case_end_date"] is None
+    assert card["bigo"] == 12345678
+    assert card["thumbnail_url"] == "https://cdn/thumb.png"
+    assert card["banner_url"] == "https://cdn/banner.png"
+    # timeline (major events) carried verbatim; non-dict entries filtered out.
+    assert card["timeline"] == [{"date": "2024-01-01", "title": "Filed"}]
+    # resolved entity binds (with per-entity outcome) ride along.
+    assert card["entities"] == entities
+
+
+def test_case_build_doc_card_entities_default_empty():
+    """Pure shaping (no ``entities`` arg) still emits a card, with no entities."""
+    doc = case_index.build_doc(_card_case())
+    assert doc["raw"]["card"]["entities"] == []

--- a/search/tests/test_search_api.py
+++ b/search/tests/test_search_api.py
@@ -121,6 +121,20 @@ def test_search_api_passes_sort_and_filters_through():
 
 
 @pytest.mark.django_db
+def test_search_api_threads_status_facet_through():
+    """The case-list ?type=case&status=ongoing filter reaches the OpenSearch DSL."""
+    client = MagicMock()
+    client.search.return_value = _canned()
+    with patch("search.service.make_client", return_value=client):
+        resp = APIClient().get(
+            "/api/search/", {"q": "", "type": "case", "status": "ongoing"}
+        )
+    assert resp.status_code == 200
+    body = client.search.call_args.kwargs["body"]
+    assert {"terms": {"case_status": ["ongoing"]}} in body["query"]["bool"]["filter"]
+
+
+@pytest.mark.django_db
 def test_search_api_400_on_invalid_sort():
     resp = APIClient().get("/api/search/", {"q": "x", "sort": "bogus"})
     assert resp.status_code == 400

--- a/search/tests/test_search_service.py
+++ b/search/tests/test_search_service.py
@@ -502,3 +502,73 @@ def test_search_threads_sort_and_filters_to_client():
     body = kwargs["body"]
     assert body["sort"][0] == {"date": {"order": "desc", "missing": "_last"}}
     assert {"terms": {"case_type": ["CORRUPTION"]}} in body["query"]["bool"]["filter"]
+
+
+# ── status facet (case lifecycle) + denormalized case card ─────────────────────
+
+
+def test_build_query_includes_status_facet_and_filter():
+    """The ``status`` param is backed by the dedicated ``case_status`` field, NOT
+    the generic ``status`` (which holds NGM's scraper enrichment flag)."""
+    assert svc.FACET_FIELDS["status"] == "case_status"
+    body = build_query(q="x", filters={"status": ["ongoing"]})
+    assert body["aggs"]["status"]["terms"]["field"] == "case_status"
+    assert {"terms": {"case_status": ["ongoing"]}} in body["query"]["bool"]["filter"]
+
+
+def _case_card_response():
+    """A single case hit carrying the denormalized ``raw.card`` render payload."""
+    return {
+        "hits": {
+            "total": {"value": 1},
+            "hits": [
+                {
+                    "_index": "jawafdehi-cases",
+                    "_id": "https://jawafdehi.org/case/land-grab",
+                    "_score": 4.2,
+                    "_source": {
+                        "iri": "https://jawafdehi.org/case/land-grab",
+                        "source_app": "jawafdehi",
+                        "title_en": "Land grab",
+                        "type": "Case",
+                        "case_status": "ongoing",
+                        "raw": {
+                            "slug": "land-grab",
+                            "case_type": "CORRUPTION",
+                            "card": {
+                                "slug": "land-grab",
+                                "status": "ongoing",
+                                "tags": ["land"],
+                                "timeline": [{"date": "2024-01-01", "title": "Filed"}],
+                                "entities": [],
+                            },
+                        },
+                    },
+                }
+            ],
+        },
+        "aggregations": {},
+    }
+
+
+def test_case_result_surfaces_denormalized_card():
+    client = MagicMock()
+    client.search.return_value = _case_card_response()
+    out = SearchService(client=client).search(q="land", types=["case"])
+    result = out["results"][0]
+    assert result["type"] == "case"
+    # The whole card payload (incl. timeline/major events) rides on the result,
+    # so the SPA renders without a follow-up /api/cases/{slug}/ fetch.
+    assert result["card"]["slug"] == "land-grab"
+    assert result["card"]["status"] == "ongoing"
+    assert result["card"]["timeline"] == [{"date": "2024-01-01", "title": "Filed"}]
+
+
+def test_non_case_result_has_no_card_key():
+    """Only case hits carry a ``card``; other types keep the lean envelope."""
+    client = MagicMock()
+    client.search.return_value = _canned_response()
+    out = SearchService(client=client).search(q="x")
+    entity = out["results"][0]
+    assert entity["type"] == "entity"
+    assert "card" not in entity

--- a/search/views.py
+++ b/search/views.py
@@ -56,6 +56,13 @@ class SearchQuerySerializer(serializers.Serializer):
     tags = serializers.ListField(
         child=serializers.CharField(allow_blank=False), required=False, default=list
     )
+    # Coarse case lifecycle refine facet (ongoing/closed/others). Case-scoped in
+    # practice (the case list sends ?type=case&status=...); the ``status`` param
+    # filters the ``case_status`` keyword field (NOT the generic ``status`` field,
+    # which holds NGM's scraper enrichment flag).
+    status = serializers.ListField(
+        child=serializers.CharField(allow_blank=False), required=False, default=list
+    )
     page = serializers.IntegerField(required=False, min_value=1, default=1)
     page_size = serializers.IntegerField(
         required=False, min_value=1, max_value=MAX_PAGE_SIZE, default=10
@@ -123,6 +130,17 @@ class SearchQuerySerializer(serializers.Serializer):
             many=True,
             description="Refine facet: filter by keyword/tag.",
         ),
+        OpenApiParameter(
+            "status",
+            OpenApiTypes.STR,
+            OpenApiParameter.QUERY,
+            required=False,
+            many=True,
+            description=(
+                "Refine facet: coarse case lifecycle (ongoing/closed/others). "
+                "Case-scoped in practice."
+            ),
+        ),
         OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, required=False),
         OpenApiParameter(
             "page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, required=False
@@ -154,6 +172,7 @@ class UnifiedSearchView(APIView):
             "entity_type": data["entity_type"],
             "case_type": data["case_type"],
             "tags": data["tags"],
+            "status": data["status"],
         }
         try:
             response = SearchService().search(

--- a/tests/api/test_openapi_documentation.py
+++ b/tests/api/test_openapi_documentation.py
@@ -95,8 +95,9 @@ class TestOpenAPIDocumentation:
         assert "search" in search["tags"]
         parameter_names = [parameter["name"] for parameter in search["parameters"]]
         # The unified-search params: q (optional → empty = browse), type/lang
-        # filters, sort mode, refine facets (entity_type/case_type/tags), offset
-        # paging (page/page_size), and the deep-paging cursor (search_after).
+        # filters, sort mode, refine facets (entity_type/case_type/tags/status),
+        # offset paging (page/page_size), and the deep-paging cursor
+        # (search_after). ``status`` is the coarse case-lifecycle refine facet.
         assert set(parameter_names) == {
             "q",
             "type",
@@ -105,6 +106,7 @@ class TestOpenAPIDocumentation:
             "entity_type",
             "case_type",
             "tags",
+            "status",
             "page",
             "page_size",
             "cursor",


### PR DESCRIPTION
## What & why

WS1 of moving the SPA case list/browse/search off the Postgres `icontains` path (`/api/cases/?search=`) and onto the unified OpenSearch proxy (`/api/search/`), so a search hit can render a case card — including the timeline / "major events" — **without** a per-card follow-up fetch to the DRF detail endpoint. Case **DETAIL** (`/api/cases/{slug}/`) deliberately stays on DRF/Postgres (it needs live NES/NGM resolution). Frontend repoint is a separate PR (WS2).

Design/plan doc: `jawafdehi-meta/work/2026-07-07-cases-opensearch-serving/PLAN.md`.

## Changes

- **`build_doc`** now emits a self-contained `raw.card` render payload (`short_description`, `key_allegations`, `tags`, dates, `bigo`, thumbnail/banner, `timeline`, and resolved entity binds) plus a coarse lifecycle keyword. `raw` is `enabled:false` → stored + returned, never searched.
- **`case_status`** is a *new mapped keyword*, deliberately distinct from the generic `status` field (which NGM courtcases use for their internal scraper enrichment flag `pending/enriched/failed`) — so the case-lifecycle facet never blends the two vocabularies.
- **Freshness:** entity names are denormalized at index time. `build_indexed_doc` resolves them and is used by **both** the live `index()` signal path **and** the bulk `reindex_cases` driver, so a `--rebuild` *refreshes* names rather than blanking the card. `reindex_cases` now prefetches `entity_relationships`.
- **No drift:** the entity-bind shape is extracted to `nes_resolver.build_entity_binds` and shared with `CaseSerializer.get_entities`.
- **Search:** the unified service + API view expose a `status` refine facet (param `status` → `case_status` field).

## Review

Reviewed at high effort; both correctness findings addressed before this PR:
1. bulk reindex would have blanked `card.entities` → fixed via `build_indexed_doc` used on both paths (+ test).
2. `status` facet would have leaked NGM enrichment flags → fixed via the dedicated `case_status` field.
Plus cleanups: shared `build_entity_binds`, `_iso` adoption, simplified `_derive_status`.

## Tests

`search/` + `cases/` suites green (101 passed), ruff clean. New tests cover the card payload, `case_status` derivation, the bulk-path resolve, the `status` facet/filter through service + API, and entity-resolution failure tolerance.

## Deploy

After rollout, run `manage.py reindex_cases --rebuild` so the new `case_status` mapping + card payload apply (a plain reindex won't pick up the new mapped field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new case status filter in search, with facets for ongoing, closed, and other cases.
  * Search results for cases can now include a richer case card with key details, timeline, and entity information.

* **Bug Fixes**
  * Improved case search indexing so entity names are refreshed more reliably during rebuilds.
  * Search continues to work even when some entity resolution data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->