### PR TITLE
fix(cases): mark /api/cases list private (browser-only), not shared-cacheable

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -426,23 +426,29 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             "material_references",
         ).order_by("-created_at")
 
-    # Anonymous list responses are PUBLISHED-only and identical for everyone, so
-    # they are publicly cacheable. ``s-maxage`` lets the CDN edge absorb the
-    # fan-out; ``max-age`` gives browsers a short hold so an immediate reload is
-    # served from cache instead of re-paying the full query cost. Mirrors
-    # StatisticsView.CACHE_CONTROL. Authenticated/casework list responses vary by
-    # role and stay uncached.
-    LIST_CACHE_CONTROL = "public, max-age=60, s-maxage=300"
+    # This list is ROLE-SCOPED: an anonymous caller gets a PUBLISHED-only page,
+    # but the SAME URL returns a wider DRAFT/IN_REVIEW-inclusive page to an
+    # authenticated caseworker. A shared/CDN cache keys by URL and cannot vary
+    # on auth (Cloudflare honours no ``Vary`` other than Accept-Encoding), so a
+    # cached anon snapshot would be handed to a signed-in caseworker and
+    # silently hide their in-review cases. So the anon response is kept OUT of
+    # shared caches (``private``) and only the browser may hold it briefly
+    # (``max-age`` → an immediate reload is free). Deliberately NOT
+    # ``public``/``s-maxage``: unlike StatisticsView (identical for every
+    # caller, safe to edge-cache), this endpoint must never enter the edge
+    # cache. The batched entity resolution + ``material_references`` prefetch
+    # keep an uncached hit cheap, so forgoing the edge cache costs little.
+    LIST_CACHE_CONTROL = "private, max-age=60"
 
     def list(self, request, *args, **kwargs):
         response = super().list(request, *args, **kwargs)
         if not (request.user and request.user.is_authenticated):
             response["Cache-Control"] = self.LIST_CACHE_CONTROL
-            # Vary on the auth-bearing headers so a shared/CDN cache never
-            # serves this public, PUBLISHED-only snapshot to an authenticated
-            # caseworker. Auth is OIDC bearer (``Authorization``) or session
-            # (``Cookie``); those requests must miss the anon cache and get
-            # their role-scoped (DRAFT/IN_REVIEW-inclusive) list from origin.
+            # ``private`` already keeps this out of shared/CDN caches; Vary on
+            # the auth-bearing headers so the browser's OWN cache can't reuse
+            # this anon entry for a request issued after the user signs in
+            # (OIDC bearer ``Authorization`` or session ``Cookie``) — that one
+            # must fetch the role-scoped list fresh.
             patch_vary_headers(response, ["Cookie", "Authorization"])
         else:
             # Role-scoped list (may include DRAFT/IN_REVIEW cases the public

