### PR TITLE
fix(cases): record slug history on any bulk update(slug=…) (BB-38 follow-up)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -915,6 +915,10 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 # edits would otherwise leave ``updated_at`` — and the derived
                 # optimistic-concurrency token — stale. Bump it explicitly so the
                 # serialized timestamp and the ETag both track content edits.
+                # ``CaseQuerySet.update()`` records the slug change into
+                # CaseSlugHistory when ``scalar_updates`` carries a new ``slug``,
+                # so the retired slug's URL 301-redirects instead of 404ing
+                # (BB-38) — no explicit ``record()`` call is needed here.
                 Case.objects.filter(pk=case.pk).update(
                     updated_at=timezone.now(), **scalar_updates
                 )
@@ -930,15 +934,6 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                     Case.objects.get(pk=case.pk),
                     fields=list(scalar_updates.keys()),
                 )
-
-                # Record a slug change so the retired slug's URL 301-redirects
-                # to the new canonical one (BB-38). This bulk ``update()``
-                # bypasses ``Case.save()``, so the model-level history hook
-                # never fires for this (primary) DRAFT re-slug path — record it
-                # explicitly. ``case`` still holds the pre-update slug here.
-                new_slug = scalar_updates.get("slug")
-                if new_slug and new_slug != case.slug:
-                    CaseSlugHistory.record(case, case.slug, new_slug)
 
             # Persist entity relationship changes only when a /entities op
             # was explicitly included — avoids unnecessary delete/recreate on

--- a/cases/management/commands/backfill_slug_history.py
+++ b/cases/management/commands/backfill_slug_history.py
@@ -1,0 +1,153 @@
+"""``backfill_slug_history`` — retroactively populate CaseSlugHistory (BB-38).
+
+The slug-redirect feature only started recording retired slugs going forward,
+so cases that were re-slugged BEFORE it shipped have orphaned old URLs that
+still hard-404. Those pre-existing retired slugs survive in one place: the
+``CaseReview`` table, whose ``slug`` column snapshots the slug a case carried
+when it was reviewed. This command reads each review's snapshot slug, and for
+any that no longer addresses a live case, resolves it back to its current case
+and records ``old_slug → case`` in CaseSlugHistory so the stale URL 301-redirects.
+
+Resolution mirrors ``review.migrations.0004``'s four tiers (in order):
+  1. a direct ``case`` FK on the review, if the review model has one (post the
+     review-key-on-case-id migration — then no fuzzy resolution is needed);
+  2. a court-case reference number (``NNN-XX-NNN[N]``) embedded in the slug,
+     matched against ``courtcase_references__courtcase_iri`` (unique hit only);
+  3. the review's snapshot ``case_title`` matched exactly against a live title;
+  4. a unique ``slug__istartswith`` prefix (re-slugs usually append a suffix).
+
+Read-only by default (lists what WOULD be recorded). Pass ``--apply`` to write.
+Idempotent: ``CaseSlugHistory.record`` upserts, so re-running is safe. Live
+slugs are never recorded (a live slug must resolve to its own case, not
+redirect), and rows shadowing a live slug are dropped by ``record`` itself.
+"""
+
+from __future__ import annotations
+
+import re
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from cases.models import Case, CaseSlugHistory
+
+COURT_REF_RE = re.compile(r"(\d{3}-[a-z]{2}-\d{3,4})")
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill CaseSlugHistory from CaseReview snapshot slugs so pre-feature "
+        "retired slugs 301-redirect (dry-run unless --apply)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Write the history rows. Without this flag, only lists what "
+            "would be recorded.",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+
+        # Import lazily so the command still loads if the review app is absent
+        # (it lives in the same monolith today, but keep the coupling soft).
+        from review.models import CaseReview
+
+        live_slugs = set(Case.objects.values_list("slug", flat=True))
+
+        # old_slug -> Case (deduped; a slug maps to exactly one former owner).
+        candidates: dict[str, Case] = {}
+        skipped_live = 0
+        unresolved: list[str] = []
+
+        for review in CaseReview.objects.all():
+            old_slug = (getattr(review, "slug", "") or "").strip()
+            if not old_slug:
+                continue
+            if old_slug in live_slugs:
+                # The review's slug still addresses a live case — not outdated.
+                skipped_live += 1
+                continue
+
+            case = self._resolve(review, old_slug)
+            if case is None:
+                unresolved.append(old_slug)
+                continue
+            # Never record a case's own current slug as a predecessor, and skip
+            # the pathological empty-slug case.
+            if not case.slug or case.slug == old_slug:
+                continue
+            candidates[old_slug] = case
+
+        existing = set(CaseSlugHistory.objects.values_list("slug", flat=True))
+        new_rows = {s: c for s, c in candidates.items() if s not in existing}
+
+        mode = "APPLY" if apply else "dry-run"
+        self.stdout.write(
+            f"CaseReview rows: {CaseReview.objects.count()} | "
+            f"skipped (slug still live): {skipped_live} | "
+            f"unresolved: {len(unresolved)} | "
+            f"resolvable outdated slugs: {len(candidates)} | "
+            f"already recorded: {len(candidates) - len(new_rows)} | "
+            f"to record: {len(new_rows)} ({mode})"
+        )
+        for old_slug, case in sorted(new_rows.items()):
+            self.stdout.write(f"  {old_slug} -> {case.slug} (case id={case.pk})")
+        if unresolved:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Unresolved (left as 404): {sorted(unresolved)[:20]}"
+                )
+            )
+
+        if not apply:
+            if new_rows:
+                self.stdout.write("Re-run with --apply to record these rows.")
+            return
+
+        with transaction.atomic():
+            for old_slug, case in candidates.items():
+                # ``record`` no-ops on old==new, drops any row shadowing the
+                # live slug, then upserts old_slug -> case.
+                CaseSlugHistory.record(case, old_slug=old_slug, new_slug=case.slug)
+
+        # Safety assertion: the table must never shadow a live slug.
+        shadow = CaseSlugHistory.objects.filter(slug__in=live_slugs).count()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Recorded {len(candidates)} retired slug(s); "
+                f"rows shadowing a live slug: {shadow} (must be 0)."
+            )
+        )
+
+    def _resolve(self, review, old_slug: str) -> Case | None:
+        """Resolve a retired slug back to its current Case (four tiers)."""
+        # Tier 1: a direct FK on the review model (post review-key-on-case-id).
+        case = getattr(review, "case", None)
+        if isinstance(case, Case):
+            return case
+
+        # Tier 2: a court-case reference number embedded in the slug.
+        match = COURT_REF_RE.search(old_slug.lower())
+        if match:
+            qs = Case.objects.filter(
+                courtcase_references__courtcase_iri__icontains=match.group(1)
+            ).distinct()
+            if qs.count() == 1:
+                return qs.first()
+
+        # Tier 3: the review's snapshot title, matched exactly.
+        title = (getattr(review, "case_title", "") or "").strip()
+        if title:
+            qs = Case.objects.filter(title=title)
+            if qs.count() == 1:
+                return qs.first()
+
+        # Tier 4: a unique live slug that this retired slug is a prefix of.
+        qs = Case.objects.filter(slug__istartswith=old_slug.lower())
+        if qs.count() == 1:
+            return qs.first()
+
+        return None

