### PR TITLE
feat(newsletter): SendPulse double opt-in (confirmation email) support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,11 @@ SENDPULSE_CLIENT_SECRET=
 SENDPULSE_ADDRESSBOOK_ID=
 # Optional: outbound SendPulse request timeout (seconds).
 # SENDPULSE_TIMEOUT_SECONDS=5
+# Double opt-in. Turn CONFIRMATION on AND set a verified SENDER_EMAIL to make
+# SendPulse send its confirmation email and hold the contact until they click.
+# TEMPLATE_ID is optional (SendPulse's default confirmation email is used when
+# empty). MESSAGE_LANG supports en/ru/ua/tr/es/pt only (no Nepali).
+SENDPULSE_CONFIRMATION=false
+SENDPULSE_SENDER_EMAIL=
+SENDPULSE_CONFIRMATION_TEMPLATE_ID=
+# SENDPULSE_MESSAGE_LANG=en

--- a/config/settings.py
+++ b/config/settings.py
@@ -845,6 +845,15 @@ SENDPULSE_CLIENT_ID = os.getenv("SENDPULSE_CLIENT_ID", "")
 SENDPULSE_CLIENT_SECRET = os.getenv("SENDPULSE_CLIENT_SECRET", "")
 SENDPULSE_ADDRESSBOOK_ID = os.getenv("SENDPULSE_ADDRESSBOOK_ID", "")
 SENDPULSE_TIMEOUT_SECONDS = float(os.getenv("SENDPULSE_TIMEOUT_SECONDS", "5"))
+# Double opt-in: when SENDPULSE_CONFIRMATION is on AND a (verified) sender is set,
+# SendPulse sends its confirmation email and holds the contact until they click.
+# SENDPULSE_CONFIRMATION_TEMPLATE_ID is optional (SendPulse's default confirmation
+# email is used until a custom template is moderated). message_lang has no Nepali
+# option, so the bilingual template covers Nepali readers.
+SENDPULSE_CONFIRMATION = env_flag("SENDPULSE_CONFIRMATION", False)
+SENDPULSE_SENDER_EMAIL = os.getenv("SENDPULSE_SENDER_EMAIL", "")
+SENDPULSE_CONFIRMATION_TEMPLATE_ID = os.getenv("SENDPULSE_CONFIRMATION_TEMPLATE_ID", "")
+SENDPULSE_MESSAGE_LANG = os.getenv("SENDPULSE_MESSAGE_LANG", "en")
 
 # ---------------------------------------------------------------------------
 # NES/NGM config. After the service consolidation NES and NGM run IN-PROCESS — the

--- a/newsletter/sendpulse.py
+++ b/newsletter/sendpulse.py
@@ -44,6 +44,13 @@ _TOKEN_CACHE_KEY = "newsletter:sendpulse:access_token"
 _TOKEN_EXPIRY_SKEW_SECONDS = 60
 _DEFAULT_TIMEOUT_SECONDS = 5.0
 
+# Languages SendPulse accepts for the double opt-in confirmation email's
+# ``message_lang``. Nepali is NOT supported, so ``ne`` (and anything else) falls
+# back to English — our confirmation template is bilingual, so Nepali readers can
+# still confirm.
+_SUPPORTED_MESSAGE_LANGS = frozenset({"en", "ru", "ua", "tr", "es", "pt"})
+_DEFAULT_MESSAGE_LANG = "en"
+
 
 class SendPulseError(Exception):
     """Raised when a SendPulse call fails after (at most) one token refresh.
@@ -63,11 +70,23 @@ class SendPulseClient:
 
     def __init__(self, addressbook_id: str, *, api_key: str = "",
                  client_id: str = "", client_secret: str = "",
+                 confirmation: bool = False, sender_email: str = "",
+                 confirmation_template_id: str = "",
+                 message_lang: str = _DEFAULT_MESSAGE_LANG,
                  timeout: float = _DEFAULT_TIMEOUT_SECONDS):
         self._addressbook_id = addressbook_id
         self._api_key = api_key
         self._client_id = client_id
         self._client_secret = client_secret
+        # Double opt-in: SendPulse sends its confirmation email and holds the
+        # contact as "confirmation requested" until they click. It REQUIRES a
+        # (verified) sender address, so DOI is only active when both are set.
+        self._doi = bool(confirmation and sender_email)
+        self._sender_email = sender_email
+        self._confirmation_template_id = confirmation_template_id
+        self._message_lang = (
+            message_lang if message_lang in _SUPPORTED_MESSAGE_LANGS else _DEFAULT_MESSAGE_LANG
+        )
         self._timeout = timeout
 
     # -- auth ---------------------------------------------------------------
@@ -137,9 +156,12 @@ class SendPulseClient:
     def add_subscriber(self, email: str, *, name: str = "", variables: Optional[dict] = None) -> None:
         """Add an email to the configured address book.
 
