### PR TITLE
feat(newsletter): welcome email on subscribe (transactional send)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,9 @@ SENDPULSE_CONFIRMATION=false
 SENDPULSE_SENDER_EMAIL=
 SENDPULSE_CONFIRMATION_TEMPLATE_ID=
 # SENDPULSE_MESSAGE_LANG=en
+# SENDPULSE_SENDER_NAME=Jawafdehi
+# Welcome email: with WELCOME_EMAIL on and a verified SENDER_EMAIL set, each new
+# subscriber gets a transactional welcome via SendPulse (the "email send" for
+# single opt-in). Best-effort — a failure never blocks the subscribe.
+SENDPULSE_WELCOME_EMAIL=false
+# SENDPULSE_WELCOME_SUBJECT=Welcome to Jawafdehi

--- a/config/settings.py
+++ b/config/settings.py
@@ -852,8 +852,15 @@ SENDPULSE_TIMEOUT_SECONDS = float(os.getenv("SENDPULSE_TIMEOUT_SECONDS", "5"))
 # option, so the bilingual template covers Nepali readers.
 SENDPULSE_CONFIRMATION = env_flag("SENDPULSE_CONFIRMATION", False)
 SENDPULSE_SENDER_EMAIL = os.getenv("SENDPULSE_SENDER_EMAIL", "")
+SENDPULSE_SENDER_NAME = os.getenv("SENDPULSE_SENDER_NAME", "Jawafdehi")
 SENDPULSE_CONFIRMATION_TEMPLATE_ID = os.getenv("SENDPULSE_CONFIRMATION_TEMPLATE_ID", "")
 SENDPULSE_MESSAGE_LANG = os.getenv("SENDPULSE_MESSAGE_LANG", "en")
+# Welcome email: when on (and a verified SENDPULSE_SENDER_EMAIL is set), a
+# transactional welcome is sent to each new subscriber via SendPulse /smtp/emails.
+# This is the "email send" for single opt-in (double opt-in via API is unavailable
+# for this account). Best-effort — a send failure never fails the subscribe.
+SENDPULSE_WELCOME_EMAIL = env_flag("SENDPULSE_WELCOME_EMAIL", False)
+SENDPULSE_WELCOME_SUBJECT = os.getenv("SENDPULSE_WELCOME_SUBJECT", "Welcome to Jawafdehi")
 
 # ---------------------------------------------------------------------------
 # NES/NGM config. After the service consolidation NES and NGM run IN-PROCESS — the

--- a/newsletter/sendpulse.py
+++ b/newsletter/sendpulse.py
@@ -29,6 +29,7 @@ Design notes
 
 from __future__ import annotations
 
+import base64
 import logging
 from typing import Optional
 
@@ -71,7 +72,7 @@ class SendPulseClient:
     def __init__(self, addressbook_id: str, *, api_key: str = "",
                  client_id: str = "", client_secret: str = "",
                  confirmation: bool = False, sender_email: str = "",
-                 confirmation_template_id: str = "",
+                 sender_name: str = "", confirmation_template_id: str = "",
                  message_lang: str = _DEFAULT_MESSAGE_LANG,
                  timeout: float = _DEFAULT_TIMEOUT_SECONDS):
         self._addressbook_id = addressbook_id
@@ -83,11 +84,17 @@ class SendPulseClient:
         # (verified) sender address, so DOI is only active when both are set.
         self._doi = bool(confirmation and sender_email)
         self._sender_email = sender_email
+        self._sender_name = sender_name
         self._confirmation_template_id = confirmation_template_id
         self._message_lang = (
             message_lang if message_lang in _SUPPORTED_MESSAGE_LANGS else _DEFAULT_MESSAGE_LANG
         )
         self._timeout = timeout
+
+    @property
+    def can_send_email(self) -> bool:
+        """True when a verified sender is configured for transactional sends."""
+        return bool(self._sender_email)
 
     # -- auth ---------------------------------------------------------------
 
@@ -193,6 +200,43 @@ class SendPulseClient:
                 status=resp.status_code,
             )
 
