### PR TITLE
fix(materials): keep NGM-native corpus materials LISTED regardless of case referrers

### DIFF
--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -53,6 +53,24 @@ def _case(slug, state):
     )
 
 
+def _store_corpus(source, ident, material_type="court_order", visibility=Visibility.LISTED):
+    """An NGM-native corpus material (non-``jawafdehi`` source) — e.g. a court
+    order or CIAA press release that is public on its own merits, independent of
+    any case. Built directly so ``source``/``ident`` are the corpus namespace,
+    not the ``jawafdehi`` case-upload namespace that ``_store`` mints."""
+    iri = f"https://jawafdehi.org/material/{source}/{ident}"
+    mat = Material(
+        iri=iri,
+        material_type=material_type,
+        source=source,
+        ident=ident,
+        data={"@id": iri, "@type": "DigitalDocument", "name": {"en": "Corpus doc"}},
+        visibility=visibility,
+    )
+    mat.save()
+    return mat
+
+
 class TestVisibilityForStates:
     def test_empty_is_private(self):
         assert visibility_for_states([]) == Visibility.PRIVATE
@@ -427,3 +445,61 @@ class TestDiscoveryAndSearchHonorVisibility:
             _store("source:20240101:priv01", visibility=Visibility.PRIVATE)
         # on_commit fires at transaction end in tests via django_db; force it:
         assert not idx.called or dele.called
+
+
+@pytest.mark.django_db
+class TestNgmNativeGuard:
+    """NGM-native corpus materials (non-``jawafdehi`` source) are independently
+    public; case referrers must NEVER demote them. This is what makes the
+    jawafdehi-dedup re-point (case evidence: duplicate upload → canonical corpus
+    doc) safe — without the guard a DRAFT case referencing a public press release
+    would hide it."""
+
+    def test_draft_referrer_does_not_demote_corpus_material(self):
+        # The exact dedup shape: a DRAFT case is re-pointed at a canonical corpus
+        # press release. It must stay LISTED (a duplicate cleanup can't hide a
+        # public document).
+        mat = _store_corpus("ciaa_press_release", "2402", material_type="press_release")
+        case = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.LISTED
+        mat.refresh_from_db()
+        assert mat.visibility == Visibility.LISTED
+
+    def test_in_review_referrer_does_not_demote_corpus_material(self):
+        mat = _store_corpus("court_order", "special.080-cr-0001")
+        case = _case("c-review", CaseState.IN_REVIEW)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.LISTED
+        mat.refresh_from_db()
+        assert mat.visibility == Visibility.LISTED
+
+    def test_recompute_heals_a_mis_demoted_corpus_material(self):
+        # Reproduces the fleet damage: a corpus doc left PRIVATE by an
+        # unguarded recompute is healed back to LISTED on the next pass.
+        mat = _store_corpus(
+            "ciaa_press_release", "2403",
+            material_type="press_release", visibility=Visibility.PRIVATE,
+        )
+        case = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.LISTED
+        mat.refresh_from_db()
+        assert mat.visibility == Visibility.LISTED
+
+    def test_recompute_all_heals_corpus_but_still_demotes_case_source(self):
+        # One reconciler pass: the corpus doc is restored to LISTED while a
+        # genuine case-source (jawafdehi) upload referenced only by a DRAFT case
+        # is still correctly demoted to PRIVATE.
+        corpus = _store_corpus(
+            "court_order", "special.080-cr-0002", visibility=Visibility.PRIVATE
+        )
+        upload = _store("source:20240101:up0001")  # jawafdehi case-source, LISTED
+        draft = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=draft, material_iri=corpus.iri)
+        CaseMaterialReference.objects.create(case=draft, material_iri=upload.iri)
+        recompute_all()
+        corpus.refresh_from_db()
+        upload.refresh_from_db()
+        assert corpus.visibility == Visibility.LISTED
+        assert upload.visibility == Visibility.PRIVATE

--- a/materials/visibility.py
+++ b/materials/visibility.py
@@ -12,6 +12,17 @@ query ``CaseMaterialReference`` by ``material_iri`` string. Materials with NO
 case referrers keep their current visibility (NGM-native court materials stay
 LISTED by default); only materials that ARE referenced get (re)computed.
 
+**Only case-source (``jawafdehi``) materials derive visibility from case state.**
+An NGM-native corpus material (court order, CIAA press release, AG charge sheet,
+NKP precedent, ...) is independently public on its own merits — it existed and
+was LISTED before any case referenced it. Case referrers must NEVER demote it:
+a DRAFT case citing a public press release must not hide that press release from
+the site. This became load-bearing once the jawafdehi-dedup re-points a case's
+evidence FROM a duplicate upload TO the canonical corpus doc — that is the first
+time corpus materials acquire (draft/in-review) case referrers, and without this
+guard the MAX-over-states recompute would demote ~all of them. So the guard is:
+``source != JAWAF_SOURCE`` → fixed ``LISTED``, never the case-state MAX.
+
 The recompute TRIGGERS (case publish/review/unpublish/delete, evidence add/
 remove) live on the case-side transition path (wired in the evidence-cutover
 slice). A periodic ``recompute_all`` reconciler is the backstop against a missed
