### PR TITLE
fix(materials): key NKP @id on stable detail_id + fix ld+json 406

### DIFF
--- a/materials/sourcing/nkp/crawl.py
+++ b/materials/sourcing/nkp/crawl.py
@@ -238,7 +238,11 @@ class MaterialApiClient:
 
         self.url = api_base.rstrip("/") + "/api/materials/"
         self.s = requests.Session()
-        self.s.headers.update({"Accept": "application/ld+json"})
+        # The material API serves JSON-LD-shaped bodies through DRF's JSONRenderer
+        # (media type application/json) — it does not register an
+        # application/ld+json renderer, so asking only for ld+json fails content
+        # negotiation with 406. Accept plain JSON (the wire shape is identical).
+        self.s.headers.update({"Accept": "application/json"})
         if token:
             self.s.headers["Authorization"] = f"Bearer {token}"
 

--- a/materials/sourcing/nkp/shaper.py
+++ b/materials/sourcing/nkp/shaper.py
@@ -11,6 +11,7 @@ crawler under ``materials/sourcing/nkp/`` — the home for external-source shape
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from jawafdehi_shared.dates import bs_to_ad_iso
@@ -27,15 +28,38 @@ from materials.jsonld import (
 NKP_SOURCE = "nkp"
 
 
-def nkp_precedent_material_iri(decision_no: str) -> str:
-    """Canonical material ``@id`` IRI for an NKP law-journal precedent.
+def nkp_precedent_ident(decision: dict[str, Any]) -> str:
+    """Stable, unique ident for an NKP precedent's ``@id``.
 
-    ident is the citable decision number (निर्णय नं.) — unique across the journal
-    and stable across re-scrapes — so the IRI is reconstructable from the record
-    (``11376`` → ``https://<base>/material/nkp/11376``).
+    Keyed on the site's own ``detail_id`` (the ``/full_detail/{id}`` row id) — the
+    only per-decision stable primary key on nkp.gov.np. The citable decision
+    number (निर्णय नं.) is NOT unique: ~57 numbers are reused across the corpus
+    (a fresh sequence per volume/era), so keying the ``@id`` on it would upsert
+    genuinely-distinct precedents onto one row and silently lose them.
+
+    Fallback: if a record has no ``detail_id`` (none do in the current corpus —
+    purely defensive), mint an artificial ``jawa-<hash>`` ident deterministically
+    from the decision's identifying fields, so a re-scrape reproduces the same
+    ``@id`` (idempotent upsert) rather than duplicating the row.
     """
-    ident = str(decision_no).strip().lower()
-    return build_material_iri(NKP_SOURCE, ident)
+    detail_id = str(decision.get("detail_id") or "").strip().lower()
+    if detail_id:
+        return detail_id
+    basis = "|".join(
+        str(decision.get(k) or "")
+        for k in ("decision_no", "year_bs", "month", "case_name", "source_url")
+    )
+    digest = hashlib.sha1(basis.encode("utf-8")).hexdigest()[:12]
+    return f"jawa-{digest}"
+
+
+def nkp_precedent_material_iri(ident: str) -> str:
+    """Canonical material ``@id`` IRI for an NKP precedent from its stable ident.
+
+    ``ident`` is :func:`nkp_precedent_ident` (the site ``detail_id`` or a
+    ``jawa-<hash>`` fallback) — e.g. ``8880`` → ``https://<base>/material/nkp/8880``.
+    """
+    return build_material_iri(NKP_SOURCE, str(ident).strip().lower())
 
 
 def nkp_decision_to_jsonld(decision: dict[str, Any]) -> tuple[dict[str, Any], str]:
@@ -51,8 +75,10 @@ def nkp_decision_to_jsonld(decision: dict[str, Any]) -> tuple[dict[str, Any], st
     plus its ``material_type`` (the crawler is the API client).
     """
     material_type = MaterialType.PRECEDENT
+    # @id keys on the site's stable detail_id (see nkp_precedent_ident); the human
+    # decision number (निर्णय नं.) is carried as ``identifier`` but is NOT unique.
     decision_no = decision.get("decision_no") or decision.get("detail_id")
-    iri = nkp_precedent_material_iri(decision_no)
+    iri = nkp_precedent_material_iri(nkp_precedent_ident(decision))
     schema_type, additional_type = type_for(material_type)
 
     name = decision.get("title") or f"निर्णय नं. {decision_no}"

--- a/materials/tests/test_nkp_ingest.py
+++ b/materials/tests/test_nkp_ingest.py
@@ -26,6 +26,7 @@ from materials.jsonld import (
 from materials.models import Material
 from materials.sourcing.nkp.shaper import (
     nkp_decision_to_jsonld,
+    nkp_precedent_ident,
     nkp_precedent_material_iri,
 )
 
@@ -84,11 +85,37 @@ class NkpShapeTests(_NgmTestCase):
         self.assertEqual(material_type, MaterialType.PRECEDENT)
         self.assertIsInstance(doc, dict)
 
-    def test_iri_is_valid_and_keyed_on_decision_no(self):
+    def test_iri_is_valid_and_keyed_on_detail_id(self):
+        # @id keys on the site's stable detail_id (10471), NOT the decision number
+        # (निर्णय नं. 11376) — decision numbers are reused across the corpus.
         doc, _ = nkp_decision_to_jsonld(_DECISION)
-        self.assertEqual(doc["@id"], "https://jawafdehi.org/material/nkp/11376")
+        self.assertEqual(doc["@id"], "https://jawafdehi.org/material/nkp/10471")
         self.assertTrue(is_valid_material_iri(doc["@id"]))
-        self.assertEqual(doc["@id"], nkp_precedent_material_iri("11376"))
+        self.assertEqual(doc["@id"], nkp_precedent_material_iri("10471"))
+        # The human decision number is still carried as identifier.
+        self.assertEqual(doc["identifier"], "11376")
+
+    def test_reused_decision_no_yields_distinct_ids(self):
+        # Two genuinely-different decisions that share a decision number must NOT
+        # collapse onto one @id — the detail_id keeps them distinct.
+        a = dict(_DECISION, detail_id="4276", decision_no="5", case_name="A")
+        b = dict(_DECISION, detail_id="4277", decision_no="5", case_name="B")
+        doc_a, _ = nkp_decision_to_jsonld(a)
+        doc_b, _ = nkp_decision_to_jsonld(b)
+        self.assertNotEqual(doc_a["@id"], doc_b["@id"])
+        self.assertEqual(doc_a["@id"], "https://jawafdehi.org/material/nkp/4276")
+        self.assertEqual(doc_b["@id"], "https://jawafdehi.org/material/nkp/4277")
+
+    def test_missing_detail_id_falls_back_to_stable_jawa_ident(self):
+        # No detail_id (defensive — none in the current corpus): mint a
+        # deterministic jawa-<hash> so a re-scrape reproduces the same @id.
+        d = {k: v for k, v in _DECISION.items() if k != "detail_id"}
+        ident = nkp_precedent_ident(d)
+        self.assertTrue(ident.startswith("jawa-"))
+        self.assertEqual(ident, nkp_precedent_ident(dict(d)))  # deterministic
+        doc, _ = nkp_decision_to_jsonld(d)
+        self.assertTrue(is_valid_material_iri(doc["@id"]))
+        self.assertEqual(doc["@id"], nkp_precedent_material_iri(ident))
 
     def test_shaped_doc_validates(self):
         doc, _ = nkp_decision_to_jsonld(_DECISION)
@@ -163,7 +190,7 @@ class InferMaterialTypeTests(_NgmTestCase):
 class NkpApiIngestTests(_NgmTestCase):
     """Precedents source through the material API plane (POST /api/materials/)."""
 
-    _IRI = "https://jawafdehi.org/material/nkp/11376"
+    _IRI = "https://jawafdehi.org/material/nkp/10471"  # keyed on detail_id
 
     @classmethod
     def setUpTestData(cls):
@@ -264,7 +291,7 @@ class NkpCrawlerClientTests(_NgmTestCase):
         c.api = _FakeApi()
         self.assertTrue(c._post_decision(_DECISION))
         self.assertEqual(sent["material_type"], "precedent")
-        self.assertEqual(sent["doc"]["@id"], "https://jawafdehi.org/material/nkp/11376")
+        self.assertEqual(sent["doc"]["@id"], "https://jawafdehi.org/material/nkp/10471")
         self.assertEqual(c.posted_count, 1)
 
     def test_api_error_leaves_id_for_retry(self):


### PR DESCRIPTION
## Why

A pre-ingest **smoke test of the full 10,468-decision NKP cache through the material API plane** (the path added in #315) surfaced two data-integrity bugs that would have corrupted the production sourcing run. Fixing them before running against prod.

## 1. `@id` collision → silent data loss 🔴

The precedent `@id` was keyed on the **decision number** (निर्णय नं.), but that number is **reused across the corpus** — a fresh sequence per volume/era. In the scraped cache: **10,409 distinct decision numbers for 10,468 decisions** → 57 numbers shared by 2–3 decisions.

Since `POST /api/materials/` **upserts by `@id`**, ingesting the cache as-is would collapse **~59 genuinely-distinct precedents** onto ~57 rows and silently lose them. Verified these are real distinct decisions (different `detail_id`, year, and case name), not scrape duplicates.

**Fix:** key the `@id` on the site's own **`detail_id`** (the `/full_detail/{id}` row id) — unique 1:1 across the whole corpus (10,468/10,468 distinct, 0 missing). The human decision number is still carried as `identifier`. A record with no `detail_id` (none today — defensive) mints a deterministic `jawa-<hash>` ident so a re-scrape reproduces the same `@id` (idempotent upsert).

## 2. Content-negotiation 406 🔴

`MaterialApiClient` asked for `Accept: application/ld+json`, but the material API serves through DRF's `JSONRenderer` (`application/json`) with no `ld+json` renderer registered — so **every** POST failed with `406 Could not satisfy the request Accept header`. Accept `application/json` (identical wire shape).

## Verification (live, against local API)

- The two decisions sharing decision_no `5` now land as **distinct rows** (`/nkp/4276`, `/nkp/4277`) — no collapse.
- A 25-decision cache slice posts **25/25** through the fixed `MaterialApiClient`, all `detail_id`-keyed, all `precedent`, all indexed in OpenSearch.
- Tests: **+3** (collision-distinct, `jawa-` fallback, `identifier` carried); full materials suite **188 pass**; `ruff` clean.

Follow-up (not in this PR): run the crawler `--from-cache` against prod with an NGM token to source all 10,468.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API content negotiation to prevent HTTP 406 errors when submitting JSON-LD-shaped requests.
  - Stabilized precedent identifiers across re-scrapes by using source detail IDs.
  - Added deterministic fallback identifiers when detail IDs are unavailable.
  - Prevented identifier collisions when different decisions share the same decision number.

- **Tests**
  - Updated ingestion and crawler coverage for stable, detail-based identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->