### PR TITLE
feat(cases): serve IN_REVIEW cases by direct slug (unlisted, not hidden)

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -267,10 +267,11 @@ def _if_match_matches(request, case) -> bool:
         evidence, timeline) and any internal notes.
 
         **Access control:**
-        - PUBLISHED cases: accessible to everyone (public)
-        - DRAFT and IN_REVIEW cases (casework): require a casework-viewing role
-          (ReadOnly / Caseworker / Moderator / Admin, or an assigned contributor);
-          anonymous/public callers get 404
+        - PUBLISHED cases: accessible to everyone (public, listed + searchable)
+        - IN_REVIEW cases: UNLISTED but publicly retrievable by direct slug —
+          accessible to everyone, just kept out of listings and search
+        - DRAFT cases (casework): require a casework-viewing role
+          (ReadOnly / Caseworker / Moderator / Admin); anonymous/public callers get 404
         - CLOSED cases: not accessible via this API
 
         Returns 404 if the case doesn't exist or if the user is not authorized to view it.
@@ -304,10 +305,12 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
     Search:
     - Full-text search across title, description, key_allegations
 
-    Read visibility is role-based: unauthenticated/public callers see PUBLISHED
-    cases only (DRAFT and IN_REVIEW are casework → 404 for them). Admin /
-    Moderator / Caseworker / ReadOnly see all non-CLOSED cases (incl. DRAFT and
-    IN_REVIEW). CLOSED cases are never exposed via this API.
+    Read visibility is state-based. LISTING and SEARCH: unauthenticated/public
+    callers see PUBLISHED only; casework roles (Admin / Moderator / Caseworker /
+    ReadOnly) also see DRAFT + IN_REVIEW. RETRIEVE by slug is wider: PUBLISHED and
+    IN_REVIEW are public (IN_REVIEW is "unlisted" — reachable by direct slug but
+    absent from listings/search); DRAFT stays casework-only; CLOSED is never
+    exposed via this API.
     """
 
     serializer_class = CaseSerializer
@@ -357,7 +360,8 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
         List endpoint: PUBLISHED cases only for anonymous/public; casework roles
         (Admin/Moderator/Caseworker/ReadOnly) also see IN_REVIEW + DRAFT.
         Retrieve endpoint:
-          - Unauthenticated/public: PUBLISHED only (DRAFT/IN_REVIEW → 404)
+          - Unauthenticated/public: PUBLISHED + IN_REVIEW (IN_REVIEW is unlisted
+            but reachable by direct slug); DRAFT → 404
           - Casework roles: PUBLISHED, IN_REVIEW, and DRAFT (authz check in retrieve)
           - CLOSED cases are never exposed via this API
         Partial update endpoint: all cases except CLOSED (authorization check happens in partial_update).
@@ -375,17 +379,19 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             return Case.objects.exclude(state=CaseState.CLOSED)
 
         if self.action == "retrieve":
-            # Casework (DRAFT + IN_REVIEW) is viewable only by casework roles
-            # (readonly/caseworker/moderator/admin) — NOT the public. Anonymous /
-            # public callers see only PUBLISHED. (Role model: public = readonly
-            # EXCEPT no casework access; the per-object check is in retrieve().)
+            # Retrieve-by-slug is wider than listing: IN_REVIEW is "unlisted" —
+            # publicly reachable by direct slug, just absent from listings/search.
+            # DRAFT stays casework-only; the per-object gate is in retrieve().
             if self.request.user and self.request.user.is_authenticated:
                 # Exclude CLOSED cases from the API; the retrieve() gate enforces
-                # casework-role for non-PUBLISHED states.
+                # casework-role for DRAFT.
                 queryset = Case.objects.exclude(state=CaseState.CLOSED)
             else:
-                # Unauthenticated: PUBLISHED only (no in-review/draft casework).
-                queryset = Case.objects.filter(state=CaseState.PUBLISHED)
+                # Unauthenticated: PUBLISHED + IN_REVIEW (unlisted-by-slug);
+                # DRAFT and CLOSED stay hidden.
+                queryset = Case.objects.filter(
+                    state__in=[CaseState.PUBLISHED, CaseState.IN_REVIEW]
+                )
         else:
             # List endpoint: visibility depends on authentication/role.
             # - Unauthenticated: PUBLISHED only
@@ -615,9 +621,9 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
         otherwise ``None`` (the caller re-raises the 404).
 
         Visibility mirrors :meth:`retrieve` exactly, so a retired slug never
-        leaks a non-public case's existence: CLOSED is never exposed; DRAFT /
-        IN_REVIEW (casework) redirect only for a casework-viewing role; only
-        PUBLISHED redirects for anonymous callers.
+        leaks a non-public case's existence: CLOSED is never exposed; DRAFT
+        (casework) redirects only for a casework-viewing role; PUBLISHED and
+        IN_REVIEW (unlisted-but-public-by-slug) redirect for anonymous callers.
         """
         if not requested_slug:
             return None
