### PR TITLE
feat(materials): caseworker-controlled visibility_policy (public by default)

### DIFF
--- a/docs/jawafdehi/adr-cases-own-no-documents.md
+++ b/docs/jawafdehi/adr-cases-own-no-documents.md
@@ -147,6 +147,24 @@ state transitions (plan OQ5's "single chokepoint" concern now includes join-row
 edits). A periodic reconciler backstop is recommended. Without this, a draft case's
 evidence leaks into public search/sitemaps.
 
+### Amendment: `visibility` is derived from a caseworker `visibility_policy`
+
+The pure "MAX over referring case states" rule above is correct for case-uploaded
+evidence but wrong for an already-public document: once the doc-dedup work
+re-points a case's evidence from a duplicate upload onto a canonical corpus doc
+(court order, CIAA press release, charge sheet), a DRAFT referrer would demote
+that public document to PRIVATE. So `visibility` is now the DERIVED, cached result
+of a caseworker-controlled `visibility_policy` (`materials.models.Policy`):
+`PUBLIC` → always LISTED; `PRIVATE` → always PRIVATE; `CASE_GATED` → the MAX over
+referring case states (the historical rule). A material is born
+`default_policy_for(source)` — corpus (`source != jawafdehi`) → `PUBLIC`,
+case-upload (`source == jawafdehi`) → `CASE_GATED` — INSERT-only, so re-sourcing
+never clobbers a manual policy. Caseworkers flip a material's policy via
+`PATCH /api/materials/`. The recompute path (`materials.visibility`) and its
+trigger sites are unchanged; only the state→visibility map gained the policy
+short-circuit. `recompute_all()` heals the corpus documents the old rule
+mis-demoted.
+
 ## Migration (design-only for now — owner-decided)
 
 The ~799 existing `DocumentSource` rows + all evidence refs must be backfilled to

--- a/materials/migrations/0005_material_visibility_policy.py
+++ b/materials/migrations/0005_material_visibility_policy.py
@@ -1,0 +1,43 @@
+# Add the caseworker-controlled visibility_policy (see materials.models.Policy)
+# and backfill it from source. The cached `visibility` column is NOT recomputed
+# here — it is healed post-deploy by materials.visibility.recompute_all() (which
+# promotes corpus docs mis-demoted by the doc-dedup re-point back to LISTED).
+
+from django.db import migrations, models
+
+# The stable IRI namespace for case-UPLOADED materials (JAWAF_SOURCE). Anything
+# else is a corpus document that is public on its own merits.
+_JAWAF_SOURCE = "jawafdehi"
+
+
+def backfill_policy(apps, schema_editor):
+    Material = apps.get_model("materials", "Material")
+    # AddField already stamped every row PUBLIC (the field default); only the
+    # case-uploaded (jawafdehi-source) rows need flipping to CASE_GATED so raw
+    # uploads are embargoed until their case advances.
+    Material.objects.filter(source=_JAWAF_SOURCE).update(visibility_policy="CASE_GATED")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("materials", "0004_material_visibility"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="material",
+            name="visibility_policy",
+            field=models.CharField(
+                choices=[
+                    ("PUBLIC", "Public"),
+                    ("CASE_GATED", "Case-gated"),
+                    ("PRIVATE", "Private"),
+                ],
+                db_index=True,
+                default="PUBLIC",
+                max_length=12,
+            ),
+        ),
+        migrations.RunPython(backfill_policy, migrations.RunPython.noop),
+    ]

--- a/materials/migrations/0005_material_visibility_policy.py
+++ b/materials/migrations/0005_material_visibility_policy.py
@@ -12,10 +12,15 @@ _JAWAF_SOURCE = "jawafdehi"
 
 def backfill_policy(apps, schema_editor):
     Material = apps.get_model("materials", "Material")
-    # AddField already stamped every row PUBLIC (the field default); only the
-    # case-uploaded (jawafdehi-source) rows need flipping to CASE_GATED so raw
-    # uploads are embargoed until their case advances.
-    Material.objects.filter(source=_JAWAF_SOURCE).update(visibility_policy="CASE_GATED")
+    # Route to the DB currently being migrated (Material lives on ``ngm``); the
+    # router's allow_migrate gates this RunPython to that alias's pass. AddField
+    # already stamped every row PUBLIC (the field default); only the case-uploaded
+    # (jawafdehi-source) rows need flipping to CASE_GATED so raw uploads are
+    # embargoed until their case advances.
+    db_alias = schema_editor.connection.alias
+    Material.objects.using(db_alias).filter(source=_JAWAF_SOURCE).update(
+        visibility_policy="CASE_GATED"
+    )
 
 
 class Migration(migrations.Migration):

--- a/materials/models.py
+++ b/materials/models.py
@@ -16,6 +16,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 from jawafdehi_shared.entities.ids import (
+    JAWAF_SOURCE,
     MAX_IRI_LENGTH,
     is_valid_material_iri,
     parse_material_iri,
@@ -34,27 +35,67 @@ def validate_material_iri(value: str) -> None:
 
 
 class Visibility(models.TextChoices):
-    """Derived publication tier for a Material (ADR: cases own no documents).
+    """Cached publication tier for a Material (ADR: cases own no documents).
 
-    A material's visibility is the MAX over the states of all cases that
-    reference it as evidence (YouTube-unlisted semantics):
+    ``visibility`` is the DERIVED, cached result that every anon-facing consumer
+    (sitemaps, unified search, retrieve endpoint) keys on. It is computed from the
+    material's ``visibility_policy`` (the caseworker-controlled INPUT — see
+    :class:`Policy`) by ``materials.visibility.recompute_material_visibility``:
 
-    * ``LISTED``   — ≥1 PUBLISHED case references it (or it's an NGM-native
-      material with no case referrers): public, searchable, in sitemaps.
-    * ``UNLISTED`` — only IN_REVIEW referrers: reachable by direct IRI, but NOT
-      searchable and NOT in sitemaps.
-    * ``PRIVATE``  — only DRAFT/CLOSED referrers (or none, for a source-only
-      draft): not public at all; authed caseworker/readonly only. (CLOSED is the
-      case soft-delete tombstone, so a deleted case cannot keep evidence public.)
+    * ``LISTED``   — public, searchable, in sitemaps.
+    * ``UNLISTED`` — reachable by direct IRI, but NOT searchable / NOT in sitemaps.
+    * ``PRIVATE``  — not public at all; authed caseworker/readonly only.
 
