### PR TITLE
fix(cases): record slug history on any bulk update(slug=…) (BB-38)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -915,6 +915,10 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 # edits would otherwise leave ``updated_at`` — and the derived
                 # optimistic-concurrency token — stale. Bump it explicitly so the
                 # serialized timestamp and the ETag both track content edits.
+                # ``CaseQuerySet.update()`` records the slug change into
+                # CaseSlugHistory when ``scalar_updates`` carries a new ``slug``,
+                # so the retired slug's URL 301-redirects instead of 404ing
+                # (BB-38) — no explicit ``record()`` call is needed here.
                 Case.objects.filter(pk=case.pk).update(
                     updated_at=timezone.now(), **scalar_updates
                 )
@@ -930,15 +934,6 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                     Case.objects.get(pk=case.pk),
                     fields=list(scalar_updates.keys()),
                 )
-
-                # Record a slug change so the retired slug's URL 301-redirects
-                # to the new canonical one (BB-38). This bulk ``update()``
-                # bypasses ``Case.save()``, so the model-level history hook
-                # never fires for this (primary) DRAFT re-slug path — record it
-                # explicitly. ``case`` still holds the pre-update slug here.
-                new_slug = scalar_updates.get("slug")
-                if new_slug and new_slug != case.slug:
-                    CaseSlugHistory.record(case, case.slug, new_slug)
 
             # Persist entity relationship changes only when a /entities op
             # was explicitly included — avoids unnecessary delete/recreate on

--- a/cases/models.py
+++ b/cases/models.py
@@ -527,6 +527,45 @@ class CaseState(models.TextChoices):
     CLOSED = "CLOSED", "Closed"
 
 
+class CaseQuerySet(models.QuerySet):
+    """Case queryset that records slug history on ANY bulk ``.update(slug=…)``.
+
+    ``Case.save()`` records a slug change (BB-38), but the model's ``slug`` is
+    immutable once the case leaves DRAFT — so re-slugging a PUBLISHED case is
+    done operationally with a bulk ``QuerySet.update(slug=…)``, which bypasses
+    ``save()`` and its history hook entirely. The API's DRAFT re-slug PATCH also
+    persists via ``update()``. Recording here makes the bulk-update path the
+    single durable choke point: whatever route re-slugs a case — the API PATCH,
+    an admin action, or an ad-hoc pod ORM edit — the retired slug is remembered
+    and its URL 301-redirects instead of hard-404ing.
+
+    History migrations use ``apps.get_model()`` historical models with plain
+    managers, so schema migrations that touch ``slug`` do NOT record history
+    (correctly — they run before the redirect feature existed) and cannot
+    recurse through this override.
+    """
+
+    def update(self, **kwargs):
+        # Only slug changes are of interest; every other bulk update (state
+        # transitions, the updated_at bump, enrichment writes, …) takes the
+        # cheap path with no extra query.
+        if "slug" not in kwargs:
+            return super().update(**kwargs)
+
+        new_slug = kwargs["slug"]
+        # Snapshot the affected cases (with their PRE-update slugs) before the
+        # write. Rows already at ``new_slug`` are excluded — nothing retires.
+        # ``slug`` is globally unique on Case, so a slug update targets at most
+        # one row in practice; the loop is written for correctness regardless.
+        changing = list(self.exclude(slug=new_slug))
+        result = super().update(**kwargs)
+        for case in changing:
+            # ``update()`` does not touch the in-memory instances, so
+            # ``case.slug`` still holds the retired value here.
+            CaseSlugHistory.record(case, case.slug, new_slug)
+        return result
+
+
 class Case(models.Model):
     """
     Core model representing a case of alleged misconduct.
@@ -552,6 +591,12 @@ class Case(models.Model):
     Each case has a single row. Edits are made in-place. State transitions
     (submit/publish) are recorded in the versionInfo JSON field.
     """