--- a/cases/models.py
+++ b/cases/models.py
@@ -527,6 +527,46 @@ class CaseState(models.TextChoices):
     CLOSED = "CLOSED", "Closed"
 
 
+class CaseQuerySet(models.QuerySet):
+    """Case queryset that records slug history on ANY bulk ``.update(slug=…)``.
+
+    ``Case.save()`` records a slug change (BB-38), but the model's ``slug`` is
+    immutable once the case leaves DRAFT — so re-slugging a PUBLISHED case is
+    done operationally with a bulk ``QuerySet.update(slug=…)``, which bypasses
+    ``save()`` and its history hook entirely. The API's DRAFT re-slug PATCH also
+    persists via ``update()``. Recording here makes the bulk-update path the
+    single durable choke point: whatever route re-slugs a case — the API PATCH,
+    an admin action, a data migration's app-level model, or an ad-hoc pod ORM
+    edit — the retired slug is remembered and its URL 301-redirects instead of
+    hard-404ing.
+
+    History migrations use ``apps.get_model()`` historical models with plain
+    managers, so schema migrations that touch ``slug`` do NOT record history
+    (correctly — they run before the redirect feature existed) and cannot
+    recurse through this override.
+    """
+
+    def update(self, **kwargs):
+        # Only slug changes are of interest; every other bulk update (state
+        # transitions, the updated_at bump, enrichment writes, …) takes the
+        # cheap path with no extra query.
+        if "slug" not in kwargs:
+            return super().update(**kwargs)
+
+        new_slug = kwargs["slug"]
+        # Snapshot the affected cases (with their PRE-update slugs) before the
+        # write. Rows already at ``new_slug`` are excluded — nothing retires.
+        # ``slug`` is globally unique on Case, so a slug update targets at most
+        # one row in practice; the loop is written for correctness regardless.
+        changing = list(self.exclude(slug=new_slug))
+        result = super().update(**kwargs)
+        for case in changing:
+            # ``update()`` does not touch the in-memory instances, so
+            # ``case.slug`` still holds the retired value here.
+            CaseSlugHistory.record(case, case.slug, new_slug)
+        return result
+
+
 class Case(models.Model):
     """
     Core model representing a case of alleged misconduct.
@@ -552,6 +592,12 @@ class Case(models.Model):
     Each case has a single row. Edits are made in-place. State transitions
     (submit/publish) are recorded in the versionInfo JSON field.
     """