@@ -21,6 +32,8 @@ trigger (a missed demotion is a leak; a missed promotion hides a public doc).
 from __future__ import annotations
 
 import logging
+
+from jawafdehi_shared.entities.ids import JAWAF_SOURCE
 
 from .models import Material, Visibility
 
@@ -82,6 +95,17 @@ def recompute_material_visibility(material_iri: str) -> Visibility | None:
     material = Material.objects.filter(pk=material_iri, is_deleted=False).first()
     if material is None:
         return None
+    if material.source != JAWAF_SOURCE:
+        # NGM-native corpus material — independently public; case referrers never
+        # demote it. Pin LISTED (healing any prior mis-demotion), never the MAX.
+        if material.visibility != Visibility.LISTED:
+            material.visibility = Visibility.LISTED
+            material.save(update_fields=["visibility", "updated_at"])
+            logger.info(
+                "material %s visibility → LISTED (ngm-native, guarded)",
+                material_iri,
+            )
+        return Visibility.LISTED
     new_visibility = visibility_for_states(_referring_case_states(material_iri))
     if material.visibility != new_visibility:
         material.visibility = new_visibility
@@ -147,7 +171,11 @@ def recompute_all() -> int:
     changed: list[Material] = []
     now = timezone.now()
     for mat in materials:
-        new_visibility = visibility_for_states(iri_to_states.get(mat.iri, []))
+        if mat.source != JAWAF_SOURCE:
+            # NGM-native corpus material stays LISTED regardless of referrers.
+            new_visibility = Visibility.LISTED
+        else:
+            new_visibility = visibility_for_states(iri_to_states.get(mat.iri, []))
         if mat.visibility != new_visibility:
             mat.visibility = new_visibility
             mat.updated_at = now


### PR DESCRIPTION
## Why

`materials.visibility` recomputes a material's `visibility` as the **MAX over the states of every case that references it** (`_STATE_VISIBILITY`: PUBLISHED→LISTED, IN_REVIEW→UNLISTED, DRAFT/CLOSED→PRIVATE). The module's standing assumption (see its docstring) is that **only case-source (`jawafdehi`) uploads are ever referenced** — NGM-native corpus materials sit at their default `LISTED` because nothing references them.

The **jawafdehi document dedup** (see #327) breaks that assumption. Its whole job is to re-point a case's evidence **from a duplicate `jawafdehi/…` upload to the canonical corpus document** (`ciaa_press_release/<n>`, `court_order/<court>.<case>`, …). That is the first time corpus materials acquire case referrers — and since most referring cases are DRAFT/IN_REVIEW, the unguarded recompute **demotes public corpus documents**:

- a public CIAA press release cited only by a DRAFT case → `PRIVATE` → **404 on the public site**
- cited only by IN_REVIEW → `UNLISTED` → dropped from search + sitemap

Measured on prod after a dedup run over 384 canonicals: **~290 demoted to PRIVATE (404), ~88 to UNLISTED** — documents that were independently public before any case referenced them.

## Fix

Only case-source materials should derive visibility from case state. Guard both recompute paths (`recompute_material_visibility` and the `recompute_all` reconciler): a material whose **`source != JAWAF_SOURCE`** is independently public and is pinned **`LISTED`**, never the case-state MAX.

The guard also **heals** rows already mis-demoted, so a one-time reconcile after deploy restores the fleet:

```
python manage.py recompute_material_visibility   # heals the ~378 demoted corpus docs
```

No schema change; no migration.

## Tests

`materials/tests/test_visibility.py::TestNgmNativeGuard`:
- corpus material (`ciaa_press_release`, `court_order`) stays `LISTED` under a DRAFT referrer and under an IN_REVIEW referrer;
- a mis-demoted (`PRIVATE`) corpus doc is healed to `LISTED` on recompute;
- `recompute_all` heals a corpus doc **while still correctly demoting** a genuine `jawafdehi` case-source upload referenced only by a DRAFT case.

Full module green (`35 passed`); `ruff` clean.

## Relationship to #327

#327's raw-DB merge sidesteps this by not firing the recompute signal. This fix makes the invariant hold for **any** re-point path — including the REST `PATCH /evidence` plane used to run the dedup without `kubectl` — so corpus docs can never be demoted by a case citing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)