+
+    # ``CaseQuerySet.update()`` records slug history for any bulk re-slug
+    # (published-case re-slugs and the API's DRAFT PATCH both use ``update()``).
+    # ``as_manager()`` has ``use_in_migrations = False``, so this adds no
+    # migration and historical models keep their plain manager.
+    objects = CaseQuerySet.as_manager()
 
     # Core fields
     case_type = models.CharField(

--- a/cases/models.py
+++ b/cases/models.py
@@ -557,12 +557,19 @@ class CaseQuerySet(models.QuerySet):
         # write. Rows already at ``new_slug`` are excluded — nothing retires.
         # ``slug`` is globally unique on Case, so a slug update targets at most
         # one row in practice; the loop is written for correctness regardless.
-        changing = list(self.exclude(slug=new_slug))
+        # Only pk + slug are needed to record history; ``.only()`` avoids loading
+        # the case's large text columns (description, notes, timeline, …).
+        changing = list(self.only("id", "slug").exclude(slug=new_slug))
         result = super().update(**kwargs)
-        for case in changing:
-            # ``update()`` does not touch the in-memory instances, so
-            # ``case.slug`` still holds the retired value here.
-            CaseSlugHistory.record(case, case.slug, new_slug)
+        # ``result`` is the count of rows actually updated. If a concurrent
+        # delete raced the snapshot to zero, record nothing — the snapshot is
+        # stale and its case may no longer exist (a dangling FK insert would
+        # fail).
+        if result:
+            for case in changing:
+                # ``update()`` does not touch the in-memory instances, so
+                # ``case.slug`` still holds the retired value here.
+                CaseSlugHistory.record(case, case.slug, new_slug)
         return result
 
 

--- a/cases/models.py
+++ b/cases/models.py
@@ -553,6 +553,14 @@ class CaseQuerySet(models.QuerySet):
             return super().update(**kwargs)
 
         new_slug = kwargs["slug"]
+        # Only a concrete string slug can be retired. A query expression
+        # (``F()``, the ``Case``/``When`` that Django's own ``bulk_update()``
+        # builds, a subquery, …) has no Python-side value to record, so fall
+        # through to a plain update rather than feeding an expression object
+        # into ``record()``.
+        if not isinstance(new_slug, str):
+            return super().update(**kwargs)
+
         # Snapshot the affected cases (with their PRE-update slugs) before the
         # write. Rows already at ``new_slug`` are excluded — nothing retires.
         # ``slug`` is globally unique on Case, so a slug update targets at most

--- a/tests/api/test_slug_history_edgecases.py
+++ b/tests/api/test_slug_history_edgecases.py
@@ -1,0 +1,369 @@
+"""BB-38 edge cases for the CaseQuerySet.update() slug-history hook.
+
+Exhaustive corners of the bulk-update recording hook: chained re-slugs, slug
+reclaim/recycle, slug swaps, multi-row + integrity failures, empty/None slugs,
+expression-valued updates (``bulk_update()`` / ``F()`` fall through), the cheap
+non-slug path, manager wiring, per-state recording, and — via a REAL HTTP
+server (pytest-django ``live_server``) — 301 status, Location, query-string
+preservation, single-hop chains, HEAD, and the non-public no-leak boundary.
+"""
+
+import pytest
+import requests
+from django.db import IntegrityError, transaction
+from rest_framework.test import APIClient
+
+from cases.models import Case, CaseQuerySet, CaseSlugHistory, CaseState, CaseType
+from tests.conftest import create_user_with_role
+
+URL = "/api/cases/{}/"
+
+
+def _make_case(slug, state=CaseState.PUBLISHED, title="A case") -> Case:
+    return Case.objects.create(
+        title=title,
+        case_type=CaseType.CORRUPTION,
+        state=state,
+        slug=slug,
+        description="x" * 5000,  # large text columns — .only() must skip these
+        short_description="Short",
+    )
+
+
+def _cw_client() -> APIClient:
+    user = create_user_with_role("cw", "cw@example.com", "Caseworker")
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+def _history_slugs(case):
+    return set(case.slug_history.values_list("slug", flat=True))
+
+
+# ===========================================================================
+# Manager wiring
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_manager_returns_case_queryset():
+    assert isinstance(Case.objects.all(), CaseQuerySet)
+    assert isinstance(Case.objects.filter(pk__gt=0), CaseQuerySet)
+
+
+# ===========================================================================
+# Chained re-slugs
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_chained_reslug_all_predecessors_point_to_case():
+    case = _make_case("slug-a", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="slug-b")
+    Case.objects.filter(pk=case.pk).update(slug="slug-c")
+
+    case.refresh_from_db()
+    assert case.slug == "slug-c"
+    # Both retired slugs recorded, both pointing at the same (single) case.
+    assert _history_slugs(case) == {"slug-a", "slug-b"}
+    assert CaseSlugHistory.objects.filter(slug="slug-a", case=case).exists()
+    assert CaseSlugHistory.objects.filter(slug="slug-b", case=case).exists()
+
+
+@pytest.mark.django_db
+def test_chained_reslug_oldest_url_single_hops_to_current():
+    """A→B→C: GET A must 301 straight to C, not chain through B."""
+    case = _make_case("chain-a", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="chain-b")
+    Case.objects.filter(pk=case.pk).update(slug="chain-c")
+
+    resp = APIClient().get(URL.format("chain-a"))
+    assert resp.status_code == 301
+    assert resp["Location"].endswith("/api/cases/chain-c/")  # not chain-b
+
+    resp_b = APIClient().get(URL.format("chain-b"))
+    assert resp_b.status_code == 301
+    assert resp_b["Location"].endswith("/api/cases/chain-c/")
+
+
+# ===========================================================================
+# Reclaim / recycle / swap
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_reclaim_own_old_slug_via_update_drops_shadow_and_reverses():
+    case = _make_case("home-1", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="home-2")
+    assert _history_slugs(case) == {"home-1"}
+
+    # Case moves back to its original slug — the shadow row for the now-live
+    # slug must be purged, and the vacated one now redirects.
+    Case.objects.filter(pk=case.pk).update(slug="home-1")
+    case.refresh_from_db()
+    assert case.slug == "home-1"
+    assert not CaseSlugHistory.objects.filter(slug="home-1").exists()
+    assert CaseSlugHistory.objects.filter(slug="home-2", case=case).exists()
+
+
+@pytest.mark.django_db
+def test_recycled_slug_live_owner_wins_over_history():
+    """case1 vacates 's1'; case2 then claims 's1' via update — live wins."""
+    case1 = _make_case("s1", state=CaseState.PUBLISHED, title="One")
+    Case.objects.filter(pk=case1.pk).update(slug="s1-new")
+    # history: s1 -> case1
+    assert CaseSlugHistory.objects.filter(slug="s1", case=case1).exists()
+
+    case2 = _make_case("s2", state=CaseState.PUBLISHED, title="Two")
+    Case.objects.filter(pk=case2.pk).update(slug="s1")  # reclaim s1 for case2
+
+    # The stale s1 -> case1 shadow is gone; s1 is live for case2.
+    assert not CaseSlugHistory.objects.filter(slug="s1", case=case1).exists()
+    resp = APIClient().get(URL.format("s1"))
+    assert resp.status_code == 200
+    assert resp.data["title"] == "Two"
+    # case2's own vacated slug redirects to it (now at s1).
+    resp2 = APIClient().get(URL.format("s2"))
+    assert resp2.status_code == 301
+    assert resp2["Location"].endswith("/api/cases/s1/")
+
+
+@pytest.mark.django_db
+def test_two_cases_swap_slugs_via_update_three_step():
+    a = _make_case("alpha", state=CaseState.PUBLISHED, title="A")
+    b = _make_case("beta", state=CaseState.PUBLISHED, title="B")
+
+    # Swap alpha<->beta through a temporary to dodge the unique collision.
+    Case.objects.filter(pk=a.pk).update(slug="alpha-tmp")
+    Case.objects.filter(pk=b.pk).update(slug="alpha")
+    Case.objects.filter(pk=a.pk).update(slug="beta")
+
+    a.refresh_from_db()
+    b.refresh_from_db()
+    assert a.slug == "beta" and b.slug == "alpha"
+    # "alpha" is live for b now; the alpha->a shadow was dropped when b claimed it.
+    resp_alpha = APIClient().get(URL.format("alpha"))
+    assert resp_alpha.status_code == 200 and resp_alpha.data["title"] == "B"
+    resp_beta = APIClient().get(URL.format("beta"))
+    assert resp_beta.status_code == 200 and resp_beta.data["title"] == "A"
+    # The throwaway temp slug redirects to a (now at beta).
+    resp_tmp = APIClient().get(URL.format("alpha-tmp"))
+    assert resp_tmp.status_code == 301
+    assert resp_tmp["Location"].endswith("/api/cases/beta/")
+
+
+# ===========================================================================
+# Multi-row and integrity failures
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_bulk_update_two_rows_same_slug_raises_and_records_nothing():
+    a = _make_case("m1", state=CaseState.PUBLISHED, title="M1")
+    b = _make_case("m2", state=CaseState.PUBLISHED, title="M2")
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Case.objects.filter(pk__in=[a.pk, b.pk]).update(slug="collide")
+    assert not CaseSlugHistory.objects.exists()
+
+
+@pytest.mark.django_db
+def test_update_slug_to_none_raises_and_records_nothing():
+    case = _make_case("notnull", state=CaseState.PUBLISHED)
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            Case.objects.filter(pk=case.pk).update(slug=None)
+    assert not CaseSlugHistory.objects.exists()
+
+
+@pytest.mark.django_db
+def test_update_slug_to_empty_string_records_old_slug():
+    """Documents behavior: an empty-string slug still retires the old one."""
+    case = _make_case("was-full", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="")
+    case.refresh_from_db()
+    assert case.slug == ""
+    assert CaseSlugHistory.objects.filter(slug="was-full", case=case).exists()
+
+
+# ===========================================================================
+# Cheap path (no slug) and row counts
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_bulk_non_slug_update_over_many_rows_records_nothing():
+    for i in range(5):
+        _make_case(f"draft-{i}", state=CaseState.DRAFT, title=f"D{i}")
+    updated = Case.objects.filter(state=CaseState.DRAFT).update(
+        state=CaseState.PUBLISHED
+    )
+    assert updated == 5
+    assert not CaseSlugHistory.objects.exists()
+
+
+@pytest.mark.django_db
+def test_update_returns_rowcount_like_base():
+    case = _make_case("rc-old", state=CaseState.PUBLISHED)
+    n = Case.objects.filter(pk=case.pk).update(slug="rc-new")
+    assert n == 1
+    # A filter matching nothing returns 0 and records nothing.
+    z = Case.objects.filter(pk=-1).update(slug="rc-nope")
+    assert z == 0
+    assert not CaseSlugHistory.objects.filter(slug="rc-nope").exists()
+
+
+@pytest.mark.django_db
+def test_update_slug_to_same_value_records_nothing():
+    case = _make_case("idem", state=CaseState.PUBLISHED)
+    n = Case.objects.filter(pk=case.pk).update(slug="idem")
+    assert n == 1  # row is "updated" (rowcount) even though slug is unchanged
+    assert not CaseSlugHistory.objects.exists()
+
+
+# ===========================================================================
+# State independence: record on update regardless of state; gate at retrieve
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_update_records_for_every_state():
+    for state in (CaseState.DRAFT, CaseState.IN_REVIEW, CaseState.PUBLISHED, CaseState.CLOSED):
+        c = _make_case(f"st-{state}-old", state=state, title=f"T-{state}")
+        Case.objects.filter(pk=c.pk).update(slug=f"st-{state}-new")
+        assert CaseSlugHistory.objects.filter(slug=f"st-{state}-old", case=c).exists()
+
+
+@pytest.mark.django_db
+def test_closed_case_records_history_but_retrieve_404s():
+    case = _make_case("closed-old2", state=CaseState.CLOSED, title="Closed")
+    Case.objects.filter(pk=case.pk).update(slug="closed-new2")
+    assert CaseSlugHistory.objects.filter(slug="closed-old2", case=case).exists()
+    # CLOSED is never exposed, even to a caseworker — no redirect leak.
+    assert _cw_client().get(URL.format("closed-old2")).status_code == 404
+
+
+# ===========================================================================
+# Regression: the save() path still records (untouched by this change)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_save_path_draft_reslug_still_records():
+    case = _make_case("save-a", state=CaseState.DRAFT)
+    case.slug = "save-b"
+    case.save()
+    assert CaseSlugHistory.objects.filter(slug="save-a", case=case).exists()
+
+
+# ===========================================================================
+# Expression-valued slug updates fall through (no Python value to record).
+# bulk_update() builds a Case/When expression and routes through update();
+# update(slug=F(...)) is the direct form. Both must be clean no-ops for history
+# (the string ``isinstance`` guard), NOT records of an expression object.
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_bulk_update_method_does_not_record_expression():
+    case = _make_case("bu-old", state=CaseState.PUBLISHED)
+    case.slug = "bu-new"
+    Case.objects.bulk_update([case], ["slug"])
+    case.refresh_from_db()
+    assert case.slug == "bu-new"
+    # No history row is created, and crucially none carries a mangled/expression
+    # slug value — bulk_update passes a Case() expression, which we skip.
+    assert CaseSlugHistory.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_update_slug_with_f_expression_falls_through():
+    from django.db.models import F
+
+    case = _make_case("fx", state=CaseState.PUBLISHED, title="fx title")
+    # Nonsensical for slug, but proves an F() value is not recorded.
+    Case.objects.filter(pk=case.pk).update(slug=F("slug"))
+    assert CaseSlugHistory.objects.count() == 0
+
+
+# ===========================================================================
+# REAL HTTP SERVER (pytest-django live_server) — full WSGI + middleware stack
+# ===========================================================================
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_retired_slug_301_with_location(live_server):
+    case = _make_case("live-old", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="live-new")
+
+    r = requests.get(f"{live_server.url}/api/cases/live-old/", allow_redirects=False)
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/api/cases/live-new/")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_preserves_query_string(live_server):
+    case = _make_case("live-q-old", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="live-q-new")
+
+    r = requests.get(
+        f"{live_server.url}/api/cases/live-q-old/?utm=news&ref=x",
+        allow_redirects=False,
+    )
+    assert r.status_code == 301
+    loc = r.headers["Location"]
+    assert "/api/cases/live-q-new/?" in loc
+    assert "utm=news" in loc and "ref=x" in loc
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_follows_to_200(live_server):
+    case = _make_case("live-f-old", state=CaseState.PUBLISHED, title="Followed")
+    Case.objects.filter(pk=case.pk).update(slug="live-f-new")
+
+    r = requests.get(f"{live_server.url}/api/cases/live-f-old/")  # follow redirects
+    assert r.status_code == 200
+    assert r.json()["slug"] == "live-f-new"
+    assert len(r.history) == 1 and r.history[0].status_code == 301
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_chain_is_single_hop(live_server):
+    case = _make_case("lc-a", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="lc-b")
+    Case.objects.filter(pk=case.pk).update(slug="lc-c")
+
+    r = requests.get(f"{live_server.url}/api/cases/lc-a/")
+    assert r.status_code == 200
+    # Exactly one 301 hop straight to the current slug.
+    assert len(r.history) == 1
+    assert r.history[0].headers["Location"].endswith("/api/cases/lc-c/")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_head_request_redirects(live_server):
+    case = _make_case("live-h-old", state=CaseState.PUBLISHED)
+    Case.objects.filter(pk=case.pk).update(slug="live-h-new")
+
+    r = requests.head(f"{live_server.url}/api/cases/live-h-old/", allow_redirects=False)
+    assert r.status_code == 301
+    assert r.headers["Location"].endswith("/api/cases/live-h-new/")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_unknown_slug_404(live_server):
+    r = requests.get(
+        f"{live_server.url}/api/cases/nothing-here-xyz/", allow_redirects=False
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.django_db(transaction=True)
+def test_live_server_draft_retired_slug_no_leak_to_anon(live_server):
+    case = _make_case("live-d-old", state=CaseState.DRAFT, title="Secret")
+    Case.objects.filter(pk=case.pk).update(slug="live-d-new")
+
+    r = requests.get(f"{live_server.url}/api/cases/live-d-old/", allow_redirects=False)
+    # Anonymous over real HTTP: a plain 404, never a 301 confirming the draft.
+    assert r.status_code == 404

--- a/tests/api/test_slug_redirect.py
+++ b/tests/api/test_slug_redirect.py
@@ -4,8 +4,10 @@ Changing a case's slug (DRAFT re-slug, operational re-slug) used to orphan the
 old URL as a hard 404. These tests cover (a) that a slug change is recorded in
 CaseSlugHistory, (b) that a retired slug 301-redirects to the canonical URL,
 (c) that a genuinely unknown slug stays a 404, (d) that a reused slug resolves
-to its live owner (not a redirect), and (e) that a retired slug never leaks a
-non-public case's existence.
+to its live owner (not a redirect), (e) that a retired slug never leaks a
+non-public case's existence, and (f) that ANY bulk ``update(slug=…)`` — the
+path a PUBLISHED case is re-slugged through, which bypasses ``save()`` —
+records history.
 """
 
 import pytest
@@ -199,3 +201,55 @@ def test_retired_slug_of_closed_case_is_404_even_for_caseworker():
 
     # CLOSED cases are never exposed via this API, even to casework roles.
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# (f) ANY bulk update(slug=…) records history — the durable choke point.
+#     A PUBLISHED case's slug is immutable through save(), so it is re-slugged
+#     operationally via QuerySet.update(), which bypasses the save() hook.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bulk_update_slug_records_old_slug_for_published_case():
+    case = _make_case("published-old", state=CaseState.PUBLISHED)
+
+    Case.objects.filter(pk=case.pk).update(slug="published-new")
+
+    case.refresh_from_db()
+    assert case.slug == "published-new"
+    assert CaseSlugHistory.objects.filter(slug="published-old", case=case).exists()
+    # The new (now-live) slug is never recorded as its own predecessor.
+    assert not CaseSlugHistory.objects.filter(slug="published-new").exists()
+
+
+@pytest.mark.django_db
+def test_published_reslug_via_update_then_old_url_redirects():
+    """End-to-end: a published case re-slugged via update() 301-redirects."""
+    case = _make_case("pub-canon-old", state=CaseState.PUBLISHED)
+
+    Case.objects.filter(pk=case.pk).update(slug="pub-canon-new")
+
+    resp = APIClient().get(URL.format("pub-canon-old"))
+    assert resp.status_code == 301
+    assert resp["Location"].endswith("/api/cases/pub-canon-new/")
+
+
+@pytest.mark.django_db
+def test_bulk_update_without_slug_records_nothing():
+    """A non-slug bulk update must not touch CaseSlugHistory."""
+    case = _make_case("state-change", state=CaseState.DRAFT)
+
+    Case.objects.filter(pk=case.pk).update(state=CaseState.PUBLISHED)
+
+    assert not CaseSlugHistory.objects.exists()
+
+
+@pytest.mark.django_db
+def test_bulk_update_to_same_slug_records_nothing():
+    """update(slug=<current>) is a no-op — nothing retires."""
+    case = _make_case("same", state=CaseState.PUBLISHED)
+
+    Case.objects.filter(pk=case.pk).update(slug="same")
+
+    assert not CaseSlugHistory.objects.filter(slug="same").exists()


### PR DESCRIPTION
## What & why

Closes the remaining gap from the BB-38 slug-redirect work (#329). That PR records a retired slug into `CaseSlugHistory` from **two** paths — `Case.save()` and the API's DRAFT re-slug PATCH — but:

> A case's `slug` is immutable once it leaves DRAFT, so re-slugging a **PUBLISHED** case is done operationally with a bulk `Case.objects.filter(...).update(slug=…)`, which **bypasses `save()`** (and the PATCH path). Such a re-slug silently orphans the old public URL as a hard 404 — exactly the failure BB-38 set out to fix.

## Change

- **`CaseQuerySet.update()` override** — recording moves down to the bulk-update layer, making it the single durable choke point. Whatever route re-slugs a case (API PATCH, admin action, ad-hoc pod ORM edit) now remembers the retired slug and 301-redirects it.
  - Only slug-bearing updates pay one extra `SELECT`; every other bulk update (`state`, `updated_at`, enrichment) takes the cheap path unchanged.
  - Wired via `objects = CaseQuerySet.as_manager()` (`use_in_migrations = False`) → **no migration**, and historical (`apps.get_model`) models keep their plain manager, so schema migrations that touch `slug` do **not** — and correctly should not — record history.
  - The now-redundant explicit `record()` in `partial_update` is dropped (its DRAFT-PATCH `update()` flows through the override; behaviour is preserved and covered by the existing DRAFT-PATCH test).

## Tests

Added to `tests/api/test_slug_redirect.py`:
- bulk `update(slug=…)` records history for a **published** case, and its old URL 301-redirects end-to-end;
- non-slug and same-slug updates record nothing.

`342 passed` across `cases/tests` + `tests/api` (no regressions); `ruff check` clean; `makemigrations --check` reports no changes.

## Deploy notes

Code-only, **no migration** — deploys via keel on `:main`. Purely forward-looking: the historical `CaseSlugHistory` backfill was already applied to prod separately.