### PR TITLE
fix(materials): let the org-wide ReadOnly role see non-public materials

### DIFF
--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 from cases.models import Case, CaseMaterialReference, CaseState, CaseType
@@ -261,6 +262,19 @@ class TestReadSideGates:
         u.save()
         return u
 
+    def _readonly(self):
+        # The org-wide ReadOnly role as the bearer authenticator produces it:
+        # in the ReadOnly Group, but NOT is_staff / is_superuser (that flag is
+        # only ever set by the Django-admin session path, never by bearer auth).
+        u = User.objects.create_user("ro1", password="x")
+        u.groups.add(Group.objects.get_or_create(name="ReadOnly")[0])
+        return u
+
+    def _plain_authed(self):
+        # Authenticated but roleless: the boundary case. Systemwide read is the
+        # ReadOnly *role*, not mere authentication — this principal stays gated.
+        return User.objects.create_user("nobody1", password="x")
+
     def test_anon_retrieve_hides_private(self):
         mat = _store("source:20240101:aaaa01", visibility=Visibility.PRIVATE)
         client = APIClient()
@@ -336,6 +350,33 @@ class TestReadSideGates:
         resp = client.get("/api/materials/")
         ids = {d["@id"] for d in resp.json()["results"]}
         assert any("priv01" in i for i in ids)
+
+    def test_readonly_retrieve_shows_private(self):
+        # Org-wide ReadOnly is a systemwide READ role: it must resolve PRIVATE
+        # (draft-only) materials, exactly like content staff.
+        mat = _store("source:20240101:aaaa01", visibility=Visibility.PRIVATE)
+        client = APIClient()
+        client.force_authenticate(self._readonly())
+        resp = client.get(f"/api/materials/?iri={mat.iri}")
+        assert resp.status_code == 200, resp.content
+
+    def test_readonly_list_includes_private(self):
+        _store("source:20240101:list01", visibility=Visibility.LISTED)
+        _store("source:20240101:priv01", visibility=Visibility.PRIVATE)
+        client = APIClient()
+        client.force_authenticate(self._readonly())
+        resp = client.get("/api/materials/")
+        ids = {d["@id"] for d in resp.json()["results"]}
+        assert any("priv01" in i for i in ids)
+
+    def test_plain_authed_hides_private(self):
+        # Boundary: a roleless authenticated user is NOT a read role and stays
+        # gated out of PRIVATE (only the ReadOnly role / content staff lift it).
+        mat = _store("source:20240101:aaaa01", visibility=Visibility.PRIVATE)
+        client = APIClient()
+        client.force_authenticate(self._plain_authed())
+        resp = client.get(f"/api/materials/?iri={mat.iri}")
+        assert resp.status_code == 404, resp.content
 
 
 @pytest.mark.django_db

--- a/materials/views.py
+++ b/materials/views.py
@@ -96,12 +96,19 @@ def _can_see_nonpublic(request) -> bool:
     user = getattr(request, "user", None)
     if not (user and user.is_authenticated):
         return False
-    # Any authenticated staff-ish principal (NGM role, caseworker, readonly, or
-    # a superuser) may inspect drafts. HasNgmRole covers the write role; the
-    # broader "authenticated internal user" check keeps caseworker/readonly able
-    # to review their own draft evidence.
+    # A superuser (or a Django-admin-session staff principal) may inspect drafts.
     if getattr(user, "is_staff", False) or getattr(user, "is_superuser", False):
         return True
+    # Org-wide ReadOnly is the systemwide READ role: it sees non-public
+    # (draft-only) materials just like content staff. It is admitted here by
+    # group name — matching the casework read gates in cases/review/jobs, which
+    # all honour ReadOnly — because the bearer authenticator syncs roles into
+    # Groups but never sets is_staff, so the is_staff short-circuit above never
+    # catches a ReadOnly (or a bearer-only Caseworker) principal. ReadOnly stays
+    # excluded from every WRITE gate (HasNgmRole / HasContributorRole).
+    if user.groups.filter(name="ReadOnly").exists():
+        return True
+    # NGM-capable content role (Caseworker) / NGM tiers, or superuser.
     return HasNgmRole().has_permission(request, None)
 
 


### PR DESCRIPTION
## Problem

`ReadOnly` is meant to be a **systemwide read** role — it already sees draft/in-review cases (`cases`), the review queue (`review`), and jobs (`jobs`), all of which honour it by group name. But the materials read plane didn't: `materials/views.py::_can_see_nonpublic` gated `PRIVATE` (draft-only) materials on `is_staff | is_superuser | HasNgmRole`, and:

- the bearer authenticator (`jawafdehi_shared/auth/oidc.py`) syncs Zitadel roles → Django Groups but **never sets `is_staff`** (only the Django-admin session path does), and
- `HasNgmRole` admits only `Caseworker`/superuser (`NGM_ROLE_GROUPS = {"Caseworker"}`).

So a `ReadOnly` principal got a **404 on PRIVATE materials** and had them **filtered out of `GET /api/materials/`** — contradicting the module's own docstrings (which say "authed caseworker/**readonly**/NGM principal may").

Note: `UNLISTED` was already reachable by direct IRI for everyone; this only concerns the `PRIVATE` tier and the list endpoint.

## Fix

Admit `ReadOnly` by group name in `_can_see_nonpublic` (the same idiom `jobs`/`review` use). **Writes stay gated** — `HasNgmRole` / `HasContributorRole` still exclude `ReadOnly`.

## Tests

- `test_readonly_retrieve_shows_private` / `test_readonly_list_includes_private` — the fix (verified red→green: both fail on `main`).
- `test_plain_authed_hides_private` — boundary: a roleless authenticated user stays gated (systemwide read is the *role*, not mere authentication).
- Full `materials/` suite green locally (193 passed).

## Follow-up (not in this PR)

The gated raw-SQL plane `POST /courtcases/query` (`HasNgmQueryAccess`) also excludes `ReadOnly`. Its data is already fully public via the REST read plane, so extending "systemwide read" to it is low-risk but is a separate policy call — happy to do it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)