### PR TITLE
feat(newsletter): support SendPulse static API key auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,15 @@ DEV_AUTH=true
 FRONTEND_PORT=40114
 # Newsletter → SendPulse ESP. Leave these UNSET to run without a live ESP: the
 # subscribe endpoint then accepts requests (HTTP 202) and logs them instead of
-# 500-ing, so the flow is testable before the account is provisioned. Set all
-# three to enable live subscribe against a SendPulse address book. (Unsubscribe is
-# handled by SendPulse's own hosted link in emails — the backend owns no route.)
+# 500-ing, so the flow is testable before the account is provisioned. (Unsubscribe
+# is handled by SendPulse's own hosted link in emails — the backend owns no route.)
+#
+# Auth, pick ONE. Simplest is a static API key used directly as a Bearer token:
+SENDPULSE_API_KEY=
+# ...or the classic OAuth client-credentials pair (ignored when API_KEY is set):
 SENDPULSE_CLIENT_ID=
 SENDPULSE_CLIENT_SECRET=
+# Required for either auth mode — the address book to subscribe into:
 SENDPULSE_ADDRESSBOOK_ID=
 # Optional: outbound SendPulse request timeout (seconds).
 # SENDPULSE_TIMEOUT_SECONDS=5

--- a/config/settings.py
+++ b/config/settings.py
@@ -835,7 +835,12 @@ if not DEBUG:
 # these are unset (not yet provisioned, or under CI) the subscribe endpoint still
 # accepts requests (HTTP 202) and logs them — the flow degrades gracefully rather
 # than 500-ing.
+#
+# Auth is either a static SENDPULSE_API_KEY (preferred: one secret, used directly
+# as a Bearer token, no OAuth exchange) or the classic SENDPULSE_CLIENT_ID /
+# _CLIENT_SECRET pair. An address book id is required for both.
 # ---------------------------------------------------------------------------
+SENDPULSE_API_KEY = os.getenv("SENDPULSE_API_KEY", "")
 SENDPULSE_CLIENT_ID = os.getenv("SENDPULSE_CLIENT_ID", "")
 SENDPULSE_CLIENT_SECRET = os.getenv("SENDPULSE_CLIENT_SECRET", "")
 SENDPULSE_ADDRESSBOOK_ID = os.getenv("SENDPULSE_ADDRESSBOOK_ID", "")

--- a/newsletter/sendpulse.py
+++ b/newsletter/sendpulse.py
@@ -3,19 +3,26 @@
 SendPulse is the newsletter system of record: it stores subscribers, runs the
 double opt-in confirmation email, hosts the unsubscribe link in its emails, and
 owns list membership. This module wraps the address-book add call the subscribe
-endpoint needs, plus OAuth token caching.
+endpoint needs, plus SendPulse auth (a static API key used directly as a Bearer,
+or the OAuth client-credentials flow with token caching).
 
 Design notes
 ------------
-- **Config-gated.** When the ``SENDPULSE_*`` settings are unset (e.g. before the
-  ESP is provisioned, or in CI), :func:`get_client` returns ``None`` and the
-  views degrade gracefully rather than 500. This keeps the endpoints deployable
-  and fully testable before credentials land.
+- **Two auth modes.** SendPulse accepts either a static API key (newer scheme:
+  ``Authorization: Bearer <sp_apikey_...>``, no token exchange) or the classic
+  OAuth ``client_credentials`` pair. When ``SENDPULSE_API_KEY`` is set it is used
+  directly and the OAuth round-trip / token cache are skipped entirely; otherwise
+  the client falls back to ``SENDPULSE_CLIENT_ID`` / ``_CLIENT_SECRET``.
+- **Config-gated.** When neither auth mode is configured (e.g. before the ESP is
+  provisioned, or in CI), :func:`get_client` returns ``None`` and the views
+  degrade gracefully rather than 500. This keeps the endpoints deployable and
+  fully testable before credentials land.
 - **Short timeouts.** Every request uses a small timeout so a slow/500 SendPulse
   can't hang a user's subscribe. Callers translate failures into a graceful
   ``202`` (the record is accepted; SendPulse sync is retried out of band).