@@ -634,9 +640,10 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
         # CLOSED cases are never exposed via this API — don't confirm existence.
         if case.state == CaseState.CLOSED:
             return None
-        # Casework states are not public: only redirect for a casework-viewing
-        # role, else 404 (same boundary retrieve() enforces for a live case).
-        if case.state in (CaseState.DRAFT, CaseState.IN_REVIEW):
+        # DRAFT is not public: only redirect for a casework-viewing role, else
+        # 404 (same boundary retrieve() enforces for a live case). IN_REVIEW is
+        # unlisted-but-public-by-slug, so its retired slugs redirect for anyone.
+        if case.state == CaseState.DRAFT:
             user = request.user
             if not (
                 user and user.is_authenticated and can_view_case(user, case)
@@ -659,9 +666,11 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
         """
         GET /api/cases/{id}/
 
-        Retrieve a case with permission-based access control:
-        - PUBLISHED cases: accessible to everyone (public)
-        - DRAFT and IN_REVIEW cases (casework): require a casework-viewing role
+        Retrieve a case with state-based access control:
+        - PUBLISHED cases: accessible to everyone (public, listed + searchable)
+        - IN_REVIEW cases: UNLISTED but public by direct slug — accessible to
+          everyone, just absent from listings/search
+        - DRAFT cases (casework): require a casework-viewing role
           (readonly/caseworker/moderator/admin); public callers get 404
         - CLOSED cases: not accessible via public API (returns 404)
 
@@ -679,15 +688,18 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 return redirect
             raise
 
-        # Casework states (DRAFT, IN_REVIEW) are not public — require authz.
-        # Public = readonly EXCEPT no casework access, so it cannot view these.
-        if case.state in (CaseState.DRAFT, CaseState.IN_REVIEW):
+        # DRAFT is the only non-public retrieve state: it requires a casework
+        # role. IN_REVIEW is "unlisted" — public by direct slug (kept out of
+        # listings/search via get_queryset + the search indexer) — and PUBLISHED
+        # is public, so neither is gated here. CLOSED never reaches this method
+        # (excluded from every retrieve queryset).
+        if case.state == CaseState.DRAFT:
             if not request.user.is_authenticated:
                 return Response(
                     {"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND
                 )
 
-            # Check if user is authorized to view this casework case.
+            # Check if user is authorized to view this draft case.
             if not can_view_case(request.user, case):
                 return Response(
                     {"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -694,13 +694,13 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
         # is public, so neither is gated here. CLOSED never reaches this method
         # (excluded from every retrieve queryset).
         if case.state == CaseState.DRAFT:
-            if not request.user.is_authenticated:
-                return Response(
-                    {"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND
-                )
-
-            # Check if user is authorized to view this draft case.
-            if not can_view_case(request.user, case):
+            # A DRAFT is casework-only: anon or a role-less user gets 404. This
+            # mirrors history()'s gate; get_queryset already keeps DRAFT out of
+            # the anon retrieve queryset, so this is the defensive object-level
+            # check (can_view_case is False for AnonymousUser).
+            if not request.user.is_authenticated or not can_view_case(
+                request.user, case
+            ):
                 return Response(
                     {"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND
                 )

--- a/tests/api/test_public_api.py
+++ b/tests/api/test_public_api.py
@@ -39,8 +39,9 @@ def test_public_api_only_shows_published_cases(case_data, state):
     Feature: accountability-platform-core, Property 8: Public API only shows published cases
 
     For any API request to list cases, only cases with state=PUBLISHED should be returned.
-    The detail endpoint also only returns PUBLISHED cases to the public; casework
-    states (DRAFT, IN_REVIEW) require a casework-viewing role and otherwise 404.
+    The detail endpoint is wider: PUBLISHED and IN_REVIEW are public by direct
+    slug (IN_REVIEW is "unlisted" — retrievable but absent from listings/search);
+    DRAFT requires a casework-viewing role and CLOSED is never exposed (both 404).
     Validates: Requirements 6.1, 8.3
     """
 
@@ -75,16 +76,17 @@ def test_public_api_only_shows_published_cases(case_data, state):
             case.slug not in case_ids_in_response
         ), f"Case {case.slug} with state={state} should NOT appear in API list response"
 
