### PR TITLE
Court materials are documents-only; retire court_case shadows

### DIFF
--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -289,28 +289,27 @@ def _materials_metrics():
     total, by-type / by-source breakdowns, and completeness measured over
     the material ``data`` JSON-LD doc. Materials are NOT judicial records;
     they get their own block separate from ``_ngm_metrics``."""
-    total = Material.objects.count()
+    # Soft-deleted materials are off every read plane (retrieve/search/sitemap
+    # all filter ``is_deleted=False``); the coverage stats must match, else a
+    # tombstoned pile (e.g. the retired ``court`` court_case shadows) lingers in
+    # the by-source breakdown after it is gone everywhere else.
+    live = Material.objects.filter(is_deleted=False)
+    total = live.count()
 
     by_type = list(
-        Material.objects.values("material_type")
-        .annotate(count=Count("iri"))
-        .order_by("-count")
+        live.values("material_type").annotate(count=Count("iri")).order_by("-count")
     )
     by_source = list(
-        Material.objects.values("source")
-        .annotate(count=Count("iri"))
-        .order_by("-count")
+        live.values("source").annotate(count=Count("iri")).order_by("-count")
     )
 
     # Completeness signals over the stored schema.org JSON-LD doc. On Postgres
     # answered with JSON-key existence lookups; sqlite (empty local / test DB)
     # degrades to 0 without a full scan.
     if connections[Material.objects.db].vendor == "postgresql":
-        with_description = Material.objects.filter(
-            data__has_key="description"
-        ).count()
-        with_url = Material.objects.filter(data__has_key="url").count()
-        with_date = Material.objects.filter(data__has_key="dateCreated").count()
+        with_description = live.filter(data__has_key="description").count()
+        with_url = live.filter(data__has_key="url").count()
+        with_date = live.filter(data__has_key="dateCreated").count()
     else:
         with_description = with_url = with_date = 0
 

--- a/courts/importer.py
+++ b/courts/importer.py
@@ -45,7 +45,6 @@ from courts.normalize import best_effort_normalize, is_verdict_sentinel
 from materials.jsonld import (
     MaterialType,
     case_order_sources,
-    court_case_to_jsonld,
     court_order_to_jsonld,
 )
 from materials.models import Material
@@ -594,6 +593,12 @@ class CourtCaseImporter:
 
     # ── order materialization (§4) ───────────────────────────────────────────
     def _materialize_orders(self, case: CourtCase) -> None:
+        # The materials layer owns DOCUMENTS only: each order DocumentSource is
+        # materialized as a standalone ``court_order`` Material (the file). We do
+        # NOT mint a ``court_case`` Material — case identity + metadata live in
+        # the courtcase read plane (/courtcase/<court>/<num>), so a court_case
+        # Material was a redundant shadow of it. Each order ``isPartOf`` that
+        # courtcase IRI (set in court_order_to_jsonld).
         pairs = case_order_sources(case.document_sources)
         if not pairs:
             return
@@ -603,8 +608,6 @@ class CourtCaseImporter:
             )
             self._write_material(doc, MaterialType.COURT_ORDER)
             self.res.orders_materialized += 1
-        # The case-record Material references the order Materials via hasPart.
-        self._write_material(court_case_to_jsonld(case), MaterialType.COURT_CASE)
 
     def _write_material(self, doc: dict[str, Any], material_type: str) -> None:
         if self.cfg.dry_run:

--- a/materials/jsonld.py
+++ b/materials/jsonld.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 from jawafdehi_shared.entities.ids import (
+    build_courtcase_iri,
     build_material_iri,
     build_source_material_iri,
     is_valid_material_iri,
@@ -299,11 +300,15 @@ def court_order_to_jsonld(
 ) -> dict[str, Any]:
     """Shape ONE court-order ``DocumentSource`` into its own Material JSON-LD.
 
-    LOCKED #1: each order doc is a STANDALONE Material (``court_order``,
+    Each order doc is a STANDALONE Material (``court_order``,
     ``@type [Manuscript, DigitalDocument]``) carrying the order's roled file links