-        SendPulse triggers its own double opt-in confirmation for the address
-        book when configured to do so. Raises :class:`SendPulseError` on failure;
-        the ``status`` attribute carries the upstream HTTP status when available.
+        When double opt-in is configured (``confirmation`` + ``sender_email``),
+        SendPulse holds the contact as "confirmation requested", sends its
+        confirmation email, and activates the contact only after they click the
+        link. Otherwise the contact is added active (single opt-in). Raises
+        :class:`SendPulseError` on failure; the ``status`` attribute carries the
+        upstream HTTP status when available.
         """
         payload = {
             "emails": [
@@ -149,6 +171,15 @@ class SendPulseClient:
                 }
             ]
         }
+        if self._doi:
+            # Top-level DOI params alongside "emails" (per SendPulse's add-emails
+            # method). template_id is optional — SendPulse uses its default (and
+            # currently-moderating) confirmation email when it's omitted.
+            payload["confirmation"] = "force"
+            payload["sender_email"] = self._sender_email
+            payload["message_lang"] = self._message_lang
+            if self._confirmation_template_id:
+                payload["template_id"] = self._confirmation_template_id
         try:
             resp = self._request(
                 "POST", f"/addressbooks/{self._addressbook_id}/emails", json=payload
@@ -183,10 +214,25 @@ def get_client() -> Optional[SendPulseClient]:
     if not (addressbook_id and has_auth):
         return None
     timeout = float(getattr(settings, "SENDPULSE_TIMEOUT_SECONDS", _DEFAULT_TIMEOUT_SECONDS))
+    confirmation = bool(getattr(settings, "SENDPULSE_CONFIRMATION", False))
+    sender_email = str(getattr(settings, "SENDPULSE_SENDER_EMAIL", "") or "").strip()
+    template_id = str(getattr(settings, "SENDPULSE_CONFIRMATION_TEMPLATE_ID", "") or "").strip()
+    message_lang = str(getattr(settings, "SENDPULSE_MESSAGE_LANG", _DEFAULT_MESSAGE_LANG) or "").strip()
+    if confirmation and not sender_email:
+        # DOI needs a verified sender; misconfig would 400 every subscribe, so
+        # fall back to single opt-in and make the reason visible.
+        logger.warning(
+            "SENDPULSE_CONFIRMATION is set but SENDPULSE_SENDER_EMAIL is empty; "
+            "double opt-in disabled (adding contacts as active)."
+        )
     return SendPulseClient(
         addressbook_id,
         api_key=api_key,
         client_id=client_id,
         client_secret=client_secret,
+        confirmation=confirmation,
+        sender_email=sender_email,
+        confirmation_template_id=template_id,
+        message_lang=message_lang or _DEFAULT_MESSAGE_LANG,
         timeout=timeout,
     )

--- a/newsletter/tests/test_sendpulse.py
+++ b/newsletter/tests/test_sendpulse.py
@@ -166,3 +166,99 @@ def test_get_client_strips_whitespace(settings):
     c = get_client()
     assert c._api_key == "sp_apikey_test"
     assert c._addressbook_id == "719648"
+
+
+# -- double opt-in -----------------------------------------------------------
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_single_opt_in_omits_confirmation_params(mock_request):
+    """Default (no confirmation config) sends no DOI params — backward compatible."""
+    mock_request.return_value = _ok(201)
+    client = SendPulseClient("719648", api_key="k")
+
+    client.add_subscriber("reader@example.org")
+
+    _, kwargs = mock_request.call_args
+    body = kwargs["json"]
+    assert "confirmation" not in body
+    assert "sender_email" not in body
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_double_opt_in_sends_confirmation_params(mock_request):
+    """DOI attaches confirmation/sender_email/message_lang/template_id top-level."""
+    mock_request.return_value = _ok(200)
+    client = SendPulseClient(
+        "719648",
+        api_key="k",
+        confirmation=True,
+        sender_email="inquiry@jawafdehi.org",
+        confirmation_template_id="tmpl-123",
+        message_lang="en",
+    )
+
+    client.add_subscriber("reader@example.org", name="Sita")
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["confirmation"] == "force"
+    assert body["sender_email"] == "inquiry@jawafdehi.org"
+    assert body["message_lang"] == "en"
+    assert body["template_id"] == "tmpl-123"
+    # The contact + its variables still ride along in "emails".
+    assert body["emails"][0]["email"] == "reader@example.org"
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_double_opt_in_requires_sender_email(mock_request):
+    """confirmation=True without a sender is inert — SendPulse would reject it."""
+    mock_request.return_value = _ok(201)
+    client = SendPulseClient("719648", api_key="k", confirmation=True, sender_email="")
+
+    client.add_subscriber("reader@example.org")
+
+    assert "confirmation" not in mock_request.call_args.kwargs["json"]
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_unsupported_message_lang_falls_back_to_en(mock_request):
+    """Nepali isn't a supported message_lang, so it degrades to English."""
+    mock_request.return_value = _ok(200)
+    client = SendPulseClient(
+        "719648", api_key="k", confirmation=True,
+        sender_email="inquiry@jawafdehi.org", message_lang="ne",
+    )
+
+    client.add_subscriber("reader@example.org")
+
+    assert mock_request.call_args.kwargs["json"]["message_lang"] == "en"
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_double_opt_in_omits_template_id_when_unset(mock_request):
+    """No template_id → SendPulse uses its default confirmation email."""
+    mock_request.return_value = _ok(200)
+    client = SendPulseClient(
+        "719648", api_key="k", confirmation=True,
+        sender_email="inquiry@jawafdehi.org",
+    )
+
+    client.add_subscriber("reader@example.org")
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["confirmation"] == "force"
+    assert "template_id" not in body
+
+
+def test_get_client_wires_double_opt_in_settings(settings):
+    """get_client threads the DOI settings onto the client."""
+    settings.SENDPULSE_API_KEY = "k"
+    settings.SENDPULSE_ADDRESSBOOK_ID = "719648"
+    settings.SENDPULSE_CONFIRMATION = True
+    settings.SENDPULSE_SENDER_EMAIL = "  inquiry@jawafdehi.org "
+    settings.SENDPULSE_CONFIRMATION_TEMPLATE_ID = " tmpl-123 "
+    settings.SENDPULSE_MESSAGE_LANG = "en"
+    c = get_client()
+    assert c._doi is True
+    assert c._sender_email == "inquiry@jawafdehi.org"
+    assert c._confirmation_template_id == "tmpl-123"


