### PR TITLE
fix(review): classify case-type family by court forum, tier by material_type

### DIFF
--- a/review/casetype.py
+++ b/review/casetype.py
@@ -1,24 +1,42 @@
-"""Detect the Jawafdehi case type from its sources and court references.
+"""Detect the Jawafdehi case type from its court forum and its sources.
 
 Per VOL-3 operator guidance (latest), cases fall into FOUR families:
 
   1. CIAA_BASIC       — a CIAA (अख्तियार) case for which only the CIAA press
-                        release is available. No charge sheet, no special-court
-                        record.
-  2. CIAA_EXTENDED    — a CIAA case where the CIAA press release AND the charge
-                        sheet (अभियोग पत्र) are available, but the full text of
-                        the special-court verdict is NOT yet available.
+                        release is available (or, for a case still being built,
+                        no documents yet). No charge sheet, no special-court
+                        verdict.
+  2. CIAA_EXTENDED    — a CIAA case where the charge sheet (अभियोग पत्र) is
+                        available, but the full text of the special-court
+                        verdict is NOT yet available.
   3. CIAA_HAS_VERDICT — a CIAA case carried all the way through: the full text
                         of the special-court verdict (फैसला) / order (आदेश) is
                         available. These carry the most detailed information, so
                         the bar is highest.
-  4. NON_CIAA         — cases not initiated by the CIAA (e.g. the Rabi
-                        Lamichhane cooperative-fraud cases). No CIAA press
-                        release and no CIAA charge sheet.
+  4. NON_CIAA         — cases not tried in a CIAA forum (e.g. the Rabi
+                        Lamichhane cooperative-fraud cases, or a constitutional
+                        writ before the Supreme Court).
 
