### PR TITLE
fix(cases): make case notes writable via PATCH (BB-28)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -1146,8 +1146,12 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             # is the top-level case ``notes`` TextField, distinct from the nested
             # per-entity relationship ``notes`` above. Carried here so the editor's
             # ``replace /notes`` JSON-Patch op resolves against an existing key
-            # (BB-28) and the scalar-field save below can persist it.
-            "notes": case.notes,
+            # (BB-28) and the scalar-field save below can persist it. Coerce a
+            # ``None`` (the column is NOT NULL / ``default=""``, but a legacy or
+            # raw row could still read back NULL) to "" so a snapshot value never
+            # trips ``CasePatchSerializer.notes`` (``allow_blank`` but not
+            # ``allow_null``) and 422s an otherwise-unrelated PATCH.
+            "notes": case.notes or "",
         }
 
 

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -831,6 +831,10 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 "slug",
                 "missing_details",
                 "bigo",
+                # Internal casework notes (Case.notes TextField). A scalar column,
+                # so it persists via the bulk UPDATE like the other scalars — the
+                # missing entry here is what silently dropped a patched note (BB-28).
+                "notes",
             ]
         )
 
@@ -1138,6 +1142,12 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             "court_cases": case.court_cases,
             "missing_details": case.missing_details,
             "bigo": case.bigo,
+            # Internal casework notes (BB-04-gated on read; casework-only). This
+            # is the top-level case ``notes`` TextField, distinct from the nested
+            # per-entity relationship ``notes`` above. Carried here so the editor's
+            # ``replace /notes`` JSON-Patch op resolves against an existing key
+            # (BB-28) and the scalar-field save below can persist it.
+            "notes": case.notes,
         }
 
 

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -336,6 +336,10 @@ class CasePatchSerializer(CourtCaseRefsValidationMixin, serializers.Serializer):
     timeline = TimelineItemSerializer(many=True, required=False)
     evidence = EvidenceItemSerializer(many=True, required=False)
     entities = EntityPatchItemSerializer(many=True, required=False)
