### PR TITLE
feat(entities): warn on machine-transliterated (IAST) name.en

### DIFF
--- a/entities/tests/test_iast_name_guard.py
+++ b/entities/tests/test_iast_name_guard.py
@@ -1,0 +1,98 @@
+"""Tests for the IAST/machine-transliteration warning on entity name.en.
+
+The guard is LOG-ONLY: validate_jsonld_entity never rejects on a bad en, it just
+warns so a regression (a new bulk load reintroducing raw transliterations) is
+visible. These tests pin the detector's accuracy (catches the signature, no
+false positives on real English/mixed-case names) and that the warning fires
+without failing validation.
+"""
+
+import logging
+
+import pytest
+
+from entities.validation import (
+    JsonLdValidationError,
+    looks_like_iast,
+    validate_jsonld_entity,
+)
+
+# Real machine-transliterations pulled from the prod data set — must be flagged.
+IAST_NAMES = [
+    "nArAyaNI aspatAla",              # Harvard-Kyoto, नारायणी अस्पताल
+    "kAThamADauM mahAnagarapAlikA",   # काठमाडौं महानगरपालिका
+    "nepAla rASTra baiMka",           # नेपाल राष्ट्र बैंक
+    "artha mantrAlaya",               # अर्थ मन्त्रालय
+    "padmA marcenTa kampanI",         # पद्मा मर्चेन्ट कम्पनी
+    "janakapuradhAma",                # जनकपुरधाम
+    "vibhAga",                        # विभाग
+    "Nārāyaṇī",                       # academic IAST diacritics
+    "Sindhupālchok",                  # single diacritic
+    "sA~da",                          # anusvara tilde
+]
+
+# Legitimate English / clean romanization / mixed-case — must NOT be flagged.
+GOOD_NAMES = [
+    "Narayani Hospital",
+    "Kathmandu Metropolitan City",
+    "Nepal Rastra Bank",
+    "Ram Chandra Poudel",
+    "Lakshmi B.K.",
+    "Office of the Attorney General",
+    "Ward No. 3 Office, Fungling Municipality",
+    "Tribhuvan University",
+    "AsiaInfo Yunghang Software (Beijing) Limited",  # CamelCase brand
+    "UOB Singapore Bank",                            # ALLCAPS acronym
+    "McMahon Associates",                            # intra-word capital
+    "O'Brien Trust",
+    "iPhone Store Nepal",
+]
+
+
+@pytest.mark.parametrize("name", IAST_NAMES)
+def test_detects_transliterated_names(name):
+    assert looks_like_iast(name) is True
+
+
+@pytest.mark.parametrize("name", GOOD_NAMES)
+def test_passes_legitimate_names(name):
+    assert looks_like_iast(name) is False
+
+
+def test_non_string_is_not_iast():
+    assert looks_like_iast(None) is False
+    assert looks_like_iast({"en": "x"}) is False
+    assert looks_like_iast(123) is False
+
+
+def _doc(en):
+    return {
+        "@context": "https://schema.org",
+        "@id": "https://jawafdehi.org/entity/organization/narayani-hospital-x1",
+        "@type": "Hospital",
+        "name": {"ne": "नारायणी अस्पताल", "en": en},
+    }
+
+
+def test_iast_en_warns_but_does_not_reject(caplog):
+    """A transliterated en logs a warning yet validation still succeeds."""
+    doc = _doc("nArAyaNI aspatAla")
+    with caplog.at_level(logging.WARNING, logger="entities.validation"):
+        result = validate_jsonld_entity(doc)
+    assert result is doc  # not rejected
+    assert any("machine-transliterated" in r.message for r in caplog.records)
+
+
+def test_clean_en_does_not_warn(caplog):
+    doc = _doc("Narayani Hospital")
+    with caplog.at_level(logging.WARNING, logger="entities.validation"):
+        validate_jsonld_entity(doc)
+    assert not any("machine-transliterated" in r.message for r in caplog.records)
+
+
+def test_missing_name_still_raises():
+    """The pre-existing name-required rule is unchanged by the guard."""
+    doc = _doc("Narayani Hospital")
+    del doc["name"]
+    with pytest.raises(JsonLdValidationError):
+        validate_jsonld_entity(doc)

