### PR TITLE
feat(courts): admit the org-wide ReadOnly role to the gated SELECT plane

### DIFF
--- a/courts/permissions.py
+++ b/courts/permissions.py
@@ -77,7 +77,7 @@ class HasNgmRole(permissions.BasePermission):
         return bool(user_groups & NGM_ROLE_GROUPS)
 
 
-class HasNgmQueryAccess(HasNgmRole):
+class HasNgmQueryAccess(permissions.BasePermission):
     """Gate the SELECT plane on the ``ngm.query`` OAuth scope OR a read role.
 
     The FastAPI POST /query route gated on the OAuth scope ``ngm.query`` via
@@ -88,17 +88,19 @@ class HasNgmQueryAccess(HasNgmRole):
     in a query-capable Django Group. Either is sufficient.
 
     Query-capable is WIDER than ``HasNgmRole`` (the write gate): it is superuser,
-    the NGM content role (Caseworker / any NGM tier), OR the org-wide ReadOnly
-    read role. Querying is a read — the guard is SELECT-only and the rows are
-    already public via the REST read plane — so ReadOnly is admitted here even
-    though it is excluded from every write gate.
+    the NGM content role (Caseworker), OR the org-wide ReadOnly read role.
+    Querying is a read — the guard is SELECT-only and the rows are already public
+    via the REST read plane — so ReadOnly is admitted here even though it is
+    excluded from every write gate. (This deliberately shares no logic with
+    ``HasNgmRole``, so it subclasses ``BasePermission`` directly rather than
+    that gate.)
 
     Unauthenticated -> 401; authenticated but lacking scope and a read role -> 403.
     """
 
     message = (
         "The 'ngm.query' OAuth scope or a read-capable role "
-        "(ReadOnly, caseworker, or an NGM tier) is required."
+        "(ReadOnly or Caseworker) is required."
     )
 
     def has_permission(self, request, view) -> bool:
@@ -109,6 +111,7 @@ class HasNgmQueryAccess(HasNgmRole):
             return True
         if NGM_QUERY_SCOPE in token_scopes(request):
             return True
-        # One group query covers ReadOnly + the NGM role(s); NOT super()'s
-        # NGM_ROLE_GROUPS check, which excludes ReadOnly.
+        # ONE group query over the read-capable set. Note this is NGM_QUERY_GROUPS
+        # (ReadOnly + NGM roles), NOT HasNgmRole's NGM_ROLE_GROUPS, which excludes
+        # ReadOnly and gates writes only.
         return user.groups.filter(name__in=NGM_QUERY_GROUPS).exists()