-    as ``associatedMedia``. It ``isPartOf`` the case record's Material
-    (``court_case_material_iri``) — the inverse of that record's ``hasPart``. ``n``
-    disambiguates multiple orders on one case (``None`` → the sole order).
+    as ``associatedMedia`` — the ONE court material per document-bearing case (the
+    materials layer owns documents; case identity + metadata live in the courtcase
+    layer). It ``isPartOf`` the case's canonical ``/courtcase/<court>/<num>`` IRI,
+    NOT a ``court_case`` Material (those were retired as redundant shadows of the
+    courtcase read plane). ``n`` disambiguates multiple orders on one case
+    (``None`` → the sole order). ``name`` is the human case-order title (the raw
+    ``document_id`` rides on ``identifier`` only, never as the display name).
     """
     schema_type, additional_type = type_for(MaterialType.COURT_ORDER)
     iri = court_order_material_iri(court_identifier, case_number, n)
@@ -314,9 +319,9 @@ def court_order_to_jsonld(
         "@context": MATERIAL_CONTEXT,
         "@type": schema_type,  # ["Manuscript", "DigitalDocument"]
         "@id": iri,
-        "name": {"ne": str(document_id or f"{case_number} आदेश")},
+        "name": {"ne": f"{case_number} आदेश"},
         "inLanguage": "ne",
-        "isPartOf": {"@id": court_case_material_iri(court_identifier, case_number)},
+        "isPartOf": {"@id": build_courtcase_iri(court_identifier, case_number)},
         "jawafdehi:court": court_identifier,
         "jawafdehi:caseNumber": case_number,
     }
@@ -332,6 +337,12 @@ def court_order_to_jsonld(
 
 def court_case_to_jsonld(case: Any) -> dict[str, Any]:
     """Project a ``CourtCase`` ORM row into its schema.org CreativeWork JSON-LD.
+
+    NOTE: ``court_case`` Materials are NO LONGER persisted (the materials layer
+    owns documents only; case identity lives in the courtcase read plane). This
+    projection now backs solely the on-the-fly read-plane derivation for a
+    ``/material/court/<court>.<num>`` IRI with no stored row (``materials.views``
+    + ``cases.services.material_resolver``) — a graceful linked-data fallback.
 
     The case RECORD maps to ``CreativeWork`` + ``jawafdehi:CourtCase`` (schema.org
     has no LegalCase). Bilingual party/subject text rides in language-tagged

