### PR TITLE
fix(llm): label claude_cli usage bucket with the dominant model, not the first

### DIFF
--- a/llm/providers/cli.py
+++ b/llm/providers/cli.py
@@ -33,6 +33,35 @@ def _flatten(content):
     return "\n\n".join(b.get("text", "") for b in content)
 
 
+def _dominant_model(model_usage):
+    """Pick the model that did the real work from claude -p's ``modelUsage`` map.
+
+    A single ``claude -p`` call can report usage for MORE than one model — the
+    model we requested via ``--model`` plus an auxiliary the CLI drives itself
+    for internal housekeeping (e.g. a small model for a quota/title side-task).
+    Taking ``list(modelUsage)[0]`` mislabels the usage bucket with whichever key
+    hashes first, which can be the auxiliary model even though the requested
+    model produced the entire graded result (and the flat ``total_cost_usd``
+    already reflects it). Choose the model with the highest reported cost —
+    tie-broken by token count — so the bucket label names the actual grader.
+    Cost is the primary key because per-model ``inputTokens`` excludes cache
+    tokens, so a cache-heavy primary call can report fewer counted tokens than a
+    tiny uncached auxiliary one while still costing far more. Returns "" when
+    ``modelUsage`` is absent/empty/malformed so the caller can fall back.
+    """
+    if not isinstance(model_usage, dict) or not model_usage:
+        return ""
+
+    def weight(item):
+        _name, u = item
+        u = u if isinstance(u, dict) else {}
+        cost = float(u.get("costUSD") or 0.0)
+        tokens = int(u.get("inputTokens") or 0) + int(u.get("outputTokens") or 0)
+        return (cost, tokens)
+
+    return max(model_usage.items(), key=weight)[0]
+
+
 class _CliProvider(Provider):
     """Base class for subprocess-based CLI providers.
 
@@ -157,9 +186,7 @@ class ClaudeCliProvider(_CliProvider):
             usage_data = data.get("usage", {})
             model_usage = data.get("modelUsage", {})
             reported_model = (
-                list(model_usage.keys())[0]
-                if model_usage
-                else (effective_model or model_id or "claude")
+                _dominant_model(model_usage) or effective_model or model_id or "claude"
             )
             input_tokens = (
                 usage_data.get("input_tokens", 0)

--- a/tests/test_llm_cli_providers.py
+++ b/tests/test_llm_cli_providers.py
@@ -71,6 +71,88 @@ class TestClaudeCliProvider(unittest.TestCase):
             self.assertEqual(by_provider[0]["tier"], "cheap")
             self.assertEqual(by_provider[0]["model"], "claude-opus-4-7[1m]")
 
+    def test_multi_model_usage_labels_bucket_with_the_dominant_model(self):
+        """When claude -p reports usage for more than one model, the usage bucket
+        must be labelled with the model that did the real work (highest cost),
+        not whichever key the CLI happens to list first. Regression: a review
+        graded on opus was mislabelled as the auxiliary haiku the CLI runs for
+        internal housekeeping, because the parser took modelUsage's first key."""
+        provider = ClaudeCliProvider()
+
+        # The auxiliary (haiku) key is listed FIRST but is a tiny side-task; the
+        # requested opus model produced the graded result and dominates by cost.
+        sample_output = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": '{"score": 88}',
+                "total_cost_usd": 2.85,
+                "usage": {
+                    "input_tokens": 10,
+                    "cache_creation_input_tokens": 500000,
+                    "cache_read_input_tokens": 44000,
+                    "output_tokens": 11000,
+                },
+                "modelUsage": {
+                    "claude-haiku-4-5-20251001": {
+                        "inputTokens": 300,
+                        "outputTokens": 40,
+                        "costUSD": 0.0007,
+                    },
+                    "claude-opus-4-8[1m]": {
+                        "inputTokens": 10,
+                        "outputTokens": 11000,
+                        "costUSD": 2.8493,
+                    },
+                },
+            }
+        )
+
+        with patch.object(provider, "_run", return_value=sample_output):
+            usage = UsageAccumulator()
+            provider.invoke_text(
+                system="grade this",
+                content="test",
+                max_tokens=900,
+                model_id="claude-opus-4-8[1m]",
+                tier="cheap",
+                usage=usage,
+            )
+
+            by_provider = usage.as_dict()["by_provider"]
+            self.assertEqual(len(by_provider), 1)
+            self.assertEqual(by_provider[0]["model"], "claude-opus-4-8[1m]")
+
+    def test_empty_model_usage_falls_back_to_requested_model(self):
+        """With no modelUsage map, the bucket is labelled with the model we asked
+        the CLI to run (``--model``), not the "claude" last-resort default."""
+        provider = ClaudeCliProvider()
+        sample_output = json.dumps(
+            {
+                "type": "result",
+                "is_error": False,
+                "result": '{"score": 70}',
+                "total_cost_usd": 0.01,
+                "usage": {"input_tokens": 5, "output_tokens": 5},
+                # no modelUsage key at all
+            }
+        )
+
+        with patch.object(provider, "_run", return_value=sample_output):
+            usage = UsageAccumulator()
+            provider.invoke_text(
+                system="grade this",
+                content="test",
+                max_tokens=900,
+                model_id="claude-opus-4-8[1m]",
+                tier="cheap",
+                usage=usage,
+            )
+
+            by_provider = usage.as_dict()["by_provider"]
+            self.assertEqual(by_provider[0]["model"], "claude-opus-4-8[1m]")
+
     def test_invoke_text_handles_error(self):
         """Test error handling when is_error is true."""
         provider = ClaudeCliProvider()


### PR DESCRIPTION
## Problem

`claude -p --output-format json` can report `modelUsage` for **more than one model** in a single call — the model we requested via `--model`, plus an auxiliary the CLI drives itself for internal housekeeping. `ClaudeCliProvider._finalize` labelled the usage bucket with `list(modelUsage.keys())[0]`, i.e. whichever key the CLI happened to list first.

That first key can be the auxiliary model even though the requested model produced the entire graded result. The flat `total_cost_usd` was already summed correctly across models — only the per-bucket **label** was wrong.

Downstream, that mislabel flows into `result["token_usage"]["by_provider"][].model`, which the review serializers project into the **reviewer chips** and per-model **cost attribution**.

**Observed in prod:** case reviews graded on `claude-opus-4-8[1m]` (both tiers are pinned to opus in the jobs-processor) recorded a `by_provider` bucket labelled `claude-haiku-4-5-20251001` — the CLI's auxiliary model. The standing "real grader = `token_usage.model_id`" rule held only because the per-bucket label couldn't be trusted; this makes the bucket trustworthy too.

## Fix

Pick the model with the **highest reported cost** (tie-broken by token count), falling back to the requested `--model` (`effective_model`/`model_id`) when `modelUsage` is absent/empty/malformed.

Cost is the primary discriminator because per-model `inputTokens` **excludes cache tokens**, so a cache-heavy primary call can count fewer tokens than a tiny uncached auxiliary one while costing far more.

## Tests

- `test_multi_model_usage_labels_bucket_with_the_dominant_model` — auxiliary haiku listed first, opus dominates by cost → bucket labelled opus. (Fails on the old first-key logic.)
- `test_empty_model_usage_falls_back_to_requested_model` — no `modelUsage` → bucket labelled with the requested `--model`, not the `"claude"` last-resort default.
- Existing single-model parse test unchanged and green.

`pytest tests/test_llm_cli_providers.py tests/test_llm_providers.py` → 16 passed. ruff check + format clean.

No migration, no schema/API change; forward-only (labels newly-recorded usage — historical rows keep their stored label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)