--- a/tests/api/test_case_list_perf_cache.py
+++ b/tests/api/test_case_list_perf_cache.py
@@ -1,9 +1,11 @@
 """Perf/caching regression tests for the case list endpoint (GET /api/cases/).
 
 These lock in the fixes for the slow "Recently Documented Cases" home section:
-  - anonymous (public) list responses are publicly cacheable so an immediate
-    reload is served from cache instead of re-paying the query cost;
-  - authenticated/casework list responses are NOT publicly cached (role-scoped);
+  - anonymous list responses are browser-cacheable (an immediate reload is
+    free) but stay OUT of shared/CDN caches: the same URL serves a wider
+    role-scoped list to authenticated caseworkers and Cloudflare can't vary
+    the cache on auth, so a shared cache must not hold this snapshot;
+  - authenticated/casework list responses are NOT cached at all (role-scoped);
   - the per-card entity + material resolution no longer scales the SQL query
     count with the number of cards (N+1 removed via batched resolution +
     material_references prefetch).
@@ -30,14 +32,28 @@ def _make_published_case(i):
 
 
 @pytest.mark.django_db
-def test_anonymous_list_is_publicly_cacheable():
+def test_anonymous_list_is_browser_cacheable_but_not_shared_cacheable():
+    """Anon list is role-scoped-by-URL: the browser may hold it briefly, but a
+    shared/CDN cache must NOT store it. Cloudflare keys by URL and can't vary
+    on auth, so a cached ``public`` snapshot would be served to a signed-in
+    caseworker and hide their DRAFT/IN_REVIEW cases. So: ``private`` +
+    ``max-age``, and explicitly NOT ``public``/``s-maxage`` — this guards
+    against a future re-introduction of edge caching on this endpoint."""
     _make_published_case(1)
     resp = APIClient().get("/api/cases/")
     assert resp.status_code == 200
-    assert resp["Cache-Control"] == CaseViewSet.LIST_CACHE_CONTROL
-    # Must vary on the auth-bearing headers so a shared/CDN cache can't serve
-    # this public anon snapshot to an authenticated (cookie- or bearer-token)
-    # caseworker who is entitled to a wider, role-scoped list.
+    cc = resp["Cache-Control"]
+    assert cc == CaseViewSet.LIST_CACHE_CONTROL
+    # Browser may cache briefly, but the response must stay out of shared
+    # caches. Assert the directives literally (not just == the constant) so a
+    # regression in the constant itself is caught here too.
+    assert "max-age=60" in cc
+    assert "private" in cc
+    assert "public" not in cc
+    assert "s-maxage" not in cc
+    # Vary on the auth-bearing headers so the browser's own cache can't reuse
+    # this anon entry for a post-login (cookie- or bearer-token) request that
+    # is entitled to the wider, role-scoped list.
     vary = resp.get("Vary", "")
     assert "Cookie" in vary
     assert "Authorization" in vary


### PR DESCRIPTION
## Problem

PR #309 made `GET /api/cases/` cacheable and, for anonymous callers, set `Cache-Control: public, max-age=60, s-maxage=300` so the Cloudflare edge would absorb the fan-out. But `/api/cases/` is **role-scoped**: an anonymous caller gets a PUBLISHED-only page, while the *same URL* returns a wider DRAFT/IN_REVIEW-inclusive page to an authenticated caseworker.

A shared/CDN cache keys by URL and **cannot vary on auth** — Cloudflare honours no `Vary` header other than `Accept-Encoding` (per-header/cookie cache keys are Enterprise-only), so the app's `Vary: Cookie, Authorization` does nothing at the edge. And per RFC 7234 §3.2, a cached response carrying `public`/`s-maxage` **is eligible to satisfy an `Authorization`-bearing request**. So once an anon snapshot is cached, a signed-in caseworker hitting the same URL can be served the cached PUBLISHED-only list and silently miss their in-review cases (up to `s-maxage`, 300s).

This was verified live against the analogous already-cached `/api/statistics/`: a request carrying an `Authorization` header (and one carrying cookies) is served the *same* cached object (identical `Age`, `cf-cache-status: HIT`).

> Direction check: this is a **functional** regression, not a data leak. The authenticated branch is `private, no-store`, so a DRAFT-bearing response is never stored — the public can never be served drafts. The failure is only that a caseworker could be served *less* than they're entitled to.

Today the frontend happens to dodge it (anon calls use `?page=1&page_size=3` / `?page=1` / bare; casework always sends `page_size=25` or a `state=` filter; the public `/cases` browse uses the search endpoint, not this one), so no URL collides. But that safety is incidental — a `page_size`/`state` refactor could reintroduce it, and no test guards it.

## What changed

Fix at the **origin**, not with an invisible Cloudflare auth-bypass rule. (The origin is powerless once the edge holds a HIT, so edge-caching a role-scoped endpoint can *only* be made correct with un-versioned CF config — the wrong altitude for a correctness boundary.)

- `CaseViewSet.LIST_CACHE_CONTROL`: `public, max-age=60, s-maxage=300` → **`private, max-age=60`**.
  - `private` keeps the list out of every shared/CDN cache **by construction** — cross-contamination becomes impossible with no CF dependency.
  - `max-age=60` preserves the browser's short hold, so the "instant reload" UX #309 wanted still works.
  - The authenticated branch (`private, no-store`) and the N+1 elimination from #309 are unchanged; an uncached hit is already cheap, so forgoing the edge cache costs little at current scale.
- The regression test is rewritten to assert `private` + `max-age` and **explicitly not** `public`/`s-maxage`, guarding against a future re-introduction of edge caching here.

`StatisticsView` is **caller-invariant** (same aggregate for everyone) and correctly **keeps** its `public, s-maxage` edge caching — only role-scoped endpoints must avoid the shared cache.

## Verification

`tests/api/test_case_list_perf_cache.py` (all green):
- anon list is browser-cacheable (`private, max-age=60`) but asserts **not** `public`/`s-maxage`, plus the `Vary` on auth-bearing headers (browser-cache correctness);
- authenticated list stays `no-store`;
- query count stays flat across cards (the #309 N+1 guard is retained).

## Deployment notes

- **No migration.** Rolls via keel on `:main`.
- No Cloudflare change required. The existing cache rule already respects origin `Cache-Control`, so `private` responses simply won't be edge-stored.
- Post-deploy, anon `GET /api/cases/` should show `cf-cache-status: DYNAMIC`/`BYPASS` with `Cache-Control: private, max-age=60` — that's the intended end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