-Detection is heuristic, driven by source titles/types and the court_cases
-field. It returns a dict the scorer and UI can consume.
+The **family** (CIAA vs NON_CIAA) is decided first and foremost by the *court
+forum* the case is filed in — read from the ``court_cases`` IRIs — not by a
+keyword in a source title. The Special Court (विशेष अदालत) tries CIAA
+corruption cases, and a Supreme-Court corruption appeal (``…-CR-…``) is that
+same case on appeal; both are CIAA forums. A Supreme-Court constitutional writ
+(रिट — ``WC``/``WO``/``WF``/``WH``) or an ordinary district/high court is not.
+This makes a source that merely *names* the CIAA (e.g. a news report that a
+complaint was filed) unable, on its own, to promote a case into the CIAA
+family — while still correctly typing the ~thousands of Special-Court cases
+that have a court number but no attached documents yet.
+
+The **tier** within the CIAA family (BASIC / EXTENDED / HAS_VERDICT) is then
+driven by which documents are attached, read from each source's
+``material_type`` (with a title-keyword fallback), so a mistyped or
+oddly-titled charge sheet / verdict is still recognised.
+
+It returns a dict the scorer and UI can consume.
 """
+
+import re
 
 # Nepali + English signal keywords (lower-cased substring match).
 _PRESS_RELEASE = [
@@ -32,6 +50,10 @@ _CHARGESHEET = ["अभियोग", "charge sheet", "chargesheet", "अभि�
 _VERDICT = ["फैसला", "verdict", "judgement", "judgment"]
 _COURT_ORDER = ["आदेश", "court order", "अदालतको आदेश"]
 _SPECIAL_COURT = ["विशेष अदालत", "special court"]
+
+# Supreme-Court constitutional-writ registers (रिट). A case tried only under one
+# of these is a writ petition, not a CIAA corruption prosecution.
+_SUPREME_WRIT_CODES = {"wc", "wo", "wf", "wh", "ws", "wm"}
 
 
 def _titles_and_types(case):
@@ -53,24 +75,79 @@ def _any(text, keywords):
     return any(k.lower() in text for k in keywords)
 
 
+def _forum_of(iri):
+    """Classify a single court_case IRI into a forum bucket.
+
+    IRIs look like ``https://jawafdehi.org/courtcase/<court>/<number>`` where
+    ``<court>`` is e.g. ``special`` / ``supreme`` / ``kathmandudc`` / ``patanhc``
+    and ``<number>`` embeds a register code (``081-cr-0123``, ``075-wo-0696``).
+    """
+    parts = [p for p in str(iri).lower().split("/") if p]
+    court = num = ""
+    if "courtcase" in parts:
+        i = parts.index("courtcase")
+        court = parts[i + 1] if i + 1 < len(parts) else ""
+        num = parts[i + 2] if i + 2 < len(parts) else ""
+    elif len(parts) >= 2:
+        court, num = parts[-2], parts[-1]
+    elif parts:
+        court = parts[-1]
+
+    if court == "special":
+        return "special"
+    if court == "supreme":
+        m = re.search(r"[a-z]{1,3}", num)
+        code = m.group(0) if m else ""
+        if code in _SUPREME_WRIT_CODES:
+            return "supreme_writ"
+        if code == "cr":
+            return "supreme_appeal"
+        return "supreme_other"
+    if court:
+        return "ordinary"  # district / high court / any other forum
+    return "unknown"
+
+
+def _court_forum(court_cases):
+    """Reduce all of a case's court refs to one forum label, CIAA forums first.
+
+    Special Court presence always wins (it is the trying court); a Supreme-Court
+    corruption appeal wins over a writ/ordinary ref on the same case.
+    """
+    forums = {_forum_of(ref) for ref in (court_cases or [])}
+    for pref in (
+        "special",
+        "supreme_appeal",
+        "supreme_writ",
+        "supreme_other",
+        "ordinary",
+    ):
+        if pref in forums:
+            return pref
+    return "none"
+
+
 def detect(case):
     """Return {type, label, signals:{...}, rationale} for a case dict."""
     tt = _titles_and_types(case)
     court_cases = case.get("court_cases") or []
+    forum = _court_forum(court_cases)
 
     has_press_release = any(
         st == "PRESS_RELEASE" or (_any(t, _PRESS_RELEASE) and _any(t, _CIAA))
         for t, st in tt
     )
     has_ciaa_source = any(_any(t, _CIAA) for t, _ in tt)
-    # A material explicitly typed press_release is never counted as a charge
+    # Prefer the typed material_type; fall back to a title-keyword match. A
+    # material explicitly typed press_release is never counted as a charge
     # sheet, even if its title mentions the charge (अभियोग) — a press release
     # (प्रेस विज्ञप्ति) is the announcement, not the indictment.
     has_chargesheet = any(
-        _any(t, _CHARGESHEET) and st != "PRESS_RELEASE" for t, st in tt
+        st == "CHARGE_SHEET" or (_any(t, _CHARGESHEET) and st != "PRESS_RELEASE")
+        for t, st in tt
     )
     has_verdict = any(_any(t, _VERDICT) for t, _ in tt)
-    has_court_order = any(_any(t, _COURT_ORDER) for t, _ in tt)
+    has_court_order = any(st == "COURT_ORDER" or _any(t, _COURT_ORDER) for t, st in tt)
     has_special_court = any(_any(t, _SPECIAL_COURT) for t, _ in tt)
     has_court_case_no = bool(court_cases)
 
@@ -87,9 +164,22 @@ def detect(case):
         "special_court_ref": has_special_court,
         "court_case_number": has_court_case_no,
         "verdict_text_available": has_verdict_text,
+        "court_forum": forum,
     }
 
-    is_ciaa = has_chargesheet or has_press_release or has_ciaa_source
+    # --- Family: decided by the court forum, not by a keyword in a source. ---
+    if forum in ("special", "supreme_appeal"):
+        is_ciaa = True
+    elif forum in ("supreme_writ", "supreme_other", "ordinary"):
+        # Tried in a non-CIAA forum: a stray CIAA mention in a source (e.g. a
+        # news report that someone lodged a complaint) does not make it a CIAA
+        # prosecution.
+        is_ciaa = False
+    else:
+        # No court reference recorded — fall back to attached CIAA documents /
+        # an explicit special-court reference in a source. A bare CIAA *mention*
+        # is intentionally NOT enough on its own.
+        is_ciaa = has_chargesheet or has_press_release or has_special_court
 
     if is_ciaa and has_verdict_text:
         # Strongest / most detailed family: the special-court verdict full text
@@ -100,24 +190,25 @@ def detect(case):
             "(फैसला) / order (आदेश) full text is attached. Highest-detail bar."
         )
     elif is_ciaa and has_chargesheet:
-        # Press release + charge sheet, but no full verdict text yet.
+        # Charge sheet attached, but no full verdict text yet.
         ctype, label = "CIAA_EXTENDED", "CIAA case (extended — charge sheet)"
         rationale = (
-            "CIAA case with both the press release and the charge sheet "
-            "(अभियोग पत्र) attached, but no full special-court verdict text yet."
+            "CIAA case with the charge sheet (अभियोग पत्र) attached, but no full "
+            "special-court verdict text yet."
         )
     elif is_ciaa:
-        # Only the CIAA press release / CIAA source is available.
+        # A CIAA-forum case for which only the press release — or, for a case
+        # still being built, nothing yet — is attached.
         ctype, label = "CIAA_BASIC", "CIAA case (basic)"
         rationale = (
-            "CIAA (अख्तियार) case for which only the press release is available; "
-            "no charge sheet and no special-court verdict record."
+            "CIAA (अख्तियार / विशेष अदालत) case for which no charge sheet and no "
+            "special-court verdict record are attached yet."
         )
     else:
         ctype, label = "NON_CIAA", "Non-CIAA case"
         rationale = (
-            "No CIAA press release or charge sheet detected; treated as a "
-            "non-CIAA case (e.g. police/other-agency or pre-charge)."
+            "Not tried in a CIAA forum (Supreme-Court writ, ordinary court, or "
+            "no CIAA charge sheet / press release); treated as a non-CIAA case."
         )
 
     # A formal court case number is expected once a case reaches the court

--- a/tests/test_casetype.py
+++ b/tests/test_casetype.py
@@ -1,0 +1,143 @@
+"""Unit tests for the review case-type classifier (`review.casetype.detect`).
+
+The classifier decides the **family** (CIAA vs NON_CIAA) from the court forum
+read off the ``court_cases`` IRIs, then the **tier** (BASIC / EXTENDED /
+HAS_VERDICT) from the attached documents' ``material_type``. A source that
+merely names the CIAA must not, on its own, promote a case into the CIAA family.
+"""
+
+from review.casetype import detect
+
+
+def _iri(court, number):
+    return f"https://jawafdehi.org/courtcase/{court}/{number}"
+
+
+def _case(court_cases=None, evidence=None):
+    return {"court_cases": court_cases or [], "evidence": evidence or []}
+
+
+def _src(display_name, material_type):
+    return {"material": {"display_name": display_name, "material_type": material_type}}
+
+
+# --- Family from court forum -------------------------------------------------
+
+
+def test_special_court_number_is_ciaa_even_without_sources():
+    # A Special-Court case number with no attached documents (the ~2.6k draft
+    # backlog) must still be recognised as CIAA — at the BASIC tier.
+    res = detect(_case(court_cases=[_iri("special", "081-cr-0123")]))
+    assert res["type"] == "CIAA_BASIC"
+    assert res["signals"]["court_forum"] == "special"
+
+
+def test_old_format_special_number_is_ciaa():
+    # Legacy special-court numbering (93-068-0194) has no CR code but is still
+    # the Special Court.
+    res = detect(_case(court_cases=[_iri("special", "93-068-0194")]))
+    assert res["type"].startswith("CIAA")
+    assert res["signals"]["court_forum"] == "special"
+
+
+def test_supreme_writ_is_non_ciaa_despite_ciaa_mention_in_source():
+    # Giribandhu shape: a Supreme-Court writ whose only CIAA marker is a news
+    # source mentioning the CIAA, plus attached SC verdict orders. Must be
+    # NON_CIAA — the forum wins over the keyword.
+    res = detect(
+        _case(
+            court_cases=[_iri("supreme", "078-wc-0004"), _iri("supreme", "075-wo-0696")],
+            evidence=[
+                _src("Student org files complaint in CIAA against X", "document"),
+                _src("Supreme Court verdict on case no. 078-WC-0004", "court_order"),
+            ],
+        )
+    )
+    assert res["type"] == "NON_CIAA"
+    assert res["signals"]["court_forum"] == "supreme_writ"
+    # the signal is still reported, just not used to classify the family
+    assert res["signals"]["ciaa_source"] is True
+
+
+def test_supreme_corruption_appeal_is_ciaa():
+    res = detect(_case(court_cases=[_iri("supreme", "080-cr-0081")]))
+    assert res["type"].startswith("CIAA")
+    assert res["signals"]["court_forum"] == "supreme_appeal"
+
+
+def test_ordinary_courts_are_non_ciaa():
+    # Rabi Lamichhane shape: district + high + supreme writ/review, no special.
+    res = detect(
+        _case(
+            court_cases=[
+                _iri("kathmandudc", "080-c4-2408"),
+                _iri("patanhc", "081-re-1730"),
+                _iri("supreme", "081-wh-0320"),
+            ]
+        )
+    )
+    assert res["type"] == "NON_CIAA"
+
+
+def test_special_wins_when_mixed_with_writ():
+    res = detect(
+        _case(court_cases=[_iri("supreme", "078-wc-0004"), _iri("special", "081-cr-0123")])
+    )
+    assert res["type"].startswith("CIAA")
+    assert res["signals"]["court_forum"] == "special"
+
+
+# --- Tier from attached documents -------------------------------------------
+
+
+def test_typed_charge_sheet_gives_extended_even_if_title_lacks_keyword():
+    # 081-CR-0123 shape: charge_sheet-typed sources whose titles do not contain
+    # the अभियोग keyword (one says आरोप, one uses a malformed spelling).
+    res = detect(
+        _case(
+            court_cases=[_iri("special", "081-cr-0123")],
+            evidence=[
+                _src("... अख्तियारको आरोप ...", "charge_sheet"),
+                _src("अभियाेग पत्र", "charge_sheet"),  # decomposed vowel signs
+            ],
+        )
+    )
+    assert res["type"] == "CIAA_EXTENDED"
+    assert res["signals"]["charge_sheet"] is True
+
+
+def test_court_order_type_gives_has_verdict():
+    res = detect(
+        _case(
+            court_cases=[_iri("special", "081-cr-0200")],
+            evidence=[_src("फैसलाको प्रति", "court_order")],
+        )
+    )
+    assert res["type"] == "CIAA_HAS_VERDICT"
+
+
+# --- No court reference: source fallback ------------------------------------
+
+
+def test_no_court_ref_press_release_is_ciaa_basic():
+    res = detect(
+        _case(evidence=[_src("CIAA press release on X", "press_release")])
+    )
+    assert res["type"] == "CIAA_BASIC"
+    assert res["signals"]["court_forum"] == "none"
+
+
+def test_no_court_ref_bare_ciaa_mention_is_not_ciaa():
+    # A news article that merely names the CIAA, with no court number and no
+    # charge sheet / press release, is NOT enough to classify as CIAA.
+    res = detect(
+        _case(evidence=[_src("News: CIAA files case against 10 individuals", "document")])
+    )
+    assert res["type"] == "NON_CIAA"
+    assert res["signals"]["ciaa_source"] is True
+
+
+def test_empty_case_is_non_ciaa():
+    res = detect(_case())
+    assert res["type"] == "NON_CIAA"
+    assert res["signals"]["court_forum"] == "none"


### PR DESCRIPTION
## Problem

The review case-type classifier (`review/casetype.py`) decided the **CIAA vs NON_CIAA family** from a keyword match over source titles:

```python
is_ciaa = has_chargesheet or has_press_release or has_ciaa_source
#                                                 ^^^^^^^^^^^^^^^  any title containing "ciaa"/"अख्तियार"
```

So a **Supreme Court constitutional writ** whose only CIAA marker was a news source ("… files complaint in CIAA") got promoted into the top CIAA bar (`CIAA_HAS_VERDICT`) and was then gated on charge-sheet / court-number-in-title / bigo expectations that don't apply to a writ petition. Concretely this is what makes the **Giribandhu** land-swap case (`giribandhu-tea-estate-land-swa-af32f7`, `supreme/…-WC/WO-…`) score a `REJECT` off three inapplicable gates.

Two compounding bugs made a blanket "drop `ciaa_source`" fix unsafe:
1. `has_chargesheet` only matched **title keywords**, never `material_type`, so genuine `charge_sheet`-typed sources went undetected (e.g. `081-CR-0123`, whose charge sheet title is a malformed `अभियाेग` with decomposed vowel signs) — those cases were CIAA **only** via the `ciaa_source` crutch.
2. The classifier ignored the **court identity** entirely (`bool(court_cases)` only), so it couldn't tell a `special/…-CR-…` (CIAA Special Court) from a `supreme/…-WC-…` (constitutional writ), nor type the ~2.6k source-less draft cases that have a court number but no documents yet.

## Change

**Family** — decided by the **court forum**, read off the `court_cases` IRIs:
- `special/*` (विशेष अदालत) or a Supreme-Court corruption appeal (`supreme/…-CR-…`) → **CIAA**
- Supreme-Court writ (`WC/WO/WF/WH/WS/WM`) or ordinary district/high court → **NON_CIAA**
- no court reference → fall back to an attached charge sheet / press release / explicit special-court reference. A bare CIAA *mention* is no longer enough on its own.

**Tier** (BASIC / EXTENDED / HAS_VERDICT) — decided by attached documents' `material_type` (`CHARGE_SHEET` / `COURT_ORDER`), with the title-keyword match kept as a fallback. A source-less CIAA draft floors at `CIAA_BASIC`.

The output contract is unchanged (`type`/`label`/`signals`/`rationale`/`court_number_required`); `signals` gains a `court_forum` field. `ciaa_source` is still computed and reported — just no longer used to decide the family.

## Impact — verified against the live corpus (2,926 cases)

**With sources (238):** only **1** case leaves CIAA, correctly:

| Move | Count | What |
|---|---|---|
| `CIAA_HAS_VERDICT → NON_CIAA` | 1 | **Giribandhu** — Supreme Court land writ (the target fix) |
| `CIAA_BASIC → CIAA_EXTENDED` | 7 | special/CR cases with typed-but-untitled charge sheets, now detected |
| `NON_CIAA → CIAA_HAS_VERDICT` | 1 | `080-cr-0123` — false-negative the old classifier dropped |

**No genuine CIAA case is demoted.**

**Source-less drafts (2,688):** **2,667 promoted** `NON_CIAA → CIAA_BASIC` (Special-Court cases the old classifier couldn't see with no document to read); 21 with no court ref stay `NON_CIAA`.

**Sanity check** — the only 3 non-CIAA cases with sources in the whole corpus are exactly right: Giribandhu (land writ), Ncell (Supreme Court tax writ), and Rabi Lamichhane cooperative fraud (ordinary courts — the exact "not CIAA-initiated" example named in this module's own docstring).

### Downstream note
The 7 `BASIC → EXTENDED` cases now carry the stricter EXTENDED bar (court number in title, charge-sheet-attached), so their review scores may shift on re-grade — that surfaces real gaps, it isn't a regression. Deploy is keel-on-`main`; no migration. A full re-grade (or at least the movers + Giribandhu) is the natural follow-up once merged.

## Tests
`tests/test_casetype.py` — 11 pure unit tests covering forum→family (special / old-numeric-special / supreme-writ / supreme-appeal / ordinary / mixed), tier-from-material_type (typed charge sheet with keyword-evading title, court_order→verdict), and the no-court-ref source fallback. `ruff check` clean; 15/15 green locally (new + sibling review unit test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case-type classification using court forum information, including Special Court, Supreme Court, writ, appeal, and ordinary court distinctions.
  * Corrected classification when court references conflict with document text or CIAA mentions.
  * Recognized explicitly typed charge sheets and court orders even when titles lack matching keywords.
  * Improved handling of cases without court references, including press releases and empty records.

* **Tests**
  * Added coverage for court-based family classification, evidence-based tiers, precedence rules, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->