### PR TITLE
fix(materials): classify CIAA press releases as press_release, not charge_sheet

### DIFF
--- a/cases/tests/test_case_material_reference.py
+++ b/cases/tests/test_case_material_reference.py
@@ -98,7 +98,7 @@ class TestResolveMaterials:
         resolved = resolve_materials([mat.iri])
         rec = resolved[mat.iri]
         assert rec["display_name"] == "CIAA press release"
-        assert rec["material_type"] == "charge_sheet"
+        assert rec["material_type"] == "press_release"
         assert rec["urls"] == [
             {"link": "https://ciaa.gov.np/pr/1.pdf", "role": "RAW"}
         ]

--- a/materials/jsonld.py
+++ b/materials/jsonld.py
@@ -65,7 +65,8 @@ class MaterialType:
     COURT_ORDER = "court_order"        # order / verdict / manuscript scan
     PRECEDENT = "precedent"            # published law-journal precedent (नजिर) — NKP
     MANUSCRIPT = "manuscript"          # a scanned manuscript document
-    CHARGE_SHEET = "charge_sheet"      # CIAA/AG अभियोगपत्र
+    CHARGE_SHEET = "charge_sheet"      # CIAA/AG अभियोगपत्र (the indictment)
+    PRESS_RELEASE = "press_release"    # CIAA/agency प्रेस विज्ञप्ति (public announcement)
     LEGAL_CORPUS = "legal_corpus"      # acts / laws / ordinances / constitution
     OFFICIAL_REPORT = "official_report"  # OAG / annual reports
     NEWS = "news"                      # news / media article (was Jawafdehi SourceType.NEWS)
