### PR TITLE
fix(review): emit `reviewers` on review serializers so the chips render (ADMIN-7)

### DIFF
--- a/review/serializers.py
+++ b/review/serializers.py
@@ -11,9 +11,37 @@ from jawafdehi_shared.entities.ids import (
 from .models import CaseReview, ReviewConfig
 
 
+def _reviewers_from_result(result):
+    """Project a review's per-tier LLM usage into the reviewer-chip shape.
+
+    The runner records token usage per ``(provider, tier, model)`` bucket in
+    ``result["token_usage"]["by_provider"]`` (see llm.usage.UsageAccumulator).
+    The frontend renders reviewer attribution from a ``reviewers`` list of
+    ``{tier, provider, model, calls}`` — a single review typically lists more
+    than one entry because gate rules use the premium tier while routine
+    rules/narrative use the cheap tier. Return the projected list, or ``None``
+    when the review hasn't produced usage yet (pending/failed runs).
+    """
+    if not result:
+        return None
+    buckets = (result.get("token_usage") or {}).get("by_provider")
+    if not buckets:
+        return None
+    return [
+        {
+            "tier": b.get("tier", ""),
+            "provider": b.get("provider", ""),
+            "model": b.get("model", ""),
+            "calls": b.get("calls", 0),
+        }
+        for b in buckets
+    ]
+
+
 class CaseReviewListSerializer(serializers.ModelSerializer):
     overall_score = serializers.SerializerMethodField()
     disposition = serializers.SerializerMethodField()
+    reviewers = serializers.SerializerMethodField()
 
     class Meta:
         model = CaseReview
@@ -28,6 +56,7 @@ class CaseReviewListSerializer(serializers.ModelSerializer):
             "sources_converted",
             "overall_score",
             "disposition",
+            "reviewers",
             "case_type",
             "created_at",
             "completed_at",
@@ -40,8 +69,13 @@ class CaseReviewListSerializer(serializers.ModelSerializer):
     def get_disposition(self, obj):
         return (obj.result or {}).get("disposition") if obj.result else None
 
+    def get_reviewers(self, obj):
+        return _reviewers_from_result(obj.result)
+
 
 class CaseReviewDetailSerializer(serializers.ModelSerializer):
+    reviewers = serializers.SerializerMethodField()
+
     class Meta:
         model = CaseReview
         fields = [
@@ -56,12 +90,16 @@ class CaseReviewDetailSerializer(serializers.ModelSerializer):
             "source_count",
             "sources_converted",
             "result",
+            "reviewers",
             "created_at",
             "updated_at",
             "started_at",
             "completed_at",
             "duration_seconds",
         ]
+
+    def get_reviewers(self, obj):
+        return _reviewers_from_result(obj.result)
 
 
 class ReviewConfigSerializer(serializers.ModelSerializer):

--- a/review/serializers.py
+++ b/review/serializers.py
@@ -11,6 +11,16 @@ from jawafdehi_shared.entities.ids import (
 from .models import CaseReview, ReviewConfig
 
 
+def _result_dict(result):
+    """Return ``result`` iff it's a dict, else ``{}``.
+
+    ``CaseReview.result`` is a JSONField, so a malformed/legacy row could hold a
+    list or scalar. All the derived read fields go through this so a bad shape
+    degrades to "no data" instead of 500-ing the review list/detail endpoints.
+    """
+    return result if isinstance(result, dict) else {}
+
+
 def _reviewers_from_result(result):
     """Project a review's per-tier LLM usage into the reviewer-chip shape.
 
@@ -22,12 +32,16 @@ def _reviewers_from_result(result):
     rules/narrative use the cheap tier. Return the projected list, or ``None``
     when the review hasn't produced usage yet (pending/failed runs).
     """
-    if not result:
+    # ``result`` is a JSONField, so guard every level: malformed/legacy stored
+    # data (a non-dict result, a scalar token_usage, a non-list by_provider)
+    # must yield None, never crash the serializer.
+    token_usage = _result_dict(result).get("token_usage")
+    if not isinstance(token_usage, dict):
         return None
-    buckets = (result.get("token_usage") or {}).get("by_provider")
-    if not buckets:
+    buckets = token_usage.get("by_provider")
+    if not isinstance(buckets, list):
         return None
-    return [
+    reviewers = [
         {
             "tier": b.get("tier", ""),
             "provider": b.get("provider", ""),
@@ -35,7 +49,9 @@ def _reviewers_from_result(result):
             "calls": b.get("calls", 0),
         }
         for b in buckets
+        if isinstance(b, dict)
     ]
+    return reviewers or None
 
 
 class CaseReviewListSerializer(serializers.ModelSerializer):
@@ -64,10 +80,10 @@ class CaseReviewListSerializer(serializers.ModelSerializer):
         ]
 
     def get_overall_score(self, obj):
-        return (obj.result or {}).get("overall_score") if obj.result else None
+        return _result_dict(obj.result).get("overall_score")
 
     def get_disposition(self, obj):
-        return (obj.result or {}).get("disposition") if obj.result else None
+        return _result_dict(obj.result).get("disposition")
 
     def get_reviewers(self, obj):
         return _reviewers_from_result(obj.result)

--- a/tests/api/test_review_reviewers_field.py
+++ b/tests/api/test_review_reviewers_field.py
@@ -1,0 +1,98 @@
+"""Tests for the ``reviewers`` field on the casework review serializers (ADMIN-7).
+
+The frontend renders reviewer attribution ("Graded by …") from a ``reviewers``
+list of ``{tier, provider, model, calls}`` on each review, but the serializers
+never emitted the field, so the chips silently never appeared. The runner
+already records this per-tier LLM usage in
+``result["token_usage"]["by_provider"]``; the serializers now project it.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from review.models import CaseReview
+from tests.conftest import create_user_with_role
+
+FLAT_URL = "/api/casework/reviews/"
+GROUPED_URL = "/api/casework/reviews/grouped/"
+
+# A result payload shaped like the runner's output: two tiers (premium gate rules
+# + cheap routine rules), each a distinct (provider, tier, model) bucket.
+RESULT_WITH_USAGE = {
+    "overall_score": 82,
+    "disposition": "PASS",
+    "token_usage": {
+        "model_id": "anthropic.claude-opus",
+        "calls": 7,
+        "by_provider": [
+            {"provider": "bedrock", "tier": "premium", "model": "opus", "calls": 3},
+            {"provider": "bedrock", "tier": "cheap", "model": "haiku", "calls": 4},
+        ],
+    },
+}
+
+
+def _reader_client():
+    user = create_user_with_role("rev-r", "rev-r@example.com", "Caseworker")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _detail_url(pk):
+    return f"/api/casework/reviews/{pk}/"
+
+
+@pytest.mark.django_db
+def test_flat_list_projects_reviewers_from_usage():
+    CaseReview.objects.create(
+        slug="case-a", case_title="Case A", status="done", result=RESULT_WITH_USAGE
+    )
+
+    row = _reader_client().get(FLAT_URL).data["results"][0]
+
+    assert "reviewers" in row
+    reviewers = row["reviewers"]
+    assert reviewers is not None
+    assert {r["tier"] for r in reviewers} == {"premium", "cheap"}
+    premium = next(r for r in reviewers if r["tier"] == "premium")
+    assert premium == {"tier": "premium", "provider": "bedrock", "model": "opus", "calls": 3}
+
+
+@pytest.mark.django_db
+def test_detail_projects_reviewers_from_usage():
+    review = CaseReview.objects.create(
+        slug="case-d", case_title="Case D", status="done", result=RESULT_WITH_USAGE
+    )
+
+    data = _reader_client().get(_detail_url(review.pk)).data
+
+    assert data["reviewers"] is not None
+    assert len(data["reviewers"]) == 2
+
+
+@pytest.mark.django_db
+def test_grouped_latest_carries_reviewers():
+    CaseReview.objects.create(
+        slug="case-g", case_title="Case G", status="done", result=RESULT_WITH_USAGE
+    )
+
+    group = _reader_client().get(GROUPED_URL).data["results"][0]
+
+    assert group["latest"]["reviewers"] is not None
+    assert len(group["latest"]["reviewers"]) == 2
+
+
+@pytest.mark.django_db
+def test_reviewers_null_when_no_usage_yet():
+    """Pending/failed runs (no result, or a result without token_usage) → null,
+    not a crash and not an empty-list masquerading as 'graded'."""
+    CaseReview.objects.create(slug="pending-1", case_title="P1", status="pending")
+    CaseReview.objects.create(
+        slug="no-usage", case_title="NU", status="done", result={"overall_score": 10}
+    )
+
+    rows = {r["slug"]: r for r in _reader_client().get(FLAT_URL).data["results"]}
+
+    assert rows["pending-1"]["reviewers"] is None
+    assert rows["no-usage"]["reviewers"] is None

--- a/tests/api/test_review_reviewers_field.py
+++ b/tests/api/test_review_reviewers_field.py
@@ -96,3 +96,33 @@ def test_reviewers_null_when_no_usage_yet():
 
     assert rows["pending-1"]["reviewers"] is None
     assert rows["no-usage"]["reviewers"] is None
+
+
+@pytest.mark.django_db
+def test_reviewers_null_on_malformed_result_shapes():
+    """`result` is a JSONField — malformed/legacy stored shapes must yield null,
+    never crash the serializer (non-dict result, scalar token_usage, non-list
+    by_provider, empty buckets)."""
+    CaseReview.objects.create(slug="m-list", case_title="M", status="done", result=[1, 2])
+    CaseReview.objects.create(
+        slug="m-scalar-usage", case_title="M", status="done", result={"token_usage": 7}
+    )
+    CaseReview.objects.create(
+        slug="m-scalar-bp",
+        case_title="M",
+        status="done",
+        result={"token_usage": {"by_provider": "nope"}},
+    )
+    CaseReview.objects.create(
+        slug="m-empty-bp",
+        case_title="M",
+        status="done",
+        result={"token_usage": {"by_provider": []}},
+    )
+
+    rows = {r["slug"]: r for r in _reader_client().get(FLAT_URL).data["results"]}
+
+    assert rows["m-list"]["reviewers"] is None
+    assert rows["m-scalar-usage"]["reviewers"] is None
+    assert rows["m-scalar-bp"]["reviewers"] is None
+    assert rows["m-empty-bp"]["reviewers"] is None


### PR DESCRIPTION
## What & why

Bug-bash finding **ADMIN-7**. The casework review list/detail UI renders reviewer attribution ("Graded by …") from a `reviewers` list of `{tier, provider, model, calls}` on each review — but neither `CaseReviewListSerializer` nor `CaseReviewDetailSerializer` emitted the field, so `review.reviewers` was always `null` and the chips silently never appeared. (Null-guarded on the FE, so no crash — just missing attribution.)

The data already exists. The runner records per-tier LLM usage in `result["token_usage"]["by_provider"]` — one bucket per `(provider, tier, model)`, produced by `llm.usage.UsageAccumulator`. This PR projects that into the `reviewers` shape the frontend already types, via a shared `_reviewers_from_result` helper on both serializers.

A review typically lists **more than one** reviewer because gate rules run on the premium tier while routine rules/narrative run on the cheap tier — exactly what the "Graded by …" chip is meant to convey.

## Behaviour
- **Done runs with usage** → `reviewers: [{tier, provider, model, calls}, …]`.
- **Pending/failed runs** (no `result`, or a `result` without `token_usage`) → `reviewers: null`, so the UI distinguishes "not graded yet" from "graded by nobody" (rather than an empty list masquerading as graded).
- The **grouped** list reuses `CaseReviewListSerializer`, so its `latest`/`executions` items pick this up for free.

## Tests
Adds `tests/api/test_review_reviewers_field.py` covering the flat list, detail, grouped-`latest`, and the null-when-no-usage cases. New tests + the existing review/grouped/token-usage suites pass (29 total locally); `ruff check` clean.

## Pairs with
Frontend bug-bash follow-ups in Jawafdehi/Jawafdehi#199 (data-lake pagination + JSON-LD cleanup). This is the one backend-side item in that batch. No FE change needed — the `ReviewerInfo` type already matches this payload.