### PR DESCRIPTION
## What & why

**Option B** — let SendPulse own the double opt-in / "verify your email" confirmation, while keeping our own React subscribe UI. Today the backend adds contacts via the plain add-emails API, so they land **active (single opt-in)** and no confirmation email is sent (this is why a recent test subscribe never got a verification email). SendPulse supports triggering DOI through the **same** API call, so this is a small, config-gated change — no new endpoint, no view change.

When enabled, SendPulse holds the contact as **"confirmation requested"**, sends its confirmation email, and flips them to **Active** only after they click.

## Changes

- `SendPulseClient` gains `confirmation` / `sender_email` / `confirmation_template_id` / `message_lang`. `add_subscriber` attaches top-level `confirmation="force"`, `sender_email`, `message_lang` (+ optional `template_id`) **only when DOI is active**.
- **Sender required:** SendPulse rejects DOI without a verified sender, so DOI activates only when *both* `confirmation` and `sender_email` are set. `get_client()` logs and falls back to single opt-in if confirmation is set without a sender (rather than 400-ing every subscribe).
- **message_lang** validated against SendPulse's supported set (`en/ru/ua/tr/es/pt`); **Nepali → `en`** (the confirmation template is bilingual, so Nepali readers can still confirm).
- **template_id optional** — SendPulse's default confirmation email is used until a custom template is moderated, so DOI can be switched on *before* the branded template lands.
- New env: `SENDPULSE_CONFIRMATION`, `SENDPULSE_SENDER_EMAIL`, `SENDPULSE_CONFIRMATION_TEMPLATE_ID`, `SENDPULSE_MESSAGE_LANG`. **Off by default = current single-opt-in behavior**, fully backward compatible.

## Tests
6 new (`test_sendpulse.py`): single vs double opt-in payloads, sender-required gating, `ne→en` fallback, `template_id` omission, `get_client` wiring. `newsletter/` suite green (**25 passed**), `ruff` clean.

## Rollout (not in this PR)
1. Frontend confirm landing page — Jawafdehi PR #209 (`/newsletter/confirmed`).
2. SendPulse dashboard: create + moderate the bilingual confirmation email (`inquiry@jawafdehi.org` sender, redirect → `/newsletter/confirmed`), copy `template_id`.
3. Bao `kv/jawafdehi/platform/env`: `SENDPULSE_CONFIRMATION=force`, `SENDPULSE_SENDER_EMAIL=inquiry@jawafdehi.org`, `SENDPULSE_CONFIRMATION_TEMPLATE_ID=<id>`; roll; verify with a real mailbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)