### PR TITLE
feat(stats): data-quality statistics payload (CIAA split, persons-by-sector, court-year matrix)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -1149,13 +1149,20 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
     Returns:
     - `published_cases`: Number of cases with state PUBLISHED
     - `cases_under_investigation`: Number of cases with state DRAFT or IN_REVIEW
+    - `cases_in_review`: Number of cases with state IN_REVIEW (subset of
+      under-investigation — cases being prepared for publication)
     - `cases_closed`: Number of cases with state CLOSED
+    - `cases_ciaa`: Number of CIAA corruption cases (case_type CORRUPTION)
+    - `cases_non_ciaa`: Number of cases handled outside CIAA (all other types)
     - `entities_tracked`: Number of unique entities involved in published cases
-    - `nes`: NES (entities) coverage — total, by-prefix / by-type breakdowns, and
-      completeness percentages (identifier / provenance / bilingual name)
+    - `nes`: NES (entities) coverage — total, by-prefix / by-type breakdowns,
+      persons-by-sector (`persons_by_sector`, derived from the office each person
+      holds), and completeness percentages (identifier / provenance / bilingual
+      name)
     - `ngm`: NGM (judicial) coverage — court-case / court totals, by-court-type
-      breakdown, and completeness percentages (NES-resolved / registration date /
-      document sources)
+      breakdown, court-cases-per-year (`by_year`) and per-court-level-per-year
+      (`by_court_type_year`), and completeness percentages (NES-resolved /
+      registration date / document sources)
     - `materials`: NGM materials (development-project / document dataset) coverage —
       total, by-type / by-source breakdowns, and completeness percentages
       (description / url / date)