--- a/entities/validation.py
+++ b/entities/validation.py
@@ -42,7 +42,7 @@ _IAST_DIACRITICS = re.compile(r"[āīūṛṝḷḹṅñṭḍṇśṣṃḥĀĪ
 # start means real English mixed-case tokens (CamelCase "AsiaInfo", "McMahon",
 # "iPhone"; Titlecase; ALLCAPS "UOB") never match — chosen to be false-positive
 # free because this drives a log warning, not a hard rejection.
-_HK_TOKEN = re.compile(r"^[a-z]+[AIUEMR]([a-z]|$)")
+_HK_TOKEN = re.compile(r"^[a-z]+[AIU]([a-z]|$)")
 # Anusvara/nasal tilde between letters (sA~da, kAThamADau~).
 _HK_TILDE = re.compile(r"[a-zA-Z]~[a-zA-Z]")
 _TOKEN_SPLIT = re.compile(r"[\s,()]+")

--- a/entities/validation.py
+++ b/entities/validation.py
@@ -13,9 +13,54 @@ Everything else in the document is free-form JSON-LD and is stored verbatim.
 
 from __future__ import annotations
 
+import logging
+import re
 from typing import Any, Dict, List
 
 from jawafdehi_shared.entities.ids import is_valid_entity_iri
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# IAST / machine-transliteration detection for English names
+# ---------------------------------------------------------------------------
+# Historic bulk loads populated ``name.en`` with a raw character-level
+# transliteration of the Devanagari instead of a real English name — either
+# academic IAST (diacritics: नारायणी → "Nārāyaṇī") or Harvard-Kyoto/ITRANS
+# (long vowels marked by mid-word capitals: नारायणी अस्पताल → "nArAyaNI
+# aspatAla"). A proper English name TRANSLATES generic nouns (अस्पताल→Hospital)
+# and romanizes proper nouns cleanly ("Narayani Hospital"). We can't verify the
+# latter here, but we CAN cheaply spot the machine-transliteration signature and
+# warn, so a regression (a new load reintroducing it) is visible in the logs
+# rather than silent. This is observability only — it never blocks a write.
+
+# Academic IAST diacritics / accented Latin used by transliteration schemes.
+_IAST_DIACRITICS = re.compile(r"[āīūṛṝḷḹṅñṭḍṇśṣṃḥĀĪŪṚṜḶḸṄÑṬḌṆŚṢṂḤ]")
+# Harvard-Kyoto / ITRANS long-vowel + anusvara markers, matched PER TOKEN: an
+# otherwise all-lowercase token carrying an embedded/final capital A I U E M R
+# (aspatAla, baiMka, nArAyaNI, padmA, kampanI). Anchoring to a lowercase-run
+# start means real English mixed-case tokens (CamelCase "AsiaInfo", "McMahon",
+# "iPhone"; Titlecase; ALLCAPS "UOB") never match — chosen to be false-positive
+# free because this drives a log warning, not a hard rejection.
+_HK_TOKEN = re.compile(r"^[a-z]+[AIUEMR]([a-z]|$)")
+# Anusvara/nasal tilde between letters (sA~da, kAThamADau~).
+_HK_TILDE = re.compile(r"[a-zA-Z]~[a-zA-Z]")
+_TOKEN_SPLIT = re.compile(r"[\s,()]+")
+
+
+def looks_like_iast(value: Any) -> bool:
+    """True if a name string carries a machine-transliteration signature.
+
+    Detects academic IAST diacritics and Harvard-Kyoto/ITRANS capital-vowel
+    markers — the hallmark of a romanized-not-translated ``en`` name. Used for a
+    log-only warning during validation; not a hard rule. Tuned to be
+    false-positive free on legitimate English/mixed-case names.
+    """
+    if not isinstance(value, str):
+        return False
+    if _IAST_DIACRITICS.search(value) or _HK_TILDE.search(value):
+        return True
+    return any(_HK_TOKEN.search(tok) for tok in _TOKEN_SPLIT.split(value))
 
 # ---------------------------------------------------------------------------
 # Known @type vocabulary
@@ -132,7 +177,27 @@ def validate_jsonld_entity(doc: Any) -> Dict[str, Any]:
             "name is required (a string or a non-empty language map)."
         )
 
+    # name.en quality — log-only warning if it carries a machine-transliteration
+    # signature (IAST diacritics / Harvard-Kyoto capital-vowel markers). This is
+    # NOT a hard rule: it never blocks the write, only surfaces a likely-bad
+    # English name in the logs so a regression is caught. A backfill fixes the
+    # value properly; see docs / the entity-en normalization mutation set.
+    _warn_if_iast_en(doc)
+
     return doc
+
+
+def _warn_if_iast_en(doc: Dict[str, Any]) -> None:
+    """Emit a warning when ``name.en`` looks like a raw transliteration."""
+    name = doc.get("name")
+    en = name.get("en") if isinstance(name, dict) else None
+    if looks_like_iast(en):
+        logger.warning(
+            "entity %s has a machine-transliterated name.en (%r) — likely IAST/"
+            "Harvard-Kyoto, not a real English name; needs backfill.",
+            doc.get("@id"),
+            en,
+        )
 
 
 def primary_type(doc: Dict[str, Any]) -> str:


### PR DESCRIPTION
## What
Historic bulk loads populated schema.org `name.en` with raw **character-level transliterations** of the Devanagari instead of real English names — academic IAST (`नारायणी` → `Nārāyaṇī`) or Harvard-Kyoto/ITRANS (`नारायणी अस्पताल` → `nArAyaNI aspatAla`). `validate_jsonld_entity` now detects that signature and **logs a warning** so a regression (a new load reintroducing it) is visible.

## Design
- **Log-only**, never blocks a write — a bad `en` still validates; the warning surfaces it for a backfill to fix.
- `looks_like_iast()` is tuned **false-positive free**: flags IAST diacritics, anusvara tilde, or an otherwise-lowercase token with an embedded/final long-vowel capital (A I U E M R). Legitimate English/mixed-case names (AsiaInfo, McMahon, UOB, iPhone, B.K.) are untouched.
- Wired into the single choke point (`validate_jsonld_entity`) that both bulk-ingest and the entity PATCH view already call.

## Tests
27 cases: real IAST/HK strings flagged, legit English/mixed-case pass, warning fires without failing validation, existing name-required rule unchanged. Full entities suite (95) green.

## Context
Companion to a one-off mutation set that corrects the ~116k already-bad `name.en` values on prod, and to the `backfill_entity_en` generator command (separate PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when English `name` values appear to be transliterated, helping catch likely data-entry issues earlier.
  * Improved validation coverage so clean names still pass, non-string values are ignored by the check, and missing required fields continue to fail as before.
* **Tests**
  * Added test coverage for transliteration detection, warning behavior, and existing validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->