### PR TITLE
feat(stats): add materials source×type cross-tab to statistics

### DIFF
--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -113,6 +113,7 @@ def bootstrap_placeholder() -> dict:
             "total": 0,
             "by_type": [],
             "by_source": [],
+            "by_source_type": [],
             "counts": {
                 "with_description": 0,
                 "with_url": 0,
@@ -425,6 +426,16 @@ def _materials_metrics():
     by_source = list(
         live.values("source").annotate(count=Count("iri")).order_by("-count")
     )
+    # Source×type cross-tab: which document types each source contributes. Lets
+    # the frontend roll sources up into publishing institutions (e.g. CIAA press
+    # releases + annual reports → one "CIAA" row) and name the types that
+    # institution produces. Backed by the ["source", "material_type"] composite
+    # index on ``materials``.
+    by_source_type = list(
+        live.values("source", "material_type")
+        .annotate(count=Count("iri"))
+        .order_by("-count")
+    )
 
     # Completeness signals over the stored schema.org JSON-LD doc. On Postgres
     # answered with JSON-key existence lookups; sqlite (empty local / test DB)
@@ -440,6 +451,7 @@ def _materials_metrics():
         "total": total,
         "by_type": by_type,
         "by_source": by_source,
+        "by_source_type": by_source_type,
         "counts": {
             "with_description": with_description,
             "with_url": with_url,

--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -434,7 +434,9 @@ def _materials_metrics():
     by_source_type = list(
         live.values("source", "material_type")
         .annotate(count=Count("iri"))
-        .order_by("-count")
+        # Secondary keys make tie order deterministic across backends, so the
+        # snapshot payload is byte-stable between refreshes (CDN-cache friendly).
+        .order_by("-count", "source", "material_type")
     )
 
     # Completeness signals over the stored schema.org JSON-LD doc. On Postgres

--- a/tests/api/test_statistics_api.py
+++ b/tests/api/test_statistics_api.py
@@ -723,6 +723,7 @@ class TestNgmMetrics:
         assert mats["total"] == 0
         assert mats["by_type"] == []
         assert mats["by_source"] == []
+        assert mats["by_source_type"] == []
         for key in ("with_description", "with_url", "with_date"):
             assert mats["counts"][key] == 0
             assert mats["completeness"][key] == 0.0
@@ -801,6 +802,12 @@ class TestNgmMetrics:
         assert by_material_type == {"Legislation": 1}
         by_source = {row["source"]: row["count"] for row in mats["by_source"]}
         assert by_source == {"nkp": 1}
+        # Source×type cross-tab: which types each source contributes.
+        by_source_type = {
+            (row["source"], row["material_type"]): row["count"]
+            for row in mats["by_source_type"]
+        }
+        assert by_source_type == {("nkp", "Legislation"): 1}
 
         # 1 of 3 NES-resolved; 2 of 3 have a reg date; 1 of 3 has document sources.
         assert ngm["counts"]["nes_resolved"] == 1


### PR DESCRIPTION
## Summary

Follow-up to #338. Adds the `materials.by_source_type` aggregate to the `/api/statistics/` payload — a `GROUP BY (source, material_type)` cross-tab over live (non-soft-deleted) materials.

## Why

`by_source` and `by_type` are two independent 1-D breakdowns, so a consumer cannot tell which document types a given source contributes — and the marginals provably don't determine the joint (e.g. `precedent` total ≠ `nkp` + `kanun_patrika`; the 41 `ciaa_annual_report` materials are not `official_report`). The frontend's institution-centric "Where the evidence comes from" table (Jawafdehi/Jawafdehi#225) needs the joint to name the document types each publishing office contributes (Nepal Courts → court orders, CIAA → press releases + annual reports).

## Details

- Additive and non-breaking: `by_source` / `by_type` unchanged; older cached snapshots simply lack the new key and the frontend falls back.
- Backed by the existing `["source", "material_type"]` composite index; runs in the out-of-band `refresh_statistics` snapshot job, zero request-time cost.
- Cherry-picked from `feat/data-quality-rework` (`d4966da`) onto `main` post-squash of #338.

## Test plan

- [x] `uv run pytest tests/api/test_statistics_api.py` — 33 passed (includes the new cross-tab shape/count assertions and bootstrap-placeholder shape parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)