-- **Token cache.** The OAuth access token is cached in Django's cache under a
-  fixed key until shortly before it expires; a 401 forces a one-shot refresh.
+- **Token cache.** In OAuth mode the access token is cached in Django's cache
+  under a fixed key until shortly before it expires; a 401 forces a one-shot
+  refresh. A static API key is long-lived, so it is never cached or refreshed.
 - **No PII logged.** Errors log status codes and SendPulse error bodies, never the
   subscriber's email address.
 """
@@ -54,11 +61,13 @@ class SendPulseError(Exception):
 class SendPulseClient:
     """Minimal SendPulse Marketing API client (address-book membership only)."""
 
-    def __init__(self, client_id: str, client_secret: str, addressbook_id: str,
+    def __init__(self, addressbook_id: str, *, api_key: str = "",
+                 client_id: str = "", client_secret: str = "",
                  timeout: float = _DEFAULT_TIMEOUT_SECONDS):
+        self._addressbook_id = addressbook_id
+        self._api_key = api_key
         self._client_id = client_id
         self._client_secret = client_secret
-        self._addressbook_id = addressbook_id
         self._timeout = timeout
 
     # -- auth ---------------------------------------------------------------
@@ -89,6 +98,9 @@ class SendPulseClient:
         return token
 
     def _token(self, *, force_refresh: bool = False) -> str:
+        # Static API key: use it verbatim, no exchange/cache/refresh.
+        if self._api_key:
+            return self._api_key
         if not force_refresh:
             cached = cache.get(_TOKEN_CACHE_KEY)
             if cached:
@@ -96,7 +108,11 @@ class SendPulseClient:
         return self._fetch_token()
 
     def _request(self, method: str, path: str, *, json: Optional[dict] = None) -> requests.Response:
-        """Issue an authenticated request, refreshing the token once on 401."""
+        """Issue an authenticated request, refreshing the token once on 401.
+
+        A 401 refresh only helps in OAuth mode (an expired access token); a static
+        API key would just be re-sent unchanged, so the retry is skipped for it.
+        """
         token = self._token()
         resp = requests.request(
             method,
@@ -105,7 +121,7 @@ class SendPulseClient:
             headers={"Authorization": f"Bearer {token}"},
             timeout=self._timeout,
         )
-        if resp.status_code == 401:
+        if resp.status_code == 401 and not self._api_key:
             token = self._token(force_refresh=True)
             resp = requests.request(
                 method,
@@ -152,11 +168,23 @@ def get_client() -> Optional[SendPulseClient]:
 
     Views must treat ``None`` as "ESP not wired yet" and degrade gracefully — the
     subscription is still accepted so the flow works end-to-end before creds land.
+
+    Auth is configured by either a static ``SENDPULSE_API_KEY`` (preferred: one
+    secret, no token exchange) or the OAuth ``SENDPULSE_CLIENT_ID`` /
+    ``_CLIENT_SECRET`` pair. An address book id is required for both.
     """
+    api_key = getattr(settings, "SENDPULSE_API_KEY", "") or ""
     client_id = getattr(settings, "SENDPULSE_CLIENT_ID", "") or ""
     client_secret = getattr(settings, "SENDPULSE_CLIENT_SECRET", "") or ""
     addressbook_id = getattr(settings, "SENDPULSE_ADDRESSBOOK_ID", "") or ""
-    if not (client_id and client_secret and addressbook_id):
+    has_auth = bool(api_key) or bool(client_id and client_secret)
+    if not (addressbook_id and has_auth):
         return None
     timeout = float(getattr(settings, "SENDPULSE_TIMEOUT_SECONDS", _DEFAULT_TIMEOUT_SECONDS))
