### PR TITLE
fix(cases): gate internal notes to casework roles (BB-04)

### DIFF
--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -27,6 +27,11 @@ def _viewer_has_casework_access(context) -> bool:
     callers and other authenticated users are "public" and must NOT receive
     internal ``notes`` — the authoring UI labels notes "not shown publicly"
     (BB-04).
+
+    The result is memoized on the request for the life of the response: the
+    group-membership check runs a few queries and this helper is called once per
+    case for both ``notes`` and each entity's note, so a list response would
+    otherwise repeat it N times (N+1).
     """
     from cases.rules.predicates import (
         is_admin_or_moderator,
@@ -35,10 +40,26 @@ def _viewer_has_casework_access(context) -> bool:
     )
 
     request = context.get("request") if context else None
+    if request is None:
+        return False
+
+    cached = getattr(request, "_jawafdehi_casework_access", None)
+    if cached is not None:
+        return cached
+
     user = getattr(request, "user", None)
     if not (user and getattr(user, "is_authenticated", False)):
-        return False
-    return is_admin_or_moderator(user) or is_caseworker(user) or is_readonly(user)
+        result = False
+    else:
+        result = (
+            is_admin_or_moderator(user) or is_caseworker(user) or is_readonly(user)
+        )
+
+    try:
+        request._jawafdehi_casework_access = result
+    except Exception:  # pragma: no cover - request objects are normally mutable
+        pass
+    return result
 
 
 class CaseEntityRelationshipSerializer(serializers.ModelSerializer):

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -19,6 +19,28 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
+def _viewer_has_casework_access(context) -> bool:
+    """Whether the requesting user may see internal casework notes.
+
+    Mirrors the casework-visibility boundary enforced by
+    ``CaseViewSet.get_queryset`` (Admin/Moderator/Caseworker/ReadOnly). Anonymous
+    callers and other authenticated users are "public" and must NOT receive
+    internal ``notes`` — the authoring UI labels notes "not shown publicly"
+    (BB-04).
+    """
+    from cases.rules.predicates import (
+        is_admin_or_moderator,
+        is_caseworker,
+        is_readonly,
+    )
+
+    request = context.get("request") if context else None
+    user = getattr(request, "user", None)
+    if not (user and getattr(user, "is_authenticated", False)):
+        return False
+    return is_admin_or_moderator(user) or is_caseworker(user) or is_readonly(user)
+
+
 class CaseEntityRelationshipSerializer(serializers.ModelSerializer):
     """
     Serializer for the CaseEntityRelationship bind.
@@ -73,6 +95,24 @@ class CaseSerializer(serializers.ModelSerializer):
         help_text="Entity binds for this case (NES entity id, relationship type, "
         "notes), with display details resolved from NES"
     )