-    Default is ``LISTED`` so NGM-native materials (court cases/orders, bulk
-    ingest) are unaffected — only case-source materials get demoted by the
-    recompute path.
+    How ``visibility_policy`` maps here: ``PUBLIC`` → always ``LISTED``;
+    ``PRIVATE`` → always ``PRIVATE``; ``CASE_GATED`` → the MAX over the states of
+    the cases that cite the material as evidence (PUBLISHED→LISTED,
+    IN_REVIEW→UNLISTED, DRAFT/CLOSED/none→PRIVATE — YouTube-unlisted semantics).
+
+    Default is ``LISTED`` so a freshly-inserted row is public until the recompute
+    settles it (corpus materials are born ``PUBLIC`` and stay ``LISTED``).
     """
 
     LISTED = "LISTED", "Listed"
     UNLISTED = "UNLISTED", "Unlisted"
     PRIVATE = "PRIVATE", "Private"
+
+
+class Policy(models.TextChoices):
+    """Caseworker-controlled visibility policy — the INPUT that determines a
+    material's cached :class:`Visibility` (ADR: cases own no documents).
+
+    Separates a document's intrinsic publicness from the publication state of the
+    case that happens to cite it, so a DRAFT case can no longer hide an
+    already-public document:
+
+    * ``PUBLIC``     — always ``LISTED``, regardless of any citing case's state.
+      The default for corpus materials (court orders, press releases, charge
+      sheets, precedents, ...) that are public on their own merits.
+    * ``CASE_GATED`` — visibility tracks the citing cases (the historical rule):
+      not public until a case reaches in-review/published. The default for
+      case-UPLOADED evidence (``source == jawafdehi``), so raw uploads attached to
+      a draft are not exposed until a caseworker vets + publishes (or opts the
+      material into ``PUBLIC``).
+    * ``PRIVATE``    — always ``PRIVATE``: an absolute withhold for a sensitive
+      source, even after the citing case is published.
+    """
+
+    PUBLIC = "PUBLIC", "Public"
+    CASE_GATED = "CASE_GATED", "Case-gated"
+    PRIVATE = "PRIVATE", "Private"
+
+
+def default_policy_for(source: str) -> str:
+    """The visibility policy a freshly-ingested material is born with.
+
+    Keyed on ``source`` (not ``material_type``): a case-uploaded document is
+    minted at ``/material/jawafdehi/<ident>`` (``JAWAF_SOURCE``) regardless of the
+    ``material_type`` the caseworker picked, so ``source`` is the reliable signal
+    that a document was uploaded THROUGH a case (embargo by default) versus a
+    corpus document that exists on its own merits (public by default). A
+    caseworker can override either default per material (see the materials PATCH).
+    """
+    return Policy.CASE_GATED if source == JAWAF_SOURCE else Policy.PUBLIC
 
 
 #: Visibility tiers a member of the public (anon) may retrieve by direct IRI.
@@ -89,11 +130,21 @@ class Material(models.Model):
     # Soft-delete flag (accountability platform: rows are never hard-deleted).
     # Reads (list/detail) exclude ``is_deleted=True`` rows; DELETE flips it True.
     is_deleted = models.BooleanField(default=False, db_index=True)
-    # Derived publication tier (see Visibility). Default LISTED so NGM-native
-    # materials are public as before; case-source materials are demoted to
-    # UNLISTED/PRIVATE by the recompute path when only draft/in-review cases
-    # reference them. The anon-facing consumers (sitemaps, unified search,
-    # retrieve endpoint) MUST honor this or a draft case's evidence leaks.
+    # Caseworker-controlled visibility policy (see Policy) — the INPUT the
+    # recompute maps to ``visibility``. Default PUBLIC so corpus materials are
+    # public as before; case-uploaded evidence is born CASE_GATED at ingest (see
+    # default_policy_for / the upsert primitive). A re-ingest never clobbers this
+    # (create_defaults, INSERT-only); a caseworker changes it via the PATCH.
+    visibility_policy = models.CharField(
+        max_length=12,
+        choices=Policy.choices,
+        default=Policy.PUBLIC,
+        db_index=True,
+    )
+    # Cached, derived publication tier (see Visibility). Computed from
+    # ``visibility_policy`` by materials.visibility.recompute_material_visibility.
+    # The anon-facing consumers (sitemaps, unified search, retrieve endpoint) key
+    # on THIS column, so it MUST be kept in sync or a draft case's evidence leaks.
     visibility = models.CharField(
         max_length=10,
         choices=Visibility.choices,
@@ -131,8 +182,14 @@ class Material(models.Model):
     @classmethod
     def from_jsonld(cls, data: dict, *, material_type: str) -> Material:
         """Build (unsaved) a ``Material`` from a JSON-LD doc, deriving the
-        promoted ``source``/``ident`` columns from its ``@id``. Validates the
-        doc (known @type, valid @id, name present)."""
+        promoted ``source``/``ident`` columns from its ``@id`` and the source-based
+        default ``visibility_policy``. Validates the doc (known @type, valid @id,
+        name present).
+
+        The policy here is the birth default only (corpus→PUBLIC,
+        jawafdehi-upload→CASE_GATED); the upsert primitive keeps it INSERT-only so
+        a re-upsert never clobbers a caseworker's manual policy on an UPDATE.
+        """
         validate_material_jsonld(data)
         parsed = parse_material_iri(data["@id"])
         return cls(
@@ -141,4 +198,5 @@ class Material(models.Model):
             source=parsed.source,
             ident=parsed.ident,
             data=data,
+            visibility_policy=default_policy_for(parsed.source),
         )

--- a/materials/single_source_ingest.py
+++ b/materials/single_source_ingest.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from django.db import transaction
 