+    def send_email(self, to_email: str, subject: str, html: str, *, to_name: str = "") -> None:
+        """Send a one-off transactional email via SendPulse's ``/smtp/emails``.
+
+        Used for the welcome email on subscribe (double opt-in isn't available via
+        the API for this account, so single opt-in + a transactional welcome is
+        the "email send" path). ``html`` is sent base64-encoded, as the endpoint
+        requires. Raises :class:`SendPulseError` on failure (callers treat the
+        welcome as best-effort and never fail the subscribe on it).
+        """
+        if not self._sender_email:
+            raise SendPulseError("SendPulse send_email needs a configured sender_email")
+        payload = {
+            "email": {
+                "subject": subject,
+                "from": {"name": self._sender_name or "Jawafdehi", "email": self._sender_email},
+                "to": [{"email": to_email, **({"name": to_name} if to_name else {})}],
+                "html": base64.b64encode(html.encode("utf-8")).decode("ascii"),
+            }
+        }
+        try:
+            resp = self._request("POST", "/smtp/emails", json=payload)
+        except requests.RequestException as exc:  # timeout / connection error
+            raise SendPulseError(f"SendPulse request error: {exc}") from exc
+
+        if resp.status_code >= 400:
+            raise SendPulseError(
+                f"SendPulse send_email failed ({resp.status_code}): {resp.text[:200]}",
+                status=resp.status_code,
+            )
+        # SendPulse answers 200 with {"result": true|false}; treat false as failure.
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        if body.get("result") is False:
+            raise SendPulseError(f"SendPulse send_email rejected: {resp.text[:200]}")
+
 
 def get_client() -> Optional[SendPulseClient]:
     """Return a configured client, or ``None`` when SendPulse isn't provisioned.
@@ -218,6 +262,7 @@ def get_client() -> Optional[SendPulseClient]:
     sender_email = str(getattr(settings, "SENDPULSE_SENDER_EMAIL", "") or "").strip()
     template_id = str(getattr(settings, "SENDPULSE_CONFIRMATION_TEMPLATE_ID", "") or "").strip()
     message_lang = str(getattr(settings, "SENDPULSE_MESSAGE_LANG", _DEFAULT_MESSAGE_LANG) or "").strip()
+    sender_name = str(getattr(settings, "SENDPULSE_SENDER_NAME", "Jawafdehi") or "").strip()
     if confirmation and not sender_email:
         # DOI needs a verified sender; misconfig would 400 every subscribe, so
         # fall back to single opt-in and make the reason visible.
@@ -232,6 +277,7 @@ def get_client() -> Optional[SendPulseClient]:
         client_secret=client_secret,
         confirmation=confirmation,
         sender_email=sender_email,
+        sender_name=sender_name,
         confirmation_template_id=template_id,
         message_lang=message_lang or _DEFAULT_MESSAGE_LANG,
         timeout=timeout,

--- a/newsletter/templates/newsletter/welcome_email.html
+++ b/newsletter/templates/newsletter/welcome_email.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>Welcome to Jawafdehi</title>
+</head>
+<body style="margin:0; padding:0; background-color:#efeae1; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;">
+<div style="display:none; max-height:0; overflow:hidden; font-size:1px; line-height:1px; color:#efeae1; opacity:0;">
+You're subscribed to the Jawafdehi newsletter — Nepal's public accountability record.
+</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#efeae1;">
+<tr>
+<td align="center" style="padding:24px 12px;">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px; max-width:600px; background-color:#fffdfa; border-radius:14px; overflow:hidden; box-shadow:0 1px 4px rgba(14,31,59,0.08);">
+
+<tr>
+<td align="center" style="background-color:#fffdfa; padding:34px 32px 16px 32px;">
+<a href="https://jawafdehi.org" target="_blank" style="text-decoration:none;">
+<img src="https://jawafdehi.org/favicon.png" width="56" alt="Jawafdehi" style="display:block; margin:0 auto 8px auto; border:0; width:56px; height:auto;">
+</a>
+<div style="font-family:Helvetica,Arial,'Noto Sans Devanagari',sans-serif; font-size:20px; font-weight:700; color:#0e1f3b;">Jawafdehi</div>
+<div style="font-family:Helvetica,Arial,'Noto Sans Devanagari',sans-serif; font-size:12px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; color:#b5242c; padding-top:8px;">Transparency &middot; Accountability &middot; Justice</div>
+</td>
+</tr>
+
+<tr><td style="height:4px; background-color:#b5242c; line-height:4px; font-size:4px;">&nbsp;</td></tr>
+
+<tr>
+<td style="padding:36px 36px 8px 36px; font-family:Helvetica,Arial,'Noto Sans Devanagari',sans-serif;">
+<h1 style="margin:0 0 8px 0; font-size:26px; line-height:1.25; color:#0e1f3b; font-weight:700;">Welcome{% if first_name %}, {{ first_name }}{% endif %}!</h1>
+<p style="margin:0; font-size:15px; line-height:1.45; color:#6b7280;">You're subscribed to the Jawafdehi newsletter.</p>
+</td>
+</tr>
+
+<tr>
+<td style="padding:18px 36px 8px 36px; font-family:Helvetica,Arial,'Noto Sans Devanagari',sans-serif; font-size:16px; line-height:1.65; color:#1f2937;">
+<p style="margin:0 0 16px 0;">Namaste. <strong style="color:#0e1f3b;">Jawafdehi</strong> (जवाफदेही) means <em>accountability</em> — an independent, open-source archive documenting corruption cases involving public entities in Nepal, evidence-first and free for everyone.</p>
+<p style="margin:0 0 16px 0;">From time to time we'll send you short updates: newly documented cases and how the archive is growing.</p>
+</td>
+</tr>
+
+<tr>
+<td align="center" style="padding:14px 36px 6px 36px;">
+<table role="presentation" cellpadding="0" cellspacing="0">
+<tr>
+<td align="center" style="border-radius:8px; background-color:#b5242c;">
+<a href="https://jawafdehi.org/cases" target="_blank" style="display:inline-block; padding:14px 36px; font-family:Helvetica,Arial,'Noto Sans Devanagari',sans-serif; font-size:16px; font-weight:600; color:#fffdfa; text-decoration:none; border-radius:8px;">Explore the cases &rarr;</a>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+
+<tr>
+<td style="background-color:#0e1f3b; padding:26px 36px; font-family:Helvetica,Arial,'Noto Sans Devanagari',sans-serif; font-size:12px; line-height:1.6; color:#9fb0c7;">
+<p style="margin:0 0 6px 0; color:#fffdfa; font-weight:600; font-size:13px;">Jawafdehi Initiative</p>
+<p style="margin:0 0 10px 0;">An independent, non-partisan, volunteer-led civic-tech platform documenting corruption cases involving public entities in Nepal. We document public accountability and raise awareness &mdash; we are not a court or legal authority.</p>
+<p style="margin:0;">You're receiving this because you subscribed at jawafdehi.org. To unsubscribe, reply to this email with "unsubscribe" and we'll remove you.</p>
+</td>
+</tr>
+
+</table>
+</td>
+</tr>
+</table>
+</body>
+</html>

--- a/newsletter/tests/test_api.py
+++ b/newsletter/tests/test_api.py
@@ -138,3 +138,41 @@ def test_throttle_enforced_when_enabled(client, settings):
         ]
     assert codes.count(429) >= 1
     cache.clear()
+
+
+# -- welcome email -----------------------------------------------------------
+
+
+def test_subscribe_sends_welcome_when_enabled(client, settings):
+    settings.SENDPULSE_WELCOME_EMAIL = True
+    fake = _mock_client()
+    fake.can_send_email = True
+    with mock.patch("newsletter.views.get_client", return_value=fake):
+        resp = client.post(reverse("newsletter:subscribe"), VALID_PAYLOAD, format="json")
+    assert resp.status_code == 201
+    fake.send_email.assert_called_once()
+    # Sent to the (normalized) subscriber address, greeting them by first name.
+    args, kwargs = fake.send_email.call_args
+    assert args[0] == "reader@example.org"
+    assert kwargs["to_name"] == "राम"
+
+
+def test_subscribe_skips_welcome_when_disabled(client, settings):
+    settings.SENDPULSE_WELCOME_EMAIL = False
+    fake = _mock_client()
+    fake.can_send_email = True
+    with mock.patch("newsletter.views.get_client", return_value=fake):
+        resp = client.post(reverse("newsletter:subscribe"), VALID_PAYLOAD, format="json")
+    assert resp.status_code == 201
+    fake.send_email.assert_not_called()
+
+
+def test_welcome_failure_does_not_break_subscribe(client, settings):
+    """A welcome-send error is swallowed — the subscribe still returns 201."""
+    settings.SENDPULSE_WELCOME_EMAIL = True
+    fake = _mock_client()
+    fake.can_send_email = True
+    fake.send_email.side_effect = SendPulseError("smtp down")
+    with mock.patch("newsletter.views.get_client", return_value=fake):
+        resp = client.post(reverse("newsletter:subscribe"), VALID_PAYLOAD, format="json")
+    assert resp.status_code == 201

--- a/newsletter/tests/test_sendpulse.py
+++ b/newsletter/tests/test_sendpulse.py
@@ -262,3 +262,64 @@ def test_get_client_wires_double_opt_in_settings(settings):
     assert c._doi is True
     assert c._sender_email == "inquiry@jawafdehi.org"
     assert c._confirmation_template_id == "tmpl-123"
+
+
+# -- transactional welcome email --------------------------------------------
+
+
+def test_can_send_email_requires_sender():
+    assert SendPulseClient("b", api_key="k", sender_email="a@b.c").can_send_email is True
+    assert SendPulseClient("b", api_key="k").can_send_email is False
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_send_email_posts_transactional_payload(mock_request):
+    """send_email hits /smtp/emails with from/to and base64-encoded html."""
+    import base64
+
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.text = ""
+    resp.json.return_value = {"result": True}
+    mock_request.return_value = resp
+    client = SendPulseClient(
+        "719648", api_key="k", sender_email="inquiry@jawafdehi.org", sender_name="Jawafdehi"
+    )
+
+    client.send_email("reader@example.org", "Welcome", "<h1>Hi</h1>", to_name="Sita")
+
+    args, kwargs = mock_request.call_args
+    assert args[0] == "POST"
+    assert args[1].endswith("/smtp/emails")
+    body = kwargs["json"]["email"]
+    assert body["subject"] == "Welcome"
+    assert body["from"] == {"name": "Jawafdehi", "email": "inquiry@jawafdehi.org"}
+    assert body["to"] == [{"email": "reader@example.org", "name": "Sita"}]
+    assert base64.b64decode(body["html"]).decode() == "<h1>Hi</h1>"
+
+
+def test_send_email_needs_sender_configured():
+    client = SendPulseClient("719648", api_key="k")  # no sender_email
+    with pytest.raises(SendPulseError):
+        client.send_email("x@y.z", "S", "<p>h</p>")
+
+
+@mock.patch("newsletter.sendpulse.requests.request")
+def test_send_email_result_false_raises(mock_request):
+    """SendPulse answers 200 with result:false on a rejected send — treat as error."""
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.text = '{"result":false}'
+    resp.json.return_value = {"result": False}
+    mock_request.return_value = resp
+    client = SendPulseClient("719648", api_key="k", sender_email="inquiry@jawafdehi.org")
+
+    with pytest.raises(SendPulseError):
+        client.send_email("x@y.z", "S", "<p>h</p>")
+
+
+def test_get_client_wires_sender_name(settings):
+    settings.SENDPULSE_API_KEY = "k"
+    settings.SENDPULSE_ADDRESSBOOK_ID = "719648"
+    settings.SENDPULSE_SENDER_NAME = "Jawafdehi"
+    assert get_client()._sender_name == "Jawafdehi"

--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 
 from django.conf import settings
+from django.template.loader import render_to_string
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -33,7 +34,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
-from .sendpulse import SendPulseError, get_client
+from .sendpulse import SendPulseClient, SendPulseError, get_client
 from .serializers import NewsletterSubscriptionSerializer
 
 logger = logging.getLogger("newsletter.views")
@@ -41,6 +42,23 @@ logger = logging.getLogger("newsletter.views")
 # SendPulse returns 409 when the email already exists in the address book. We map
 # that to a local 409 so the SPA can show its "previously unsubscribed" copy.
 _SENDPULSE_CONFLICT_STATUS = 409
+
+
+def _send_welcome_email(client: SendPulseClient, email: str, first_name: str) -> None:
+    """Best-effort welcome email on subscribe.
+
+    Double opt-in isn't available via SendPulse's API for this account, so the
+    subscribe is single opt-in and this transactional welcome is the "email send"
+    step. It never fails the subscribe: any error is logged and swallowed.
+    """
+    if not getattr(settings, "SENDPULSE_WELCOME_EMAIL", False) or not client.can_send_email:
+        return
+    try:
+        html = render_to_string("newsletter/welcome_email.html", {"first_name": first_name})
+        subject = getattr(settings, "SENDPULSE_WELCOME_SUBJECT", "Welcome to Jawafdehi")
+        client.send_email(email, subject, html, to_name=first_name)
+    except Exception as exc:  # noqa: BLE001 — welcome is best-effort, never block subscribe
+        logger.warning("Newsletter welcome email failed (subscribe still succeeded): %s", exc)
 
 
 class NewsletterRateThrottle(AnonRateThrottle):
@@ -160,11 +178,13 @@ class NewsletterSubscriptionView(_ThrottledPublicView):
                 status=status.HTTP_202_ACCEPTED,
             )
 
+        _send_welcome_email(client, email, data["firstName"])
+
         return Response(
             {
                 "email": email,
                 "status": "subscribed",
-                "message": "Please check your inbox to confirm your subscription.",
+                "message": "You're subscribed. Check your inbox for a welcome email.",
             },
             status=status.HTTP_201_CREATED,
         )


### PR DESCRIPTION
## What & why

Delivers **single opt-in + email send** for the newsletter. Double opt-in via the SendPulse API is **not usable for this account** — `confirmation=force` returns `HTTP 422 "Badly formed data"` for *every* auth (both static keys + OAuth) and *every* request encoding, verified exhaustively against the live API (the `a3e…f26` template is valid/Active, single opt-in works, so it's a SendPulse-side gap). So the subscribe stays single opt-in, and this adds the "email send" via SendPulse's **transactional** `/smtp/emails` endpoint — which I confirmed works live.

## Changes

- **`SendPulseClient.send_email()`** — `POST /smtp/emails` with `from`/`to` + **base64-encoded** html; `can_send_email` property gates on a configured sender; a 200 with `result:false` is treated as an error.
- **View** sends the welcome after a successful add, **best-effort** — any failure (render or send) is logged and swallowed, so it *never* fails the subscribe. Gated by `SENDPULSE_WELCOME_EMAIL` (off = pure single opt-in, current behavior). The 201 message no longer says "confirm your subscription" (there's no confirmation step now).
- **Branded welcome template** (`newsletter/templates/newsletter/welcome_email.html`) — greets by first name, links to `/cases`; reply-to-unsubscribe (the backend owns no unsubscribe route; SendPulse *campaigns* carry their own `{{unsubscribe}}`).
- **New env:** `SENDPULSE_WELCOME_EMAIL`, `SENDPULSE_WELCOME_SUBJECT`, `SENDPULSE_SENDER_NAME` (reuses `SENDPULSE_SENDER_EMAIL` = `inquiry@jawafdehi.org`).

## Tests
8 new: welcome sent when enabled / skipped when off / send-failure non-fatal (view); `send_email` payload + base64 + sender-required + `result:false` (client). `newsletter/` suite green (**33 passed**), `ruff` clean.

## Verified live
Rendered the actual template (incl. Devanagari) and sent it via `/smtp/emails` → `{"result":true}` (200). Preview delivered to `inquiry@`.

## Rollout
After merge + keel rolls `:main`, set in Bao `kv/jawafdehi/platform/env`: `SENDPULSE_WELCOME_EMAIL=true` (+ `SENDPULSE_SENDER_EMAIL=inquiry@jawafdehi.org` if not already), roll, verify a real subscribe delivers the welcome.

> Supersedes the DOI approach (#317, merged but inert against the live API). DOI can be revisited if SendPulse support resolves the `21357` rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New subscribers can receive a branded welcome email after subscribing.
  * Welcome emails include personalized greetings, helpful information, and a link to explore cases.
  * Added configuration for enabling welcome emails and customizing their subject and sender name.
  * Subscription confirmation now advises subscribers to check for the welcome email.

* **Bug Fixes**
  * Welcome-email delivery failures no longer prevent successful newsletter subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->