### PR TITLE
Exclude soft-deleted + non-LISTED materials from reindex_materials

### DIFF
--- a/materials/management/commands/reindex_materials.py
+++ b/materials/management/commands/reindex_materials.py
@@ -1,7 +1,15 @@
 """``reindex_materials`` — bulk-(re)index NGM materials into ``ngm-materials``.
 
-Streams every ``Material`` through the material indexer into OpenSearch.
-``--rebuild`` drops + recreates the index. The router pins ``Material`` to ``ngm``.
+Streams the SEARCHABLE ``Material`` set through the material indexer into
+OpenSearch. ``--rebuild`` drops + recreates the index. The router pins
+``Material`` to ``ngm``.
+
+Only ``is_deleted=False`` + ``visibility=LISTED`` rows are indexed — the SAME
+gate the live ``post_save`` signal applies (``materials.signals``: a soft-deleted
+or non-LISTED row is EVICTED, not indexed). Without this filter a ``--rebuild``
+would re-add every soft-deleted material (tombstones resurrected) and every
+UNLISTED/PRIVATE case-source material (a draft case's evidence leaked into anon
+search) — the exact rows the signal spent its writes evicting.
 """
 
 from __future__ import annotations
@@ -11,7 +19,7 @@ from django.core.management.base import BaseCommand
 from jawafdehi_shared.search.opensearch import MATERIAL_INDEX
 from jawafdehi_shared.search.reindex import reindex
 from materials import search_index
-from materials.models import Material
+from materials.models import Material, Visibility
 
 
 class Command(BaseCommand):
@@ -32,7 +40,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        qs = Material.objects.all()
+        # Mirror the live indexer's gate (materials.signals): index ONLY the
+        # searchable set (live + LISTED). A --rebuild otherwise resurrects
+        # soft-deleted rows and leaks non-LISTED (draft/in-review) evidence.
+        qs = Material.objects.filter(
+            is_deleted=False, visibility=Visibility.LISTED
+        )
         if options.get("since") and not options["rebuild"]:
             qs = qs.filter(updated_at__gte=options["since"])
         result = reindex(

--- a/materials/tests/test_sync_materials.py
+++ b/materials/tests/test_sync_materials.py
@@ -22,7 +22,7 @@ from materials.jsonld import (
 from materials.management.commands.sync_materials_from_index import (
     parse_court_order_id,
 )
-from materials.models import Material
+from materials.models import Material, Visibility
 
 
 class CourtOrderReconciliationTests(SimpleTestCase):
@@ -94,12 +94,30 @@ class CourtOrderReconciliationTests(SimpleTestCase):
 class ReindexMaterialsSinceTests(TestCase):
     databases = "__all__"
 
-    def _make(self, ident: str) -> Material:
+    def _make(self, ident: str, **extra) -> Material:
         iri = f"https://jawafdehi.org/material/nkp/{ident}"
         return Material.objects.using("ngm").create(
             iri=iri, material_type="legal_corpus", source="nkp", ident=ident,
             data={"@type": "Legislation", "@id": iri, "name": {"ne": ident}},
+            **extra,
         )
+
+    def test_only_searchable_rows_are_reindexed(self):
+        # A full rebuild must index the SAME set the live signal keeps: live +
+        # LISTED. Soft-deleted (tombstoned) and non-LISTED (draft/in-review case
+        # evidence) rows must NOT be re-added, else a rebuild resurrects/leaks them.
+        live = self._make("live-act")
+        self._make("gone-act", is_deleted=True)
+        self._make("unlisted-act", visibility=Visibility.UNLISTED)
+        self._make("private-act", visibility=Visibility.PRIVATE)
+        with mock.patch(
+            "materials.management.commands.reindex_materials.reindex",
+            return_value={"indexed": 0, "skipped": 0},
+        ) as m:
+            call_command("reindex_materials", rebuild=True)
+        iris = {r.iri for r in m.call_args.kwargs["records"]}
+        self.assertEqual(iris, {live.iri})
+        self.assertTrue(m.call_args.kwargs["rebuild"])
 
     def test_since_indexes_only_recently_touched(self):
         old = self._make("old-act")
@@ -110,7 +128,7 @@ class ReindexMaterialsSinceTests(TestCase):
         )
         cutoff = (timezone.now() - datetime.timedelta(days=1)).isoformat()
         with mock.patch(
-            "jawafdehi_shared.search.reindex.reindex",
+            "materials.management.commands.reindex_materials.reindex",
             return_value={"indexed": 0, "skipped": 0},
         ) as m:
             call_command("reindex_materials", since=cutoff)


### PR DESCRIPTION
## Why

`reindex_materials` streamed `Material.objects.all()` into the `ngm-materials` search index with **no `is_deleted` / `visibility` filter**. That contradicts the live indexer: the `post_save` signal (`materials.signals`) *evicts* a material from the index when it is soft-deleted **or** non-LISTED. So a `reindex_materials --rebuild` would **re-add every row the signal had deliberately removed**:

- **Soft-deleted (tombstoned) materials** — e.g. the 23,208 `court_case` shadows just retired in #320 would reappear as public search hits, silently undoing that cleanup.
- **UNLISTED / PRIVATE case-source materials** — a draft or in-review case's evidence would leak into anonymous unified search (the ADR: cases own no documents; only LISTED is searchable).

Same bug class as the statistics by-source gap fixed in #320.

## What

- Filter the reindex queryset to `is_deleted=False, visibility=LISTED`, mirroring the signal's gate and the sitemap corpus (`discovery.corpus._iter_materials`). Applies to both `--rebuild` and the incremental `--since` path.
- Added a test asserting a rebuild indexes only the live+LISTED row (soft-deleted / UNLISTED / PRIVATE excluded).
- Fixed a latent **test-order fragility**: the existing `--since` test patched `reindex` at its *definition* site (`jawafdehi_shared.search.reindex.reindex`), but the command binds it via `from … import reindex`; once another test imported the command module first, the patch no longer intercepted. Patch at the command's own namespace instead, so it works regardless of import order.

## Tests

`materials/` suite green (189 passed), ruff clean; verified the two reindex tests pass in both orderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reindexing now includes only live, publicly listed materials.
  * Soft-deleted, private, and otherwise non-listed materials are excluded from search results after rebuilds or incremental reindexing.

* **Tests**
  * Added coverage to verify that only searchable materials are reindexed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->