### PR TITLE
fix(entities): bridge Devanagari<->Latin in admin entity search (BB-12)

### DIFF
--- a/entities/persistence.py
+++ b/entities/persistence.py
@@ -442,9 +442,14 @@ def _search_forms(text: str) -> frozenset:
     low = (text or "").strip().lower()
     if low:
         forms.update(low.split())
-    roman = to_roman_colloquial(text or "").strip().lower()
-    if roman:
-        forms.update(roman.split())
+        # Skip transliteration for plain ASCII text: it is already Latin, so
+        # ``to_roman_colloquial`` is a no-op cost on the hot path (called per
+        # candidate, up to MAX_SEARCH_CANDIDATES). Only non-ASCII (Devanagari,
+        # IAST/ITRANS diacritics) needs script bridging.
+        if not low.isascii():
+            roman = to_roman_colloquial(text).strip().lower()
+            if roman:
+                forms.update(roman.split())
     return frozenset(forms)
 
 

--- a/entities/persistence.py
+++ b/entities/persistence.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from functools import lru_cache
+
 from django.db import connections, router
 from django.db.models import Q, QuerySet
 from jawafdehi_shared.entities.ids import canonicalize_entity_iri, parse_entity_iri
+from jawafdehi_shared.search.transliterate import to_roman_colloquial
 
 from .models import HeldEntity, StoredAuthor, StoredEntity, StoredVersion
 from .validation import primary_type
@@ -275,6 +278,7 @@ class EntityRepository:
 
         # Textual query: score in Python over a CAPPED candidate set.
         needle = query.lower()
+        needle_forms = _search_forms(query)
         wanted = set(keywords) if (keywords and not keywords_pushed_down) else None
         candidates: List[Dict[str, Any]] = []
         for data in qs.values_list("data", flat=True)[:MAX_SEARCH_CANDIDATES].iterator():
@@ -282,7 +286,7 @@ class EntityRepository:
                 continue
             candidates.append(data)
 
-        scored = [(d, _relevance_score(d, needle)) for d in candidates]
+        scored = [(d, _relevance_score(d, needle, needle_forms)) for d in candidates]
         scored = [(d, s) for d, s in scored if s > 0]
         scored.sort(key=lambda x: (-x[1], x[0].get("@id", "")))
         return [d for d, _ in scored][offset : offset + limit]
@@ -418,32 +422,68 @@ class EntityRepository:
         }
 
 
-def _relevance_score(doc: Dict[str, Any], needle: str) -> float:
+@lru_cache(maxsize=8192)
+def _search_forms(text: str) -> frozenset:
+    """Lowercased word-tokens for a name or query, bridging scripts (BB-12).
+
+    Combines the raw lowercased words with a *colloquial romanization* of any
+    Devanagari — diacritics folded to plain ASCII, word-final schwa emitted both
+    kept and dropped — so a Latin query ("bharat") matches a Devanagari-stored
+    name ("भरत") and vice versa, and IAST/ITRANS spellings collapse to a common
+    ASCII form ("śarmā"/"sharma"). Mirrors the index-time romanization added for
+    case-title search in #272, applied here at query time because the admin
+    entity search has no OpenSearch backend and scores in Python.
+
+    Cached because the same stored names recur across searches. Only word-final
+    schwa is bridged (platform-wide v1 limitation in ``to_roman_colloquial``), so
+    a medial-schwa gap ("bhojraj" vs stored "bhojaraj") can still miss.
+    """
+    forms: set = set()
+    low = (text or "").strip().lower()
+    if low:
+        forms.update(low.split())
+    roman = to_roman_colloquial(text or "").strip().lower()
+    if roman:
+        forms.update(roman.split())
+    return frozenset(forms)
+
+
+def _relevance_score(
+    doc: Dict[str, Any], needle: str, needle_forms: frozenset
+) -> float:
     """Lightweight name/keyword relevance for the no-backend fallback search.
 
     Scores over the JSON-LD ``name``/``alternateName`` (string or language map)
-    and ``keywords``.
+    and ``keywords``. Name matching is token-based over romanization-normalized
+    forms (see :func:`_search_forms`): each query token scores ``weight_exact``
+    on a whole-token hit or ``weight_sub`` when it is a substring of a stored
+    token (partial typing). ``keywords`` stay a raw substring match on the query.
     """
     score = 0.0
 
     def _score_name(value: Any, weight_exact: float, weight_sub: float) -> float:
-        s = 0.0
-        texts: List[str] = []
+        text_forms: set = set()
         if isinstance(value, str):
-            texts = [value]
+            text_forms |= _search_forms(value)
         elif isinstance(value, dict):
-            texts = [v for v in value.values() if isinstance(v, str)]
+            for v in value.values():
+                if isinstance(v, str):
+                    text_forms |= _search_forms(v)
         elif isinstance(value, list):
             for item in value:
                 if isinstance(item, str):
-                    texts.append(item)
+                    text_forms |= _search_forms(item)
                 elif isinstance(item, dict):