+    notes = serializers.SerializerMethodField(
+        help_text="Internal casework notes. Returned only to authenticated "
+        "casework roles (Admin/Moderator/Caseworker/ReadOnly); an empty string "
+        "for public/anonymous callers (notes are 'not shown publicly')."
+    )
+
+    @extend_schema_field(serializers.CharField(allow_blank=True))
+    def get_notes(self, obj):
+        """Return internal notes only to casework viewers, else an empty string.
+
+        ``notes`` is internal-only (the authoring UI labels it "not shown
+        publicly"). Gating here — rather than dropping the field from the
+        serializer — keeps the casework/admin editor round-trip working, since it
+        reloads existing notes through this same read endpoint before PATCHing.
+        """
+        if _viewer_has_casework_access(self.context):
+            return obj.notes
+        return ""
 
     @extend_schema_field(
         inline_serializer(
@@ -100,6 +140,9 @@ class CaseSerializer(serializers.ModelSerializer):
         try:
             relationships = list(obj.entity_relationships.all())
             resolved = resolve_entities(rel.nes_id for rel in relationships)
+            # Per-entity relationship notes are internal-only, same as the
+            # case-level notes field (BB-04): expose them to casework roles only.
+            notes_visible = _viewer_has_casework_access(self.context)
             return [
                 {
                     "nes_id": rel.nes_id,
@@ -107,7 +150,7 @@ class CaseSerializer(serializers.ModelSerializer):
                     "entity_type": resolved[rel.nes_id]["entity_type"],
                     "type": rel.relationship_type,
                     "outcome": rel.outcome,
-                    "notes": rel.notes,
+                    "notes": rel.notes if notes_visible else "",
                 }
                 for rel in relationships
             ]

--- a/tests/e2e/test_public_api_e2e.py
+++ b/tests/e2e/test_public_api_e2e.py
@@ -12,6 +12,7 @@ from rest_framework.test import APIClient
 from cases.models import CaseMaterialReference, CaseState, CaseType
 from tests.conftest import (
     create_case_with_entities,
+    create_user_with_role,
 )
 
 VALID_MATERIAL_IRI = "https://jawafdehi.org/material/jawafdehi/20240115.ab12cd"
@@ -238,18 +239,28 @@ class TestPublicAPIWorkflows:
             in_review_case.slug not in case_ids
         ), "In Review cases should not appear in list"
 
-    def test_notes_field_in_case_detail(self):
+    def test_notes_are_hidden_from_public_but_shown_to_casework(self):
         """
-        E2E Test: Verify notes field is included when retrieving case details.
+        E2E Test: internal ``notes`` are gated by casework role (BB-04).
+
+        ``notes`` (case-level and per-entity relationship notes) are internal —
+        the authoring UI labels them "not shown publicly". The public/anonymous
+        response must carry the ``notes`` key (schema stability) but with an empty
+        value; an authenticated casework role sees the real content.
 
         Workflow:
-        1. Create a published case with notes
-        2. Retrieve the case via API
-        3. Verify notes field is included in the response
+        1. Create a published case with case-level and per-entity notes.
+        2. Retrieve anonymously -> notes gated to "" (no leak).
+        3. Retrieve as a Caseworker -> real notes returned (editor round-trip).
 
-        Validates: Requirements 6.3
+        Validates: Requirements 6.3 (corrected: notes are casework-only).
         """
-        # Step 1: Create a published case with notes
+        internal_note = (
+            "## Background\n\nThis case involves corruption at the ministry level."
+        )
+        entity_note = "Internal: suspected primary beneficiary."
+
+        # Step 1: Create a published case with case-level + per-entity notes.
         case = create_case_with_entities(
             title="Case with Notes",
             alleged_entities=["https://jawafdehi.org/entity/person/test-official"],
@@ -258,28 +269,39 @@ class TestPublicAPIWorkflows:
             description="A case with markdown notes.",
             state=CaseState.PUBLISHED,
         )
-        case.notes = (
-            "## Background\n\nThis case involves corruption at the ministry level."
-        )
+        case.notes = internal_note
         case.save()
+        rel = case.entity_relationships.first()
+        rel.notes = entity_note
+        rel.save()
 
-        # Step 2: Retrieve the case via API
+        # Step 2: Anonymous retrieval must NOT leak notes.
         response = self.client.get(f"/api/cases/{case.slug}/")
         assert response.status_code == 200
+        public_detail = response.data
+        assert "notes" in public_detail, "notes key should remain for schema stability"
+        assert public_detail["notes"] == "", "case notes must be hidden from the public"
+        assert all(
+            e["notes"] == "" for e in public_detail["entities"]
+        ), "per-entity notes must be hidden from the public"
 
-        case_detail = response.data
+        # audit_history is still never exposed.
+        assert "audit_history" not in public_detail
 
-        # Step 3: Verify notes field is included
-        assert "notes" in case_detail, "Detail endpoint should include notes field"
-        assert (
-            case_detail["notes"]
-            == "## Background\n\nThis case involves corruption at the ministry level."
-        ), "Notes content should match what was saved"
-
-        # Verify audit_history is NOT included
-        assert (
-            "audit_history" not in case_detail
-        ), "Detail endpoint should not include audit_history"
+        # Step 3: A casework role (Caseworker) still sees the real notes so the
+        # admin editor can reload and round-trip them.
+        caseworker = create_user_with_role(
+            "cw-notes", "cw-notes@example.com", "Caseworker"
+        )
+        casework_client = APIClient()
+        casework_client.force_authenticate(user=caseworker)
+        cw_response = casework_client.get(f"/api/cases/{case.slug}/")
+        assert cw_response.status_code == 200
+        cw_detail = cw_response.data
+        assert cw_detail["notes"] == internal_note, "casework must see case notes"
+        assert any(
+            e["notes"] == entity_note for e in cw_detail["entities"]
+        ), "casework must see per-entity notes"
 
     def test_filter_by_tags_workflow(self):
         """


### PR DESCRIPTION
## BB-04 — Internal `notes` leaked on the public case page & API (S1 privacy)

### Problem
Internal case notes were serialized to **anonymous** callers on the public case endpoints, despite the authoring UI labelling the field *"Internal casework notes (not shown publicly)"* (`AdminCaseForm.tsx:486`).

**Reproduced live** against `api.jawafdehi.org`:
```
GET /api/cases/narayani-hospital-construction-scandal-b1d326/   (no auth)
→ "notes": "Prepared by Niroj Aryal (BALLB Fifth Year law Student)."
→ entities[].notes: "<internal Devanagari casework note>"
```
Both the case-level `Case.notes` and per-entity relationship notes leaked, and the public case page renders them (`CaseDetail.tsx:157,617-620`).

### Root cause
`CaseDetailSerializer` (retrieve) inherits `CaseSerializer.Meta.fields`, which lists `notes` (`cases/serializers.py`), and `get_entities` returned `rel.notes` unconditionally. Visibility was enforced only at the **row** level (published-only), never at the **field** level.

### Fix
Gate `notes` behind a casework-role check (`Admin/Moderator/Caseworker/ReadOnly`) via a small `_viewer_has_casework_access(context)` helper that mirrors the boundary already used in `CaseViewSet.get_queryset`.

- **Public/anonymous** → `notes` (case-level and per-entity) returns `""`. The key is kept for schema stability; empty value makes the FE's `hasNotes` falsy so the public Notes section/nav disappear automatically.
- **Casework roles** → real notes, so the admin editor's reload-then-PATCH round-trip (which loads notes through this same read endpoint) keeps working.

Gating rather than deleting the field is deliberate — a blanket removal would wipe notes on the next admin PATCH.

### Files
- `cases/serializers.py` — `_viewer_has_casework_access` helper; `notes` → gated `SerializerMethodField`; per-entity `notes` gated in `get_entities`.
- `tests/e2e/test_public_api_e2e.py` — the prior test asserted notes were public (encoded the bug); rewritten to pin the corrected contract (public hidden, casework visible), covering case-level **and** per-entity notes.

### Verification
- `python -m py_compile` clean on both files.
- ⚠️ **pytest was not run locally** — no Django toolchain in the investigation env. Please rely on CI for the full suite. Checked structurally: the OpenAPI/doc-integration tests still hold (`notes` stays a string property in the schema and the response key remains present).

### Notes / scope
Part of the Jawafdehi bug-bash. This is the S1 privacy item; other bugs are being sent as separate branches/PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)