### PR TITLE
feat(cases): persist Bikram Sambat (BS) case start/end dates (BB-11, BB-25)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -380,6 +380,8 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             "banner_url",
             "case_start_date",
             "case_end_date",
+            "case_start_date_bs",
+            "case_end_date_bs",
             "tags",
             "key_allegations",
             "timeline",
@@ -657,6 +659,8 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 "banner_url",
                 "case_start_date",
                 "case_end_date",
+                "case_start_date_bs",
+                "case_end_date_bs",
                 "tags",
                 "key_allegations",
                 "timeline",
@@ -862,6 +866,11 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 str(case.case_start_date) if case.case_start_date else None
             ),
             "case_end_date": str(case.case_end_date) if case.case_end_date else None,
+            # BS dates are stored as strings; expose the key (even when empty) so
+            # a `replace /case_start_date_bs` op has a target and no longer errors
+            # with "can't replace a non-existent object" (BB-11).
+            "case_start_date_bs": case.case_start_date_bs or None,
+            "case_end_date_bs": case.case_end_date_bs or None,
             "case_type": case.case_type,
             "tags": list(case.tags) if case.tags else [],
             "key_allegations": (

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -226,6 +226,21 @@ class CaseEntityValidationMixin:
         return cleaned
 
 
+# Bikram Sambat (BS) dates are stored as strings; enforce the same YYYY-MM-DD
+# shape the timeline BS dates use (TimelineItemSerializer._BS_DATE_RE).
+_CASE_BS_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _validate_optional_bs_date(value):
+    """Normalize an optional BS date: empty/whitespace/None → None; otherwise
+    require the YYYY-MM-DD shape (rejects malformed values at API time)."""
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return None
+    if not _CASE_BS_DATE_RE.match(value):
+        raise serializers.ValidationError("BS date must be in the format YYYY-MM-DD.")
+    return value
+
+
 class CaseCreateSerializer(
     CourtCaseRefsValidationMixin, CaseEntityValidationMixin, serializers.Serializer
 ):
@@ -296,6 +311,12 @@ class CaseCreateSerializer(
             return None
         return value
 
+    def validate_case_start_date_bs(self, value):
+        return _validate_optional_bs_date(value)
+
+    def validate_case_end_date_bs(self, value):
+        return _validate_optional_bs_date(value)
+
     def validate_slug(self, value):
         """Normalize empty/whitespace slugs to None."""
         if value is None or (isinstance(value, str) and not value.strip()):
@@ -360,6 +381,12 @@ class CasePatchSerializer(CourtCaseRefsValidationMixin, serializers.Serializer):
         if value is None or (isinstance(value, str) and not value.strip()):
             return None
         return value
+
+    def validate_case_start_date_bs(self, value):
+        return _validate_optional_bs_date(value)
+
+    def validate_case_end_date_bs(self, value):
+        return _validate_optional_bs_date(value)
 
     def validate_slug(self, value):
         """

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -244,6 +244,12 @@ class CaseCreateSerializer(
     banner_url = serializers.URLField(required=False, allow_blank=True, max_length=500)
     case_start_date = serializers.DateField(required=False, allow_null=True)
     case_end_date = serializers.DateField(required=False, allow_null=True)
+    case_start_date_bs = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, max_length=10
+    )
+    case_end_date_bs = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, max_length=10
+    )
     tags = serializers.ListField(child=serializers.CharField(), required=False)
     key_allegations = serializers.ListField(
         child=serializers.CharField(), required=False
@@ -308,6 +314,12 @@ class CasePatchSerializer(CourtCaseRefsValidationMixin, serializers.Serializer):
     banner_url = serializers.URLField(required=False, allow_blank=True, max_length=500)
     case_start_date = serializers.DateField(required=False, allow_null=True)
     case_end_date = serializers.DateField(required=False, allow_null=True)
+    case_start_date_bs = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, max_length=10
+    )
+    case_end_date_bs = serializers.CharField(
+        required=False, allow_null=True, allow_blank=True, max_length=10
+    )
     case_type = serializers.ChoiceField(choices=CaseType.choices)
     tags = serializers.ListField(child=serializers.CharField(), required=False)
     key_allegations = serializers.ListField(

--- a/cases/migrations/0048_case_bs_dates.py
+++ b/cases/migrations/0048_case_bs_dates.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cases', '0047_caseentityrelationship_outcome'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='case',
+            name='case_start_date_bs',
+            field=models.CharField(blank=True, help_text="Bikram Sambat (BS) start date, e.g. '2080-09-18' (optional)", max_length=10, null=True),
+        ),
+        migrations.AddField(
+            model_name='case',
+            name='case_end_date_bs',
+            field=models.CharField(blank=True, help_text="Bikram Sambat (BS) end date, e.g. '2080-09-18' (optional)", max_length=10, null=True),
+        ),
+    ]

--- a/cases/models.py
+++ b/cases/models.py
@@ -567,6 +567,22 @@ class Case(models.Model):
     case_end_date = models.DateField(
         null=True, blank=True, help_text="When the alleged incident ended"
     )
+    # Optional source-recorded Bikram Sambat (BS) dates, stored as strings
+    # (e.g. "2080-09-18"). BS is not a Gregorian calendar, so these are plain
+    # CharFields rather than DateFields, and are distinct from the AD dates
+    # above (which the frontend can also render as a computed BS value).
+    case_start_date_bs = models.CharField(
+        max_length=10,
+        blank=True,
+        null=True,
+        help_text="Bikram Sambat (BS) start date, e.g. '2080-09-18' (optional)",
+    )
+    case_end_date_bs = models.CharField(
+        max_length=10,
+        blank=True,
+        null=True,
+        help_text="Bikram Sambat (BS) end date, e.g. '2080-09-18' (optional)",
+    )
 
     # Entity relationships live on the CaseEntityRelationship bind (the
     # ``entity_relationships`` reverse relation), which holds the canonical NES

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -198,6 +198,8 @@ class CaseSerializer(serializers.ModelSerializer):
             "banner_url",
             "case_start_date",
             "case_end_date",
+            "case_start_date_bs",
+            "case_end_date_bs",
             "entities",
             "tags",
             "description",

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -105,6 +105,37 @@ def test_patch_replace_scalar_field():
 
 
 @pytest.mark.django_db
+def test_patch_replace_bs_dates_when_previously_unset():
+    """Regression for BB-11.
+
+    Replacing a Bikram Sambat (BS) date on a case that never had one used to
+    fail with "can't replace a non-existent object 'case_start_date_bs'":
+    there was no such column, so the patch snapshot omitted the key and the
+    RFC-6902 ``replace`` had no target. The BS date columns now exist and are
+    part of the snapshot, so the replace op succeeds and persists.
+    """
+    user = _contributor("gita")
+    case = _make_case()  # no BS dates set
+    case.contributors.add(user)
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[
+            {"op": "replace", "path": "/case_start_date_bs", "value": "2080-09-18"},
+            {"op": "replace", "path": "/case_end_date_bs", "value": "2080-10-01"},
+        ],
+        format="json",
+    )
+    assert response.status_code == 200, response.data
+    assert response.data["case_start_date_bs"] == "2080-09-18"
+    assert response.data["case_end_date_bs"] == "2080-10-01"
+    case.refresh_from_db()
+    assert case.case_start_date_bs == "2080-09-18"
+    assert case.case_end_date_bs == "2080-10-01"
+
+
+@pytest.mark.django_db
 def test_patch_replace_timeline_item_title():
     user = _contributor("sita")
     case = _make_case(

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -136,6 +136,22 @@ def test_patch_replace_bs_dates_when_previously_unset():
 
 
 @pytest.mark.django_db
+def test_patch_rejects_malformed_bs_date():
+    """A malformed BS date (not YYYY-MM-DD) is rejected at API time (422)."""
+    user = _contributor("gopal")
+    case = _make_case()
+    case.contributors.add(user)
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/case_start_date_bs", "value": "2080/09/18"}],
+        format="json",
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
 def test_patch_replace_timeline_item_title():
     user = _contributor("sita")
     case = _make_case(


### PR DESCRIPTION
## BB-11 — Saving a BS date errors "can't replace a non-existent object 'case_start_date_bs'"  ·  BB-25 (data layer)

### Root cause
The `Case` model had **no** `case_start_date_bs` / `case_end_date_bs` columns. The case editor always emits `replace /case_start_date_bs` (and `/case_end_date_bs`), but the PATCH snapshot (`_build_snapshot`) lacked those keys, so `jsonpatch` raised `can't replace a non-existent object 'case_start_date_bs'` — **every** BS-date save failed (not just "previously unset"). It also meant a source-recorded BS date could never be stored or returned (BB-25).

### Fix
Add two optional `CharField` columns (BS is not Gregorian, so a string like `"2080-09-18"`, not a `DateField`) + migration, wired through the full patchable surface:
- **model** `cases/models.py` — `case_start_date_bs`, `case_end_date_bs` (`blank=True, null=True, max_length=10`)
- **migration** `0048_case_bs_dates.py`
- **read** `CaseSerializer.Meta.fields` — returned in the API
- **write** `CaseCreateSerializer` + `CasePatchSerializer` — accepted
- **persist** `_CREATE_MODEL_FIELDS` + `scalar_fields` — create/PATCH write them
- **snapshot** `_build_snapshot` — exposes the key (even when empty) so the `replace` op has a target

### Test
`test_patch_replace_bs_dates_when_previously_unset` patches both BS dates on a case that never had one (the exact previously-failing path) and asserts 200 + persistence.

### Notes / scope
- **BB-25 display half** (public page preferring a stored source BS over the AD-derived BS) is a **frontend follow-up**; this PR provides the data layer it needs.
- The hand-written migration matches the model field definitions (incl. `help_text`) so `makemigrations --check` stays clean.
- ⚠️ **pytest not run locally** (no Django toolchain here); `py_compile` clean, relies on CI.

Part of the Jawafdehi bug-bash backend batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional BS start and end date fields to case create, edit, and standard case responses.
  * JSON Patch updates now support setting these date fields even when they were previously empty.

* **Bug Fixes**
  * Fixed patch handling so replacing unset BS dates no longer fails due to missing snapshot values.

* **Tests**
  * Added coverage for updating BS dates through the patch endpoint and verifying persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->