### PR TITLE
feat(audit): capture every ORM change across all models and databases

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -36,7 +36,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
-from jawafdehi_shared.drf.auditlog import AuditlogActorMixin, log_bulk_update
+from jawafdehi_shared.drf.auditlog import AuditlogActorMixin
 from jawafdehi_shared.identity import (
     JAWAFDEHI_USER_ID_HEADER,
     resolve_or_create_identity,
@@ -922,18 +922,12 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 Case.objects.filter(pk=case.pk).update(
                     updated_at=timezone.now(), **scalar_updates
                 )
-                # ``QuerySet.update()`` bypasses ``post_save``, so auditlog's UPDATE
-                # receiver never fires for scalar content edits — the same bypass the
-                # explicit search re-index below compensates for. Record the diff
-                # explicitly so content changes (description, timeline, allegations, …)
-                # are attributable, not just workflow/state saves. ``case`` still holds
-                # the pre-update values here (``update()`` doesn't touch the in-memory
-                # instance); it is refreshed to the new values on the next line.
-                log_bulk_update(
-                    case,
-                    Case.objects.get(pk=case.pk),
-                    fields=list(scalar_updates.keys()),
-                )
+                # ``QuerySet.update()`` bypasses ``post_save``, so auditlog's
+                # UPDATE receiver never fires for scalar content edits. ``Case``
+                # carries the audited manager (jawafdehi_shared.db.audited), whose
+                # ``update()`` override records the scalar diff (with the request
+                # actor; the auto_now ``updated_at`` bump above is excluded) — so
+                # this write is logged automatically, no explicit call needed.
 
             # Persist entity relationship changes only when a /entities op
             # was explicitly included — avoids unnecessary delete/recreate on

--- a/cases/apps.py
+++ b/cases/apps.py
@@ -7,24 +7,40 @@ class CasesConfig(AppConfig):
 
     def ready(self):
 
-        # Register models with auditlog
-        from auditlog.registry import auditlog
+        # Register models with auditlog. ``register_audited`` both registers the
+        # model AND swaps its manager so bulk ``QuerySet.update()`` writes (the
+        # pod-ORM / management-command pattern) are captured, not just saves.
+        from jawafdehi_shared.db.audited import register_audited
 
         from cases.models import (
             Case,
             CaseCourtCaseReference,
             CaseEntityRelationship,
             CaseMaterialReference,
+            ChatUserIdentity,
+            Feedback,
         )
 
-        auditlog.register(Case)
+        register_audited(Case)
         # JawafEntity + DocumentSource were removed (NES owns entities, NGM owns
         # documents). Audit the Case<->NES-entity, Case<->NGM-material, and
         # Case<->court-case binds so evidence/relationship/reference changes
         # stay tracked.
-        auditlog.register(CaseEntityRelationship)
-        auditlog.register(CaseMaterialReference)
-        auditlog.register(CaseCourtCaseReference)
+        register_audited(CaseEntityRelationship)
+        register_audited(CaseMaterialReference)
+        register_audited(CaseCourtCaseReference)
+        # Public feedback + chat-identity mapping. Both carry PII, so the
+        # submitter's contact details / free text / OWUI identifiers are masked
+        # in the change diff (auditlog stores a redaction marker, not the value)
+        # — we track WHO changed WHAT (e.g. triage status), not personal content.
+        register_audited(
+            Feedback, mask_fields=["description", "contact_info", "ip_address"]
+        )
+        register_audited(
+            ChatUserIdentity, mask_fields=["owui_user_id", "owui_user_name"]
+        )
+        # NOTE: CaseStateChange (itself an append-only audit trail) and
+        # StatisticsSnapshot (a derived cache) are intentionally NOT audited.
 
         # Wire live unified-search indexing signals (best-effort, on_commit).
         from . import signals  # noqa: F401

--- a/cases/migrations/0052_widen_auditlog_object_pk.py
+++ b/cases/migrations/0052_widen_auditlog_object_pk.py
@@ -1,0 +1,46 @@
+"""Widen ``auditlog_logentry.object_pk`` from ``varchar(255)`` to ``text``.
+
+django-auditlog stores a non-integer primary key in ``LogEntry.object_pk``, a
+``CharField(max_length=255)``. Expanding audit coverage to the IRI-keyed models
+(``entities.StoredEntity``, ``entities.HeldEntity``, ``materials.Material``)
+means those primary keys — full URLs that routinely exceed 255 chars — land
+there, which would truncate/raise. PostgreSQL ``varchar(255)`` -> ``text`` is a
+cheap, no-rewrite change that lifts the limit; Django never enforces
+``CharField.max_length`` on ``.save()``, so auditlog's model definition is left
+untouched (DB-only change, no state operation) and its dependent index is
+rebuilt automatically by the ``ALTER``.
+
+Guarded to PostgreSQL: on the SQLite test/CI database ``varchar`` length is not
+enforced, so the column already accepts long IRIs and this is a no-op. Lives in
+the ``cases`` app (a ``default``-DB app) because auditlog is a third-party app
+we do not add migrations to; the router keeps ``cases`` migrations on
+``default`` only, which is where ``auditlog_logentry`` lives.
+"""
+
+from django.db import migrations
+
+FORWARD = "ALTER TABLE auditlog_logentry ALTER COLUMN object_pk TYPE text"
+REVERSE = "ALTER TABLE auditlog_logentry ALTER COLUMN object_pk TYPE varchar(255)"
+
+
+def widen_object_pk(apps, schema_editor):
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute(FORWARD)
+
+
+def narrow_object_pk(apps, schema_editor):
+    # Best-effort reverse; fails loudly if a stored object_pk exceeds 255 chars.
+    if schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute(REVERSE)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cases", "0051_caseslughistory"),
+        ("auditlog", "0017_add_actor_email"),
+    ]
+
+    operations = [
+        migrations.RunPython(widen_object_pk, narrow_object_pk),
+    ]