--- a/materials/tests/test_single_source_ingest.py
+++ b/materials/tests/test_single_source_ingest.py
@@ -1,9 +1,11 @@
 """Tests for single-source Material ingest + standalone court-order materialization.
 
 Covers the gate-BYPASS write path (court orders are inherently single-publisher,
-so the bulk ≥2-source HOLD gate must not apply) and the LOCKED #1 shape: each
-order becomes its OWN ``court_order`` Material and the case record REFERENCES it
-via ``hasPart``. Run from the repo root:
+so the bulk ≥2-source HOLD gate must not apply) and the documents-only shape:
+each order becomes its OWN ``court_order`` Material that ``isPartOf`` the case's
+canonical ``/courtcase/<court>/<num>`` IRI. NO ``court_case`` shadow Material is
+minted — case identity + metadata live in the courtcase read plane. Run from the
+repo root:
 
     TESTING=true DATABASE_URL=sqlite:// NES_DB_URL=sqlite:// NGM_DATABASE_URL=sqlite:// \
         uv run pytest materials/tests/test_single_source_ingest.py
@@ -16,9 +18,9 @@ from datetime import date
 from django.test import TestCase
 
 from courts.importer import CourtCaseImporter, ImportConfig, ImportMode
+from jawafdehi_shared.entities.ids import build_courtcase_iri
 from materials.jsonld import (
     MaterialType,
-    court_case_material_iri,
     court_order_material_iri,
     court_order_to_jsonld,
 )
@@ -70,9 +72,14 @@ class CourtOrderShapeTests(_NgmTestCase):
         )
         self.assertEqual(doc["@type"], ["Manuscript", "DigitalDocument"])
         self.assertEqual(len(doc["associatedMedia"]), 2)
+        # isPartOf the case's canonical courtcase IRI (NOT a court_case shadow
+        # Material); name is the human case-order title (raw document_id rides on
+        # identifier only).
         self.assertEqual(
-            doc["isPartOf"]["@id"], court_case_material_iri("supreme", "081-CR-0081")
+            doc["isPartOf"]["@id"], build_courtcase_iri("supreme", "081-CR-0081")
         )
+        self.assertEqual(doc["name"], {"ne": "081-CR-0081 आदेश"})
+        self.assertEqual(doc["identifier"], "ngm:court-order:supreme:081-CR-0081")
 
     def test_iri_is_stable_and_derivable_for_dedup(self):
         # cross-ref spec 06: the same (court, case_number) yields the SAME order IRI
@@ -116,19 +123,22 @@ class MaterializeOrdersViaImporterTests(_NgmTestCase):
         cfg.update(over)
         return CourtCaseImporter(ImportConfig(**cfg)).run()
 
-    def test_order_is_standalone_material_referenced_by_case(self):
+    def test_order_is_standalone_material_and_no_case_shadow(self):
         res = self._run()
         self.assertEqual(res.orders_materialized, 1)
         order_iri = court_order_material_iri("supreme", "081-CR-0081")
         order = Material.objects.using("ngm").get(iri=order_iri)
         self.assertEqual(order.data["@type"], ["Manuscript", "DigitalDocument"])
         self.assertEqual(len(order.data["associatedMedia"]), 2)
-        # the case record Material references the order via hasPart (not embedded).
-        case_mat = Material.objects.using("ngm").get(
-            iri=court_case_material_iri("supreme", "081-CR-0081")
+        # Documents-only: the order isPartOf the case's canonical /courtcase IRI,
+        # and NO court_case shadow Material is minted.
+        self.assertEqual(
+            order.data["isPartOf"]["@id"],
+            build_courtcase_iri("supreme", "081-CR-0081"),
         )
-        self.assertIn({"@id": order_iri}, case_mat.data["hasPart"])
-        self.assertNotIn("associatedMedia", case_mat.data)
+        self.assertFalse(
+            Material.objects.using("ngm").filter(source="court").exists()
+        )
 
     def test_rerun_is_idempotent(self):
         self._run()
@@ -137,8 +147,10 @@ class MaterializeOrdersViaImporterTests(_NgmTestCase):
         self.assertEqual(
             Material.objects.using("ngm").filter(source="court_order").count(), 1
         )
+        # No court_case shadow Material is minted (case identity lives in the
+        # courtcase read plane, /courtcase/<court>/<num>).
         self.assertEqual(
-            Material.objects.using("ngm").filter(source="court").count(), 1
+            Material.objects.using("ngm").filter(source="court").count(), 0
         )
 
     def test_dry_run_materializes_nothing(self):

--- a/tests/api/test_statistics_api.py
+++ b/tests/api/test_statistics_api.py
@@ -693,3 +693,36 @@ class TestNgmMetrics:
         assert ngm["completeness"]["nes_resolved"] == pytest.approx(33.3)
         assert ngm["completeness"]["with_registration_date"] == pytest.approx(66.7)
         assert ngm["completeness"]["with_document_sources"] == pytest.approx(33.3)
+
+    def test_materials_exclude_soft_deleted(self, api_client):
+        # Soft-deleted materials are off every read plane (retrieve/search/sitemap
+        # filter is_deleted=False); the coverage stats must match, so a tombstoned
+        # court_case shadow does not linger in the by-source breakdown.
+        Material.objects.create(
+            iri="https://jawafdehi.org/material/nkp/live-1",
+            material_type="Legislation",
+            source="nkp",
+            ident="live-1",
+            data={
+                "@id": "https://jawafdehi.org/material/nkp/live-1",
+                "@type": "Legislation",
+                "name": "Live",
+            },
+        )
+        Material.objects.create(
+            iri="https://jawafdehi.org/material/court/sc.082-cr-0009",
+            material_type="court_case",
+            source="court",
+            ident="sc.082-cr-0009",
+            is_deleted=True,
+            data={
+                "@id": "https://jawafdehi.org/material/court/sc.082-cr-0009",
+                "@type": "CreativeWork",
+                "name": "Tombstoned shadow",
+            },
+        )
+
+        mats = api_client.get("/api/statistics/").json()["materials"]
+        assert mats["total"] == 1
+        assert {row["source"] for row in mats["by_source"]} == {"nkp"}
+        assert {row["material_type"] for row in mats["by_type"]} == {"Legislation"}


### PR DESCRIPTION
## Why

The site surfaced **two** near-identical ~23k material piles — **"Court records"** (`source=court`, `court_case`) and **"Court orders"** (`source=court_order`) — that a caseworker flagged as duplicates. Investigation confirmed they are:

1. **A 1:1 twin of each other** — every one of the 23,208 `court_case` materials has exactly one matching `court_order` (0 multi-order cases), differing only in the IRI `source` segment. The `court_case` held the metadata; the `court_order` held the file; they cross-linked.
2. **A redundant shadow of the courtcase layer** — the 23,208 `court_case` materials are *only* the subset of the ~1.6M relational court cases that have an attached order document. Every field in `court_case_to_jsonld` is derived 100% from the `CourtCase` row, and that case already has a full public identity in the **courtcase read plane** (`/courtcase/<court>/<num>`, indexed as `ngm-courtcases`, with parties **and** resolved NES entity IRIs). So `court_case` added nothing but a pointer to the order.

Zero editorial evidence references point at court materials (all 801 `CaseMaterialReference` rows are `jawafdehi`-source), so no citations depend on these.

## What

The materials layer now owns **court documents only**. The order becomes the one court material per document-bearing case; case identity lives in the courtcase layer.

- `court_order_to_jsonld`: `isPartOf` → the canonical `/courtcase/<court>/<num>` IRI (via `build_courtcase_iri`), not a `court_case` Material; `name` → human `"<case_number> आदेश"` (the raw `ngm:court-order:…` id now rides on `identifier` only, not the display name).
- `importer._materialize_orders`: stops minting `court_case` Materials.
- `court_case_to_jsonld` retained solely for the on-the-fly `/material/court/…` read-plane derivation (`materials.views` + `cases.services.material_resolver`) — a graceful linked-data fallback; unchanged behavior.
- `statistics._materials_metrics`: filter `is_deleted=False` (pre-existing gap) so a tombstoned `court_case` pile does not linger in the by-source breakdown after backfill — every other read plane already excludes soft-deleted rows.

## Not in this PR

- **Backfill** (retire the 23,208 existing `court_case` Materials + repoint the live orders' `isPartOf`/`name`) runs **in-place** after this deploys, gated on explicit go — soft-delete auto-evicts from search (post_save signal) + sitemap (`corpus.py`) + retrieve; a pre-image snapshot is taken first for rollback.
- **Frontend** (small follow-up): 301-redirect `/material/court/:ident` → `/courtcase/…`; hide the now-empty "Court records" materials tile (the homepage *"~1.6M Special Court records"* stat is a different metric — `court_cases_total` — and is unaffected).

## Tests

`materials/`, `courts/`, and `tests/api/test_statistics_api.py` all green (348 passed); ruff clean. Updated the importer/shaper tests to assert the documents-only shape (order `isPartOf` → courtcase IRI, human name, **no** `court_case` row) and added a statistics test locking in the soft-delete exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Court order records now link directly to canonical court case pages.
  * Court case linked-data responses can be generated when no stored record exists.

* **Bug Fixes**
  * Statistics now exclude soft-deleted materials from totals, breakdowns, and completeness metrics.
  * Court imports no longer create redundant court case material records.

* **Tests**
  * Added coverage for soft-deleted statistics and updated court order import expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->