-    # Test detail endpoint - only PUBLISHED is publicly accessible; casework
-    # states (DRAFT, IN_REVIEW) and CLOSED return 404 to anonymous callers.
+    # Test detail endpoint - PUBLISHED and IN_REVIEW are publicly retrievable by
+    # direct slug (IN_REVIEW is unlisted, not hidden); DRAFT (casework) and
+    # CLOSED return 404 to anonymous callers.
     detail_response = client.get(f"/api/cases/{case.slug}/")
 
-    if state == CaseState.PUBLISHED:
+    if state in (CaseState.PUBLISHED, CaseState.IN_REVIEW):
         assert (
             detail_response.status_code == 200
-        ), "PUBLISHED case should be accessible via detail endpoint"
+        ), f"{state} case should be retrievable by direct slug"
     else:
-        # DRAFT, IN_REVIEW (casework), and CLOSED are not publicly accessible.
+        # DRAFT (casework) and CLOSED are not publicly accessible.
         assert (
             detail_response.status_code == 404
         ), f"{state} case should NOT be publicly accessible via detail endpoint"
@@ -580,15 +582,16 @@ def test_api_exposes_state_field():
 @pytest.mark.django_db
 @settings(max_examples=10, deadline=800)
 @given(case_data=complete_case_data())
-def test_public_api_hides_in_review_case_from_retrieve(case_data):
+def test_public_api_unlists_in_review_but_serves_by_slug(case_data):
     """
-    Feature: IN_REVIEW cases are casework and NOT publicly accessible.
+    Feature: IN_REVIEW cases are UNLISTED but publicly retrievable by direct slug.
 
-    Under the new role model (public = readonly EXCEPT no casework), an IN_REVIEW
-    case is casework. The retrieve (detail) endpoint must return 404 to anonymous
-    callers, and IN_REVIEW cases must NOT appear in the public list endpoint.
+    An IN_REVIEW case is "unlisted" (like an unlisted video): reachable by anyone
+    who has the exact slug, but kept out of the public list endpoint (and search).
+    So the retrieve (detail) endpoint returns 200 to an anonymous caller, while
+    the list endpoint must NOT include it.
 
-    Validates: in-review = casework = not public
+    Validates: in-review = unlisted (slug-accessible, not listed)
     """
     # Create an IN_REVIEW case
     case = create_case_with_entities(**case_data)
@@ -597,13 +600,14 @@ def test_public_api_hides_in_review_case_from_retrieve(case_data):
 
     client = APIClient()
 