--- a/config/settings.py
+++ b/config/settings.py
@@ -338,6 +338,15 @@ MIDDLEWARE = [
 ROOT_URLCONF = "config.urls"
 WSGI_APPLICATION = "config.wsgi.application"
 
+# django-auditlog: the audited manager (jawafdehi_shared.db.audited) logs one
+# LogEntry per changed row for a bulk ``QuerySet.update()`` / ``bulk_update()``
+# up to this many affected rows; a larger write records a single summary entry
+# instead, bounding both LogEntry growth and the O(rows) diff cost of a big
+# backfill. AUDITLOG_STORE_JSON_CHANGES is intentionally left at its default
+# (False → ``{field: [old, new]}``); flipping it would change the stored diff
+# shape that existing rows/tests rely on.
+AUDIT_BULK_UPDATE_MAX_ROWS = 1000
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",

--- a/courts/apps.py
+++ b/courts/apps.py
@@ -7,5 +7,26 @@ class CourtsConfig(AppConfig):
     label = "courts"
 
     def ready(self):
+        # Audit the NGM court layer. CourtCase (~1.6M) / CourtCaseHearing (~5.2M)
+        # are bulk-COPY-loaded and frozen, so live ORM writes are rare; the
+        # audited manager's row cap (AUDIT_BULK_UPDATE_MAX_ROWS) bounds any large
+        # ``update()``, and bulk COPY loads stay unaudited by design (ORM-level
+        # capture only). LogEntry rows are written cross-DB to ``default``.
+        from jawafdehi_shared.db.audited import register_audited
+
+        from courts.models import (
+            BlacklistedFirm,
+            CaseEntity,
+            Court,
+            CourtCase,
+            CourtCaseHearing,
+        )
+
+        register_audited(Court)
+        register_audited(CourtCase)
+        register_audited(CourtCaseHearing)
+        register_audited(CaseEntity)
+        register_audited(BlacklistedFirm)
+
         # Wire live unified-search indexing signals (best-effort, on_commit).
         from . import signals  # noqa: F401

--- a/courts/importer.py
+++ b/courts/importer.py
@@ -213,6 +213,8 @@ class CourtCaseImporter:
     # ── signal muting (suppress per-row OpenSearch upserts during bulk write) ──
     @contextmanager
     def _signals_muted(self) -> Iterator[None]:
+        from auditlog.context import disable_auditlog
+
         from courts import signals as s
         from materials import signals as ms
         from materials.models import Material
@@ -239,7 +241,14 @@ class CourtCaseImporter:
             if sig.disconnect(dispatch_uid=uid, sender=sender):
                 disconnected.append((sig, sender, uid, func))
         try:
-            yield
+            # Also suppress audit logging for the whole bulk import: the surgical
+            # per-row ``.update()`` (via the audited manager) and ``update_or_create``
+            # saves here are a bulk data load, not human edits, and would otherwise
+            # write a cross-DB LogEntry per row across the 1.6M/5.2M ngm tables.
+            # ``disable_auditlog`` gates both the post_save signal path AND the
+            # audited manager (which honors the same context flag).
+            with disable_auditlog():
+                yield
         finally:
             for sig, sender, uid, func in disconnected:
                 sig.connect(func, sender=sender, dispatch_uid=uid)

--- a/entities/apps.py
+++ b/entities/apps.py
@@ -7,5 +7,23 @@ class EntitiesConfig(AppConfig):
     label = "entities"
 
     def ready(self):
+        # Audit the NES entity store. StoredEntity already keeps a rich JSON-LD
+        # version history (StoredVersion + /versions); auditlog is additive —
+        # it records who/when/field-diff and, via the audited manager, catches
+        # pod-ORM ``update()`` writes that bypass the version-snapshotting path.
+        # LogEntry rows are written cross-DB to ``default``; the long IRI PKs are
+        # why cases migration 0051 widens ``object_pk`` to TEXT. StoredVersion
+        # itself is skipped — it IS the entity audit trail.
+        from jawafdehi_shared.db.audited import register_audited
+
+        from entities.models import HeldEntity, StoredAuthor, StoredEntity
+
+        # ``updated_at`` is excluded: it is set on every re-publish (it is a
+        # ``default=timezone.now`` column, not ``auto_now``, so the manager's
+        # touch-column filter does not catch it) and is not a substantive edit.
+        register_audited(StoredEntity, exclude_fields=["updated_at"])
+        register_audited(StoredAuthor)
+        register_audited(HeldEntity)
+
         # Wire live unified-search indexing signals (best-effort, on_commit).
         from . import signals  # noqa: F401

--- a/jawafdehi_shared/db/audited.py
+++ b/jawafdehi_shared/db/audited.py
@@ -1,0 +1,225 @@
+"""ORM-level audit capture for ``QuerySet.update()`` / ``bulk_update()``.
+
+django-auditlog hooks ``post_save`` / ``pre_save`` / ``post_delete``. A bulk
+``QuerySet.update()`` emits none of those, so those edits — which is how most
+data is actually changed on this platform (interactive pod-ORM shells,
+management commands, backfills) — leave no trail. ``QuerySet.delete()`` already
+logs: a registered ``post_delete`` receiver disables Django's fast-delete path
+so per-row ``post_delete`` fires. This module therefore deliberately does NOT
+touch ``delete()`` — only ``update()`` / ``bulk_update()``.
+
+Register a model with :func:`register_audited` (from its ``AppConfig.ready()``)
+to both register it with auditlog and swap its manager for one whose queryset
+mixes in :class:`AuditedQuerySet`. Its overrides write the same UPDATE
+``LogEntry`` rows a per-instance ``save()`` would, honoring the model's
+registered field include/exclude/mask config (``model_instance_diff`` reads the
+registry). Actor /
+remote_addr / cid ride the ambient auditlog context (see
+:class:`jawafdehi_shared.drf.auditlog.AuditlogActorMixin`), so request-driven
+bulk writes attribute to the user and out-of-band ones log ``actor=NULL``
+(honest — there is no request).
+
+Rows are diffed individually up to ``AUDIT_BULK_UPDATE_MAX_ROWS``; a larger
+write records a single summary entry (row count + fields) instead, so a big
+backfill can neither explode the ``LogEntry`` table nor pay an O(rows) diff cost.
+The read used to snapshot the pre-/post-image is pinned to the WRITE database
+(never a read replica) so it always sees its own write and so ``nes`` / ``ngm``
+models — whose ``LogEntry`` rows are cross-DB writes to ``default`` — snapshot
+from the right connection.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.db import models, router
+
+from auditlog import get_logentry_model
+from auditlog.cid import get_cid
+from auditlog.context import auditlog_disabled
+from auditlog.registry import auditlog
+
+from jawafdehi_shared.drf.auditlog import log_bulk_update
+
+#: Fallback when ``AUDITLOG`` settings do not pin a threshold. Above this many
+#: affected rows a single summary entry is written instead of one-per-row.
+DEFAULT_BULK_UPDATE_MAX_ROWS = 1000
+
+
+def _max_rows() -> int:
+    return getattr(
+        settings, "AUDIT_BULK_UPDATE_MAX_ROWS", DEFAULT_BULK_UPDATE_MAX_ROWS
+    )
+
+
+def _logging_disabled() -> bool:
+    """Mirror auditlog's own ``check_disable`` gate for the signal path."""
+    try:
+        return auditlog_disabled.get()
+    except LookupError:
+        return False
+
+
+def _auditable_fields(model, fields):
+    """Drop ``auto_now`` touch columns from a set of updated field names.
+
+    ``updated_at``-style ``auto_now`` timestamps are bumped on essentially every
+    write (the DRF write paths set them explicitly on ``update()`` since
+    ``auto_now`` does not fire for a queryset update), so a change to one of them
+    alone is not a substantive edit. Ignoring them keeps a pure touch — and a
+    no-op content PATCH that only refreshes the timestamp — from manufacturing a
+    spurious audit entry, and strips timestamp noise from real diffs.
+    """
+    auto_now = {f.name for f in model._meta.fields if getattr(f, "auto_now", False)}
+    return [f for f in fields if f not in auto_now]
+
+
+def _log_bulk_summary(model, count, fields):
+    """Write one summary ``LogEntry`` for an update too large to diff per row.
+
+    Not anchored to a single object (there are many) — ``object_pk`` is left
+    blank and the payload records the affected row count and field names so the
+    trail still shows *that* a mass edit happened, by whom and when, without the
+    O(rows) cost or table growth of per-row entries.
+    """
+    # Imported lazily: this module is loaded from AppConfig.ready(), and keeping
+    # the ContentType model import out of module scope avoids any app-registry
+    # ordering surprise if it is ever imported earlier.
+    from django.contrib.contenttypes.models import ContentType
+
+    log_entry_model = get_logentry_model()
+    return log_entry_model.objects.create(
+        content_type=ContentType.objects.get_for_model(model),
+        object_pk="",
+        object_repr=f"bulk update: {count} {model._meta.label} row(s)",
+        action=log_entry_model.Action.UPDATE,
+        changes={
+            "__bulk_update__": {"rows": count, "fields": sorted(fields)},
+        },
+        cid=get_cid(),
+    )
+
+
+class AuditedQuerySet(models.QuerySet):
+    """QuerySet that logs ``update()`` / ``bulk_update()`` to auditlog.
+
+    Only acts for models registered with auditlog; for anything else (or when
+    auditing is disabled in the current context) it is a transparent
+    passthrough.
+    """
+
+    def update(self, **kwargs):
+        model = self.model
+        if _logging_disabled() or not kwargs or not auditlog.contains(model):
+            return super().update(**kwargs)
+
+        fields = _auditable_fields(model, list(kwargs.keys()))
+        if not fields:
+            # Only auto_now touch columns changed — nothing substantive to log.
+            return super().update(**kwargs)
+
+        # Count first, before materializing anything: an update above the cap
+        # collapses to one summary entry WITHOUT loading a PK (let alone a full
+        # instance) per row — otherwise the guard would itself OOM on a
+        # multi-million-row ngm table, the case it exists to make cheap.
+        count = self.count()
+        if count == 0:
+            return super().update(**kwargs)
+        if count > _max_rows():
+            rows = super().update(**kwargs)
+            _log_bulk_summary(model, count, fields)
+            return rows
+
+        # Snapshot pre-/post-image by PK from the WRITE db (never a replica, so
+        # the post-read sees our own write); diff each row via the shared helper.
+        write_db = self._db or router.db_for_write(model)
+        base = model._base_manager.db_manager(write_db)
+        pks = list(self.values_list("pk", flat=True))
+        old = base.in_bulk(pks)
+        rows = super().update(**kwargs)
+        new = base.in_bulk(pks)
+        for pk, old_obj in old.items():
+            new_obj = new.get(pk)
+            if new_obj is not None:
+                log_bulk_update(old_obj, new_obj, fields=fields)
+        return rows
+
+    def bulk_update(self, objs, fields, batch_size=None):
+        objs = list(objs)
+        model = self.model
+        if (
+            _logging_disabled()
+            or not objs
+            or not fields
+            or not auditlog.contains(model)
+        ):
+            return super().bulk_update(objs, fields, batch_size=batch_size)
+
+        # ``fields`` drives the actual write; ``audit_fields`` (touch columns
+        # stripped) drives the diff — keep them separate so the write is intact.
+        audit_fields = _auditable_fields(model, list(fields))
+        if not audit_fields:
+            return super().bulk_update(objs, fields, batch_size=batch_size)
+
+        write_db = self._db or router.db_for_write(model)
+        base = model._base_manager.db_manager(write_db)
+        pks = [obj.pk for obj in objs]
+
+        if len(objs) > _max_rows():
+            result = super().bulk_update(objs, fields, batch_size=batch_size)
+            _log_bulk_summary(model, len(objs), audit_fields)
+            return result
+
+        old = base.in_bulk(pks)
+        result = super().bulk_update(objs, fields, batch_size=batch_size)
+        # ``objs`` already hold the new values (they are what was written).
+        for obj in objs:
+            old_obj = old.get(obj.pk)
+            if old_obj is not None:
+                log_bulk_update(old_obj, obj, fields=audit_fields)
+        return result
+
+
+def register_audited(model, **register_kwargs):
+    """Register ``model`` with auditlog AND make its ``objects`` capture bulk writes.
+
+    Call once per model from an ``AppConfig.ready()`` (in place of a bare
+    ``auditlog.register(model)``). ``register_kwargs`` are forwarded verbatim to
+    ``auditlog.register`` (``include_fields`` / ``exclude_fields`` / ``mask_fields``
+    / ``m2m_fields``). At ``ready()`` time the model's default ``objects`` manager
+    is swapped for one whose queryset mixes in :class:`AuditedQuerySet`, so
+    ``Model.objects.filter(...).update(...)`` — the interactive pod-ORM /
+    management-command / backfill pattern — is logged, not just ``save()``-driven
+    writes.
+
+    If the model already defines its own ``QuerySet`` override (e.g.
+    ``cases.Case``'s slug-history ``update()``), :class:`AuditedQuerySet` is
+    *woven in* rather than replacing it: the composed MRO runs the model's
+    ``update()`` first, which calls ``super().update()`` into the audit hook,
+    then the real DB write — so both behaviors run. Idempotent: a no-op if the
+    queryset is already audited.
+    """
+    auditlog.register(model, **register_kwargs)
+
+    existing = getattr(model, "objects", None)
+    existing_qs = getattr(existing, "_queryset_class", models.QuerySet)
+    if issubclass(existing_qs, AuditedQuerySet):
+        return  # already audited
+    if issubclass(AuditedQuerySet, existing_qs):
+        # The model uses a plain QuerySet (a base of AuditedQuerySet), so the
+        # audited queryset already subsumes it — use it directly.
+        audited_qs = AuditedQuerySet
+    else:
+        # The model has its own QuerySet override; weave the audit hook in so
+        # both ``update()`` overrides run via cooperative ``super()``.
+        audited_qs = type(
+            f"Audited{existing_qs.__name__}", (existing_qs, AuditedQuerySet), {}
+        )
+
+    # ``add_to_class`` alone would leave the pre-existing ``objects`` manager
+    # shadowing the new one: ``Options.managers`` dedups by name and keeps the
+    # first entry in ``local_managers``. Drop it first, then attach — that path
+    # (``add_to_class`` -> ``Options.add_manager``) expires the manager caches,
+    # so ``objects`` now resolves to the audited manager.
+    opts = model._meta
+    opts.local_managers = [m for m in opts.local_managers if m.name != "objects"]
+    model.add_to_class("objects", audited_qs.as_manager())

--- a/materials/apps.py
+++ b/materials/apps.py
@@ -7,5 +7,18 @@ class MaterialsConfig(AppConfig):
     label = "materials"
 
     def ready(self):
+        # Audit NGM materials. ``visibility`` is EXCLUDED: it is system-derived
+        # (recomputed as the MAX over referring case states, see
+        # materials/visibility.py), so auditing it would be pure machine noise —
+        # human/content edits to ``data`` etc. are what we track. ``updated_at``
+        # is likewise excluded as a non-substantive touch column. The IRI PK is
+        # why cases migration 0051 widens ``object_pk`` to TEXT; LogEntry rows
+        # are written cross-DB to ``default``.
+        from jawafdehi_shared.db.audited import register_audited
+
+        from materials.models import Material
+
+        register_audited(Material, exclude_fields=["visibility", "updated_at"])
+
         # Wire live unified-search indexing signals (best-effort, on_commit).
         from . import signals  # noqa: F401

--- a/review/apps.py
+++ b/review/apps.py
@@ -4,3 +4,16 @@ from django.apps import AppConfig
 class ReviewConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "review"
+
+    def ready(self):
+        # Audit review-workflow records. ``CaseReview`` is driven by the jobs
+        # poller via ``QuerySet.update()`` (jobs/consumers.py), so the audited
+        # manager is what captures those transitions; ``ReviewConfig`` is the
+        # admin-edited grading config.
+        from jawafdehi_shared.db.audited import register_audited
+
+        from review.models import CaseReview
+        from review.models import ReviewConfig as ReviewConfigModel
+
+        register_audited(CaseReview)
+        register_audited(ReviewConfigModel)

--- a/tests/api/test_audit_bulk_capture.py
+++ b/tests/api/test_audit_bulk_capture.py
@@ -1,0 +1,269 @@
+"""Audit capture for bulk ``QuerySet.update()`` / ``bulk_update()`` writes.
+
+These exercise the ORM-level bypass closure (``jawafdehi_shared.db.audited``):
+django-auditlog only hooks ``save()`` / ``delete()``, so a bulk ``update()`` — the
+pod-ORM / management-command / backfill pattern — used to vanish from the trail.
+The audited manager now logs those, across all three databases, honoring each
+model's registered include/exclude/mask config and bounding huge writes.
+"""
+
+import pytest
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+
+from cases.models import Case, CaseState, CaseType
+
+
+def _make_case(**kwargs) -> Case:
+    defaults = dict(
+        title="Bulk case",
+        case_type=CaseType.CORRUPTION,
+        state=CaseState.DRAFT,
+        description="Original",
+        short_description="Short",
+    )
+    defaults.update(kwargs)
+    return Case.objects.create(**defaults)
+
+
+def _updates_for(instance):
+    return LogEntry.objects.get_for_object(instance).filter(
+        action=LogEntry.Action.UPDATE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core: a bare QuerySet.update() is logged (the pod-ORM path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_bare_queryset_update_logs_scoped_entry():
+    """``Model.objects.filter(...).update(...)`` outside any request is logged."""
+    case = _make_case(description="Original")
+
+    before = _updates_for(case).count()
+    Case.objects.filter(pk=case.pk).update(description="Amended")
+
+    entries = _updates_for(case)
+    assert entries.count() == before + 1
+    entry = entries.first()
+    assert entry.changes["description"] == ["Original", "Amended"]
+    # No HTTP request/context -> honest NULL actor (not a fabricated one).
+    assert entry.actor_id is None
+
+
+@pytest.mark.django_db
+def test_update_of_only_auto_now_touch_column_is_not_logged():
+    """A pure ``updated_at`` bump is not a substantive edit -> no entry."""
+    from django.utils import timezone
+
+    case = _make_case()
+    before = _updates_for(case).count()
+    Case.objects.filter(pk=case.pk).update(updated_at=timezone.now())
+    assert _updates_for(case).count() == before
+
+
+@pytest.mark.django_db
+def test_no_op_update_creates_no_entry():
+    """Writing the same value back yields an empty diff -> no entry."""
+    case = _make_case(description="Same")
+    before = _updates_for(case).count()
+    Case.objects.filter(pk=case.pk).update(description="Same")
+    assert _updates_for(case).count() == before
+
+
+@pytest.mark.django_db
+def test_disable_auditlog_suppresses_bulk_capture():
+    """Bulk loads wrap writes in ``disable_auditlog()`` (e.g. the courts importer);
+    the audited manager must honor that flag and log nothing."""
+    from auditlog.context import disable_auditlog
+
+    case = _make_case(description="orig")
+    before = _updates_for(case).count()
+    with disable_auditlog():
+        Case.objects.filter(pk=case.pk).update(description="loaded in bulk")
+    assert _updates_for(case).count() == before
+
+
+@pytest.mark.django_db
+def test_multi_row_update_logs_one_entry_per_changed_row():
+    a = _make_case(description="a")
+    b = _make_case(description="b")
+    Case.objects.filter(pk__in=[a.pk, b.pk]).update(description="shared")
+    assert _updates_for(a).count() == 1
+    assert _updates_for(b).count() == 1
+
+
+@pytest.mark.django_db
+def test_audit_composes_with_case_slug_history_override():
+    """``Case`` has its own ``CaseQuerySet.update()`` (records slug history). The
+    audit hook must WEAVE IN, not clobber it — a bulk re-slug does both."""
+    from cases.models import CaseSlugHistory
+
+    case = _make_case(state=CaseState.PUBLISHED)
+    old_slug = case.slug
+    Case.objects.filter(pk=case.pk).update(slug="reslugged-audit-xyz")
+
+    # Slug-history behavior (CaseQuerySet.update) preserved …
+    assert CaseSlugHistory.objects.filter(slug=old_slug, case=case).exists()
+    # … and the audit entry (AuditedQuerySet.update) is added.
+    entry = _updates_for(case).first()
+    assert entry is not None
+    assert entry.changes["slug"][1] == "reslugged-audit-xyz"
+
+
+@pytest.mark.django_db
+def test_bulk_update_method_is_logged():
+    a = _make_case(description="a")
+    b = _make_case(description="b")
+    a.description = "a2"
+    b.description = "b2"
+    Case.objects.bulk_update([a, b], ["description"])
+    assert _updates_for(a).first().changes["description"] == ["a", "a2"]
+    assert _updates_for(b).first().changes["description"] == ["b", "b2"]
+
+
+# ---------------------------------------------------------------------------
+# Volume guard: a very large update collapses to one summary entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(AUDIT_BULK_UPDATE_MAX_ROWS=2)
+def test_large_update_writes_single_summary_entry():
+    cases = [_make_case(description=f"c{i}") for i in range(3)]
+    ct = ContentType.objects.get_for_model(Case)
+    before = LogEntry.objects.filter(
+        action=LogEntry.Action.UPDATE, content_type=ct
+    ).count()
+
+    Case.objects.filter(pk__in=[c.pk for c in cases]).update(description="mass")
+
+    entries = LogEntry.objects.filter(action=LogEntry.Action.UPDATE, content_type=ct)
+    # One summary row, not three per-row rows.
+    assert entries.count() == before + 1
+    summary = entries.order_by("-id").first().changes["__bulk_update__"]
+    assert summary["rows"] == 3
+    assert summary["fields"] == ["description"]
+
+
+# ---------------------------------------------------------------------------
+# Deletes must keep logging (we deliberately do NOT override delete())
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_queryset_delete_still_logs():
+    case = _make_case()
+    ct = ContentType.objects.get_for_model(Case)
+    pk = case.pk  # integer PK -> auditlog indexes it in object_id
+    Case.objects.filter(pk=case.pk).delete()
+    assert LogEntry.objects.filter(
+        action=LogEntry.Action.DELETE, content_type=ct, object_id=pk
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# PII masking on a registered default-DB model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_feedback_pii_fields_are_masked_in_diff():
+    from cases.models import Feedback, FeedbackType
+
+    fb = Feedback.objects.create(
+        feedback_type=FeedbackType.BUG,
+        subject="s",
+        description="secret personal detail",
+        contact_info={"email": "someone@example.com"},
+    )
+    Feedback.objects.filter(pk=fb.pk).update(description="another secret detail")
+    entry = _updates_for(fb).first()
+    assert entry is not None
+    # The field is tracked (it appears), but its values are redaction markers,
+    # not the raw personal text.
+    masked = entry.changes["description"]
+    assert "another secret detail" not in masked
+    assert "secret personal detail" not in masked
+
+
+# ---------------------------------------------------------------------------
+# Cross-DB: nes (entities) — long IRI PK + LogEntry lands in default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(databases=["default", "nes"])
+def test_entity_update_logs_cross_db_with_long_iri_pk():
+    from entities.models import StoredEntity
+
+    long_iri = "https://jawafdehi.org/entity/person/" + "a" * 300  # > 255 chars
+    ent = StoredEntity.objects.create(
+        iri=long_iri,
+        entity_type="Person",
+        prefix="person",
+        slug="a" * 300,
+        data={"@id": long_iri},
+    )
+
+    StoredEntity.objects.filter(pk=long_iri).update(entity_type="Organization")
+
+    ct = ContentType.objects.get_for_model(StoredEntity)
+    entry = (
+        LogEntry.objects.filter(
+            action=LogEntry.Action.UPDATE, content_type=ct, object_pk=long_iri
+        )
+        .order_by("-id")
+        .first()
+    )
+    assert entry is not None, "cross-DB LogEntry for the entity update was not written"
+    assert entry.object_pk == long_iri  # full IRI preserved, not truncated
+    assert entry.changes["entity_type"] == ["Person", "Organization"]
+    _ = ent  # keep the created row referenced
+
+
+# ---------------------------------------------------------------------------
+# Cross-DB: ngm (materials) — derived ``visibility`` is excluded from the trail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(databases=["default", "ngm"])
+def test_material_visibility_change_is_not_logged_but_content_is():
+    from materials.models import Material, Visibility
+
+    iri = "https://jawafdehi.org/material/ciaa/case-0001-chargesheet"
+    mat = Material.objects.create(
+        iri=iri,
+        material_type="charge_sheet",
+        source="ciaa",
+        ident="case-0001-chargesheet",
+        data={"title": "orig"},
+    )
+    ct = ContentType.objects.get_for_model(Material)
+
+    # System-derived visibility recompute -> excluded -> no entry.
+    before = LogEntry.objects.filter(
+        action=LogEntry.Action.UPDATE, content_type=ct, object_pk=iri
+    ).count()
+    Material.objects.filter(pk=iri).update(visibility=Visibility.UNLISTED)
+    assert (
+        LogEntry.objects.filter(
+            action=LogEntry.Action.UPDATE, content_type=ct, object_pk=iri
+        ).count()
+        == before
+    )
+
+    # A human/content edit IS logged.
+    Material.objects.filter(pk=iri).update(source="ag")
+    entry = (
+        LogEntry.objects.filter(
+            action=LogEntry.Action.UPDATE, content_type=ct, object_pk=iri
+        )
+        .order_by("-id")
+        .first()
+    )
+    assert entry is not None
+    assert entry.changes["source"] == ["ciaa", "ag"]
+    _ = mat


### PR DESCRIPTION
## Why

django-auditlog only hooks `save()` / `delete()`. A bulk `QuerySet.update()` — the way **most** data is actually changed on this platform (interactive pod-ORM shells, management commands, backfills) — emits no signal, so those edits left **no audit trail**. Only 4 `cases`-app models were registered at all. Goal: audit **every** ORM change, to **every** model, across all three databases.

## What

- **`jawafdehi_shared/db/audited.py`** — `AuditedQuerySet` / `AuditedManager` overriding `update()` / `bulk_update()` to write UPDATE `LogEntry` rows (reusing `log_bulk_update`). `delete()` is deliberately **not** overridden — auditlog's `post_delete` receiver already disables Django fast-delete, so queryset deletes are logged. `register_audited()` registers a model and swaps in the manager from `AppConfig.ready()`.
  - Diffs per-row up to `AUDIT_BULK_UPDATE_MAX_ROWS` (1000), else one summary entry — and **counts before materializing** any PKs, so the guard stays cheap on the 1.6M/5.2M ngm tables.
  - Ignores `auto_now` touch columns so a no-op PATCH / pure timestamp bump doesn't fabricate an entry.
  - Snapshots from the **write** DB (never a replica) so cross-DB `LogEntry` writes (`nes`/`ngm` → `default`) see their own write.
- **Registrations** across `cases` / `review` / `entities` / `courts` / `materials`. PII masked on `Feedback` + `ChatUserIdentity`; derived `visibility` and touch `updated_at` excluded where appropriate.
- **`cases/0051`** widens `auditlog_logentry.object_pk` `varchar(255)` → `text` (Postgres-only; SQLite unenforced) so long IRI PKs (entities/materials) fit.
- **Courts bulk importer** now runs under `disable_auditlog()` — a 1.6M-row load is a bulk import, not a stream of human edits.
- Removed the now-redundant explicit `log_bulk_update` call in `CaseViewSet.partial_update` (the manager covers it; keeping both double-logged).

**Skipped (documented in code):** `jobs.Job` (hot queue churn), `CaseStateChange` / `StatisticsSnapshot` / `StoredVersion` (themselves audit trails / derived), `ArticlePage` (Wagtail-native revisions).

## Out of scope

Raw SQL / direct `psql` / bulk `COPY` are not captured (ORM-level trade-off). No read/UI surface. Retention is a recommended follow-up: `LogEntry` now grows faster (esp. ngm) — an `auditlogflush` CronJob should follow.

## Deploy

Run migrations on **`default`** (`manage.py migrate`); the `object_pk` widen is the only schema change and `nes`/`ngm` need none (registration is code-only).

## Test

New `tests/api/test_audit_bulk_capture.py` (bulk update/bulk_update, volume-guard summary, delete-still-logs, `disable_auditlog` suppression, PII masking, cross-DB nes/ngm + long-IRI round-trip) + existing auditlog tests. **Full suite: 662 passed**, ruff clean, `makemigrations --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)