+    # Internal casework notes (Case.notes TextField; no max_length). Casework-only
+    # — read gating stays in the read serializer's SerializerMethodField (BB-04);
+    # this only makes the field writable via PATCH (BB-28). Mirrors the create path.
+    notes = serializers.CharField(required=False, allow_blank=True)
     slug = serializers.SlugField(
         max_length=50,
         required=False,

--- a/cases/caseworker_serializers.py
+++ b/cases/caseworker_serializers.py
@@ -339,6 +339,9 @@ class CasePatchSerializer(CourtCaseRefsValidationMixin, serializers.Serializer):
     # Internal casework notes (Case.notes TextField; no max_length). Casework-only
     # — read gating stays in the read serializer's SerializerMethodField (BB-04);
     # this only makes the field writable via PATCH (BB-28). Mirrors the create path.
+    # NOT ``allow_null``: the model column is NOT NULL (``default=""``), so a JSON
+    # ``null`` can't be stored — clear notes by sending "" (allow_blank). A literal
+    # ``null`` is rejected (422) rather than silently coerced, matching the column.
     notes = serializers.CharField(required=False, allow_blank=True)
     slug = serializers.SlugField(
         max_length=50,

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -2,10 +2,13 @@
 Tests for PATCH /api/cases/{id}/ (RFC 6902 JSON Patch endpoint).
 """
 
+from unittest import mock
+
 import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 
+from cases.api_views import CaseViewSet
 from cases.models import (
     Case,
     CaseEntityRelationship,
@@ -154,6 +157,45 @@ def test_patch_scalar_only_leaves_existing_notes_untouched():
     case.refresh_from_db()
     assert case.title == "Retitled"
     assert case.notes == "pre-existing internal note"
+
+
+@pytest.mark.django_db
+def test_build_snapshot_coerces_null_notes_to_empty_string():
+    # Regression (Gemini HIGH): a legacy/raw row whose notes reads back NULL must
+    # not put ``None`` into the snapshot — CasePatchSerializer.notes is allow_blank
+    # but NOT allow_null, so a None would 422 EVERY patch to that case. The column
+    # is NOT NULL (default=""), so we exercise the coercion directly on the
+    # snapshot builder with an in-memory None (which the ORM can't persist).
+    case = _make_case()
+    case.notes = None  # simulate a NULL read-back
+    snapshot = CaseViewSet()._build_snapshot(case)
+    assert snapshot["notes"] == ""
+
+
+@pytest.mark.django_db
+def test_patch_unrelated_field_survives_null_notes_row():
+    # Regression (Gemini HIGH), end-to-end: with a row whose notes reads back NULL,
+    # patching an UNRELATED field must return 200 (not 422). The NOT NULL column
+    # can't hold NULL via the ORM, so we force the fetched instance's notes to None
+    # and let the real _build_snapshot coercion run through the endpoint.
+    user = _contributor("null-notes")
+    case = _make_case(title="Original title")
+    case.notes = None
+
+    client = _authed_client(user)
+    # get_object() is the single source of the case the view reads/writes; return
+    # our NULL-notes instance so _build_snapshot sees None and must coerce it.
+    with mock.patch.object(CaseViewSet, "get_object", return_value=case):
+        response = client.patch(
+            URL.format(case.slug),
+            data=[{"op": "replace", "path": "/title", "value": "Renamed"}],
+            format="json",
+        )
+    assert response.status_code == 200, response.data
+    case.refresh_from_db()
+    assert case.title == "Renamed"
+    # The coerced-empty note landed as "" (never NULL), consistent with the column.
+    assert case.notes == ""
 
 
 @pytest.mark.django_db

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -108,6 +108,55 @@ def test_patch_replace_scalar_field():
 
 
 @pytest.mark.django_db
+def test_patch_replace_notes_persists_on_case_without_notes():
+    # BB-28: the editor sends `replace /notes`, but the patch surface omitted
+    # `notes` (no snapshot key, no serializer field, no scalar write), so the
+    # patch failed with 400 "can't replace a non-existent object 'notes'".
+    # Same class as BB-11 (a writable field missing from the patch surface).
+    user = _contributor("bikash")
+    case = _make_case()  # notes defaults to ""
+    assert case.notes == ""
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/notes", "value": "internal note"}],
+        format="json",
+    )
+    assert response.status_code == 200, response.data
+    # The patched note is persisted to the Case row.
+    case.refresh_from_db()
+    assert case.notes == "internal note"
+    # And it survives the editor's reload path — the casework read serializer
+    # returns notes to casework viewers (BB-04). (The PATCH response body itself
+    # blanks notes because CaseSerializer is built there without request context;
+    # that's pre-existing and orthogonal to this persistence fix.)
+    reload = client.get(URL.format(case.slug))
+    assert reload.status_code == 200
+    assert reload.data["notes"] == "internal note"
+
+
+@pytest.mark.django_db
+def test_patch_scalar_only_leaves_existing_notes_untouched():
+    # A PATCH that does NOT touch /notes must not clobber an existing note: the
+    # snapshot carries the current notes value, so a scalar-only edit round-trips
+    # it back unchanged.
+    user = _contributor("chandra")
+    case = _make_case(notes="pre-existing internal note")
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/title", "value": "Retitled"}],
+        format="json",
+    )
+    assert response.status_code == 200, response.data
+    case.refresh_from_db()
+    assert case.title == "Retitled"
+    assert case.notes == "pre-existing internal note"
+
+
+@pytest.mark.django_db
 def test_patch_replace_timeline_item_title():
     user = _contributor("sita")
     case = _make_case(

--- a/tests/api/test_caseworker_patch_integration.py
+++ b/tests/api/test_caseworker_patch_integration.py
@@ -135,6 +135,33 @@ def test_patch_multi_operation_end_to_end_persists_all_changes():
 
 
 @pytest.mark.django_db
+def test_patch_notes_persists_and_survives_read_back_for_caseworker():
+    # BB-28 end-to-end: replace /notes on a case with no notes -> 200, the note
+    # persists, and reloading the case through the read endpoint (the way the
+    # editor reloads before the next PATCH) returns it to the caseworker.
+    user = create_user_with_role("bimala", "bimala@example.com", "Caseworker")
+    case = _make_case()
+    assert case.notes == ""
+
+    client = _authed_client(user)
+    response = client.patch(
+        URL.format(case.slug),
+        data=[{"op": "replace", "path": "/notes", "value": "internal casework note"}],
+        format="json",
+    )
+    assert response.status_code == 200, response.data
+
+    case.refresh_from_db()
+    assert case.notes == "internal casework note"
+
+    # Reload via GET — the casework read serializer exposes notes to casework
+    # roles (BB-04), so the editor's round-trip shows the saved note.
+    reload = client.get(URL.format(case.slug))
+    assert reload.status_code == 200
+    assert reload.data["notes"] == "internal casework note"
+
+
+@pytest.mark.django_db
 def test_patch_rejects_invalid_state_transition_in_multi_op_without_partial_write():
     # v3 authz: a Caseworker is authorized to publish, but publishing an
     # incomplete case (no accused entity / key allegation) fails validation.


### PR DESCRIPTION
## BB-28 (S2): case `notes` cannot be saved

### Root cause
The case editor sends an RFC-6902 JSON-Patch `replace /notes`, but the PATCH surface in the cases API omitted the top-level `notes` field entirely:

- `_build_snapshot()` had no top-level `notes` key (the `notes` present there is the *nested per-entity-relationship* note, not the case-level field), so `jsonpatch.apply_patch` raised **400 "can't replace a non-existent object 'notes'"**.
- `CasePatchSerializer` had no `notes` field.
- The scalar-field save set in `partial_update` didn't include `notes`, so even a value that got through would never be persisted.

`Case.notes` is a real column (`TextField`, `default=""`) and the create path (`_CREATE_MODEL_FIELDS`) already writes it — only the PATCH path was broken. This is the **same class as BB-11**: a writable field missing from the patch surface.

### Fix (mirrors the create path)
- `_build_snapshot()`: add `"notes": case.notes` at the top level so `replace /notes` resolves against an existing key.
- `CasePatchSerializer`: add `notes = serializers.CharField(required=False, allow_blank=True)` (TextField → no `max_length`).
- `partial_update` scalar-field set: add `notes` so the patched value persists via the bulk `UPDATE`.

### Read gating unchanged (stays casework-only)
`notes` is internal. Read gating is untouched: the read serializer's `get_notes` `SerializerMethodField` still returns `""` to non-casework callers (BB-04). The existing public-gating e2e test (`test_notes_are_hidden_from_public_but_shown_to_casework`) still passes.

Note (pre-existing, out of scope): the PATCH *response body* blanks `notes` because `CaseSerializer` is instantiated in `partial_update` without request context, so casework access can't be detected there. Persistence and the editor's GET-reload path both work correctly; this only affects the echoed PATCH response body, and is orthogonal to the persistence fix.

### Tests
- `tests/api/test_caseworker_patch.py`: caseworker `replace /notes` on a case with no notes → 200, note persists on reload (GET), plus a scalar-only PATCH that must leave an existing note untouched.
- `tests/api/test_caseworker_patch_integration.py`: end-to-end `replace /notes` → 200, `refresh_from_db` shows the note, and a GET reload returns it to the caseworker.

Local run: `uv run pytest tests/api/test_caseworker_patch.py tests/api/test_caseworker_patch_integration.py -q` → **43 passed**. BB-04 gating e2e, `notes` model tests, public API, and schema/documentation tests also pass. `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)