-    # Test 1: Detail endpoint must hide IN_REVIEW cases from the public (404)
+    # Test 1: Detail endpoint serves IN_REVIEW cases by direct slug (200)
     detail_response = client.get(f"/api/cases/{case.slug}/")
     assert (
-        detail_response.status_code == 404
-    ), "IN_REVIEW case should NOT be publicly accessible via detail endpoint"
+        detail_response.status_code == 200
+    ), "IN_REVIEW case SHOULD be retrievable by direct slug (unlisted, not hidden)"
+    assert detail_response.data["slug"] == case.slug
 
-    # Test 2: List endpoint should NOT show IN_REVIEW cases
+    # Test 2: List endpoint must NOT show IN_REVIEW cases (unlisted)
     list_response = client.get("/api/cases/")
     assert list_response.status_code == 200
 

--- a/tests/api/test_slug_history_edgecases.py
+++ b/tests/api/test_slug_history_edgecases.py
@@ -244,6 +244,20 @@ def test_closed_case_records_history_but_retrieve_404s():
     assert _cw_client().get(URL.format("closed-old2")).status_code == 404
 
 
+@pytest.mark.django_db
+def test_in_review_retired_slug_301s_for_anon():
+    # IN_REVIEW is unlisted-but-public-by-slug, so a retired IN_REVIEW slug must
+    # 301-redirect an ANONYMOUS caller to the canonical URL (this is what makes
+    # the BB-38 backfill of historically re-slugged in-review cases pay off).
+    case = _make_case("inrev-old", state=CaseState.IN_REVIEW, title="In review")
+    Case.objects.filter(pk=case.pk).update(slug="inrev-new")
+    assert CaseSlugHistory.objects.filter(slug="inrev-old", case=case).exists()
+
+    resp = APIClient().get(URL.format("inrev-old"))
+    assert resp.status_code == 301
+    assert resp["Location"].endswith("/api/cases/inrev-new/")
+
+
 # ===========================================================================
 # Regression: the save() path still records (untouched by this change)
 # ===========================================================================

--- a/tests/api/test_token_auth_draft_cases.py
+++ b/tests/api/test_token_auth_draft_cases.py
@@ -141,11 +141,11 @@ class TestTokenAuthDraftCases:
         assert response.data["slug"] == case.slug
         assert response.data["state"] == CaseState.PUBLISHED
 
-    def test_in_review_case_requires_authorization(self):
-        """IN_REVIEW is casework: anonymous gets 404, a casework-role user gets 200.
+    def test_in_review_case_is_unlisted_but_slug_retrievable(self):
+        """IN_REVIEW is UNLISTED: retrievable by direct slug for anyone, incl. anon.
 