--- a/courts/permissions.py
+++ b/courts/permissions.py
@@ -32,6 +32,13 @@ NGM_ROLE_GROUPS = frozenset(
 # service-account clients granted only the scope) are not silently dropped.
 NGM_QUERY_SCOPE = "ngm.query"
 
+# Django Groups that may run the gated SELECT plane (``HasNgmQueryAccess``).
+# WIDER than NGM_ROLE_GROUPS (the write gate): the org-wide ReadOnly read role is
+# admitted here because querying is a read — the guard is SELECT-only and the
+# rows are already public via the REST read plane. ReadOnly stays OUT of
+# NGM_ROLE_GROUPS, so it remains excluded from ingestion / mutations.
+NGM_QUERY_GROUPS = frozenset({"ReadOnly"}) | NGM_ROLE_GROUPS
+
 
 def token_scopes(request) -> set[str]:
     """Return the set of OAuth scopes from the token's ``scope`` claim.
@@ -71,27 +78,37 @@ class HasNgmRole(permissions.BasePermission):
 
 
 class HasNgmQueryAccess(HasNgmRole):
-    """Gate the SQL plane on EITHER the ``ngm.query`` OAuth scope OR an NGM role.
+    """Gate the SELECT plane on the ``ngm.query`` OAuth scope OR a read role.
 
     The FastAPI POST /query route gated on the OAuth scope ``ngm.query`` via
     ``require_scope``; the initial Django port gated purely on role/group, which
     silently dropped the scope control. This restores scope-awareness without
     breaking role-based access: a token bearing the ``ngm.query`` scope is
     accepted (so scope-only clients like MCP keep working), and so is a principal
-    in an NGM-capable Django Group (the role model). Either is sufficient.
+    in a query-capable Django Group. Either is sufficient.
 
-    Unauthenticated -> 401; authenticated but lacking both scope and role -> 403.
+    Query-capable is WIDER than ``HasNgmRole`` (the write gate): it is superuser,
+    the NGM content role (Caseworker / any NGM tier), OR the org-wide ReadOnly
+    read role. Querying is a read — the guard is SELECT-only and the rows are
+    already public via the REST read plane — so ReadOnly is admitted here even
+    though it is excluded from every write gate.
+
+    Unauthenticated -> 401; authenticated but lacking scope and a read role -> 403.
     """
 
     message = (
-        "The 'ngm.query' OAuth scope or an NGM role "
-        "(caseworker or an NGM tier) is required."
+        "The 'ngm.query' OAuth scope or a read-capable role "
+        "(ReadOnly, caseworker, or an NGM tier) is required."
     )
 
     def has_permission(self, request, view) -> bool:
         user = getattr(request, "user", None)
         if not (user and user.is_authenticated):
             return False  # 401 via the authenticator's WWW-Authenticate header
+        if user.is_superuser:
+            return True
         if NGM_QUERY_SCOPE in token_scopes(request):
             return True
-        return super().has_permission(request, view)
+        # One group query covers ReadOnly + the NGM role(s); NOT super()'s
+        # NGM_ROLE_GROUPS check, which excludes ReadOnly.
+        return user.groups.filter(name__in=NGM_QUERY_GROUPS).exists()

--- a/courts/tests/test_api.py
+++ b/courts/tests/test_api.py
@@ -170,6 +170,9 @@ class QueryGateTests(_DbAPITestCase):
         cls.user = User.objects.create(username="oidc-sub-123")
         cls.user.groups.add(cls.contrib_group)
         cls.nobody = User.objects.create(username="oidc-sub-norole")
+        cls.readonly_group, _ = Group.objects.get_or_create(name="ReadOnly")
+        cls.readonly = User.objects.create(username="oidc-sub-readonly")
+        cls.readonly.groups.add(cls.readonly_group)
 
     def test_unauth_is_401(self):
         resp = self.client.post("/api/query/", {"query": "SELECT 1"}, format="json")
@@ -209,6 +212,17 @@ class QueryGateTests(_DbAPITestCase):
         self.assertIn("rows", resp.data)
         self.assertEqual(resp.data["max_rows"], 500)
 
+    def test_readonly_role_may_query(self):
+        # ReadOnly is a systemwide READ role: the SELECT-only query plane returns
+        # data already public via the REST read plane, so it is admitted — even
+        # though ReadOnly is excluded from the write / ingestion gates.
+        self.client.force_authenticate(user=self.readonly)
+        resp = self.client.post(
+            "/api/query/", {"query": "SELECT identifier FROM courts"}, format="json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("rows", resp.data)
+
     def test_ngm_query_scope_grants_access_without_role(self):
         # A principal with no NGM role but bearing the ``ngm.query`` OAuth scope
         # (the FastAPI scope control) is accepted — scope OR role suffices.
@@ -235,10 +249,26 @@ class IngestionGateTests(_DbAPITestCase):
         g, _ = Group.objects.get_or_create(name="Caseworker")
         cls.user = User.objects.create(username="ingest-user")
         cls.user.groups.add(g)
+        ro, _ = Group.objects.get_or_create(name="ReadOnly")
+        cls.readonly = User.objects.create(username="ingest-readonly")
+        cls.readonly.groups.add(ro)
 
     def test_unauth_ingestion_is_401(self):
         resp = self.client.post("/api/ingestion/cases/", {"items": []}, format="json")
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_readonly_role_cannot_ingest_is_403(self):
+        # The read/write split: ReadOnly may run the SELECT query plane but must
+        # NOT reach any ingestion writer — HasNgmRole (NGM_ROLE_GROUPS) excludes
+        # it. Guards against widening the write gate when widening the read one.
+        self.client.force_authenticate(user=self.readonly)
+        for path in (
+            "/api/ingestion/cases/",
+            "/api/ingestion/entities/resolve/",
+            "/api/ingestion/documents/",
+        ):
+            resp = self.client.post(path, {"items": []}, format="json")
+            self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN, msg=path)
 
     def test_authed_ingestion_requires_items_list(self):
         # The ingestion writers are now REAL: a body with no `items` list is a

--- a/tests/security/test_write_endpoint_escalation.py
+++ b/tests/security/test_write_endpoint_escalation.py
@@ -23,10 +23,13 @@ pytestmark = [pytest.mark.security, pytest.mark.django_db]
 
 
 # (method, url, json-body) for each role-gated write endpoint.
+#
+# NOTE: ``/api/query/`` is deliberately NOT here — it is a SELECT-only READ
+# surface, so the org-wide ReadOnly role is admitted to it (see
+# ``test_query_plane_is_read_not_write`` below), unlike these write planes.
 WRITE_ENDPOINTS = [
     ("post", "/api/entities", {"@type": "Person", "@id": "x"}),
     ("post", "/api/courtcases/", {}),
-    ("post", "/api/query/", {"sql": "SELECT 1"}),
     ("post", "/api/ingestion/cases/", {}),
     ("post", "/api/admin/reindex", {}),
 ]
@@ -68,3 +71,32 @@ def test_readonly_can_still_read_but_not_write_cases():
     # DjangoModelPermissions gates POST on cases.add_case, which ReadOnly lacks.
     resp = client.post("/api/cases/", {"case_type": "CORRUPTION", "title": "x"}, format="json")
     assert resp.status_code == 403
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_query_plane_is_read_not_write():
+    """``/api/query/`` is a SELECT-only READ surface, so its role contract differs
+    from the write planes above: anon → 401, a lower-privilege authenticated role
+    (Public) → 403, but the org-wide ReadOnly read role is ADMITTED (passes the
+    auth gate). Writes still can't ride through it — the SELECT-only guard is
+    covered by courts/tests/test_query_guard_security.py."""
+    body = {"query": "SELECT 1"}
+
+    # Anonymous: 401 (authenticator sets WWW-Authenticate).
+    assert APIClient().post("/api/query/", body, format="json").status_code == 401
+
+    # Public (authenticated, no query role): still forbidden.
+    public = create_user_with_role("esc-pub-q", "esc-pub-q@example.com", "Public")
+    pc = APIClient()
+    pc.force_authenticate(user=public)
+    assert pc.post("/api/query/", body, format="json").status_code == 403
+
+    # ReadOnly: admitted — it must clear the auth gate (NOT 401/403); the response
+    # is then a normal query outcome (200, or a guard/DB 400), never a rejection.
+    readonly = create_user_with_role("esc-ro-q", "esc-ro-q@example.com", "ReadOnly")
+    rc = APIClient()
+    rc.force_authenticate(user=readonly)
+    ro_status = rc.post("/api/query/", body, format="json").status_code
+    assert ro_status not in (401, 403), (
+        f"ReadOnly must clear the /api/query/ auth gate, got {ro_status}"
+    )


### PR DESCRIPTION
Completes "ReadOnly = systemwide read" (after #331 / #332) for the last read surface that still excluded it.

## Problem

`POST /api/query/` (the gated raw-SQL SELECT plane) is guarded by `HasNgmQueryAccess`, which accepted only the `ngm.query` OAuth scope or an NGM role (Caseworker/superuser). The org-wide **ReadOnly** role got a **403** — even though the plane is SELECT-only (query_guard: allowlist, `scraped_dates` blocked, row cap, statement timeout) and returns data already fully public via the REST read plane.

## Fix

Admit ReadOnly on the **query** gate only:

```python
NGM_QUERY_GROUPS = frozenset({"ReadOnly"}) | NGM_ROLE_GROUPS
...
return user.groups.filter(name__in=NGM_QUERY_GROUPS).exists()
```

The critical safety property: this does **not** touch `NGM_ROLE_GROUPS`, which still gates every **write** surface (`HasNgmRole` → ingestion `/api/ingestion/*`, soft-delete, mutations) and keeps excluding ReadOnly. Read widens; write does not. Resolved in a single group query (superuser / scope short-circuit first).

| Principal | before | after |
|---|---|---|
| superuser | 200 | 200 |
| `ngm.query` scope | 200 | 200 |
| Caseworker / NGM tier | 200 | 200 |
| **ReadOnly** | **403** | **200** |
| roleless authed | 403 | 403 |
| anon | 401 | 401 |

## Tests

- `test_readonly_role_may_query` — ReadOnly runs a SELECT → 200 (verified red→green: 403 on `main`).
- `test_readonly_role_cannot_ingest_is_403` — ReadOnly is still 403 on all three ingestion writers, locking the read-yes/write-no split against a future regression that widens the write gate.
- Roleless/anon 403/401 tests unchanged.
- Full `courts/` suite green: **132 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)