### PR TITLE
chore(sentry): skip init on dev / local / test environments

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -50,13 +50,21 @@ load_dotenv()
 configure_structlog()
 
 _sentry_dsn = os.getenv("SENTRY_DSN")
-if _sentry_dsn:
+_sentry_environment = os.getenv("SENTRY_ENVIRONMENT", "production")
+# Belt-and-suspenders: never ship events from local / dev runs even if a DSN
+# leaked into a developer's .env. Prod sets SENTRY_ENVIRONMENT=production.
+if _sentry_dsn and _sentry_environment.strip().lower() not in {
+    "local",
+    "dev",
+    "development",
+    "test",
+}:
     sentry_sdk.init(
         dsn=_sentry_dsn,
         integrations=[DjangoIntegration()],
         traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "1.0")),
         send_default_pii=False,
-        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+        environment=_sentry_environment,
     )
 
 


### PR DESCRIPTION
## What
Skip Sentry initialization when `SENTRY_ENVIRONMENT` names a non-production environment, even if a DSN is present.

## Why
Defense-in-depth. `main` already only inits Sentry when `SENTRY_DSN` is set, so local dev without a DSN is already silent — this guards the case where a prod-like DSN is copied into a developer `.env`.

## How
`config/settings.py`: init only when `_sentry_dsn` is set **and** `SENTRY_ENVIRONMENT` is not one of `local` / `dev` / `development` / `test`. Prod sets `SENTRY_ENVIRONMENT=production` (from the `jawafdehi-api-env` secret) and is unaffected.

`workers.dev` does not apply here — the API is a Django server, so the axis is environment, not host.

`py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