-        Under the new role model (public = readonly EXCEPT no casework), an
-        IN_REVIEW case is casework and is no longer publicly retrievable.
+        IN_REVIEW is "unlisted" (reachable by exact slug, absent from listings /
+        search), so both an anonymous caller and a casework-role user get 200.
         """
         # Create an IN_REVIEW case
         case = create_case_with_entities(
@@ -157,11 +157,13 @@ class TestTokenAuthDraftCases:
             state=CaseState.IN_REVIEW,
         )
 
-        # Anonymous (public) access is denied with 404.
+        # Anonymous (public) access by direct slug succeeds (unlisted, not hidden).
         response = self.client.get(f"/api/cases/{case.slug}/")
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert response.data["slug"] == case.slug
+        assert response.data["state"] == CaseState.IN_REVIEW
 
-        # A casework-role user (Caseworker) can retrieve the in-review case.
+        # A casework-role user (Caseworker) can also retrieve the in-review case.
         self.client.force_authenticate(user=self.contributor_user)
         response = self.client.get(f"/api/cases/{case.slug}/")
 

--- a/tests/e2e/test_public_api_e2e.py
+++ b/tests/e2e/test_public_api_e2e.py
@@ -215,7 +215,7 @@ class TestPublicAPIWorkflows:
             response.status_code == 404
         ), "Closed cases should not be accessible via detail endpoint"
 
-        # Test 4: Create an IN_REVIEW case and verify accessibility
+        # Test 4: Create an IN_REVIEW case and verify unlisted-but-slug-accessible
         in_review_case = create_case_with_entities(
             title="In Review Case",
             alleged_entities=["https://jawafdehi.org/entity/person/test-person"],
@@ -225,14 +225,14 @@ class TestPublicAPIWorkflows:
             state=CaseState.IN_REVIEW,
         )
 
-        # IN_REVIEW is casework → NOT publicly accessible via detail (role model:
-        # public = readonly EXCEPT no casework). Anonymous gets 404.
+        # IN_REVIEW is UNLISTED but public by direct slug: an anonymous caller
+        # with the exact slug retrieves it (200), it's just kept out of listings.
         response = self.client.get(f"/api/cases/{in_review_case.slug}/")
         assert (
-            response.status_code == 404
-        ), "IN_REVIEW (casework) must not be retrievable by an anonymous/public caller"
+            response.status_code == 200
+        ), "IN_REVIEW must be retrievable by direct slug (unlisted, not hidden)"
 
-        # IN_REVIEW cases should not appear in list endpoint
+        # IN_REVIEW cases should still not appear in the list endpoint (unlisted)
         response = self.client.get("/api/cases/")
         case_ids = [case["slug"] for case in response.data.get("results", [])]
         assert (

--- a/tests/security/test_nonpublic_case_enumeration.py
+++ b/tests/security/test_nonpublic_case_enumeration.py
@@ -1,8 +1,12 @@
-"""Adversarial: a non-public case must not leak through ANY read surface.
+"""Adversarial: a non-public case must not leak through any ENUMERATION surface.
 
-Threat: an anonymous visitor (or the accused party) tries to discover a case that
-has not cleared the verification queue — DRAFT / IN_REVIEW / CLOSED — by hitting
-every surface that enumerates or resolves cases, not just /api/cases/.
+Threat model by state:
+- DRAFT / CLOSED are fully hidden: no read surface may confirm they exist, even
+  to a caller who guesses the exact slug (horizontal IDOR).
+- IN_REVIEW is "unlisted": intentionally retrievable by a caller who already has
+  the exact slug, but must NOT be discoverable — absent from the list endpoint,
+  search, the statistics payload (aggregate-only), and the sitemap/discovery
+  corpus. Knowing a slug is allowed; enumerating slugs is not.
 
 Run with: ``uv run pytest -m security``.
 """
@@ -39,14 +43,30 @@ def _make_case(state, slug, title=SECRET_TITLE):
     "state,slug",
     [
         (CaseState.DRAFT, "secret-draft"),
-        (CaseState.IN_REVIEW, "secret-in-review"),
         (CaseState.CLOSED, "secret-closed"),
     ],
 )
-def test_nonpublic_case_404s_on_detail_for_anon(state, slug):
+def test_hidden_case_404s_on_detail_for_anon(state, slug):
+    # DRAFT and CLOSED are fully hidden — the detail endpoint must not confirm
+    # they exist. (IN_REVIEW is deliberately slug-retrievable; see below.)
     _make_case(state, slug)
     resp = APIClient().get(f"/api/cases/{slug}/")
     assert resp.status_code == 404, resp.content