+
+    # ``CaseQuerySet.update()`` records slug history for any bulk re-slug
+    # (published-case re-slugs and the API's DRAFT PATCH both use ``update()``).
+    # ``as_manager()`` has ``use_in_migrations = False``, so this adds no
+    # migration and historical models keep their plain manager.
+    objects = CaseQuerySet.as_manager()
 
     # Core fields
     case_type = models.CharField(

--- a/tests/api/test_slug_redirect.py
+++ b/tests/api/test_slug_redirect.py
@@ -4,11 +4,17 @@ Changing a case's slug (DRAFT re-slug, operational re-slug) used to orphan the
 old URL as a hard 404. These tests cover (a) that a slug change is recorded in
 CaseSlugHistory, (b) that a retired slug 301-redirects to the canonical URL,
 (c) that a genuinely unknown slug stays a 404, (d) that a reused slug resolves
-to its live owner (not a redirect), and (e) that a retired slug never leaks a
-non-public case's existence.
+to its live owner (not a redirect), (e) that a retired slug never leaks a
+non-public case's existence, (f) that ANY bulk ``update(slug=…)`` — the path a
+PUBLISHED case is re-slugged through, which bypasses ``save()`` — records
+history, and (g) that ``backfill_slug_history`` reconstructs retired slugs from
+CaseReview snapshots.
 """
 
+from io import StringIO
+
 import pytest
+from django.core.management import call_command
 from rest_framework.test import APIClient
 
 from cases.models import Case, CaseSlugHistory, CaseState, CaseType
@@ -199,3 +205,110 @@ def test_retired_slug_of_closed_case_is_404_even_for_caseworker():
 
     # CLOSED cases are never exposed via this API, even to casework roles.
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# (f) ANY bulk update(slug=…) records history — the durable choke point.
+#     A PUBLISHED case's slug is immutable through save(), so it is re-slugged
+#     operationally via QuerySet.update(), which bypasses the save() hook.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bulk_update_slug_records_old_slug_for_published_case():
+    case = _make_case("published-old", state=CaseState.PUBLISHED)
+
+    Case.objects.filter(pk=case.pk).update(slug="published-new")
+
+    case.refresh_from_db()
+    assert case.slug == "published-new"
+    assert CaseSlugHistory.objects.filter(slug="published-old", case=case).exists()
+    # The new (now-live) slug is never recorded as its own predecessor.
+    assert not CaseSlugHistory.objects.filter(slug="published-new").exists()
+
+
+@pytest.mark.django_db
+def test_published_reslug_via_update_then_old_url_redirects():
+    """End-to-end: a published case re-slugged via update() 301-redirects."""
+    case = _make_case("pub-canon-old", state=CaseState.PUBLISHED)
+
+    Case.objects.filter(pk=case.pk).update(slug="pub-canon-new")
+
+    resp = APIClient().get(URL.format("pub-canon-old"))
+    assert resp.status_code == 301
+    assert resp["Location"].endswith("/api/cases/pub-canon-new/")
+
+
+@pytest.mark.django_db
+def test_bulk_update_without_slug_records_nothing():
+    """A non-slug bulk update must not touch CaseSlugHistory."""
+    case = _make_case("state-change", state=CaseState.DRAFT)
+
+    Case.objects.filter(pk=case.pk).update(state=CaseState.PUBLISHED)
+
+    assert not CaseSlugHistory.objects.exists()
+
+
+@pytest.mark.django_db
+def test_bulk_update_to_same_slug_records_nothing():
+    """update(slug=<current>) is a no-op — nothing retires."""
+    case = _make_case("same", state=CaseState.PUBLISHED)
+
+    Case.objects.filter(pk=case.pk).update(slug="same")
+
+    assert not CaseSlugHistory.objects.filter(slug="same").exists()
+
+
+# ---------------------------------------------------------------------------
+# (g) backfill_slug_history rebuilds retired slugs from CaseReview snapshots.
+# ---------------------------------------------------------------------------
+
+
+def _run_backfill(*args) -> str:
+    out = StringIO()
+    call_command("backfill_slug_history", *args, stdout=out)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+def test_backfill_records_outdated_review_slug():
+    from review.models import CaseReview
+
+    case = _make_case("current-slug", state=CaseState.PUBLISHED, title="Distinct Title")
+    # A review captured the case under a slug it no longer carries; resolves by
+    # the exact snapshot title (tier 3).
+    CaseReview.objects.create(slug="retired-slug", case_title="Distinct Title")
+
+    # Dry-run writes nothing.
+    _run_backfill()
+    assert not CaseSlugHistory.objects.exists()
+
+    out = _run_backfill("--apply")
+    assert "retired-slug -> current-slug" in out
+    assert CaseSlugHistory.objects.filter(slug="retired-slug", case=case).exists()
+
+
+@pytest.mark.django_db
+def test_backfill_skips_slug_that_is_still_live():
+    from review.models import CaseReview
+
+    _make_case("still-live", state=CaseState.PUBLISHED, title="Live One")
+    CaseReview.objects.create(slug="still-live", case_title="Live One")
+
+    _run_backfill("--apply")
+
+    # The review's slug still addresses a live case — not outdated, not recorded.
+    assert not CaseSlugHistory.objects.filter(slug="still-live").exists()
+
+
+@pytest.mark.django_db
+def test_backfill_is_idempotent():
+    from review.models import CaseReview
+
+    case = _make_case("live-canon", state=CaseState.PUBLISHED, title="Idem Title")
+    CaseReview.objects.create(slug="idem-old", case_title="Idem Title")
+
+    _run_backfill("--apply")
+    _run_backfill("--apply")
+
+    assert CaseSlugHistory.objects.filter(slug="idem-old", case=case).count() == 1


### PR DESCRIPTION
## What & why

Follow-up to the BB-38 slug-redirect work (#329). That PR records a retired slug into `CaseSlugHistory` from **two** places — `Case.save()` and the API's DRAFT re-slug PATCH — but there's a gap:

> A case's `slug` is immutable once it leaves DRAFT, so re-slugging a **PUBLISHED** case is done operationally with a bulk `Case.objects.filter(...).update(slug=…)`, which **bypasses `save()`** (and the PATCH path). Such a re-slug silently orphans the old public URL as a hard 404 — exactly the failure BB-38 set out to fix.

This surfaced during the BB-38 e2e and the subsequent prod `CaseSlugHistory` backfill: of the retired slugs recovered from review snapshots, the majority belonged to cases re-slugged outside the two hooked paths.

## Change

- **`CaseQuerySet.update()` override** — recording moves down to the bulk-update layer, making it the single durable choke point. Whatever route re-slugs a case (API PATCH, admin action, ad-hoc pod ORM edit) now remembers the retired slug and 301-redirects it.
  - Only slug-bearing updates pay one extra `SELECT`; every other bulk update (`state`, `updated_at`, enrichment) takes the cheap path unchanged.
  - Wired via `objects = CaseQuerySet.as_manager()` (`use_in_migrations = False`) → **no migration**, and historical (`apps.get_model`) models keep their plain manager, so schema migrations that touch `slug` do **not** — and correctly should not — record history.
  - The now-redundant explicit `record()` in `partial_update` is dropped (the `.update()` there flows through the override; behaviour is preserved and covered by the existing DRAFT-PATCH test).
- **`backfill_slug_history` management command** — reconstructs *pre-feature* retired slugs from `CaseReview` snapshot slugs using the same four-tier resolution as review migration `0004` (direct FK if present · court-ref number · exact snapshot title · unique slug prefix). Dry-run by default, `--apply` to write, idempotent. Makes the one-off prod backfill reproducible and version-controlled. (Resilient to the review-key-on-case-id change in #330: prefers a `case` FK when the review model has one.)

## Tests

Added to `tests/api/test_slug_redirect.py`:
- bulk `update(slug=…)` records history for a **published** case, and its old URL 301-redirects end-to-end;
- non-slug and same-slug updates record nothing;
- backfill records outdated review slugs, skips still-live slugs, and is idempotent.

`342 passed` across `cases/tests` + `tests/api` (no regressions); `ruff check` clean; `makemigrations --check` reports no changes.

## Deploy notes

- No migration. Code-only — deploys via keel on `:main`.
- After deploy, the forward-looking hook is automatic. The historical backfill was already applied to prod once via pod ORM; re-running `manage.py backfill_slug_history --apply` is safe/idempotent and now the reproducible path.