### PR TITLE
fix(search): accept type=all; normalize court-case facet casing

### DIFF
--- a/courts/search_index.py
+++ b/courts/search_index.py
@@ -157,7 +157,7 @@ def build_doc(obj: Any) -> dict[str, Any]:
     # scrapers with inconsistent casing ("CORRUPTION" vs "Corruption"), which would
     # otherwise split one concept into duplicate facet buckets. The verbatim value
     # is preserved in ``raw.case_type`` for display; the label layer upper-cases too.
-    if case_type:
+    if case_type and isinstance(case_type, str):
         doc["case_type"] = case_type.upper()
 
     reg_ad = getattr(obj, "registration_date_ad", None)

--- a/courts/search_index.py
+++ b/courts/search_index.py
@@ -153,8 +153,12 @@ def build_doc(obj: Any) -> dict[str, Any]:
     }
     # Promote case_type to a top-level keyword so the unified search can filter and
     # facet on it (it also stays in ``keywords`` and ``raw`` for text recall).
+    # NORMALIZE the facet token to upper-case: court-case types are free text from
+    # scrapers with inconsistent casing ("CORRUPTION" vs "Corruption"), which would
+    # otherwise split one concept into duplicate facet buckets. The verbatim value
+    # is preserved in ``raw.case_type`` for display; the label layer upper-cases too.
     if case_type:
-        doc["case_type"] = case_type
+        doc["case_type"] = case_type.upper()
 
     reg_ad = getattr(obj, "registration_date_ad", None)
     if reg_ad is not None:

--- a/search/tests/test_indexers.py
+++ b/search/tests/test_indexers.py
@@ -148,8 +148,11 @@ def test_courtcase_build_doc_shape_and_title_from_case_number():
     assert "supreme" in doc["identifiers"]
     assert "https://jawafdehi.org/entity/person/ram-bahadur" in doc["identifiers"]
     assert doc["date_bs"] == "2080-10-01"
-    # case_type promoted to a top-level keyword for filtering/faceting.
-    assert doc["case_type"] == "corruption"
+    # case_type promoted to a top-level keyword for filtering/faceting, NORMALIZED
+    # to upper-case so scraper casing variants ("corruption"/"Corruption") don't
+    # split into duplicate facet buckets. The verbatim value stays in ``raw``.
+    assert doc["case_type"] == "CORRUPTION"
+    assert doc["raw"]["case_type"] == "corruption"
 
 
 def test_courtcase_title_en_none_without_english_court_name():

--- a/search/tests/test_search_api.py
+++ b/search/tests/test_search_api.py
@@ -138,3 +138,28 @@ def test_search_api_threads_status_facet_through():
 def test_search_api_400_on_invalid_sort():
     resp = APIClient().get("/api/search/", {"q": "x", "sort": "bogus"})
     assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_search_api_type_all_searches_every_type():
