### PR TITLE
fix(review): target api.jawafdehi.org for casework NGM/JDS clients, not the retired portal host

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -939,7 +939,7 @@ JAZZMIN_SETTINGS = {
 # Casework Review System (VOL-3)
 # ============================================================================
 REVIEW_CASE_SOURCE = os.getenv("REVIEW_CASE_SOURCE", "local")
-JAWAFDEHI_API_BASE = os.getenv("JAWAFDEHI_API_BASE", "https://portal.jawafdehi.org/api")
+JAWAFDEHI_API_BASE = os.getenv("JAWAFDEHI_API_BASE", "https://api.jawafdehi.org/api")
 JAWAFDEHI_API_TOKEN = os.getenv("JAWAFDEHI_API_TOKEN", "")
 JAWAFDEHI_S3_BASE = os.getenv("JAWAFDEHI_S3_BASE", "https://s3.jawafdehi.org")
 

--- a/review/jds_client.py
+++ b/review/jds_client.py
@@ -27,7 +27,7 @@ class JdsError(Exception):
 
 def _base():
     return getattr(
-        settings, "JAWAFDEHI_API_BASE", "https://portal.jawafdehi.org/api"
+        settings, "JAWAFDEHI_API_BASE", "https://api.jawafdehi.org/api"
     ).rstrip("/")
 
 

--- a/review/ngm_client.py
+++ b/review/ngm_client.py
@@ -11,7 +11,7 @@ targets the read plane directly:
   * ``GET {ngm_base}/courtcases/{court}/{number}/hearings``   → hearings (paginated)
 
 It still speaks HTTP (not the ORM) because casework can run against a REMOTE
-portal (``JAWAFDEHI_API_BASE`` may point at portal.jawafdehi.org while the
+API host (``JAWAFDEHI_API_BASE`` may point at api.jawafdehi.org while the
 review worker runs elsewhere). ``get_court_case`` reassembles the case +
 hearings + entities into one dict so its callers keep the previous contract.
 
@@ -55,7 +55,7 @@ def _ngm_base():
     already the ``/api`` base; normalize to end in exactly ``/api``.
     """
     base = getattr(
-        settings, "JAWAFDEHI_API_BASE", "https://portal.jawafdehi.org/api"
+        settings, "JAWAFDEHI_API_BASE", "https://api.jawafdehi.org/api"
     ).rstrip("/")
     if not base.endswith("/api"):
         base = f"{base}/api"
@@ -116,9 +116,18 @@ def _auth_headers():
 
 
 def _get(url, timeout, *, allow_404=False):
-    """GET ``url`` with auth headers; return parsed JSON (or None on allowed 404)."""
+    """GET ``url`` with auth headers; return parsed JSON (or None on allowed 404).
+
+    Redirects are NOT followed: the read plane answers 2xx JSON directly, so a
+    3xx means the configured base URL is wrong (e.g. it points at a retired host
+    that 301s to the SPA). Surfacing that — and any non-JSON 200 body — as an
+    NgmError keeps a base-URL misconfiguration from masquerading as a clean
+    "court record not found" result.
+    """
     try:
-        r = requests.get(url, headers=_auth_headers(), timeout=timeout)
+        r = requests.get(
+            url, headers=_auth_headers(), timeout=timeout, allow_redirects=False
+        )
     except requests.RequestException as e:
         raise NgmError(f"NGM request failed: {e}") from e
     if r.status_code == 404 and allow_404:
@@ -127,7 +136,10 @@ def _get(url, timeout, *, allow_404=False):
         raise NgmNotFound(f"NGM resource not found: {url}")
     if r.status_code != 200:
         raise NgmError(f"NGM HTTP {r.status_code}: {r.text[:300]}")
-    return r.json()
+    try:
+        return r.json()
+    except ValueError as e:
+        raise NgmError(f"NGM non-JSON response from {url}: {e}") from e
 
 
 def _collect_paginated(url, timeout):

--- a/tests/test_casework_oidc_clients.py
+++ b/tests/test_casework_oidc_clients.py
@@ -98,7 +98,7 @@ def test_ngm_get_court_case_sends_bearer(oidc_configured, monkeypatch):
     _stub_token(monkeypatch)
     captured = {}
 
-    def fake_get(url, headers=None, timeout=None):
+    def fake_get(url, headers=None, timeout=None, allow_redirects=None):
         captured["headers"] = headers
         return FakeResponse(json_body={"entities": []})
 
@@ -117,7 +117,7 @@ def test_ngm_no_auth_header_when_unconfigured(settings, monkeypatch):
     cc.reset_provider()
     captured = {}
 
-    def fake_get(url, headers=None, timeout=None):
+    def fake_get(url, headers=None, timeout=None, allow_redirects=None):
         captured["headers"] = headers
         return FakeResponse(json_body={"entities": []})
 
@@ -125,6 +125,41 @@ def test_ngm_no_auth_header_when_unconfigured(settings, monkeypatch):
     ngm_client.get_court_case("https://jawafdehi.org/courtcase/special/081-cr-0079")
     assert "Authorization" not in captured["headers"]
     cc.reset_provider()
+
+
+def test_ngm_get_raises_on_redirect(oidc_configured, monkeypatch):
+    """A 3xx (e.g. a retired host 301-ing to the SPA) surfaces as NgmError.
+
+    Regression guard: JAWAFDEHI_API_BASE once defaulted to a decommissioned host
+    that 301-redirected to the SPA; with redirects followed, ``.json()`` then
+    choked on the HTML page and the failure masqueraded as "court record not
+    found" instead of a loud misconfiguration.
+    """
+    _stub_token(monkeypatch)
+
+    def fake_get(url, headers=None, timeout=None, allow_redirects=None):
+        assert allow_redirects is False
+        return FakeResponse(status_code=301, text="<!doctype html>")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    with pytest.raises(ngm_client.NgmError):
+        ngm_client.get_court_case("https://jawafdehi.org/courtcase/special/081-cr-0079")
+
+
+def test_ngm_get_raises_on_non_json_body(oidc_configured, monkeypatch):
+    """A 200 with a non-JSON body raises NgmError, not an unhandled ValueError."""
+    _stub_token(monkeypatch)
+
+    class HtmlResponse(FakeResponse):
+        def json(self):
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+    def fake_get(url, headers=None, timeout=None, allow_redirects=None):
+        return HtmlResponse(status_code=200, text="<!doctype html>")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    with pytest.raises(ngm_client.NgmError):
+        ngm_client.get_court_case("https://jawafdehi.org/courtcase/special/081-cr-0079")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`JAWAFDEHI_API_BASE` defaults to `https://portal.jawafdehi.org/api` in `config/settings.py`, `review/ngm_client.py`, and `review/jds_client.py`. **`portal.jawafdehi.org` was decommissioned on 2026-07-10** and now 301-redirects to the SPA.

For the NGM court-record lookup that means:

1. `ngm_client._get()` GETs `portal.jawafdehi.org/api/courtcases/<court>/<number>`
2. `requests` follows the 301 → lands on the `jawafdehi.org` SPA → `200 text/html`
3. `r.json()` raises `Expecting value: line 1 column 1 (char 0)`
4. `scorer.py` swallows it as `ngm_court_record = {"error": ...}`

The `accused_list_matches_court_record` review rule therefore lost its **authoritative** cross-check against the judicial DB for **every case carrying a court number** since the portal was retired (~10 of the last 60 review runs showed explicit NGM failures; the rest silently fell back to the attached court-order doc). It never blocked a review because that rule is a soft LLM signal, not a gate — cases kept PASSing on unverified accused lists.

## Fix

- Default `JAWAFDEHI_API_BASE` → `https://api.jawafdehi.org/api` in `settings.py`, `ngm_client.py`, and `jds_client.py` (+ drop the stale `portal.jawafdehi.org` example in the `ngm_client` module docstring).
- **Harden `ngm_client._get`** so a bad base URL can't fail silently again:
  - `allow_redirects=False` — a 3xx now surfaces as `NgmError` instead of being followed to a non-JSON page.
  - wrap `r.json()` in `NgmError` — any non-JSON 200 body becomes a typed error instead of an unhandled `ValueError`.
- Regression tests: `test_ngm_get_raises_on_redirect`, `test_ngm_get_raises_on_non_json_body`.

## Verification

Root cause proven against mainline + the running pod. The live read plane at `https://api.jawafdehi.org/api/courtcases/special/080-cr-0007` returns `200 application/json`; with the base corrected, `defendants_for_case` returns `['राजु पुरी', 'श्रृजना गिरी']` with zero errors.

An env stopgap (`JAWAFDEHI_API_BASE=https://api.jawafdehi.org/api`) was applied live on `cronjob/platform-jobs-processor` + `deploy/jawafdehi-platform` and a re-run (review 502) confirmed the accused-list rule went 80 → 100 with no NGM-failure markers. **Once this merges and deploys, that env override can be removed** (the code default is then correct).

`ruff check` clean; `tests/test_casework_oidc_clients.py` + `tests/test_review_accused_gate.py` pass (13).

## Follow-up (separate)

Cases reviewed 2026-07-10 → 2026-07-14 had a void NGM cross-check and warrant a re-review sweep (depth TBD, prioritizing multi-defendant cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated casework and review API connections to use the dedicated API service.
  * Improved handling of redirects and unexpected non-JSON responses, providing clearer errors instead of unhandled failures.
  * Casework requests now use OIDC bearer authorization consistently.
* **Tests**
  * Added coverage for authorization headers, redirect responses, and invalid response formats to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->