### PR TITLE
fix(entities): allow @type edits to correct mis-typed entities (BB-10)

### DIFF
--- a/entities/tests/test_api.py
+++ b/entities/tests/test_api.py
@@ -272,12 +272,42 @@ class WritePlaneAuthTests(_DbAPITestCase):
     def test_patch_blocked_path_rejected(self):
         self.client.force_authenticate(user=self.contributor)
         self.client.post("/api/entities", _person_payload("blocked-patch"), format="json")
-        for blocked in ("/@id", "/@type", "/@context", "/jawafdehi:version"):
+        for blocked in ("/@id", "/@context", "/jawafdehi:version"):
             patch = {"patch_ops": [{"op": "replace", "path": blocked, "value": "x"}]}
             resp = self.client.patch("/api/entities/person/blocked-patch", patch, format="json")
             self.assertEqual(
                 resp.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY, msg=blocked
             )
+
+    def test_patch_type_is_editable(self):
+        # BB-10: a mis-typed entity must be correctable in place. @type is not
+        # part of the identity (prefix+slug is), so a PATCH may re-type it and the
+        # promoted ``entity_type`` is re-derived from the new @type.
+        self.client.force_authenticate(user=self.contributor)
+        self.client.post("/api/entities", _person_payload("mistyped"), format="json")
+        patch = {
+            "patch_ops": [{"op": "replace", "path": "/@type", "value": "Organization"}],
+            "change_description": "correct entity type",
+        }
+        resp = self.client.patch("/api/entities/person/mistyped", patch, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK, msg=resp.data)
+        self.assertEqual(resp.data["@type"], "Organization")
+        # Identity (the IRI) is unchanged — no reference breakage.
+        self.assertEqual(resp.data["@id"], _person_iri("mistyped"))
+        # The re-typed entity now surfaces under the corrected type filter.
+        by_type = self.client.get("/api/entities?entity_type=Organization")
+        self.assertIn(
+            _person_iri("mistyped"),
+            [e["@id"] for e in by_type.data["entities"]],
+        )
+
+    def test_patch_type_rejects_unknown_type(self):
+        # A re-type to a non-schema type is still rejected by validation.
+        self.client.force_authenticate(user=self.contributor)
+        self.client.post("/api/entities", _person_payload("retype-bad"), format="json")
+        patch = {"patch_ops": [{"op": "replace", "path": "/@type", "value": "Wizard"}]}
+        resp = self.client.patch("/api/entities/person/retype-bad", patch, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
 
 class BulkIngestServiceTests(_DbAPITestCase):

--- a/entities/write_validation.py
+++ b/entities/write_validation.py
@@ -39,13 +39,20 @@ JSONLD_CONTEXT: List[Any] = [
     },
 ]
 
-# JSON Pointer prefixes that may never be touched by a PATCH. The @id and @type
-# are the immutable identity/classification; @context/version provenance is
-# owned by the publication service.
+# JSON Pointer prefixes that may never be touched by a PATCH. The @id is the
+# immutable identity (the IRI is the join key other services store); @context and
+# version provenance are owned by the publication service.
+#
+# @type is intentionally NOT blocked (BB-10): a mis-typed entity (e.g. a Location
+# authored as a Person) must be correctable in place. @type is not part of the
+# IRI — the identity is prefix+slug (jawafdehi_shared.entities.ids), and the
+# promoted ``entity_type`` column is re-derived from the doc's @type on every
+# write — so a re-typed doc stays consistent and breaks no inbound references. The
+# patched doc is still re-run through ``validate_jsonld_entity``, which rejects an
+# unknown @type.
 PATCH_BLOCKED_PATH_PREFIXES = frozenset(
     {
         "/@id",
-        "/@type",
         "/@context",
         "/jawafdehi:version",
     }


### PR DESCRIPTION
## Bug
BB-10 (ADMIN / data-integrity): a mis-typed entity (e.g. a Location authored as a Person) could not be corrected — the entity `@type` was read-only, forcing a delete + recreate.

## Root cause
The RFC-6902 PATCH guard `PATCH_BLOCKED_PATH_PREFIXES` (`entities/write_validation.py`) blocked `/@type`, so any `replace /@type` returned 422. `@type` was grouped with `@id` as "immutable identity/classification".

## Why it's safe to allow
`@type` is **not** part of the entity identity — the IRI is `entity/<prefix>/<slug>` (`jawafdehi_shared/entities/ids.py`), and the promoted `entity_type` column is **re-derived from the doc `@type` on every write** (`persistence.update_entity` → `primary_type`). So a re-typed doc:
- keeps the same `@id` → **breaks no inbound references** (other services join on the IRI),
- gets its `entity_type` filter column refreshed automatically,
- is still re-run through `validate_jsonld_entity`, which rejects an unknown `@type`.

## Change
- Remove `/@type` from `PATCH_BLOCKED_PATH_PREFIXES` (`@id`/`@context`/version stay blocked).
- Tests: `@type` PATCH succeeds, IRI unchanged, entity now surfaces under the corrected `entity_type` filter; unknown `@type` still 422; existing blocked-path test updated.

Note: the IRI *path segment* (`.../entity/location/...`) still reads the original prefix for a re-typed entity — cosmetic only (prefix is not authoritative for type). Fully re-minting the IRI + migrating references is a separate, heavier story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PATCH updates can now change an entity’s type while keeping the same entity ID.
  * Updated entity-type filtering to reflect the new type after a retype operation.

* **Bug Fixes**
  * Tightened PATCH validation so identity, context, and version fields remain protected.
  * Continued to reject invalid retype attempts to unknown or unsupported types with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->