-    return SendPulseClient(client_id, client_secret, addressbook_id, timeout=timeout)
+    return SendPulseClient(
+        addressbook_id,
+        api_key=api_key,
+        client_id=client_id,
+        client_secret=client_secret,
+        timeout=timeout,
+    )

--- a/newsletter/sendpulse.py
+++ b/newsletter/sendpulse.py
@@ -173,10 +173,12 @@ def get_client() -> Optional[SendPulseClient]:
     secret, no token exchange) or the OAuth ``SENDPULSE_CLIENT_ID`` /
     ``_CLIENT_SECRET`` pair. An address book id is required for both.
     """
-    api_key = getattr(settings, "SENDPULSE_API_KEY", "") or ""
-    client_id = getattr(settings, "SENDPULSE_CLIENT_ID", "") or ""
-    client_secret = getattr(settings, "SENDPULSE_CLIENT_SECRET", "") or ""
-    addressbook_id = getattr(settings, "SENDPULSE_ADDRESSBOOK_ID", "") or ""
+    # str()+strip(): tolerate an int address book id and drop stray whitespace/
+    # newlines a copy-pasted key or a Bao→env round-trip can leave on the value.
+    api_key = str(getattr(settings, "SENDPULSE_API_KEY", "") or "").strip()
+    client_id = str(getattr(settings, "SENDPULSE_CLIENT_ID", "") or "").strip()
+    client_secret = str(getattr(settings, "SENDPULSE_CLIENT_SECRET", "") or "").strip()
+    addressbook_id = str(getattr(settings, "SENDPULSE_ADDRESSBOOK_ID", "") or "").strip()
     has_auth = bool(api_key) or bool(client_id and client_secret)
     if not (addressbook_id and has_auth):
         return None

--- a/newsletter/tests/test_sendpulse.py
+++ b/newsletter/tests/test_sendpulse.py
@@ -126,3 +126,43 @@ def test_oauth_mode_fetches_and_uses_token(mock_request, mock_post, settings):
     _, kwargs = mock_request.call_args
     assert kwargs["headers"]["Authorization"] == "Bearer tok_abc"
     cache.clear()
+
+
+@mock.patch("newsletter.sendpulse.requests.post")
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_oauth_mode_retries_once_on_401(mock_request, mock_post):
+    """A cached-but-rejected token: the 401 forces one refresh and one retry."""
+    from django.core.cache import cache
+
+    from newsletter.sendpulse import _TOKEN_CACHE_KEY
+
+    # Seed a stale token so the first request uses it (no fetch); the 401 is what
+    # drives the single refresh — the branch this test guards.
+    cache.set(_TOKEN_CACHE_KEY, "tok_stale", 3600)
+    token_resp = mock.Mock()
+    token_resp.status_code = 200
+    token_resp.json.return_value = {"access_token": "tok_fresh", "expires_in": 3600}
+    mock_post.return_value = token_resp
+    mock_request.side_effect = [_ok(401), _ok(201)]
+
+    client = SendPulseClient("719648", client_id="id", client_secret="secret")
+    client.add_subscriber("reader@example.org")
+
+    assert mock_request.call_count == 2  # initial 401 + retry
+    mock_post.assert_called_once()  # exactly one token refresh (no initial fetch)
+    first_headers = mock_request.call_args_list[0].kwargs["headers"]
+    retry_headers = mock_request.call_args_list[1].kwargs["headers"]
+    assert first_headers["Authorization"] == "Bearer tok_stale"
+    assert retry_headers["Authorization"] == "Bearer tok_fresh"
+    cache.clear()
+
+
+def test_get_client_strips_whitespace(settings):
+    """A key with stray whitespace (copy-paste / env round-trip) is trimmed."""
+    settings.SENDPULSE_API_KEY = "  sp_apikey_test\n"
+    settings.SENDPULSE_CLIENT_ID = ""
+    settings.SENDPULSE_CLIENT_SECRET = ""
+    settings.SENDPULSE_ADDRESSBOOK_ID = " 719648 "
+    c = get_client()
+    assert c._api_key == "sp_apikey_test"
+    assert c._addressbook_id == "719648"

--- a/newsletter/tests/test_sendpulse.py
+++ b/newsletter/tests/test_sendpulse.py
@@ -1,0 +1,128 @@
+"""Auth-mode tests for the SendPulse client.
+
+Complements ``test_api.py`` (which mocks the client at the view layer) by
+exercising :mod:`newsletter.sendpulse` itself: the config-gating in
+:func:`get_client` and, critically, that a static ``SENDPULSE_API_KEY`` is sent
+as a Bearer token *without* the OAuth ``/oauth/access_token`` round-trip.
+"""
+
+from unittest import mock
+
+import pytest
+
+from newsletter.sendpulse import SendPulseClient, SendPulseError, get_client
+
+pytestmark = pytest.mark.django_db  # get_client reads cache in the OAuth path
+
+
+def _ok(status=201):
+    resp = mock.Mock()
+    resp.status_code = status
+    resp.text = ""
+    return resp
+
+
+# -- get_client config-gating ------------------------------------------------
+
+
+def test_get_client_none_when_unconfigured(settings):
+    settings.SENDPULSE_API_KEY = ""
+    settings.SENDPULSE_CLIENT_ID = ""
+    settings.SENDPULSE_CLIENT_SECRET = ""
+    settings.SENDPULSE_ADDRESSBOOK_ID = ""
+    assert get_client() is None
+
+
+def test_get_client_prefers_static_api_key(settings):
+    settings.SENDPULSE_API_KEY = "sp_apikey_test"
+    settings.SENDPULSE_CLIENT_ID = ""
+    settings.SENDPULSE_CLIENT_SECRET = ""
+    settings.SENDPULSE_ADDRESSBOOK_ID = "719648"
+    c = get_client()
+    assert isinstance(c, SendPulseClient)
+    assert c._api_key == "sp_apikey_test"
+
+
+def test_get_client_falls_back_to_oauth_pair(settings):
+    settings.SENDPULSE_API_KEY = ""
+    settings.SENDPULSE_CLIENT_ID = "id"
+    settings.SENDPULSE_CLIENT_SECRET = "secret"
+    settings.SENDPULSE_ADDRESSBOOK_ID = "719648"
+    c = get_client()
+    assert isinstance(c, SendPulseClient)
+    assert c._api_key == ""
+    assert c._client_id == "id"
+
+
+def test_get_client_requires_addressbook(settings):
+    """Auth alone isn't enough — without an address book there's nowhere to add."""
+    settings.SENDPULSE_API_KEY = "sp_apikey_test"
+    settings.SENDPULSE_ADDRESSBOOK_ID = ""
+    assert get_client() is None
+
+
+def test_get_client_requires_full_oauth_pair(settings):
+    """A half-configured OAuth pair (id without secret) is not usable."""
+    settings.SENDPULSE_API_KEY = ""
+    settings.SENDPULSE_CLIENT_ID = "id"
+    settings.SENDPULSE_CLIENT_SECRET = ""
+    settings.SENDPULSE_ADDRESSBOOK_ID = "719648"
+    assert get_client() is None
+
+
+# -- static-key request path -------------------------------------------------
+
+
+@mock.patch("newsletter.sendpulse.requests.post")
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_static_key_sends_bearer_and_skips_oauth(mock_request, mock_post):
+    """The API key goes out as a Bearer header; the token endpoint is never hit."""
+    mock_request.return_value = _ok(201)
+    client = SendPulseClient("719648", api_key="sp_apikey_test")
+
+    client.add_subscriber("reader@example.org", variables={"consent_source": "x"})
+
+    mock_post.assert_not_called()  # no /oauth/access_token exchange
+    mock_request.assert_called_once()
+    _, kwargs = mock_request.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer sp_apikey_test"
+    args, _ = mock_request.call_args
+    assert args[0] == "POST"
+    assert args[1].endswith("/addressbooks/719648/emails")
+
+
+@mock.patch("newsletter.sendpulse.requests.post")
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_static_key_does_not_retry_on_401(mock_request, mock_post):
+    """A 401 refresh only helps OAuth; a static key is re-sent as-is, so no retry."""
+    mock_request.return_value = _ok(401)
+    client = SendPulseClient("719648", api_key="sp_apikey_test")
+
+    with pytest.raises(SendPulseError) as exc:
+        client.add_subscriber("reader@example.org")
+
+    assert exc.value.status == 401
+    mock_request.assert_called_once()  # not retried
+    mock_post.assert_not_called()
+
+
+@mock.patch("newsletter.sendpulse.requests.post")
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_oauth_mode_fetches_and_uses_token(mock_request, mock_post, settings):
+    """Without an API key, the client exchanges id/secret for a Bearer token."""
+    from django.core.cache import cache
+
+    cache.clear()
+    token_resp = mock.Mock()
+    token_resp.status_code = 200
+    token_resp.json.return_value = {"access_token": "tok_abc", "expires_in": 3600}
+    mock_post.return_value = token_resp
+    mock_request.return_value = _ok(201)
+
+    client = SendPulseClient("719648", client_id="id", client_secret="secret")
+    client.add_subscriber("reader@example.org")
+
+    mock_post.assert_called_once()  # token exchange happened
+    _, kwargs = mock_request.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer tok_abc"
+    cache.clear()


### PR DESCRIPTION
## What & why

Follow-up to #310. The merged newsletter proxy authenticates to SendPulse via the **OAuth `client_credentials`** flow (`client_id`/`secret` → `/oauth/access_token` → Bearer). But the credential we have provisioned is SendPulse's **newer static API key** (`sp_apikey_…`) — the same key already used for the 2026-07-06 audience import — which is used **directly as a Bearer token, no OAuth exchange**.

Rather than mint and store a second OAuth credential, this adds a static-key auth mode so the existing key drives the endpoint.

## Changes

- **`newsletter/sendpulse.py`** — `SendPulseClient` takes an optional `api_key`. When set, `_token()` returns it verbatim (no `/oauth/access_token` call, no token cache), and a 401 is **not** retried (re-sending an unchanged key can't help; OAuth is the only mode a refresh helps). `get_client()` now enables when an address book id is present **and** either an `api_key` **or** a full `client_id`/`secret` pair is configured — OAuth stays as a fallback, so this is backward compatible.
- **`config/settings.py`** — new `SENDPULSE_API_KEY` env setting.
- **`.env.example`** — document the two auth modes (static key preferred).
- **`newsletter/tests/test_sendpulse.py`** — 8 new tests: `get_client` config-gating (unconfigured→None, static-key preferred, OAuth fallback, requires address book, requires full OAuth pair) and the request path (static key → `Authorization: Bearer <key>` with the token endpoint never called; static-key 401 not retried; OAuth mode fetches+uses a token).

## Testing

`newsletter/` suite green locally (**17 passed**), `ruff check` clean. No migrations (still model-less).

## Deploy note (not in this PR)

Once merged and the `:main` image rolls, the two keys land via Bao `kv/jawafdehi/platform/env` (`SENDPULSE_API_KEY` = the existing `sendpulse/api` value, `SENDPULSE_ADDRESSBOOK_ID` = `719648` "Newsletter — External"), which `platform-env` ExternalSecret already pulls wholesale — no manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SendPulse API key authentication using a Bearer token.
  * Retained OAuth client-credentials authentication as an alternative.
  * API key authentication now takes precedence when both methods are configured.

* **Bug Fixes**
  * Improved authentication handling and retry behavior for failed requests.
  * Added validation for required newsletter configuration.

* **Documentation**
  * Updated environment configuration guidance to explain the available authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->