@@ -1176,7 +1183,10 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             "properties": {
                 "published_cases": {"type": "integer", "example": 127},
                 "cases_under_investigation": {"type": "integer", "example": 43},
+                "cases_in_review": {"type": "integer", "example": 12},
                 "cases_closed": {"type": "integer", "example": 31},
+                "cases_ciaa": {"type": "integer", "example": 88},
+                "cases_non_ciaa": {"type": "integer", "example": 39},
                 "entities_tracked": {"type": "integer", "example": 89},
                 "nes": {"type": "object", "description": "NES coverage metrics"},
                 "ngm": {

--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -232,7 +232,10 @@ def _sector_for_roles(roles) -> str:
                 continue
             member = role.get("memberOf")
             if isinstance(member, dict):
-                iri = member.get("@id") or ""
+                # ``@id`` should be a string; coerce anything else to "" so a single
+                # malformed entity can't crash the whole refresh_statistics job.
+                val = member.get("@id")
+                iri = val if isinstance(val, str) else ""
             elif isinstance(member, str):
                 iri = member
             else:

--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -19,8 +19,11 @@ request-blocking recompute or an error.
 
 from __future__ import annotations
 
+import json
+
 from django.db import connections
 from django.db.models import Count, Q
+from django.db.models.functions import ExtractYear
 from django.utils import timezone
 
 # NES + NGM models live in sibling apps; the DB router (config.db_router) sends
@@ -34,6 +37,7 @@ from cases.models import (
     Case,
     CaseEntityRelationship,
     CaseState,
+    CaseType,
     StatisticsSnapshot,
 )
 
@@ -76,6 +80,7 @@ def bootstrap_placeholder() -> dict:
             "total": 0,
             "by_prefix": [],
             "by_type": [],
+            "persons_by_sector": [],
             "counts": {
                 "with_identifier": 0,
                 "with_provenance": 0,
@@ -91,6 +96,8 @@ def bootstrap_placeholder() -> dict:
             "court_cases_total": 0,
             "courts_total": 0,
             "by_court_type": [],
+            "by_year": [],
+            "by_court_type_year": [],
             "counts": {
                 "nes_resolved": 0,
                 "with_registration_date": 0,
@@ -128,12 +135,23 @@ def _case_counts() -> dict:
         under_investigation=Count(
             "pk", filter=Q(state__in=[CaseState.DRAFT, CaseState.IN_REVIEW])
         ),
+        # "In review" (being prepared for publication) split out of the broader
+        # under-investigation bucket, which also covers DRAFT.
+        in_review=Count("pk", filter=Q(state=CaseState.IN_REVIEW)),
         closed=Count("pk", filter=Q(state=CaseState.CLOSED)),
+        # CIAA vs non-CIAA split. CIAA corruption cases are drafted with
+        # case_type=CORRUPTION (see ciaa_draft_case_service); every other type
+        # (bribery, forgery, embezzlement, ...) runs through other bodies.
+        ciaa=Count("pk", filter=Q(case_type=CaseType.CORRUPTION)),
+        non_ciaa=Count("pk", filter=~Q(case_type=CaseType.CORRUPTION)),
     )
     return {
         "published_cases": by_state["published"],
         "cases_under_investigation": by_state["under_investigation"],
+        "cases_in_review": by_state["in_review"],
         "cases_closed": by_state["closed"],
+        "cases_ciaa": by_state["ciaa"],
+        "cases_non_ciaa": by_state["non_ciaa"],
         # Unique NES entities tracked across published cases (binds hold the
         # nes_id directly; NES owns the entity records).
         "entities_tracked": (
@@ -169,6 +187,82 @@ def refresh_statistics() -> dict:
         update_fields=["data", "computed_at", "is_placeholder"],
     )
     return stats
+
+
+def _sector_from_member_iri(iri: str) -> str | None:
+    """Map an organization IRI (a person's ``memberOf``) to a person sector.
+
+    The org IRI path encodes its kind (``.../organization/government/ward/...``),
+    so the sector is read straight off the structured identifier — no free-text /
+    keyword guessing. Only the org kinds that actually occur in the dataset are
+    distinguished; any other resolvable org is ``other``. Returns None when the
+    IRI carries no organization segment (so the caller can keep scanning roles).
+    """
+    if (
+        "/organization/government/ward" in iri
+        or "/organization/government/localunit" in iri
+    ):
+        return "local_gov"
+    if "/organization/political_party" in iri:
+        return "politicians"
+    if "/organization/hospital" in iri:
+        return "health"
+    if "/organization" in iri:
+        return "other"
+    return None
+
+
+def _sector_for_roles(roles) -> str:
+    """A person's sector from their ``hasOccupation`` value (dict | list | None).
+
+    Takes the first role whose ``memberOf`` resolves to a sector; a person with
+    no role, or no resolvable office, is ``not_recorded`` (shown honestly rather
+    than dropped). Defensive against the value arriving JSON-encoded (sqlite).
+    """
+    if isinstance(roles, str):
+        try:
+            roles = json.loads(roles)
+        except (ValueError, TypeError):
+            return "not_recorded"
+    if isinstance(roles, dict):
+        roles = [roles]
+    if isinstance(roles, list):
+        for role in roles:
+            if not isinstance(role, dict):
+                continue
+            member = role.get("memberOf")
+            if isinstance(member, dict):
+                iri = member.get("@id") or ""
+            elif isinstance(member, str):
+                iri = member
+            else:
+                iri = ""
+            sector = _sector_from_member_iri(iri)
+            if sector:
+                return sector
+    return "not_recorded"
+
+
+def _persons_by_sector() -> list[dict]:
+    """Tally Person entities by the sector of the office they hold.
+
+    Reads only the ``hasOccupation`` sub-document per person (a JSON key
+    projection, not the whole doc) and streams with a server-side cursor, so the
+    scan stays cheap enough for the out-of-band refresh. Ordered largest-first.
+    """
+    tally: dict[str, int] = {}
+    roles_iter = (
+        StoredEntity.objects.filter(entity_type="Person")
+        .values_list("data__hasOccupation", flat=True)
+        .iterator(chunk_size=5000)
+    )
+    for roles in roles_iter:
+        sector = _sector_for_roles(roles)
+        tally[sector] = tally.get(sector, 0) + 1
+    return [
+        {"sector": sector, "count": count}
+        for sector, count in sorted(tally.items(), key=lambda kv: -kv[1])
+    ]
 
 
 def _nes_metrics():
@@ -221,6 +315,7 @@ def _nes_metrics():
         "total": total,
         "by_prefix": by_prefix,
         "by_type": by_type,
+        "persons_by_sector": _persons_by_sector(),
         "counts": {
             "with_identifier": with_identifier,
             "with_provenance": with_provenance,
@@ -246,6 +341,29 @@ def _ngm_metrics():
         .order_by("-count")
     )
 
+    # Court cases filed per year, and per court level per year (the matrix). Both
+    # key off the indexed registration_date_ad; cases with no registration date
+    # are excluded so a null year never appears as a column. Capped to the most
+    # recent N years so an outlier/dirty registration year cannot make the matrix
+    # grow unbounded (the heatmap has one column per kept year).
+    _MATRIX_YEARS = 25
+    dated = CourtCase.objects.exclude(registration_date_ad__isnull=True).annotate(
+        year=ExtractYear("registration_date_ad")
+    )
+    year_rows = list(
+        dated.values("year").annotate(count=Count("case_number")).order_by("year")
+    )
+    # Keep the most-recent N years, but return them ascending (frontend order).
+    kept_years = {row["year"] for row in year_rows[-_MATRIX_YEARS:]}
+    by_year = [row for row in year_rows if row["year"] in kept_years]
+    by_court_type_year = [
+        row
+        for row in dated.values("court__court_type", "year")
+        .annotate(count=Count("case_number"))
+        .order_by("court__court_type", "year")
+        if row["year"] in kept_years
+    ]
+
     nes_resolved = (
         CourtCase.objects.exclude(nes_id__isnull=True).exclude(nes_id="").count()
     )
@@ -267,6 +385,8 @@ def _ngm_metrics():
         "court_cases_total": court_cases_total,
         "courts_total": Court.objects.count(),
         "by_court_type": by_court_type,
+        "by_year": by_year,
+        "by_court_type_year": by_court_type_year,
         "counts": {
             "nes_resolved": nes_resolved,
             "with_registration_date": with_registration_date,

--- a/tests/api/test_statistics_api.py
+++ b/tests/api/test_statistics_api.py
@@ -65,8 +65,14 @@ class TestStatisticsEndpoint:
         assert "published_cases" in data
         assert "entities_tracked" in data
         assert "cases_under_investigation" in data
+        assert "cases_in_review" in data
         assert "cases_closed" in data
+        assert "cases_ciaa" in data
+        assert "cases_non_ciaa" in data
         assert "last_updated" in data
+        # NGM court-cases-per-year aggregations for the coverage matrix.
+        assert "by_year" in data["ngm"]
+        assert "by_court_type_year" in data["ngm"]
 
     def test_statistics_field_types(self, api_client):
         """Test that all fields have correct types."""
@@ -258,8 +264,49 @@ class TestStatisticsCounting:
 
         assert data["published_cases"] == 1
         assert data["cases_under_investigation"] == 2
+        assert data["cases_in_review"] == 1
         assert data["cases_closed"] == 1
         assert data["entities_tracked"] == 1
+        # All four cases are CORRUPTION -> all CIAA, none non-CIAA.
+        assert data["cases_ciaa"] == 4
+        assert data["cases_non_ciaa"] == 0
+
+    def test_ciaa_split_by_case_type(self, api_client):
+        """CIAA count = CORRUPTION cases; every other case_type is non-CIAA."""
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION, state=CaseState.PUBLISHED, title="Corruption 1"
+        )
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION, state=CaseState.DRAFT, title="Corruption 2"
+        )
+        Case.objects.create(
+            case_type=CaseType.BRIBERY, state=CaseState.PUBLISHED, title="Bribery"
+        )
+        Case.objects.create(
+            case_type=CaseType.EMBEZZLEMENT, state=CaseState.CLOSED, title="Embezzlement"
+        )
+
+        data = api_client.get("/api/statistics/").json()
+
+        assert data["cases_ciaa"] == 2
+        assert data["cases_non_ciaa"] == 2
+
+    def test_cases_in_review_is_subset_of_under_investigation(self, api_client):
+        """cases_in_review counts only IN_REVIEW; under-investigation keeps DRAFT+IN_REVIEW."""
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION, state=CaseState.IN_REVIEW, title="Review 1"
+        )
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION, state=CaseState.IN_REVIEW, title="Review 2"
+        )
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION, state=CaseState.DRAFT, title="Draft"
+        )
+
+        data = api_client.get("/api/statistics/").json()
+
+        assert data["cases_in_review"] == 2
+        assert data["cases_under_investigation"] == 3
 
 
 @pytest.mark.django_db
