### PR TITLE
review(search): address post-merge PR feedback on case card enrichment

### DIFF
--- a/cases/search_index.py
+++ b/cases/search_index.py
@@ -106,7 +106,12 @@ def _safe_resolve_entities(case: Any) -> list[dict[str, Any]]:
         resolved = resolve_entities(rel.nes_id for rel in relationships)
     except Exception:  # noqa: BLE001 — best-effort; index without names on failure.
         resolved = {}
-    return build_entity_binds(relationships, resolved)
+    # build_entity_binds is inside the guard too: a corrupt relationship row
+    # (missing nes_id/relationship_type) must not crash the best-effort indexer.
+    try:
+        return build_entity_binds(relationships, resolved)
+    except (AttributeError, TypeError):
+        return []
 
 
 def build_doc(case: Any, *, entities: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -199,6 +204,9 @@ def build_doc(case: Any, *, entities: list[dict[str, Any]] | None = None) -> dic
     # there, which must not blend into a case lifecycle facet.
     case_status = _derive_status(case)
     doc["case_status"] = case_status
+    # Also in ``raw`` so ``_serialize_hit`` surfaces it as ``extra.case_status``
+    # (the SPA's non-card fallback for a hit's lifecycle).
+    doc["raw"]["case_status"] = case_status
 
     # Card payload: everything the SPA case card/list renders, denormalized so a
     # search hit needs no follow-up call to /api/cases/{slug}/. Lives under ``raw``

--- a/search/tests/test_indexer_index_calls.py
+++ b/search/tests/test_indexer_index_calls.py
@@ -148,3 +148,20 @@ def test_case_index_survives_entity_resolution_failure(monkeypatch):
     entity = kwargs["body"]["raw"]["card"]["entities"][0]
     assert entity["display_name"] is None
     assert entity["type"] == "accused"
+
+
+def test_case_index_survives_corrupt_relationship_row(monkeypatch):
+    """A relationship row missing expected attrs must not crash the best-effort
+    indexer — the case is still indexed, with empty entities."""
+    corrupt = SimpleNamespace()  # no nes_id / relationship_type
+    case = _case("PUBLISHED")
+    case.entity_relationships = SimpleNamespace(all=lambda: [corrupt])
+    monkeypatch.setattr(
+        "cases.services.nes_resolver.resolve_entities", lambda ids: {}
+    )
+
+    client = MagicMock()
+    case_index.index(case, client=client)
+    client.index.assert_called_once()
+    _, kwargs = client.index.call_args
+    assert kwargs["body"]["raw"]["card"]["entities"] == []

--- a/search/tests/test_indexers.py
+++ b/search/tests/test_indexers.py
@@ -257,6 +257,13 @@ def test_case_build_doc_status_ongoing_closed_others():
     assert others["case_status"] == "others"
 
 
+def test_case_build_doc_mirrors_case_status_into_raw():
+    """``raw.case_status`` must be set so ``_serialize_hit`` can surface it as
+    ``extra.case_status`` (the SPA's non-card lifecycle fallback)."""
+    doc = case_index.build_doc(_card_case())
+    assert doc["raw"]["case_status"] == doc["case_status"] == "ongoing"
+
+
 def test_build_indexed_doc_resolves_entities_for_bulk_path(monkeypatch):
     """The bulk/live wrapper resolves NES names so a rebuild refreshes (not blanks)
     the card entities — the pure build_doc alone would leave them empty."""


### PR DESCRIPTION
Follow-up to #294 (merged) addressing the bot review comments that landed after merge.

## Fixes

1. **`raw.case_status` was never written** (CodeRabbit, Major). `_serialize_hit()` reads `raw.case_status` to populate `extra.case_status`, but `build_doc()` only set the top-level `case_status` and `raw.card.status` — so `extra.case_status` was always empty for case hits. Now mirrored into `raw`. (The SPA's non-card fallback reads `extra.case_status`.)
2. **`build_entity_binds` was outside the best-effort guard** (Gemini, High). A corrupt relationship row (missing `nes_id`/`relationship_type`) would propagate and crash the best-effort indexer. Now wrapped, falling back to empty entities.

## Tests

- `raw.case_status` mirrors the top-level `case_status`.
- A corrupt relationship row leaves `card.entities` empty instead of crashing `index()`.

`search/` + `cases/` suites green (117 passed), ruff clean. Rebased on current `main` (composes cleanly with the BB-04 `include_notes` change to `build_entity_binds`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The case search index now handles malformed relationship data more gracefully, allowing indexing to continue even when some relationship details are missing or invalid.
  * Case status is now included in the indexed raw record as well as the main indexed fields, improving consistency in search results.

* **Tests**
  * Added coverage for indexing cases with corrupt relationship rows.
  * Added a test to verify case status is mirrored into the raw search payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->