### PR TITLE
perf(materials): resolve the non-public read gate in a single group query

### DIFF
--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -275,6 +275,14 @@ class TestReadSideGates:
         # ReadOnly *role*, not mere authentication — this principal stays gated.
         return User.objects.create_user("nobody1", password="x")
 
+    def _caseworker(self):
+        # The NGM content role via bearer auth: in the Caseworker Group but NOT
+        # is_staff (bearer auth never sets it), so it exercises the NGM-group
+        # read path rather than the is_staff short-circuit.
+        u = User.objects.create_user("cw1", password="x")
+        u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+        return u
+
     def test_anon_retrieve_hides_private(self):
         mat = _store("source:20240101:aaaa01", visibility=Visibility.PRIVATE)
         client = APIClient()
@@ -377,6 +385,27 @@ class TestReadSideGates:
         client.force_authenticate(self._plain_authed())
         resp = client.get(f"/api/materials/?iri={mat.iri}")
         assert resp.status_code == 404, resp.content
+
+    def test_caseworker_retrieve_shows_private(self):
+        # A bearer-only Caseworker (content role, not is_staff/superuser) resolves
+        # PRIVATE materials via the NGM-group read path — the branch the
+        # single-query gate now covers alongside ReadOnly.
+        mat = _store("source:20240101:aaaa01", visibility=Visibility.PRIVATE)
+        client = APIClient()
+        client.force_authenticate(self._caseworker())
+        resp = client.get(f"/api/materials/?iri={mat.iri}")
+        assert resp.status_code == 200, resp.content
+
+    def test_nonpublic_gate_uses_single_group_query(self, django_assert_num_queries):
+        # Efficiency guard: a role-carrying principal is resolved in ONE group
+        # query — not a ReadOnly `.exists()` miss followed by a second NGM query.
+        from types import SimpleNamespace
+
+        from materials.views import _can_see_nonpublic
+
+        cw = self._caseworker()
+        with django_assert_num_queries(1):
+            assert _can_see_nonpublic(SimpleNamespace(user=cw)) is True
 
 
 @pytest.mark.django_db

--- a/materials/views.py
+++ b/materials/views.py
@@ -35,7 +35,7 @@ from jawafdehi_shared.entities.ids import (
 )
 from jawafdehi_shared.drf.base import PlatformCursorPagination
 from jawafdehi_shared.storage import store_file_as_link
-from courts.permissions import HasNgmRole
+from courts.permissions import NGM_ROLE_GROUPS, HasNgmRole
 
 from . import jsonld
 from . import provenance
@@ -85,6 +85,14 @@ def _require_ngm_role(request):
     return None
 
 
+# Django Groups whose members may READ non-public (draft-only) materials: the
+# org-wide ReadOnly read role plus the NGM-capable content role(s) that
+# ``HasNgmRole`` gates (Caseworker / any future NGM tier). Derived from
+# ``NGM_ROLE_GROUPS`` so that set stays the single source of truth. Writes stay
+# gated separately — ``HasNgmRole`` / ``HasContributorRole`` exclude ReadOnly.
+_NONPUBLIC_READ_GROUPS = frozenset({"ReadOnly"}) | NGM_ROLE_GROUPS
+
+
 def _can_see_nonpublic(request) -> bool:
     """True iff the principal may see PRIVATE (draft-only) materials.
 
@@ -99,17 +107,12 @@ def _can_see_nonpublic(request) -> bool:
     # A superuser (or a Django-admin-session staff principal) may inspect drafts.
     if getattr(user, "is_staff", False) or getattr(user, "is_superuser", False):
         return True
-    # Org-wide ReadOnly is the systemwide READ role: it sees non-public
-    # (draft-only) materials just like content staff. It is admitted here by
-    # group name — matching the casework read gates in cases/review/jobs, which
-    # all honour ReadOnly — because the bearer authenticator syncs roles into
-    # Groups but never sets is_staff, so the is_staff short-circuit above never
-    # catches a ReadOnly (or a bearer-only Caseworker) principal. ReadOnly stays
-    # excluded from every WRITE gate (HasNgmRole / HasContributorRole).
-    if user.groups.filter(name="ReadOnly").exists():
-        return True
-    # NGM-capable content role (Caseworker) / NGM tiers, or superuser.
-    return HasNgmRole().has_permission(request, None)
+    # Everyone else needs a read-capable role. ReadOnly (systemwide read) and the
+    # NGM content role(s) are checked in a SINGLE group query — the bearer
+    # authenticator syncs roles into Groups but never sets is_staff, so a
+    # ReadOnly or bearer-only Caseworker principal is caught here, not by the
+    # is_staff short-circuit above.
+    return user.groups.filter(name__in=_NONPUBLIC_READ_GROUPS).exists()
 
 
 def _upsert_material(data, *, material_type: str | None, expected_iri: str | None = None):


### PR DESCRIPTION
Follow-up to #331 (the code-review efficiency finding).

## Problem

After #331, `materials/views.py::_can_see_nonpublic` checked `groups.filter(name="ReadOnly").exists()` and, on a miss, fell through to `HasNgmRole().has_permission()` — which runs a **second** `groups.values_list()`. So every non-ReadOnly authenticated principal (e.g. a bearer Caseworker) paid **two** group queries on a read-permission path.

## Fix

Collapse both into a single query:

```python
_NONPUBLIC_READ_GROUPS = frozenset({"ReadOnly"}) | NGM_ROLE_GROUPS
...
return user.groups.filter(name__in=_NONPUBLIC_READ_GROUPS).exists()
```

`NGM_ROLE_GROUPS` (imported from `courts.permissions`) stays the single source of truth for the NGM role set. **Behaviour is unchanged** — verified equivalent for every principal class:

| Principal | before | after |
|---|---|---|
| superuser / is_staff | `True` (short-circuit) | `True` (short-circuit, unchanged) |
| ReadOnly | `True` | `True` |
| Caseworker / NGM tier | `True` (via HasNgmRole) | `True` |
| roleless authed | `False` | `False` |
| anon | `False` | `False` |

`HasNgmRole` is still imported — `_require_ngm_role` (the write gate) uses it.

## Tests

- `test_nonpublic_gate_uses_single_group_query` — `django_assert_num_queries(1)` guard; **fails on the pre-refactor two-query form**, passes now.
- `test_caseworker_retrieve_shows_private` — bearer-only Caseworker (group=Caseworker, `is_staff=False`) gets 200 on a PRIVATE material, exercising the NGM-group path the refactor folds in (also closes the coverage gap noted in the #331 review).
- Full `materials/` suite green locally: **195 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)