@@ -571,9 +618,68 @@ class TestNesMetrics:
         assert nes["total"] == 0
         assert nes["by_prefix"] == []
         assert nes["by_type"] == []
+        assert nes["persons_by_sector"] == []
         for key in ("with_identifier", "with_provenance", "with_bilingual_name"):
             assert nes["counts"][key] == 0
             assert nes["completeness"][key] == 0.0
+
+    def test_persons_by_sector_classifies_by_memberof_org(self, api_client):
+        """Each person is bucketed by the org (memberOf) they hold a position in;
+        a person with no resolvable office is 'not_recorded'."""
+        _make_entity(
+            "person",
+            "ward-mayor",
+            "Person",
+            {
+                "hasOccupation": [
+                    {
+                        "roleName": "Mayor",
+                        "memberOf": {
+                            "@id": "https://jawafdehi.org/entity/organization/government/ward/ktm-1"
+                        },
+                    }
+                ]
+            },
+        )
+        _make_entity(
+            "person",
+            "party-chair",
+            "Person",
+            {
+                "hasOccupation": {
+                    "roleName": "Chair",
+                    "memberOf": {
+                        "@id": "https://jawafdehi.org/entity/organization/political_party/abc"
+                    },
+                }
+            },
+        )
+        _make_entity(
+            "person",
+            "hospital-director",
+            "Person",
+            {
+                "hasOccupation": [
+                    {
+                        "memberOf": {
+                            "@id": "https://jawafdehi.org/entity/organization/hospital/bir"
+                        }
+                    }
+                ]
+            },
+        )
+        _make_entity("person", "unaffiliated", "Person", {})
+
+        data = api_client.get("/api/statistics/").json()
+        by_sector = {
+            row["sector"]: row["count"] for row in data["nes"]["persons_by_sector"]
+        }
+        assert by_sector == {
+            "local_gov": 1,
+            "politicians": 1,
+            "health": 1,
+            "not_recorded": 1,
+        }
 
     def test_nes_total_and_breakdowns(self, api_client):
         _make_entity("person", "ram", "Person", {"name": {"en": "Ram", "ne": "राम"}})