-from .models import Material, default_policy_for
+from .models import Material
 
 
 def upsert_single_source_material(
@@ -59,6 +59,12 @@ def upsert_single_source_material(
     # Validate the doc + the promoted-column agreement on a transient instance
     # (validate_unique=False — an existing ``@id`` is an UPDATE, not a duplicate).
     candidate = Material.from_jsonld(jsonld, material_type=material_type)
+    # from_jsonld already set the source-based birth default; an explicit override
+    # wins. Assign it BEFORE full_clean so an invalid policy is REJECTED by the
+    # choices check rather than silently persisted (this is the single validation
+    # point for a direct caller that bypasses the API's _clean_policy).
+    if visibility_policy is not None:
+        candidate.visibility_policy = visibility_policy
     candidate.full_clean(validate_unique=False)
     # Mutable columns written on every upsert (create AND update). Reviving on
     # re-upsert: an incoming write to a soft-deleted @id republishes it — omitting
@@ -71,15 +77,13 @@ def upsert_single_source_material(
         "data": candidate.data,
         "is_deleted": False,
     }
-    # An explicit override applies on update too; an implicit default must NOT (it
-    # would reset a caseworker's manual policy every re-ingest), so it goes only
-    # into create_defaults.
+    # An explicit override applies on update too; the implicit birth default must
+    # NOT (it would reset a caseworker's manual policy every re-ingest), so it
+    # goes only into create_defaults (candidate.visibility_policy is the single,
+    # already-validated source of truth for both).
     if visibility_policy is not None:
-        mutable["visibility_policy"] = visibility_policy
-    create_defaults = {
-        **mutable,
-        "visibility_policy": visibility_policy or default_policy_for(candidate.source),
-    }
+        mutable["visibility_policy"] = candidate.visibility_policy
+    create_defaults = {**mutable, "visibility_policy": candidate.visibility_policy}
     with transaction.atomic(using="ngm"):
         material, _ = Material.objects.using("ngm").update_or_create(
             iri=candidate.iri,

--- a/materials/single_source_ingest.py
+++ b/materials/single_source_ingest.py
@@ -35,34 +35,55 @@ from typing import Any
 
 from django.db import transaction
 
-from .models import Material
+from .models import Material, default_policy_for
 
 
 def upsert_single_source_material(
-    jsonld: dict[str, Any], *, material_type: str
+    jsonld: dict[str, Any], *, material_type: str, visibility_policy: str | None = None
 ) -> Material:
     """Validate + upsert ONE ``Material`` from a JSON-LD doc by ``@id``.
 
     The single upsert primitive (see the module docstring): idempotent by ``@id``,
     preserves ``created_at``, fires the ngm-materials indexer, and REVIVES a
     soft-deleted row (``is_deleted=False`` in ``defaults`` — the write wins).
+
+    ``visibility_policy`` (see ``materials.models.Policy``): when omitted, a NEW
+    row is born at ``default_policy_for(source)`` (corpus→PUBLIC,
+    jawafdehi-upload→CASE_GATED) via ``create_defaults`` — INSERT-only, so
+    re-sourcing a document NEVER clobbers a caseworker's manual policy. When
+    supplied it is an explicit override, applied on both create AND update (it
+    also lands in ``defaults``). Note: the cached ``visibility`` still needs a
+    recompute afterwards to reflect the policy — the API views do this; bulk
+    importers rely on ``recompute_all`` / the case-side trigger.
     """
     # Validate the doc + the promoted-column agreement on a transient instance
     # (validate_unique=False — an existing ``@id`` is an UPDATE, not a duplicate).
     candidate = Material.from_jsonld(jsonld, material_type=material_type)
     candidate.full_clean(validate_unique=False)
+    # Mutable columns written on every upsert (create AND update). Reviving on
+    # re-upsert: an incoming write to a soft-deleted @id republishes it — omitting
+    # is_deleted would overwrite the row's data while leaving it hidden AND
+    # trigger an index eviction on save.
+    mutable = {
+        "material_type": candidate.material_type,
+        "source": candidate.source,
+        "ident": candidate.ident,
+        "data": candidate.data,
+        "is_deleted": False,
+    }
+    # An explicit override applies on update too; an implicit default must NOT (it
+    # would reset a caseworker's manual policy every re-ingest), so it goes only
+    # into create_defaults.
+    if visibility_policy is not None:
+        mutable["visibility_policy"] = visibility_policy
+    create_defaults = {
+        **mutable,
+        "visibility_policy": visibility_policy or default_policy_for(candidate.source),
+    }
     with transaction.atomic(using="ngm"):
         material, _ = Material.objects.using("ngm").update_or_create(
             iri=candidate.iri,
-            defaults={
-                "material_type": candidate.material_type,
-                "source": candidate.source,
-                "ident": candidate.ident,
-                "data": candidate.data,
-                # Revive on re-upsert: an incoming write to a soft-deleted @id
-                # republishes it. Omitting this would overwrite the row's data
-                # while leaving it hidden AND trigger an index eviction on save.
-                "is_deleted": False,
-            },
+            defaults=mutable,
+            create_defaults=create_defaults,
         )
     return material

--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -21,11 +21,13 @@ from rest_framework.test import APIClient
 
 from cases.models import Case, CaseMaterialReference, CaseState, CaseType
 from materials.jsonld import documentsource_to_jsonld
-from materials.models import Material, Visibility
+from materials.models import Material, Policy, Visibility, default_policy_for
+from materials.single_source_ingest import upsert_single_source_material
 from materials.visibility import (
     recompute_all,
     recompute_for_case,
     recompute_material_visibility,
+    visibility_for_policy,
     visibility_for_states,
 )
 
@@ -39,6 +41,24 @@ def _store(source_id, title="Doc", source_type="MISC", url=None, visibility=None
     mat = Material.from_jsonld(doc, material_type=mtype)
     if visibility is not None:
         mat.visibility = visibility
+    mat.save()
+    return mat
+
+
+def _store_corpus(source, ident, material_type="court_order", visibility=Visibility.LISTED):
+    """A corpus material (non-``jawafdehi`` source) — e.g. a court order or CIAA
+    press release that is public on its own merits, independent of any case. Built
+    directly so ``source``/``ident`` are the corpus namespace (policy defaults to
+    PUBLIC), not the ``jawafdehi`` case-upload namespace that ``_store`` mints."""
+    iri = f"https://jawafdehi.org/material/{source}/{ident}"
+    mat = Material(
+        iri=iri,
+        material_type=material_type,
+        source=source,
+        ident=ident,
+        data={"@id": iri, "@type": "DigitalDocument", "name": {"en": "Corpus doc"}},
+        visibility=visibility,
+    )
     mat.save()
     return mat
 
@@ -427,3 +447,246 @@ class TestDiscoveryAndSearchHonorVisibility:
             _store("source:20240101:priv01", visibility=Visibility.PRIVATE)
         # on_commit fires at transaction end in tests via django_db; force it:
         assert not idx.called or dele.called
+
+
+class TestVisibilityForPolicy:
+    def test_public_is_always_listed(self):
+        # states_fn must NOT be consulted for a PUBLIC policy (no DB round-trip).
+        def _boom():
+            raise AssertionError("states_fn should not be called for PUBLIC")
+
+        assert visibility_for_policy(Policy.PUBLIC, _boom) == Visibility.LISTED
+
+    def test_private_is_always_private(self):
+        def _boom():
+            raise AssertionError("states_fn should not be called for PRIVATE")
+
+        assert visibility_for_policy(Policy.PRIVATE, _boom) == Visibility.PRIVATE
+
+    def test_case_gated_defers_to_states(self):
+        assert visibility_for_policy(Policy.CASE_GATED, lambda: ["DRAFT"]) == (
+            Visibility.PRIVATE
+        )
+        assert visibility_for_policy(Policy.CASE_GATED, lambda: ["PUBLISHED"]) == (
+            Visibility.LISTED
+        )
+
+    def test_unknown_policy_treated_as_case_gated(self):
+        assert visibility_for_policy("BOGUS", lambda: ["PUBLISHED"]) == Visibility.LISTED
+
+
+class TestDefaultPolicyForSource:
+    def test_case_upload_source_is_case_gated(self):
+        assert default_policy_for("jawafdehi") == Policy.CASE_GATED
+
+    def test_corpus_sources_are_public(self):
+        assert default_policy_for("court_order") == Policy.PUBLIC
+        assert default_policy_for("ciaa_press_release") == Policy.PUBLIC
+        assert default_policy_for("court") == Policy.PUBLIC
+
+    def test_from_jsonld_derives_policy_from_source(self):
+        # A case-uploaded document (jawafdehi source) is born CASE_GATED …
+        doc, mtype = documentsource_to_jsonld(
+            source_id="source:20240101:pol01", title="D", source_type="MISC", url=None
+        )
+        assert Material.from_jsonld(doc, material_type=mtype).visibility_policy == (
+            Policy.CASE_GATED
+        )
+        # … a corpus document (non-jawafdehi source) is born PUBLIC.
+        corpus = {
+            "@id": "https://jawafdehi.org/material/court_order/pol02",
+            "@type": "DigitalDocument",
+            "name": {"en": "Order"},
+        }
+        assert Material.from_jsonld(corpus, material_type="court_order").visibility_policy == (
+            Policy.PUBLIC
+        )
+
+
+@pytest.mark.django_db
+class TestPolicyRecompute:
+    """The bug fix: a corpus document (PUBLIC policy) stays LISTED no matter what
+    state the citing case is in — a DRAFT case can no longer hide it. This is what
+    makes the doc-dedup re-point (case evidence: duplicate upload → canonical
+    corpus doc) safe."""
+
+    def test_public_material_cited_by_draft_stays_listed(self):
+        mat = _store_corpus("ciaa_press_release", "2402", material_type="press_release")
+        case = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.LISTED
+        mat.refresh_from_db()
+        assert mat.visibility == Visibility.LISTED
+
+    def test_public_material_cited_by_in_review_stays_listed(self):
+        mat = _store_corpus("court_order", "special.080-cr-0001")
+        case = _case("c-review", CaseState.IN_REVIEW)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.LISTED
+
+    def test_recompute_heals_a_mis_demoted_public_material(self):
+        # The dedup fleet damage: a corpus doc left PRIVATE by an earlier unguarded
+        # recompute is healed back to LISTED once its policy is PUBLIC.
+        mat = _store_corpus(
+            "ciaa_press_release", "2403",
+            material_type="press_release", visibility=Visibility.PRIVATE,
+        )
+        case = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.LISTED
+
+    def test_private_policy_withholds_even_from_published_case(self):
+        # An absolute withhold: PRIVATE policy beats a PUBLISHED referrer.
+        mat = _store_corpus("court_order", "special.080-cr-0009")
+        mat.visibility_policy = Policy.PRIVATE
+        mat.save(update_fields=["visibility_policy"])
+        case = _case("c-pub", CaseState.PUBLISHED)
+        CaseMaterialReference.objects.create(case=case, material_iri=mat.iri)
+        assert recompute_material_visibility(mat.iri) == Visibility.PRIVATE
+
+    def test_recompute_all_settles_every_policy(self):
+        # One reconciler pass over a mix: corpus (PUBLIC) → LISTED, case-upload
+        # (CASE_GATED) referenced only by a DRAFT → PRIVATE, and an UNREFERENCED
+        # PRIVATE-policy withhold → PRIVATE (the full scan reaches it even with no
+        # CaseMaterialReference).
+        corpus = _store_corpus(
+            "court_order", "special.080-cr-0002", visibility=Visibility.PRIVATE
+        )
+        upload = _store("source:20240101:up0001")  # jawafdehi CASE_GATED, LISTED
+        withheld = _store_corpus("court_order", "special.080-cr-0003")
+        withheld.visibility_policy = Policy.PRIVATE
+        withheld.save(update_fields=["visibility_policy"])
+        draft = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=draft, material_iri=corpus.iri)
+        CaseMaterialReference.objects.create(case=draft, material_iri=upload.iri)
+        recompute_all()
+        corpus.refresh_from_db()
+        upload.refresh_from_db()
+        withheld.refresh_from_db()
+        assert corpus.visibility == Visibility.LISTED
+        assert upload.visibility == Visibility.PRIVATE
+        assert withheld.visibility == Visibility.PRIVATE
+
+
+@pytest.mark.django_db
+class TestUpsertPolicyDefaults:
+    def _doc(self, source_id):
+        doc, mtype = documentsource_to_jsonld(
+            source_id=source_id, title="D", source_type="MISC", url=None
+        )
+        return doc, mtype
+
+    def test_upsert_births_case_upload_case_gated(self):
+        doc, mtype = self._doc("source:20240101:ins01")
+        mat = upsert_single_source_material(doc, material_type=mtype)
+        assert mat.visibility_policy == Policy.CASE_GATED
+
+    def test_reupsert_preserves_manual_policy(self):
+        # A caseworker sets PUBLIC on a case-upload; re-sourcing the SAME @id must
+        # NOT reset it to the CASE_GATED birth default (create_defaults is
+        # INSERT-only).
+        doc, mtype = self._doc("source:20240101:ins02")
+        mat = upsert_single_source_material(doc, material_type=mtype)
+        mat.visibility_policy = Policy.PUBLIC
+        mat.save(update_fields=["visibility_policy"])
+        again = upsert_single_source_material(doc, material_type=mtype)
+        assert again.visibility_policy == Policy.PUBLIC
+
+    def test_explicit_override_applies_on_update(self):
+        doc, mtype = self._doc("source:20240101:ins03")
+        upsert_single_source_material(doc, material_type=mtype)  # CASE_GATED
+        again = upsert_single_source_material(
+            doc, material_type=mtype, visibility_policy=Policy.PRIVATE
+        )
+        assert again.visibility_policy == Policy.PRIVATE
+
+
+@pytest.mark.django_db
+class TestPatchVisibilityPolicy:
+    def _caseworker(self):
+        u = User.objects.create_user("cw-patch", password="x")
+        u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+        return u
+
+    def test_anon_patch_is_401(self):
+        mat = _store_corpus("court_order", "special.080-cr-0100")
+        resp = APIClient().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "PRIVATE"},
+            format="json",
+        )
+        assert resp.status_code == 401
+
+    def test_roleless_authed_patch_is_403(self):
+        mat = _store_corpus("court_order", "special.080-cr-0101")
+        client = APIClient()
+        client.force_authenticate(User.objects.create_user("nobody-patch", password="x"))
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "PRIVATE"},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_caseworker_patch_sets_policy_and_recomputes(self):
+        # A public court order cited by a DRAFT case is LISTED; a caseworker PATCHes
+        # it to CASE_GATED → it demotes to PRIVATE (draft-only) and 404s for anon;
+        # PATCH back to PUBLIC → LISTED and visible again.
+        mat = _store_corpus("court_order", "special.080-cr-0102")
+        draft = _case("c-draft", CaseState.DRAFT)
+        CaseMaterialReference.objects.create(case=draft, material_iri=mat.iri)
+        client = APIClient()
+        client.force_authenticate(self._caseworker())
+
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "CASE_GATED"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert resp.data["jawafdehi:visibilityPolicy"] == Policy.CASE_GATED
+        assert resp.data["jawafdehi:visibility"] == Visibility.PRIVATE
+        mat.refresh_from_db()
+        assert mat.visibility == Visibility.PRIVATE
+        assert APIClient().get(f"/api/materials/?iri={mat.iri}").status_code == 404
+
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "PUBLIC"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert resp.data["jawafdehi:visibility"] == Visibility.LISTED
+        assert APIClient().get(f"/api/materials/?iri={mat.iri}").status_code == 200
+
+    def test_patch_invalid_policy_is_400(self):
+        mat = _store_corpus("court_order", "special.080-cr-0103")
+        client = APIClient()
+        client.force_authenticate(self._caseworker())
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "SORTA_PUBLIC"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+    def test_patch_missing_material_is_404(self):
+        client = APIClient()
+        client.force_authenticate(self._caseworker())
+        resp = client.patch(
+            "/api/materials/?iri=https://jawafdehi.org/material/court_order/nope",
+            {"visibility_policy": "PRIVATE"},
+            format="json",
+        )
+        assert resp.status_code == 404
+
+    def test_authed_get_surfaces_policy(self):
+        mat = _store_corpus("court_order", "special.080-cr-0104")
+        client = APIClient()
+        client.force_authenticate(self._caseworker())
+        resp = client.get(f"/api/materials/?iri={mat.iri}")
+        assert resp.status_code == 200
+        assert resp.data["jawafdehi:visibilityPolicy"] == Policy.PUBLIC
+        # Anon never sees the admin fields.
+        anon = APIClient().get(f"/api/materials/?iri={mat.iri}")
+        assert "jawafdehi:visibilityPolicy" not in anon.data