@@ -90,6 +91,10 @@ MATERIAL_TYPES: dict[str, tuple[Any, str | None]] = {
     MaterialType.MANUSCRIPT: (["Manuscript", "DigitalDocument"], None),
     # Charge sheet → DigitalDocument + jawafdehi:ChargeSheet.
     MaterialType.CHARGE_SHEET: ("DigitalDocument", "jawafdehi:ChargeSheet"),
+    # Press release (प्रेस विज्ञप्ति): a public announcement, NOT the indictment.
+    # schema.org has no PressRelease term, so CreativeWork + jawafdehi:PressRelease
+    # (distinct additionalType from charge_sheet's jawafdehi:ChargeSheet).
+    MaterialType.PRESS_RELEASE: ("CreativeWork", "jawafdehi:PressRelease"),
     # Legal corpus (acts/laws/ordinances/constitution) → Legislation.
     MaterialType.LEGAL_CORPUS: ("Legislation", None),
     # Official report (OAG audit, annual reports) → Report.
@@ -418,7 +423,7 @@ def court_case_to_jsonld(case: Any) -> dict[str, Any]:
 #: *value* strings (``cases.models.SourceType``) to avoid importing the enum here
 #: (keeps this module Django-model-free).
 JAWAF_SOURCE_TYPE_TO_MATERIAL: dict[str, str] = {
-    "CIAA_PRESS_RELEASE": MaterialType.CHARGE_SHEET,
+    "CIAA_PRESS_RELEASE": MaterialType.PRESS_RELEASE,
     "AG_ABHIYOG_PATRA": MaterialType.CHARGE_SHEET,
     "OAG_AUDIT_REPORT": MaterialType.OFFICIAL_REPORT,
     "COURT_ORDER": MaterialType.COURT_ORDER,
@@ -513,7 +518,7 @@ def _case_entity_iris(case: Any) -> list[str]:
 #: to the right schema.org @type. Mirrors ngm.index.models.SourceType.
 INDEX_SOURCE_TYPE_TO_MATERIAL = {
     "COURT_ORDER": MaterialType.COURT_ORDER,
-    "CIAA_PRESS_RELEASE": MaterialType.CHARGE_SHEET,
+    "CIAA_PRESS_RELEASE": MaterialType.PRESS_RELEASE,
     "AG_ABHIYOG_PATRA": MaterialType.CHARGE_SHEET,
     "OAG_AUDIT_REPORT": MaterialType.OFFICIAL_REPORT,
     "LAW_OR_BILL": MaterialType.LEGAL_CORPUS,

--- a/materials/tests/test_materials.py
+++ b/materials/tests/test_materials.py
@@ -360,13 +360,15 @@ class IndexJsonLdNodeShapeTests(_DbAPITestCase):
         self.assertEqual(len(doc["associatedMedia"]), 2)
         self.assertEqual(doc["associatedMedia"][0]["jawafdehi:linkRole"], "RAW")
 
-    def test_press_release_maps_to_charge_sheet(self):
+    def test_press_release_maps_to_press_release(self):
+        # A CIAA press release is the public announcement, not the indictment:
+        # it must shape to press_release, distinct from a charge sheet.
         doc = manuscript_jsonld(
             {"document_id": "ngm:ciaa-press-release:42", "source_type": "CIAA_PRESS_RELEASE",
              "links": [], "metadata": {}}
         )
-        self.assertEqual(doc["@type"], "DigitalDocument")
-        self.assertEqual(doc["additionalType"], "jawafdehi:ChargeSheet")
+        self.assertEqual(doc["@type"], "CreativeWork")
+        self.assertEqual(doc["additionalType"], "jawafdehi:PressRelease")
 
     def test_leaf_node_shape(self):
         node = {

--- a/materials/tests/test_source_material_shaper.py
+++ b/materials/tests/test_source_material_shaper.py
@@ -47,7 +47,7 @@ class TestMaterialTypeMapping:
     @pytest.mark.parametrize(
         "source_type,expected",
         [
-            ("CIAA_PRESS_RELEASE", MaterialType.CHARGE_SHEET),
+            ("CIAA_PRESS_RELEASE", MaterialType.PRESS_RELEASE),
             ("AG_ABHIYOG_PATRA", MaterialType.CHARGE_SHEET),
             ("OAG_AUDIT_REPORT", MaterialType.OFFICIAL_REPORT),
             ("COURT_ORDER", MaterialType.COURT_ORDER),
@@ -74,16 +74,18 @@ class TestDocumentSourceToJsonld:
                 {"link": "https://ciaa.gov.np/pr/1.pdf", "role": "RAW"},
                 {"link": "https://ciaa.gov.np/pr/1", "role": "SOURCE_PAGE"},
             ],
-            description="A charge sheet summary.",
+            description="A press release summary.",
             related_entities=["https://jawafdehi.org/entity/person/ram-bahadur"],
             publication_date=date(2024, 1, 15),
         )
-        assert material_type == MaterialType.CHARGE_SHEET
+        # A CIAA press release is the announcement, NOT the indictment: it must
+        # shape to press_release, distinct from a charge sheet (अभियोगपत्र).
+        assert material_type == MaterialType.PRESS_RELEASE
         assert doc["@id"] == "https://jawafdehi.org/material/jawafdehi/20240115.ab12cd"
-        assert doc["@type"] == "DigitalDocument"
-        assert doc["additionalType"] == "jawafdehi:ChargeSheet"
+        assert doc["@type"] == "CreativeWork"
+        assert doc["additionalType"] == "jawafdehi:PressRelease"
         assert doc["name"] == {"ne": "CIAA press release on X"}
-        assert doc["description"] == {"ne": "A charge sheet summary."}
+        assert doc["description"] == {"ne": "A press release summary."}
         assert doc["jawafdehi:sourceType"] == "CIAA_PRESS_RELEASE"
         assert doc["datePublished"] == "2024-01-15"
         # roled links → associatedMedia MediaObjects, order + roles preserved
@@ -96,6 +98,19 @@ class TestDocumentSourceToJsonld:
         assert doc["about"] == [
             {"@id": "https://jawafdehi.org/entity/person/ram-bahadur"}
         ]
+
+    def test_charge_sheet_shape_is_distinct_from_press_release(self):
+        # An AG अभियोगपत्र (the indictment) stays charge_sheet: DigitalDocument +
+        # jawafdehi:ChargeSheet — NOT the press_release type/additionalType.
+        doc, material_type = documentsource_to_jsonld(
+            source_id="source:20240115:cs0001",
+            title="AG Charge Sheet - 081-CR-0095",
+            source_type="AG_ABHIYOG_PATRA",
+            url=None,
+        )
+        assert material_type == MaterialType.CHARGE_SHEET
+        assert doc["@type"] == "DigitalDocument"
+        assert doc["additionalType"] == "jawafdehi:ChargeSheet"
 
     def test_minimal_shape_no_optional_fields(self):
         doc, material_type = documentsource_to_jsonld(

--- a/review/casetype.py
+++ b/review/casetype.py
@@ -59,13 +59,16 @@ def detect(case):
     court_cases = case.get("court_cases") or []
 
     has_press_release = any(
-        (_any(t, _PRESS_RELEASE) and (_any(t, _CIAA) or st == "OFFICIAL_GOVERNMENT"))
-        or _any(t, _CIAA)
-        and _any(t, _PRESS_RELEASE)
+        st == "PRESS_RELEASE" or (_any(t, _PRESS_RELEASE) and _any(t, _CIAA))
         for t, st in tt
     )
     has_ciaa_source = any(_any(t, _CIAA) for t, _ in tt)
-    has_chargesheet = any(_any(t, _CHARGESHEET) for t, _ in tt)
+    # A material explicitly typed press_release is never counted as a charge
+    # sheet, even if its title mentions the charge (अभियोग) — a press release
+    # (प्रेस विज्ञप्ति) is the announcement, not the indictment.
+    has_chargesheet = any(
+        _any(t, _CHARGESHEET) and st != "PRESS_RELEASE" for t, st in tt
+    )
     has_verdict = any(_any(t, _VERDICT) for t, _ in tt)
     has_court_order = any(_any(t, _COURT_ORDER) for t, _ in tt)
     has_special_court = any(_any(t, _SPECIAL_COURT) for t, _ in tt)

--- a/review/rules_engine.py
+++ b/review/rules_engine.py
@@ -175,8 +175,14 @@ def structural_completeness(case):
 # Authoritative material types — the NGM equivalents of the old
 # OFFICIAL_GOVERNMENT / LEGAL_* "strong" source types (ADR: cases own no
 # documents). A case with at least one of these has an authoritative source.
+# press_release stays here on purpose: a CIAA प्रेस विज्ञप्ति is a primary
+# government source (the old OFFICIAL_GOVERNMENT) and counts as authoritative
+# sourcing, even though it is NOT the charge sheet — the charge_sheet detector
+# tracks the indictment separately, so a press-release-only case is still typed
+# CIAA_BASIC. Do not drop it or press-release-only cases lose their sourcing.
 _STRONG_MATERIAL_TYPES = {
     "CHARGE_SHEET",
+    "PRESS_RELEASE",
     "COURT_ORDER",
     "OFFICIAL_REPORT",
     "LEGAL_CORPUS",
@@ -209,7 +215,7 @@ def sourcing(case):
     if not strong:
         issues.append(
             "No authoritative material (charge sheet / court order / official "
-            "report / legal corpus) present."
+            "report / legal corpus / CIAA press release) present."
         )
     return _clamp(pts), issues
 
@@ -217,8 +223,7 @@ def sourcing(case):
 def ciaa_press_release(case):
     tt = _source_titles(case)
     present = any(
-        (_any(t, _PRESS_RELEASE) and (_any(t, _CIAA) or st == "OFFICIAL_GOVERNMENT"))
-        or (_any(t, _CIAA) and _any(t, _PRESS_RELEASE))
+        st == "PRESS_RELEASE" or (_any(t, _PRESS_RELEASE) and _any(t, _CIAA))
         for t, st in tt
     )
     if present:
@@ -233,7 +238,9 @@ def ciaa_press_release(case):
 
 def charge_sheet(case):
     tt = _source_titles(case)
-    has_cs = any(_any(t, _CHARGESHEET) for t, _ in tt)
+    # Exclude anything explicitly typed press_release — a CIAA press release is
+    # not the charge sheet (अभियोग पत्र), even if its title mentions the charge.
+    has_cs = any(_any(t, _CHARGESHEET) and st != "PRESS_RELEASE" for t, st in tt)
     if has_cs:
         return 100, []
     return 0, ["No charge sheet (अभियोग पत्र) document among sources."]
@@ -241,7 +248,7 @@ def charge_sheet(case):
 
 def court_record(case):
     tt = _source_titles(case)
-    has_cs = any(_any(t, _CHARGESHEET) for t, _ in tt)
+    has_cs = any(_any(t, _CHARGESHEET) and st != "PRESS_RELEASE" for t, st in tt)
     has_verdict = any(_any(t, _VERDICT) for t, _ in tt)
     has_order = any(_any(t, _COURT_ORDER) for t, _ in tt)
     pts = 0

--- a/tests/cases/test_material_ingest.py
+++ b/tests/cases/test_material_ingest.py
@@ -35,7 +35,7 @@ class TestUpsertSourceMaterial:
         )
         assert iri == "https://jawafdehi.org/material/jawafdehi/20240115.ab12cd"
         mat = Material.objects.get(iri=iri)
-        assert mat.material_type == "charge_sheet"
+        assert mat.material_type == "press_release"
         assert mat.data["associatedMedia"][0]["contentUrl"] == (
             "https://ciaa.gov.np/pr/1.pdf"
         )
@@ -149,9 +149,10 @@ class TestCIAADraftServiceIngest:
         iris = CIAADraftCaseService().create_material_evidence(ciaa_json, case)
         assert len(iris) == 3
         assert case.material_references.count() == 3
-        # material types cover charge_sheet (PR + AG) and court_order
+        # material types: press_release (PR), charge_sheet (AG abhiyogpatra), court_order
         types = set(
             Material.objects.filter(iri__in=iris).values_list("material_type", flat=True)
         )
+        assert "press_release" in types
         assert "charge_sheet" in types
         assert "court_order" in types


### PR DESCRIPTION
## Problem

The material shaper (`materials/jsonld.py`) mapped **both** `CIAA_PRESS_RELEASE` and `AG_ABHIYOG_PATRA` source types to `MaterialType.CHARGE_SHEET` — in `JAWAF_SOURCE_TYPE_TO_MATERIAL` (case-source fold) **and** `INDEX_SOURCE_TYPE_TO_MATERIAL` (R2 published index). A CIAA press release (प्रेस विज्ञप्ति) is a public announcement, **not** the indictment (अभियोगपत्र), so every ingested press release was mislabelled a charge sheet:

- wrong FE badge ("Charge sheet"),
- wrong public JSON-LD `additionalType` (`jawafdehi:ChargeSheet`),
- wrong `material_type` filtering/counts,
- and it let the `charge_sheet` review detector fire on press-release-only cases.

## Fix

- Add `MaterialType.PRESS_RELEASE` → `CreativeWork` + `jawafdehi:PressRelease` (distinct `additionalType` from charge sheets). Remap `CIAA_PRESS_RELEASE → PRESS_RELEASE` in both source-type tables. `AG_ABHIYOG_PATRA` stays `charge_sheet`.
- Harden the review detectors (`review/casetype.py`, `review/rules_engine.py` — `ciaa_press_release` / `charge_sheet` / `court_record`): an explicit `press_release` material_type is a **positive** press-release signal and a **negative** charge-sheet signal, so a press release whose title mentions the charge is no longer counted as a charge sheet. Dropped the dead `st == "OFFICIAL_GOVERNMENT"` literal.
- **Sourcing score is preserved** (this is a pure relabel, not a scoring change): `PRESS_RELEASE` is added to `rules_engine._STRONG_MATERIAL_TYPES` so a CIAA press release still counts as an *authoritative source* (it's a primary government document — the old `OFFICIAL_GOVERNMENT`), even though it is not the charge sheet. This separates "is a charge sheet" (no) from "is authoritative sourcing" (yes), so press-release-only `CIAA_BASIC` cases keep their prior sourcing score.
- Changes are **additive** over the existing title heuristics, so they are correct in both data states — nothing regresses in the window before existing rows are retyped.
- Tests updated + a new "charge sheet stays distinct" shape test.

## Verification

- Pure shaper/index/AG tests green (20/20 shaper).
- Review detectors exercised directly: press-release-only → `CIAA_BASIC`, `charge_sheet` detector 0, `ciaa_press_release` detector 100, `sourcing()` = 56 pts with **no** "No authoritative material" issue; a press release with अभियोग in the title → not counted as a charge sheet; a stale pre-backfill row (still `charge_sheet`) stays `CIAA_BASIC` (no regression).

## Follow-up (not in this PR)

A one-time in-place backfill retypes **3,664** already-mislabelled prod rows (3,438 `source=ciaa_press_release` + 226 case-source; the 99,750 real AG charge sheets are untouched) to `press_release` and rewrites their `@type`/`additionalType`. To be run **after** this merges + deploys (idempotent). Then reindex the OpenSearch material-type facet.

Companion frontend PR: **Jawafdehi/Jawafdehi#211** adds the `press_release` option to the material-type dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)