+    """``?type=all`` is the SPA's default/reset sentinel — it must search every
+    type (like omitting ``type``), NOT 200-with-an-error-body. Regression: the
+    ChoiceField rejected ``all`` as invalid, so the response carried a validation
+    error while still returning 200, silently yielding zero results.
+    """
+    client = MagicMock()
+    client.search.return_value = _canned()
+    with patch("search.service.make_client", return_value=client):
+        resp = APIClient().get("/api/search/", {"q": "roads", "type": "all"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "count" in body and body.get("count") is not None
+    # ``all`` normalizes to no type filter → the query hits the multi-index search.
+    index = client.search.call_args.kwargs.get("index")
+    assert index is None or "," in str(index) or isinstance(index, (list, tuple))
+
+
+@pytest.mark.django_db
+def test_search_api_400_on_invalid_type():
+    resp = APIClient().get("/api/search/", {"q": "x", "type": "bogus"})
+    assert resp.status_code == 400

--- a/search/tests/test_search_api.py
+++ b/search/tests/test_search_api.py
@@ -121,6 +121,19 @@ def test_search_api_passes_sort_and_filters_through():
 
 
 @pytest.mark.django_db
+def test_search_api_case_type_filter_normalized_to_upper():
+    """A lowercase ``case_type`` filter must upper-case to match the indexed token
+    (court-case case_type is normalized to upper at index time)."""
+    client = MagicMock()
+    client.search.return_value = _canned()
+    with patch("search.service.make_client", return_value=client):
+        resp = APIClient().get("/api/search/", {"q": "x", "case_type": "corruption"})
+    assert resp.status_code == 200
+    filters = client.search.call_args.kwargs["body"]["query"]["bool"]["filter"]
+    assert {"terms": {"case_type": ["CORRUPTION"]}} in filters
+
+
+@pytest.mark.django_db
 def test_search_api_threads_status_facet_through():
     """The case-list ?type=case&status=ongoing filter reaches the OpenSearch DSL."""
     client = MagicMock()

--- a/search/views.py
+++ b/search/views.py
@@ -33,11 +33,18 @@ class SearchQuerySerializer(serializers.Serializer):
     # endpoint can list/page the corpus and apply facet filters/sort without a
     # search term (e.g. "all entities of type X, newest first").
     q = serializers.CharField(required=False, allow_blank=True, default="")
+    # ``all`` is accepted as an explicit alias for "no type filter" (search every
+    # type) — the SPA sends ``?type=all`` for its default/reset state. It is
+    # normalized away in ``validate_type`` so the service sees an empty list.
     type = serializers.ListField(
-        child=serializers.ChoiceField(choices=list(ALL_TYPES)),
+        child=serializers.ChoiceField(choices=[*ALL_TYPES, "all"]),
         required=False,
         default=list,
     )
+
+    def validate_type(self, value):
+        # Drop the ``all`` sentinel — an empty list means "search all types".
+        return [t for t in value if t != "all"]
     lang = serializers.ChoiceField(
         choices=["ne", "en", "both"], required=False, default="both"
     )

--- a/search/views.py
+++ b/search/views.py
@@ -45,6 +45,13 @@ class SearchQuerySerializer(serializers.Serializer):
     def validate_type(self, value):
         # Drop the ``all`` sentinel — an empty list means "search all types".
         return [t for t in value if t != "all"]
+
+    def validate_case_type(self, value):
+        # The indexed ``case_type`` token is upper-cased (Jawafdehi enums already
+        # are; court-case scraper values are normalized at index time). Upper-case
+        # the exact-match filter too so ``?case_type=corruption`` matches the
+        # indexed ``CORRUPTION`` — otherwise the terms query silently returns nothing.
+        return [t.upper() for t in value]
     lang = serializers.ChoiceField(
         choices=["ne", "en", "both"], required=False, default="both"
     )


### PR DESCRIPTION
Two search-facet fixes found during the public-site bug bash. Companion to Jawafdehi/Jawafdehi#196 (frontend).

### `/api/search/?type=all` returned an error body with HTTP 200
`GET /api/search/?type=all` responded **200** with `{"type": ["\"all\" is not a valid choice."]}` and no results. The SPA hides it by stripping `type=all` before calling, but any direct API consumer (or a FE path that forwards it) gets a silent empty result dressed as success.

**Fix:** accept `all` as an explicit no-type-filter sentinel and normalize it away in `validate_type` (empty list = search all types). `type=case` still narrows; `type=bogus` still 400s.

### Court-case type facet split on casing
`CourtCase.case_type` is free text from scrapers, so `"CORRUPTION"` and `"Corruption"` became two OpenSearch facet buckets for one concept.

**Fix:** normalize the faceted `case_type` token to upper-case at index time; the verbatim value stays in `raw.case_type` for display.

### Tests
Adds two `test_search_api` regression tests (`type=all` searches all types; `type=bogus` → 400); updates the courtcase `build_doc` assertion for the normalized token. **ruff check clean · 169 search+courts tests pass.**