--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -690,3 +690,67 @@ class TestPatchVisibilityPolicy:
         # Anon never sees the admin fields.
         anon = APIClient().get(f"/api/materials/?iri={mat.iri}")
         assert "jawafdehi:visibilityPolicy" not in anon.data
+
+    def test_anon_patch_without_iri_is_401_not_422(self):
+        # Auth precedes iri-param validation: an anon caller gets 401, never a
+        # 422/400 input-validation disclosure (matches the DELETE branch).
+        resp = APIClient().patch(
+            "/api/materials/", {"visibility_policy": "PRIVATE"}, format="json"
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+class TestControlKeysNotPersisted:
+    """Server-owned keys must never land in a Material's stored JSON-LD `data`."""
+
+    def _caseworker_client(self):
+        u = User.objects.create_user("cw-strip", password="x")
+        u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+        c = APIClient()
+        c.force_authenticate(u)
+        return c
+
+    def test_bare_put_strips_control_key_but_applies_policy(self):
+        # A bare PUT body carrying a top-level `visibility_policy` must NOT persist
+        # that key into `data` (it would leak to anon), yet the policy IS applied.
+        iri = "https://jawafdehi.org/material/court_order/strip01"
+        client = self._caseworker_client()
+        resp = client.put(
+            "/api/materials/court_order/strip01",
+            {
+                "@id": iri,
+                "@type": "DigitalDocument",
+                "name": {"en": "Order"},
+                "visibility_policy": "PRIVATE",
+            },
+            format="json",
+        )
+        assert resp.status_code in (200, 201)
+        mat = Material.objects.get(pk=iri)
+        assert "visibility_policy" not in mat.data
+        assert mat.visibility_policy == Policy.PRIVATE
+
+    def test_annotated_authed_get_does_not_round_trip_into_data(self):
+        # GET as caseworker (doc is annotated with jawafdehi:visibility[Policy]),
+        # then PUT that exact doc back — the annotations must be stripped, not baked
+        # into the stored document.
+        mat = _store_corpus("court_order", "strip02")
+        client = self._caseworker_client()
+        got = client.get(f"/api/materials/?iri={mat.iri}")
+        assert "jawafdehi:visibilityPolicy" in got.data
+        client.put("/api/materials/court_order/strip02", got.data, format="json")
+        mat.refresh_from_db()
+        assert "jawafdehi:visibility" not in mat.data
+        assert "jawafdehi:visibilityPolicy" not in mat.data
+
+    def test_primitive_rejects_invalid_explicit_policy(self):
+        from django.core.exceptions import ValidationError
+
+        doc, mtype = documentsource_to_jsonld(
+            source_id="source:20240101:bad01", title="D", source_type="MISC", url=None
+        )
+        with pytest.raises(ValidationError):
+            upsert_single_source_material(
+                doc, material_type=mtype, visibility_policy="NOT_A_POLICY"
+            )

--- a/materials/views.py
+++ b/materials/views.py
@@ -39,7 +39,7 @@ from courts.permissions import NGM_ROLE_GROUPS, HasNgmRole
 
 from . import jsonld
 from . import provenance
-from .models import Material
+from .models import Material, Policy
 from .single_source_ingest import upsert_single_source_material
 
 LD_JSON = "application/ld+json"
@@ -115,14 +115,52 @@ def _can_see_nonpublic(request) -> bool:
     return user.groups.filter(name__in=_NONPUBLIC_READ_GROUPS).exists()
 
 
-def _upsert_material(data, *, material_type: str | None, expected_iri: str | None = None):
+def _with_admin_visibility(row) -> dict:
+    """A COPY of a stored material's JSON-LD annotated with its cached
+    ``visibility`` + caseworker ``visibility_policy``, for authed (caseworker/
+    readonly) reads so the FE editor can render + drive the policy control. Public
+    reads never see these fields; derived (court-case) docs have no stored row and
+    are not annotated. We copy so the stored ``data`` dict is never mutated.
+    """
+    doc = dict(row.data)
+    doc["jawafdehi:visibility"] = row.visibility
+    doc["jawafdehi:visibilityPolicy"] = row.visibility_policy
+    return doc
+
+
+def _clean_policy(body):
+    """Extract + validate an optional ``visibility_policy`` from a write body.
+
+    Returns ``(policy_or_None, error_response_or_None)``: ``(None, None)`` when the
+    key is absent (no change), ``(POLICY, None)`` when valid, or
+    ``(None, Response(400))`` when present but not a known ``Policy``.
+    """
+    if not isinstance(body, dict) or "visibility_policy" not in body:
+        return None, None
+    policy = str(body.get("visibility_policy") or "").strip().upper()
+    if policy not in Policy.values:
+        return None, Response(
+            {"detail": f"visibility_policy must be one of {sorted(Policy.values)}."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return policy, None
+
+
+def _upsert_material(
+    data,
+    *,
+    material_type: str | None,
+    expected_iri: str | None = None,
+    visibility_policy: str | None = None,
+):
     """Validate + upsert a Material from a JSON-LD body. Returns (doc, status, error).
 
     On success: ``(doc, 200_or_201, None)``. On validation failure:
     ``(None, 400, {"detail": ...})``. ``material_type`` is inferred from the doc's
     ``additionalType``/``@type`` (via :func:`jsonld.infer_material_type`) when not
     supplied. When ``expected_iri`` is set (the PUT path) the body's @id must match
-    the URL's IRI.
+    the URL's IRI. ``visibility_policy`` (optional) is an explicit caseworker
+    override; when omitted a NEW row is born at the source-derived default.
     """
     if not isinstance(data, dict) or "@id" not in data:
         return None, status.HTTP_400_BAD_REQUEST, {
@@ -142,10 +180,22 @@ def _upsert_material(data, *, material_type: str | None, expected_iri: str | Non
         # Delegate the write to the one upsert primitive (validation +
         # update_or_create by @id + created_at preservation + soft-delete revive
         # + post_save indexing all live there).
-        material = upsert_single_source_material(data, material_type=mtype)
+        material = upsert_single_source_material(
+            data, material_type=mtype, visibility_policy=visibility_policy
+        )
     except (ValueError, DjangoValidationError) as exc:
         detail = exc.message_dict if isinstance(exc, DjangoValidationError) else str(exc)
         return None, status.HTTP_400_BAD_REQUEST, {"detail": detail}
+    # Settle the cached ``visibility`` from the (possibly new) policy so an anon
+    # read reflects it immediately. The materials API is low-volume (not the bulk
+    # importer, which relies on recompute_all / the case-side trigger), so a
+    # per-write recompute is cheap. Best-effort: never fail a stored write on it.
+    try:
+        from .visibility import recompute_material_visibility
+
+        recompute_material_visibility(material.iri)
+    except Exception:  # noqa: BLE001 - the row is written; visibility can heal.
+        logger.warning("visibility recompute failed for %s", material.iri, exc_info=True)
     code = status.HTTP_200_OK if existed else status.HTTP_201_CREATED
     return material.data, code, None
 
@@ -169,7 +219,11 @@ def _resolve_material(iri: str, *, include_nonpublic: bool = False) -> dict | No
         # (court cases are a public read plane in their own right).
         return _derive_court_case_jsonld(iri)
 
-    if include_nonpublic or row.visibility in PUBLIC_VISIBILITIES:
+    if include_nonpublic:
+        # Authed caseworker/readonly: surface the cached visibility + policy so the
+        # FE editor can render + drive the control.
+        return _with_admin_visibility(row)
+    if row.visibility in PUBLIC_VISIBILITIES:
         return row.data
     # A PRIVATE (draft-only) stored row is treated as ABSENT for the public.
     # We must NOT fall through to _derive_court_case_jsonld here: doing so would
@@ -223,12 +277,52 @@ def _soft_delete_material(iri: str) -> bool:
     return True
 
 
-@api_view(["GET", "PUT", "DELETE"])
+def _patch_visibility_policy(request, iri: str) -> Response:
+    """``PATCH`` a material's caseworker ``visibility_policy`` + recompute.
+
+    Body ``{"visibility_policy": "PUBLIC"|"CASE_GATED"|"PRIVATE"}``. NGM-role
+    (Caseworker) gated. Sets the policy on the existing stored row, then settles
+    the cached ``visibility`` via ``recompute_material_visibility`` (which also
+    reconciles the search index through ``post_save``). Returns the updated doc
+    annotated with ``jawafdehi:visibility``/``jawafdehi:visibilityPolicy`` (200),
+    404 if no live stored row exists (derived court-case materials have no policy).
+    """
+    denied = _require_ngm_role(request)
+    if denied is not None:
+        return denied
+    body = request.data if isinstance(request.data, dict) else {}
+    policy, error = _clean_policy(body)
+    if error is not None:
+        return error
+    if policy is None:
+        return Response(
+            {"detail": "Body must include a 'visibility_policy'."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    row = Material.objects.filter(pk=iri, is_deleted=False).first()
+    if row is None:
+        return Response(
+            {"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND
+        )
+    if row.visibility_policy != policy:
+        row.visibility_policy = policy
+        row.save(update_fields=["visibility_policy", "updated_at"])
+    from .visibility import recompute_material_visibility
+
+    recompute_material_visibility(iri)
+    row.refresh_from_db()
+    return Response(
+        _with_admin_visibility(row), status=status.HTTP_200_OK, content_type=LD_JSON
+    )
+
+
+@api_view(["GET", "PUT", "PATCH", "DELETE"])
 @permission_classes([AllowAny])
 def material_detail(request, source: str, ident: str):
     """``GET /api/materials/<source>/<ident>`` → the material JSON-LD doc.
 
-    ``PUT`` replaces the material's stored JSON-LD (NGM-role gated). ``DELETE``
+    ``PUT`` replaces the material's stored JSON-LD (NGM-role gated). ``PATCH``
+    sets the caseworker ``visibility_policy`` (NGM-role gated). ``DELETE``
     soft-deletes the stored material (NGM-role gated, 204). The GET path is
     byte-identical to before (stored row, else on-the-fly court-case fallback).
     """
@@ -240,6 +334,9 @@ def material_detail(request, source: str, ident: str):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    if request.method == "PATCH":
+        return _patch_visibility_policy(request, iri)
+
     if request.method == "PUT":
         denied = _require_ngm_role(request)
         if denied is not None:
@@ -247,8 +344,11 @@ def material_detail(request, source: str, ident: str):
         body = request.data if isinstance(request.data, dict) else {}
         material_type = body.get("material_type") if isinstance(body, dict) else None
         doc = body.get("material") if isinstance(body, dict) and "material" in body else body
+        policy, error = _clean_policy(body)
+        if error is not None:
+            return error
         result, code, error = _upsert_material(
-            doc, material_type=material_type, expected_iri=iri
+            doc, material_type=material_type, expected_iri=iri, visibility_policy=policy
         )
         if error is not None:
             return Response(error, status=code)
@@ -422,8 +522,9 @@ def _list_materials(request) -> Response:
     """
     from .models import Visibility
 
+    can_see_nonpublic = _can_see_nonpublic(request)
     qs = Material.objects.filter(is_deleted=False)
-    if not _can_see_nonpublic(request):
+    if not can_see_nonpublic:
         qs = qs.filter(visibility=Visibility.LISTED)
     params = request.query_params
     if (source := params.get("source")):
@@ -433,11 +534,15 @@ def _list_materials(request) -> Response:
 
     paginator = PlatformCursorPagination()
     page = paginator.paginate_queryset(qs, request)
-    docs = [row.data for row in page]
+    # Authed callers get the cached visibility + policy per row (for the admin
+    # table); anon callers get the raw JSON-LD unchanged.
+    docs = [
+        _with_admin_visibility(row) if can_see_nonpublic else row.data for row in page
+    ]
     return paginator.get_paginated_response(docs)
 
 
-@api_view(["GET", "POST", "DELETE"])
+@api_view(["GET", "POST", "PATCH", "DELETE"])
 @permission_classes([AllowAny])
 def material_by_iri(request):
     """``GET /api/materials/`` → paginated list of materials (``{results, next}``);
@@ -449,9 +554,11 @@ def material_by_iri(request):
     ``POST`` creates/upserts a material from a JSON-LD body (NGM-role gated); the
     body is either a bare JSON-LD doc (``@id`` present) or the
     ``{"material": {...}, "material_type": "..."}`` envelope (``material_type`` is
-    inferred from the doc's ``additionalType``/``@type`` when absent).
-    ``DELETE /api/materials/?iri=<full-iri>`` soft-deletes the material (NGM-role
-    gated, 204).
+    inferred from the doc's ``additionalType``/``@type`` when absent). An optional
+    top-level ``visibility_policy`` sets the caseworker policy on the write.
+    ``PATCH /api/materials/?iri=<full-iri>`` sets just the ``visibility_policy``
+    (NGM-role gated). ``DELETE /api/materials/?iri=<full-iri>`` soft-deletes the
+    material (NGM-role gated, 204).
     """
     if request.method == "POST":
         denied = _require_ngm_role(request)
@@ -460,12 +567,31 @@ def material_by_iri(request):
         body = request.data if isinstance(request.data, dict) else {}
         material_type = body.get("material_type") if isinstance(body, dict) else None
         doc = body.get("material") if isinstance(body, dict) and "material" in body else body
-        result, code, error = _upsert_material(doc, material_type=material_type)
+        policy, error = _clean_policy(body)
+        if error is not None:
+            return error
+        result, code, error = _upsert_material(
+            doc, material_type=material_type, visibility_policy=policy
+        )
         if error is not None:
             return Response(error, status=code)
         return Response(result, status=code, content_type=LD_JSON)
 
     iri = (request.query_params.get("iri") or "").strip()
+
+    if request.method == "PATCH":
+        if not iri:
+            return Response(
+                {"detail": "Query parameter 'iri' is required."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+        iri = _normalize_iri_param(iri)
+        if not is_valid_material_iri(iri):
+            return Response(
+                {"detail": "Not a valid material @id IRI."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return _patch_visibility_policy(request, iri)
 
     if request.method == "DELETE":
         denied = _require_ngm_role(request)

--- a/materials/views.py
+++ b/materials/views.py
@@ -56,6 +56,16 @@ _UPLOAD_ROLES = frozenset(
 #: Excludes MARKDOWN (our own extraction output) + SOURCE_PAGE (HTML, not a scan).
 _CONVERTIBLE_ROLES = frozenset({"RAW", "ALTERNATE", "PERMALINK"})
 
+#: Server-owned keys that must NEVER be persisted into a Material's stored JSON-LD
+#: ``data``: the write-envelope control field ``visibility_policy`` and the
+#: authed-read annotations ``jawafdehi:visibility``/``jawafdehi:visibilityPolicy``.
+#: Stripped at the write chokepoint so a bare body — or a read-modify-write
+#: round-trip of an annotated authed GET — can't bake them into the canonical doc
+#: (which would leak the policy to anon and serve a stale visibility snapshot).
+_RESERVED_WRITE_KEYS = frozenset(
+    {"visibility_policy", "jawafdehi:visibility", "jawafdehi:visibilityPolicy"}
+)
+
 logger = logging.getLogger("materials.views")
 
 #: Upper bound on an uploaded material file. Generous (scanned court orders /
@@ -166,6 +176,12 @@ def _upsert_material(
         return None, status.HTTP_400_BAD_REQUEST, {
             "detail": "Body must be a JSON-LD object with an '@id'."
         }
+    # Drop server-owned control/annotation keys so they never land in stored data
+    # (a bare body's top-level visibility_policy; a round-tripped authed GET's
+    # jawafdehi:visibility[Policy]). The policy itself arrives via the dedicated
+    # `visibility_policy` argument, not the document.
+    if _RESERVED_WRITE_KEYS.intersection(data):
+        data = {k: v for k, v in data.items() if k not in _RESERVED_WRITE_KEYS}
     if expected_iri is not None and data.get("@id") != expected_iri:
         return None, status.HTTP_400_BAD_REQUEST, {
             "detail": f"Body @id {data.get('@id')!r} must match the URL IRI {expected_iri!r}."
@@ -304,13 +320,16 @@ def _patch_visibility_policy(request, iri: str) -> Response:
         return Response(
             {"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND
         )
-    if row.visibility_policy != policy:
-        row.visibility_policy = policy
-        row.save(update_fields=["visibility_policy", "updated_at"])
-    from .visibility import recompute_material_visibility
+    # Derive the new cached visibility from the new policy and persist BOTH in one
+    # save — a synchronized write, so post_save fires exactly once with the final
+    # state (the search-index reconcile never sees a stale intermediate).
+    from .visibility import _referring_case_states, visibility_for_policy
 
-    recompute_material_visibility(iri)
-    row.refresh_from_db()
+    new_visibility = visibility_for_policy(policy, lambda: _referring_case_states(iri))
+    if row.visibility_policy != policy or row.visibility != new_visibility:
+        row.visibility_policy = policy
+        row.visibility = new_visibility
+        row.save(update_fields=["visibility_policy", "visibility", "updated_at"])
     return Response(
         _with_admin_visibility(row), status=status.HTTP_200_OK, content_type=LD_JSON
     )
@@ -580,6 +599,12 @@ def material_by_iri(request):
     iri = (request.query_params.get("iri") or "").strip()
 
     if request.method == "PATCH":
+        # Authenticate BEFORE validating the iri query param (matches the sibling
+        # DELETE branch + _require_ngm_role's contract: anon is 401, not a 400/422
+        # input-validation disclosure).
+        denied = _require_ngm_role(request)
+        if denied is not None:
+            return denied
         if not iri:
             return Response(
                 {"detail": "Query parameter 'iri' is required."},

--- a/materials/visibility.py
+++ b/materials/visibility.py
@@ -1,28 +1,34 @@
-"""Derived-visibility recompute for case-source Materials (ADR: cases own no
-documents).
+"""Visibility recompute for Materials (ADR: cases own no documents).
 
-A Material that originated as case evidence has no intrinsic publicness — its
-visibility is the MAX over the states of every case that references it via
-``CaseMaterialReference`` (YouTube-unlisted semantics; see
-``materials.models.Visibility``). This module is the single place that maps
-"the set of referring case states" → a ``Visibility`` and writes it back.
+A material's cached ``visibility`` is derived from its caseworker-controlled
+``visibility_policy`` (see ``materials.models.Policy``). This module is the
+single place that maps a policy (plus, for ``CASE_GATED``, the states of the
+cases that cite the material) → a ``Visibility`` and writes it back:
+
+* ``PUBLIC``     → ``LISTED`` (a corpus document is public on its own merits, so
+  a DRAFT case that cites it can no longer hide it — the bug this fixes).
+* ``PRIVATE``    → ``PRIVATE`` (an absolute withhold).
+* ``CASE_GATED`` → the MAX over the states of every case that references the
+  material via ``CaseMaterialReference`` (YouTube-unlisted semantics:
+  PUBLISHED→LISTED, IN_REVIEW→UNLISTED, DRAFT/CLOSED/none→PRIVATE).
 
 Cross-app, in-process, NO cross-DB FK: we import the cases app's models and
-query ``CaseMaterialReference`` by ``material_iri`` string. Materials with NO
-case referrers keep their current visibility (NGM-native court materials stay
-LISTED by default); only materials that ARE referenced get (re)computed.
+query ``CaseMaterialReference`` by ``material_iri`` string; the states query runs
+ONLY for a ``CASE_GATED`` material.
 
 The recompute TRIGGERS (case publish/review/unpublish/delete, evidence add/
 remove) live on the case-side transition path (wired in the evidence-cutover
-slice). A periodic ``recompute_all`` reconciler is the backstop against a missed
-trigger (a missed demotion is a leak; a missed promotion hides a public doc).
+slice) and only call ``recompute_material_visibility`` — the policy logic lives
+here, so those trigger sites are unchanged. A periodic ``recompute_all``
+reconciler is the backstop against a missed trigger (a missed demotion is a
+leak; a missed promotion hides a public doc).
 """
 
 from __future__ import annotations
 
 import logging
 
-from .models import Material, Visibility
+from .models import Material, Policy, Visibility
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +64,22 @@ def visibility_for_states(states) -> Visibility:
     return best
 
 
+def visibility_for_policy(policy: str, states_fn) -> Visibility:
+    """Map a caseworker ``Policy`` → a cached ``Visibility``.
+
+    ``PUBLIC`` → LISTED and ``PRIVATE`` → PRIVATE are fixed and never touch the
+    DB. ``CASE_GATED`` defers to the MAX over the citing cases' states, which
+    ``states_fn()`` supplies lazily — so the referring-states query runs ONLY for
+    a case-gated material. An unknown policy is treated as ``CASE_GATED``
+    (conservative: never more public than the citing cases allow).
+    """
+    if policy == Policy.PUBLIC:
+        return Visibility.LISTED
+    if policy == Policy.PRIVATE:
+        return Visibility.PRIVATE
+    return visibility_for_states(states_fn())
+
+
 def _referring_case_states(material_iri: str) -> list[str]:
     """States of all cases referencing ``material_iri`` as evidence.
 
@@ -74,7 +96,7 @@ def _referring_case_states(material_iri: str) -> list[str]:
 
 
 def recompute_material_visibility(material_iri: str) -> Visibility | None:
-    """Recompute + persist the visibility of one case-source Material.
+    """Recompute + persist the visibility of one Material from its policy.
 
     Returns the new ``Visibility`` (written only if changed), or ``None`` if no
     live Material row exists for the IRI. A soft-deleted material is left alone.
@@ -82,7 +104,10 @@ def recompute_material_visibility(material_iri: str) -> Visibility | None:
     material = Material.objects.filter(pk=material_iri, is_deleted=False).first()
     if material is None:
         return None
-    new_visibility = visibility_for_states(_referring_case_states(material_iri))
+    new_visibility = visibility_for_policy(
+        material.visibility_policy,
+        lambda: _referring_case_states(material_iri),
+    )
     if material.visibility != new_visibility:
         material.visibility = new_visibility
         material.save(update_fields=["visibility", "updated_at"])
@@ -106,17 +131,21 @@ def recompute_for_case(case) -> None:
 
 
 def recompute_all() -> int:
-    """Reconciler backstop: recompute every Material that any case references.
+    """Reconciler backstop: recompute EVERY live Material from its policy.
 
     Returns the number of materials whose visibility CHANGED. Safe to run
     periodically (mirrors the casework reaper) to heal any visibility drift from
     a missed trigger.
 
     Bulk, not per-material: the naive loop over ``recompute_material_visibility``
-    is O(N) round-trips (~2400 queries for ~800 prod materials). The DBs are
-    routed independently (no cross-DB JOIN), so instead: (1) one query for all
-    ``(material_iri, case_state)`` pairs, (2) one query for the referenced
-    Materials, (3) compute in memory + ``bulk_update`` the changed rows. Because
+    is O(N) round-trips. The DBs are routed independently (no cross-DB JOIN), so
+    instead: (1) one query for all ``(material_iri, case_state)`` pairs, (2) one
+    query for every live Material, (3) compute in memory + ``bulk_update`` the
+    changed rows. A FULL pass (not a referenced-only scan) is what settles the
+    policies that have no ``CaseMaterialReference`` at all — a ``PRIVATE``-policy
+    withhold and an unreferenced ``CASE_GATED`` upload must both resolve to
+    PRIVATE even though no case row points at them. The materials table is the
+    curated document set (hundreds of rows), so the full scan is cheap. Because
     ``bulk_update`` does NOT fire ``post_save``, the search-index eviction/index
     that the signal normally performs is done explicitly here for changed rows —
     else a material demoted to non-LISTED by the reconciler would linger in public
@@ -135,19 +164,20 @@ def recompute_all() -> int:
     ):
         if iri:
             iri_to_states[iri].append(state)
-    if not iri_to_states:
-        return 0
 
-    # 2. The referenced, live Materials (single query, ngm DB).
-    materials = list(
-        Material.objects.filter(iri__in=iri_to_states.keys(), is_deleted=False)
-    )
+    # 2. Every live Material (single query, ngm DB).
+    materials = list(Material.objects.filter(is_deleted=False))
 
-    # 3. Compute in memory; bulk_update only the changed rows.
+    # 3. Compute in memory per policy; bulk_update only the changed rows. The
+    #    states lambda binds ``mat`` per-iteration (default-arg) and is consulted
+    #    only for a CASE_GATED policy.
     changed: list[Material] = []
     now = timezone.now()
     for mat in materials:
-        new_visibility = visibility_for_states(iri_to_states.get(mat.iri, []))
+        new_visibility = visibility_for_policy(
+            mat.visibility_policy,
+            lambda mat=mat: iri_to_states.get(mat.iri, []),
+        )
         if mat.visibility != new_visibility:
             mat.visibility = new_visibility
             mat.updated_at = now


### PR DESCRIPTION
## Problem

`Material.visibility` is currently *purely derived* — the MAX over the workflow states of every case that cites the material as evidence. So a **DRAFT case citing an already-public document** (a court order, CIAA press release, or charge sheet) demotes that public document to `PRIVATE`, dropping it from the read plane, search, and sitemaps. This became a live regression once the doc-dedup work started re-pointing case evidence from duplicate uploads onto canonical corpus docs.

Root cause: the model conflated the *case write-up's* publication state with the *document's* intrinsic publicness. The derived-only rule can only ever demote.

## Fix

Introduce a caseworker-controlled **`visibility_policy`** as the INPUT that the recompute maps to the cached `visibility` (which every consumer already keys on):

| `visibility_policy` | resulting `visibility` |
| --- | --- |
| `PUBLIC` *(default for corpus)* | always `LISTED` |
| `CASE_GATED` *(default for case uploads)* | MAX over referring case states (the historical rule) |
| `PRIVATE` | always `PRIVATE` (absolute withhold) |

- **Source-based default** via `default_policy_for(source)`: corpus (`source != jawafdehi`) → `PUBLIC`; case-uploaded evidence (`source == jawafdehi`) → `CASE_GATED`. Reliable even for a mislabeled `material_type`.
- Born INSERT-only via `create_defaults`, so **re-sourcing never clobbers** a caseworker's manual policy.
- Caseworkers flip policy via **`PATCH /api/materials/`** (NGM-role gated); an optional `visibility_policy` also rides the `POST`/`PUT` envelope. Authed reads surface `jawafdehi:visibility` / `jawafdehi:visibilityPolicy` for the FE editor; anon responses are unchanged.
- `recompute_all()` is now a full policy-aware scan that also settles `PRIVATE`-policy and unreferenced `CASE_GATED` materials, and **heals the corpus docs the old rule mis-demoted**.

Downstream consumers (read plane, `discovery/corpus.py` sitemaps, search index via `signals.py`) are untouched — they all key on the cached `visibility` column.

## Tests

`materials/tests/test_visibility.py`: policy-map branches, the bug regression (a `PUBLIC` doc cited by a `DRAFT` case stays `LISTED`), `PRIVATE` withhold beating a published referrer, `recompute_all` settling every policy, `create_defaults` birth/preservation/override, and the `PATCH` endpoint (anon 401 / roleless 403 / caseworker 200 + recompute + surfaced fields + 400/404). Full `materials/` + `discovery/` + case-side visibility tests pass; ruff clean; `makemigrations --check` reports no drift.

## Deploy (no auto-migrate)

After the image is live: `manage.py migrate materials`, then run `recompute_all()` once to heal existing drift.

## Follow-up (separate)

FE evidence editor gets a policy selector (Public / Case-gated / Private) reading `jawafdehi:visibilityPolicy` and issuing the `PATCH` — handed over separately in the user-driven SPA. This supersedes the local-only `fix/material-visibility-ngm-native-guard` branch (a narrower source guard with no caseworker control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility policies for materials: Public, Private, and Case-gated.
  * Authorized staff can update a material’s visibility policy through the API.
  * Authorized responses now show visibility policy details; public responses remain unchanged.
  * New materials receive source-appropriate default visibility policies.

* **Bug Fixes**
  * Re-ingesting materials preserves manually selected visibility policies.
  * Visibility is recalculated consistently across existing materials and policy changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->