-                    texts.extend(v for v in item.values() if isinstance(v, str))
-        for t in texts:
-            low = t.lower()
-            if low == needle:
+                    for v in item.values():
+                        if isinstance(v, str):
+                            text_forms |= _search_forms(v)
+        if not text_forms:
+            return 0.0
+        s = 0.0
+        for n in needle_forms:
+            if n in text_forms:
                 s += weight_exact
-            elif needle in low:
+            elif any(n in t for t in text_forms):
                 s += weight_sub
         return s
 

--- a/entities/tests/test_api.py
+++ b/entities/tests/test_api.py
@@ -174,6 +174,59 @@ class SearchAndCountTests(_DbAPITestCase):
         self.assertGreaterEqual(len(resp.data["entities"]), 1)
 
 
+class RomanizedEntitySearchTests(_DbAPITestCase):
+    """BB-12: admin entity search must bridge Devanagari <-> Latin spellings.
+
+    The admin ``GET /api/entities?query=`` scores in Python (no OpenSearch
+    backend). Before the fix it was a raw case-insensitive substring match, so a
+    Latin query could never reach a Devanagari-stored name (and vice versa).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from entities.persistence import EntityRepository
+        from entities.write_validation import normalize_authoring_payload
+
+        cls.repo = EntityRepository()
+
+        def _seed(slug, name):
+            doc = normalize_authoring_payload(
+                {"prefix": "person", "slug": slug, "type": "Person", "name": name}
+            )
+            cls.repo.put_entity(doc, version=1, created_at=_now())
+            return doc["@id"]
+
+        cls.bharat = _seed("bharat-devanagari", {"ne": "भरत ताल"})
+        cls.sunila = _seed("sunila-devanagari", {"ne": "सुनिला पौडेल"})
+        cls.sharma = _seed("sharma-devanagari", {"ne": "शर्मा"})
+
+    def _ids(self, query):
+        from urllib.parse import quote
+
+        resp = self.client.get(f"/api/entities?query={quote(query)}")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        return [e["@id"] for e in resp.data["entities"]]
+
+    def test_latin_query_finds_devanagari_name(self):
+        # Word-final schwa: typed "bharat" reaches stored "भरत" (IAST "bharata").
+        self.assertIn(self.bharat, self._ids("bharat"))
+
+    def test_latin_token_finds_devanagari_multiword_name(self):
+        self.assertIn(self.sunila, self._ids("sunila"))
+        self.assertIn(self.sunila, self._ids("paudel"))
+
+    def test_devanagari_query_finds_devanagari_name(self):
+        # Same-script native query still works (raw form retained).
+        self.assertIn(self.bharat, self._ids("भरत"))
+
+    def test_sibilant_name_matched_by_colloquial_spelling(self):
+        # शर्मा romanizes (IAST "śarmā") to the colloquial spelling "sharma".
+        self.assertIn(self.sharma, self._ids("sharma"))
+
+    def test_unrelated_query_does_not_match(self):
+        self.assertNotIn(self.bharat, self._ids("kathmandu"))
+
+
 class WritePlaneAuthTests(_DbAPITestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
## Bug
BB-12 (SEARCH / admin): admin entity search returned no results for names like `sunila pauDela` / `bhojraj` — Devanagari-stored names were unreachable from Latin queries and vice versa.

## Root cause
There are two entity-search paths. The public unified search (OpenSearch `nes-entities` index) already got colloquial romanization for free via #272 (which fixed the shared indexer). But the **admin/authoring** path — `GET /api/entities?query=` → `EntityRepository.search_entities` → `_relevance_score` (`entities/persistence.py`) — has **no search backend** and scores in Python with a raw case-insensitive **substring** match. It applied **zero transliteration** on either side, so cross-script queries never matched.

## Change
- Normalize both the query and the stored `name`/`alternateName` through the shared `to_roman_colloquial` (Devanagari→colloquial Latin, diacritics folded, word-final schwa kept + dropped) before matching — the same recall bridge #272 applied at index time for cases.
- Match per token so partial typing still hits (`weight_exact` on a whole-token hit, `weight_sub` on a substring). Keyword matching unchanged.
- Normalization is `lru_cache`d (stored names recur across searches).

## Tests
Latin query finds Devanagari name (word-final schwa), Latin token finds a multi-word Devanagari name, native-script query still works, sibilant `शर्मा` matched by `sharma`, unrelated query doesn't match.

## Known limitation (documented in code)
Only **word-final** schwa is bridged (a platform-wide v1 limitation in `to_roman_colloquial`), so a **medial**-schwa gap (`bhojraj` vs stored `bhojaraj`) can still miss. Fixing that is a separate transliteration-layer change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now better matches names written in different scripts, including romanized and non-ASCII text.
  * Multiword queries can find results even when stored names use a different script or transliteration.

* **Bug Fixes**
  * Improved search relevance so exact token matches rank ahead of looser partial matches.
  * Reduced missed results for names entered in common romanized forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->