@@ -675,6 +781,16 @@ class TestNgmMetrics:
             row["court__court_type"]: row["count"] for row in ngm["by_court_type"]
         }
         assert by_court_type == {"district": 2, "supreme": 1}
+
+        # Court-cases-per-year and per-court-level-per-year (the bare case with
+        # no registration date is excluded, so only the 2 dated cases count).
+        by_year = {row["year"]: row["count"] for row in ngm["by_year"]}
+        assert by_year == {2026: 2}
+        by_type_year = {
+            (row["court__court_type"], row["year"]): row["count"]
+            for row in ngm["by_court_type_year"]
+        }
+        assert by_type_year == {("district", 2026): 1, ("supreme", 2026): 1}
 
         # Materials now live in their own top-level block, not under ngm.
         mats = payload["materials"]


### PR DESCRIPTION
## What

Extends `/api/statistics/` with the fields the reworked **Data Quality** page needs:

- **CIAA corruption-case split**
- **persons-by-sector** (`nes.persons_by_sector`)
- **court-year matrix** (`ngm.by_court_type_year`)

## Compatibility

**Additive** — existing fields (`materials.by_source` / `by_type`, totals, etc.) are unchanged, so nothing currently consuming the endpoint breaks. The new fields are computed in `cases/services/statistics.py` at snapshot-refresh time.

> **Deploy note:** ship this **first or together** with the frontend PR (Jawafdehi#225). The frontend degrades gracefully without these fields, but the new page sections only populate once this is live.

## Verification

- `tests/api/test_statistics_api.py` — **33 tests pass** (sqlite, no external services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)