+
+
+def test_in_review_is_unlisted_but_slug_retrievable_for_anon():
+    # IN_REVIEW is "unlisted": an anon caller WITH the exact slug may retrieve it
+    # (200), but it must stay out of the public list endpoint.
+    case = _make_case(CaseState.IN_REVIEW, "secret-in-review")
+    client = APIClient()
+
+    detail = client.get(f"/api/cases/{case.slug}/")
+    assert detail.status_code == 200, detail.content
+    assert detail.json()["slug"] == case.slug
+
+    listing = client.get("/api/cases/")
+    slugs = {c.get("slug") for c in listing.json().get("results", [])}
+    assert case.slug not in slugs, "unlisted IN_REVIEW case leaked into the list"
 
 
 @pytest.mark.parametrize(
@@ -115,8 +135,10 @@ def test_nonpublic_case_absent_from_public_corpus():
         assert not any(leaked in iri for iri in iris), f"{leaked} in public corpus"
 
 
-def test_guessing_a_valid_nonpublic_slug_still_404s_for_anon():
-    # Horizontal IDOR: knowing the exact slug of a non-public case must not help.
-    _make_case(CaseState.IN_REVIEW, "known-slug-abc123")
+def test_guessing_a_hidden_slug_still_404s_for_anon():
+    # Horizontal IDOR: knowing the exact slug of a fully-hidden case (DRAFT /
+    # CLOSED) must not help. (IN_REVIEW is intentionally slug-reachable — it is
+    # unlisted, not hidden — so it is excluded here.)
+    _make_case(CaseState.DRAFT, "known-slug-abc123")
     resp = APIClient().get("/api/cases/known-slug-abc123/")
     assert resp.status_code == 404


### PR DESCRIPTION
## What

IN_REVIEW cases are now **unlisted, not hidden**: retrievable by direct slug (like an unlisted video) but kept out of every discovery surface.

Motivation: a caseworker reported an IN_REVIEW case 404-ing at its public `/case/<slug>` URL. IN_REVIEW was casework-only on *every* read surface, so:
- an anonymous caller with the exact slug got 404 on `/api/cases/<slug>/`;
- the public SSR case-detail page (prefetched anonymously, no browser token) 404'd for **everyone**, including logged-in caseworkers;
- BB-38 slug-history redirects for historically re-slugged in-review cases resolved to an invisible case (still 404).

Product decision (confirmed): **IN_REVIEW = unlisted but slug-accessible; DRAFT stays private; CLOSED never exposed.**

## Change (retrieve path only)

- `get_queryset` (retrieve, anonymous): `PUBLISHED + IN_REVIEW` (was PUBLISHED-only)
- `retrieve()`: gate **DRAFT only**; IN_REVIEW & PUBLISHED are public
- `_slug_history_redirect()`: retired **IN_REVIEW** slugs `301` for anyone (DRAFT still casework-gated, CLOSED never redirects)

**Unchanged** (so IN_REVIEW stays unlisted, not discoverable): listing, unified search (indexer already evicts non-PUBLISHED), statistics (aggregate-only), sitemap/discovery corpus. Internal `notes` remain role-gated regardless of case state.

## Privacy note

This makes **pre-publication** allegations world-readable *by exact link* (not crawlable/enumerable). That was an explicit product call. Pairs with a frontend change (separate PR) that adds `noindex` + an "under review" banner to non-PUBLISHED case pages.

## Tests

Updated to the new boundary: `test_public_api`, `test_token_auth_draft_cases`, `test_public_api_e2e`, and the `security/` enumeration suite. New coverage:
- anon retrieves IN_REVIEW by slug (200) but it never appears in listings;
- a retired IN_REVIEW slug `301`s for anon (the BB-38 payoff);
- DRAFT/CLOSED still 404 on detail and stay non-enumerable (list/search/stats/sitemap).

`tests/api` + `tests/security` + e2e + role/permission + `cases/tests` all green locally (sqlite gate).

## Follow-up (after deploy)

Run the BB-38 slug-history backfill for the ~31 historically re-slugged **IN_REVIEW** cases (incl. the 51 priority set) — their old shared/indexed URLs will then 301→200. See `jawafdehi-meta:work/bug-bash-triage/BB38-404-BACKFILL.md` (Table B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cases in review can now be accessed directly by their exact slug, including through retired-slug redirects.
  * In-review cases remain excluded from public listings, search, and discovery.

* **Bug Fixes**
  * Draft and closed cases remain hidden from unauthorized visitors and cannot be accessed through guessed slugs.
  * Case visibility and redirect behavior are now consistent across public and authenticated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->