### PR TITLE
fix(materials): source case uploads by material_type, not the jawafdehi bucket

### DIFF
--- a/cases/services/material_ingest.py
+++ b/cases/services/material_ingest.py
@@ -13,9 +13,12 @@ evidence entry. They now:
      additional_details), deduped by ``(case, material_iri)``.
 
 The Material @id is derived from the source's stable ``source_id`` via
-``build_source_material_iri`` (``/material/jawafdehi/<ident>``), so re-ingesting
-the same source is idempotent and callers that lack a source_id can pass any
-stable natural key (e.g. a hashed URL) as ``source_id``.
+``build_source_material_iri``, sourced by the document's ``material_type``
+(``/material/<material_type>/<ident>`` — news → ``news``, a misc upload →
+``document``, …) rather than the legacy monolithic ``/material/jawafdehi/``
+bucket, so an upload's source reads as its kind and it is born ``PUBLIC``.
+Re-ingesting the same source is idempotent, and callers that lack a source_id
+can pass any stable natural key (e.g. a hashed URL) as ``source_id``.
 """
 
 from __future__ import annotations
@@ -179,12 +182,14 @@ def ingest_source_as_evidence(
         additional_details=additional_details or description or "",
         ordinal=ordinal,
     )
-    # A freshly-upserted Material is born at the model default visibility=LISTED,
-    # and its post_save signal has already indexed it into public search. Ingest
-    # runs outside the API's on_commit recompute (e.g. management commands), so
-    # recompute NOW from the binding case's state — else a DRAFT case's evidence
-    # is momentarily (or lastingly) public. This is the ADR draft-leak guard on
-    # the ingest path. Best-effort: never let a visibility issue abort the ingest.
+    # Settle the cached visibility from the material's policy now. A case upload
+    # is born PUBLIC (→ LISTED), so this is usually a no-op; but it correctly
+    # HONORS a caseworker who has embargoed this @id (CASE_GATED/PRIVATE) on an
+    # earlier pass — recompute maps that policy to the right cached visibility
+    # from the binding case's state, rather than leaving the model-default LISTED.
+    # Ingest runs outside the API's on_commit recompute (e.g. management
+    # commands), so we recompute here. Best-effort: never let a visibility issue
+    # abort the ingest.
     try:
         from materials.visibility import recompute_material_visibility
 

--- a/jawafdehi_shared/entities/ids.py
+++ b/jawafdehi_shared/entities/ids.py
@@ -195,16 +195,19 @@ def canonicalize_material_iri(value: str) -> str:
     return build_material_iri(parsed.source, parsed.ident)
 
 
-#: Material IRI ``source`` segment for a document that originated as a Jawafdehi
-#: case source (``/material/jawafdehi/<ident>``). NGM court materials use
-#: ``court``/``court_order``; issuer collections use ``ciaa``/``ag``/…; a document
-#: that has no NGM-native home (a news link, a social post, a misc upload cited
-#: only by a case) lands under ``jawafdehi``. Kept as a distinct source segment
-#: so provenance ("came in via a case") stays legible.
+#: Legacy Material IRI ``source`` segment for a document uploaded through a
+#: Jawafdehi case (``/material/jawafdehi/<ident>``). NGM court materials use
+#: ``court``/``court_order``; issuer collections use ``ciaa``/``ag``/…. Case
+#: uploads are now sourced by their ``material_type`` instead (news → ``news``, a
+#: misc upload → ``document``, …) so ``source`` reads as the kind of document,
+#: not "came in via a case" — see ``documentsource_to_jsonld``. Kept as a valid
+#: segment for the historical namespace, but no longer minted for new uploads.
 JAWAF_SOURCE = "jawafdehi"
 
 
-def build_source_material_iri(source_id: str, base: str | None = None) -> str:
+def build_source_material_iri(
+    source_id: str, base: str | None = None, *, source: str = JAWAF_SOURCE
+) -> str:
     """Canonical material ``@id`` IRI for a Jawafdehi case-source document.
 
     The legacy ``DocumentSource.source_id`` (``source:YYYYMMDD:hex8``) carries
@@ -213,9 +216,14 @@ def build_source_material_iri(source_id: str, base: str | None = None) -> str:
     map ``:`` separators to ``.``, lowercase, then coerce any remaining
     out-of-grammar characters to ``-`` and ensure a valid leading char so an
     arbitrary caller-supplied ``source_id`` never raises
-    (``source:20240115:ab12cd`` → ``jawafdehi/20240115.ab12cd``). Idempotent for
+    (``source:20240115:ab12cd`` → ``<source>/20240115.ab12cd``). Idempotent for
     an already-normalized id. Raises ``ValueError`` only if the id is empty after
     normalization.
+
+    ``source`` is the IRI's source segment; it defaults to ``JAWAF_SOURCE`` for
+    back-compat, but the case-source shaper passes the document's
+    ``material_type`` so uploads land under a type-legible source rather than the
+    monolithic ``jawafdehi`` bucket.
     """
     ident = source_id.strip()
     if ident.startswith("source:"):
@@ -227,7 +235,7 @@ def build_source_material_iri(source_id: str, base: str | None = None) -> str:
     ident = ident.lstrip("._-")
     if not ident:
         raise ValueError(f"source_id normalizes to an empty material ident: {source_id!r}")
-    return build_material_iri(JAWAF_SOURCE, ident, base)
+    return build_material_iri(source, ident, base)
 
 
 # ── Case ids (Jawafdehi published cases) ─────────────────────────────────────

--- a/materials/jsonld.py
+++ b/materials/jsonld.py
@@ -413,8 +413,12 @@ def court_case_to_jsonld(case: Any) -> dict[str, Any]:
 # A Jawafdehi case "document source" is the same modality as an NGM material:
 # a titled document with roled file links + related entities. When sources fold
 # into materials (ADR: cases-own-no-documents), each source becomes a first-class
-# Material at /material/jawafdehi/<ident>. This shaper is the projection; it is a
-# PURE function (no DB) so it unit-tests like court_case_to_jsonld.
+# Material sourced by its material_type (/material/<material_type>/<ident>) —
+# news → /material/news/…, a charge sheet → /material/charge_sheet/…, a misc
+# upload → /material/document/… — so source reads as the kind of document rather
+# than the legacy monolithic /material/jawafdehi/ bucket. This shaper is the
+# projection; it is a PURE function (no DB) so it unit-tests like
+# court_case_to_jsonld.
 
 #: Jawafdehi ``SourceType`` value → NGM ``MaterialType`` token. Governance docs
 #: map to their issuer-faithful material types; news/social get first-class
@@ -454,15 +458,17 @@ def documentsource_to_jsonld(
 
     Returns the material_type alongside the doc because ``Material`` stores it as
     a promoted column and ``from_jsonld`` requires it explicitly. The ``@id`` is
-    ``/material/jawafdehi/<normalized source_id>``; roled links become
-    ``associatedMedia`` (reusing ``media_objects_from_document_sources``);
-    ``related_entities`` NES IRIs ride as ``about``; ``publication_date`` →
-    ``datePublished``. Accepts primitive fields (not the ORM object) so it stays
-    a pure, DB-free projection.
+    ``/material/<material_type>/<normalized source_id>`` (the source segment is
+    the document's material_type, NOT the legacy ``jawafdehi`` bucket — so an
+    upload's source reads as its kind, and, being non-``jawafdehi``, it is born
+    ``PUBLIC`` per ``default_policy_for``); roled links become ``associatedMedia``
+    (reusing ``media_objects_from_document_sources``); ``related_entities`` NES
+    IRIs ride as ``about``; ``publication_date`` → ``datePublished``. Accepts
+    primitive fields (not the ORM object) so it stays a pure, DB-free projection.
     """
     material_type = material_type_for_source_type(source_type)
     schema_type, additional_type = type_for(material_type)
-    iri = build_source_material_iri(source_id)
+    iri = build_source_material_iri(source_id, source=material_type)
 
     doc: dict[str, Any] = {
         "@context": MATERIAL_CONTEXT,

--- a/materials/models.py
+++ b/materials/models.py
@@ -70,12 +70,14 @@ class Policy(models.TextChoices):
 
     * ``PUBLIC``     — always ``LISTED``, regardless of any citing case's state.
       The default for corpus materials (court orders, press releases, charge
-      sheets, precedents, ...) that are public on their own merits.
+      sheets, precedents, ...) that are public on their own merits — and now also
+      the default for case uploads (see ``default_policy_for``), which are sourced
+      by their material_type rather than the legacy ``jawafdehi`` bucket.
     * ``CASE_GATED`` — visibility tracks the citing cases (the historical rule):
-      not public until a case reaches in-review/published. The default for
-      case-UPLOADED evidence (``source == jawafdehi``), so raw uploads attached to
-      a draft are not exposed until a caseworker vets + publishes (or opts the
-      material into ``PUBLIC``).
+      not public until a case reaches in-review/published. No longer a birth
+      default; a caseworker sets it explicitly (via the materials PATCH) to
+      embargo a document until its case is vetted + published. It also still
+      governs any residual ``jawafdehi``-sourced rows.
     * ``PRIVATE``    — always ``PRIVATE``: an absolute withhold for a sensitive
       source, even after the citing case is published.
     """
@@ -88,12 +90,13 @@ class Policy(models.TextChoices):
 def default_policy_for(source: str) -> str:
     """The visibility policy a freshly-ingested material is born with.
 
-    Keyed on ``source`` (not ``material_type``): a case-uploaded document is
-    minted at ``/material/jawafdehi/<ident>`` (``JAWAF_SOURCE``) regardless of the
-    ``material_type`` the caseworker picked, so ``source`` is the reliable signal
-    that a document was uploaded THROUGH a case (embargo by default) versus a
-    corpus document that exists on its own merits (public by default). A
-    caseworker can override either default per material (see the materials PATCH).
+    Every non-``jawafdehi`` material is born ``PUBLIC``. Case uploads are now
+    sourced by their ``material_type`` (news → ``news``, a misc upload →
+    ``document``, …), so they too are born ``PUBLIC`` — a case-attached document
+    is public on ingest, and a caseworker embargoes a sensitive one by explicitly
+    setting ``CASE_GATED``/``PRIVATE`` via the materials PATCH. The legacy
+    ``jawafdehi`` source is retained here as ``CASE_GATED`` for any residual rows
+    in that historical namespace, but new uploads never land there.
     """
     return Policy.CASE_GATED if source == JAWAF_SOURCE else Policy.PUBLIC
 

--- a/materials/tests/test_source_material_shaper.py
+++ b/materials/tests/test_source_material_shaper.py
@@ -2,9 +2,11 @@
 documents). Pure functions — no DB — mirroring the court_case_to_jsonld tests.
 
 Covers:
-- build_source_material_iri: source_id (with colons) → canonical /material/jawafdehi/<ident>,
+- build_source_material_iri: source_id (with colons) → canonical ident; source
+  segment defaults to /material/jawafdehi/ but is caller-selectable,
 - material_type_for_source_type mapping (governance/news/social/misc),
-- documentsource_to_jsonld shape: @id/@type/name/associatedMedia/about/datePublished,
+- documentsource_to_jsonld shape: @id sourced by material_type (NOT jawafdehi),
+  plus @type/name/associatedMedia/about/datePublished,
 - the produced doc validates under validate_material_jsonld + Material.from_jsonld.
 """
 
@@ -41,6 +43,13 @@ class TestBuildSourceMaterialIri:
     def test_lowercases_ident(self):
         iri = build_source_material_iri("source:20240115:AB12CD")
         assert iri.endswith("/20240115.ab12cd")
+
+    def test_source_segment_is_caller_selectable(self):
+        # The case-source shaper routes uploads by material_type instead of the
+        # legacy jawafdehi bucket; the ident normalization is identical.
+        iri = build_source_material_iri("source:20240115:ab12cd", source="news")
+        assert iri == "https://jawafdehi.org/material/news/20240115.ab12cd"
+        assert is_valid_material_iri(iri)
 
 
 class TestMaterialTypeMapping:
@@ -81,7 +90,8 @@ class TestDocumentSourceToJsonld:
         # A CIAA press release is the announcement, NOT the indictment: it must
         # shape to press_release, distinct from a charge sheet (अभियोगपत्र).
         assert material_type == MaterialType.PRESS_RELEASE
-        assert doc["@id"] == "https://jawafdehi.org/material/jawafdehi/20240115.ab12cd"
+        # Sourced by material_type (press_release), NOT the legacy jawafdehi bucket.
+        assert doc["@id"] == "https://jawafdehi.org/material/press_release/20240115.ab12cd"
         assert doc["@type"] == "CreativeWork"
         assert doc["additionalType"] == "jawafdehi:PressRelease"
         assert doc["name"] == {"ne": "CIAA press release on X"}
@@ -111,6 +121,35 @@ class TestDocumentSourceToJsonld:
         assert material_type == MaterialType.CHARGE_SHEET
         assert doc["@type"] == "DigitalDocument"
         assert doc["additionalType"] == "jawafdehi:ChargeSheet"
+        assert doc["@id"] == "https://jawafdehi.org/material/charge_sheet/20240115.cs0001"
+
+    @pytest.mark.parametrize(
+        "source_type,expected_source",
+        [
+            ("CIAA_PRESS_RELEASE", "press_release"),
+            ("AG_ABHIYOG_PATRA", "charge_sheet"),
+            ("OAG_AUDIT_REPORT", "official_report"),
+            ("COURT_ORDER", "court_order"),
+            ("LAW_OR_BILL", "legal_corpus"),
+            ("NEWS", "news"),
+            ("SOCIAL_MEDIA", "social_media"),
+            ("COURT_FILING_OTHER", "document"),
+            ("MISC", "document"),
+            (None, "document"),
+        ],
+    )
+    def test_id_is_sourced_by_material_type_not_jawafdehi(self, source_type, expected_source):
+        # The @id's source segment is the document's material_type, so an upload
+        # is type-legible and (being non-jawafdehi) born PUBLIC — never the
+        # monolithic /material/jawafdehi/ bucket.
+        doc, _ = documentsource_to_jsonld(
+            source_id="source:20240115:ab12cd",
+            title="T",
+            source_type=source_type,
+            url=None,
+        )
+        assert doc["@id"] == f"https://jawafdehi.org/material/{expected_source}/20240115.ab12cd"
+        assert "/material/jawafdehi/" not in doc["@id"]
 
     def test_minimal_shape_no_optional_fields(self):
         doc, material_type = documentsource_to_jsonld(
@@ -157,7 +196,11 @@ class TestDocumentSourceToJsonld:
 
         mat = Material.from_jsonld(doc, material_type=material_type)
         assert mat.iri == doc["@id"]
-        assert mat.source == "jawafdehi"
+        # source segment == material_type (news), so from_jsonld births it PUBLIC.
+        assert mat.source == "news"
         assert mat.ident == "20240115.ab12cd"
         assert mat.material_type == MaterialType.NEWS
+        from materials.models import Policy
+
+        assert mat.visibility_policy == Policy.PUBLIC
         mat.clean()  # promoted-column agreement + jsonld validation

--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -485,14 +485,16 @@ class TestDefaultPolicyForSource:
         assert default_policy_for("court") == Policy.PUBLIC
 
     def test_from_jsonld_derives_policy_from_source(self):
-        # A case-uploaded document (jawafdehi source) is born CASE_GATED …
+        # A case upload is now sourced by material_type (MISC → document), so it is
+        # non-jawafdehi and born PUBLIC — case uploads are public by default.
         doc, mtype = documentsource_to_jsonld(
             source_id="source:20240101:pol01", title="D", source_type="MISC", url=None
         )
+        assert doc["@id"] == "https://jawafdehi.org/material/document/20240101.pol01"
         assert Material.from_jsonld(doc, material_type=mtype).visibility_policy == (
-            Policy.CASE_GATED
+            Policy.PUBLIC
         )
-        # … a corpus document (non-jawafdehi source) is born PUBLIC.
+        # A corpus document (non-jawafdehi source) is likewise born PUBLIC.
         corpus = {
             "@id": "https://jawafdehi.org/material/court_order/pol02",
             "@type": "DigitalDocument",
@@ -500,6 +502,15 @@ class TestDefaultPolicyForSource:
         }
         assert Material.from_jsonld(corpus, material_type="court_order").visibility_policy == (
             Policy.PUBLIC
+        )
+        # Only a residual jawafdehi-sourced row stays CASE_GATED at birth.
+        legacy = {
+            "@id": "https://jawafdehi.org/material/jawafdehi/pol03",
+            "@type": "DigitalDocument",
+            "name": {"en": "Legacy upload"},
+        }
+        assert Material.from_jsonld(legacy, material_type="document").visibility_policy == (
+            Policy.CASE_GATED
         )
 
 

--- a/materials/tests/test_visibility.py
+++ b/materials/tests/test_visibility.py
@@ -35,10 +35,15 @@ User = get_user_model()
 
 
 def _store(source_id, title="Doc", source_type="MISC", url=None, visibility=None):
+    # A CASE-GATED upload. Case uploads are now type-sourced and born PUBLIC, so
+    # pin the caseworker-embargoed policy these gating tests exercise: a
+    # CASE_GATED material tracks its citing cases (draft/in-review/closed →
+    # PRIVATE/UNLISTED via recompute), which is the behaviour under test here.
     doc, mtype = documentsource_to_jsonld(
         source_id=source_id, title=title, source_type=source_type, url=url
     )
     mat = Material.from_jsonld(doc, material_type=mtype)
+    mat.visibility_policy = Policy.CASE_GATED
     if visibility is not None:
         mat.visibility = visibility
     mat.save()
@@ -563,7 +568,7 @@ class TestPolicyRecompute:
         corpus = _store_corpus(
             "court_order", "special.080-cr-0002", visibility=Visibility.PRIVATE
         )
-        upload = _store("source:20240101:up0001")  # jawafdehi CASE_GATED, LISTED
+        upload = _store("source:20240101:up0001")  # a CASE_GATED upload, LISTED
         withheld = _store_corpus("court_order", "special.080-cr-0003")
         withheld.visibility_policy = Policy.PRIVATE
         withheld.save(update_fields=["visibility_policy"])
@@ -587,25 +592,29 @@ class TestUpsertPolicyDefaults:
         )
         return doc, mtype
 
-    def test_upsert_births_case_upload_case_gated(self):
+    def test_upsert_births_case_upload_public(self):
+        # Case uploads are now type-sourced (MISC → /material/document/…), so —
+        # being non-jawafdehi — they are born PUBLIC. A caseworker embargoes a
+        # sensitive one by explicitly setting CASE_GATED/PRIVATE afterward.
         doc, mtype = self._doc("source:20240101:ins01")
         mat = upsert_single_source_material(doc, material_type=mtype)
-        assert mat.visibility_policy == Policy.CASE_GATED
+        assert mat.source == "document"
+        assert mat.visibility_policy == Policy.PUBLIC
 
     def test_reupsert_preserves_manual_policy(self):
-        # A caseworker sets PUBLIC on a case-upload; re-sourcing the SAME @id must
-        # NOT reset it to the CASE_GATED birth default (create_defaults is
-        # INSERT-only).
+        # A caseworker embargoes a case-upload (CASE_GATED — now a non-default
+        # override); re-sourcing the SAME @id must NOT reset it to the PUBLIC
+        # birth default (create_defaults is INSERT-only).
         doc, mtype = self._doc("source:20240101:ins02")
         mat = upsert_single_source_material(doc, material_type=mtype)
-        mat.visibility_policy = Policy.PUBLIC
+        mat.visibility_policy = Policy.CASE_GATED
         mat.save(update_fields=["visibility_policy"])
         again = upsert_single_source_material(doc, material_type=mtype)
-        assert again.visibility_policy == Policy.PUBLIC
+        assert again.visibility_policy == Policy.CASE_GATED
 
     def test_explicit_override_applies_on_update(self):
         doc, mtype = self._doc("source:20240101:ins03")
-        upsert_single_source_material(doc, material_type=mtype)  # CASE_GATED
+        upsert_single_source_material(doc, material_type=mtype)  # born PUBLIC
         again = upsert_single_source_material(
             doc, material_type=mtype, visibility_policy=Policy.PRIVATE
         )

--- a/tests/api/test_case_evidence_write.py
+++ b/tests/api/test_case_evidence_write.py
@@ -17,7 +17,7 @@ from cases.models import (
     RelationshipType,
 )
 from materials.jsonld import documentsource_to_jsonld
-from materials.models import Material, Visibility
+from materials.models import Material, Policy, Visibility
 from tests.conftest import create_user_with_role
 
 URL = "/api/cases/{}/"
@@ -54,6 +54,11 @@ def _store_material(source_id, visibility=Visibility.LISTED):
         source_id=source_id, title="Doc", source_type="MISC", url=None
     )
     mat = Material.from_jsonld(doc, material_type=mtype)
+    # These triggers test the CASE-GATED machinery (visibility tracks the citing
+    # case's state). Case uploads are now sourced by material_type (→ non-jawafdehi)
+    # and born PUBLIC, so pin the policy to CASE_GATED explicitly — otherwise the
+    # recompute short-circuits to LISTED and the demote/promote is never exercised.
+    mat.visibility_policy = Policy.CASE_GATED
     mat.visibility = visibility
     mat.save()
     return mat

--- a/tests/cases/test_material_ingest.py
+++ b/tests/cases/test_material_ingest.py
@@ -12,7 +12,7 @@ from cases.services.material_ingest import (
     ingest_source_as_evidence,
     upsert_source_material,
 )
-from materials.models import Material, Visibility
+from materials.models import Material, Policy, Visibility
 
 
 def _case(slug="ingest-case"):
@@ -33,7 +33,9 @@ class TestUpsertSourceMaterial:
             source_type="CIAA_PRESS_RELEASE",
             source_id="source:20240115:ab12cd",
         )
-        assert iri == "https://jawafdehi.org/material/jawafdehi/20240115.ab12cd"
+        # Sourced by material_type (a CIAA press release → press_release), NOT the
+        # legacy monolithic jawafdehi bucket.
+        assert iri == "https://jawafdehi.org/material/press_release/20240115.ab12cd"
         mat = Material.objects.get(iri=iri)
         assert mat.material_type == "press_release"
         assert mat.data["associatedMedia"][0]["contentUrl"] == (
@@ -106,13 +108,32 @@ class TestBindAndIngest:
         assert ingest_source_as_evidence(case, title="") is None
         assert case.material_references.count() == 0
 
-    def test_ingest_into_draft_case_does_not_leak_public(self):
-        # Regression: a Material is born LISTED; ingest must recompute from the
-        # DRAFT case's state so the evidence is not publicly searchable/crawlable.
-        case = _case("draft-leak", )
+    def test_ingest_into_draft_case_is_public_by_default(self):
+        # Case uploads are sourced by material_type (→ non-jawafdehi) and born
+        # PUBLIC, so an upload is publicly LISTED on ingest regardless of the
+        # binding case's state — a caseworker embargoes a sensitive one explicitly
+        # (see test_ingest_honors_prior_embargo).
+        case = _case("draft-pub")
         assert case.state == CaseState.DRAFT
         iri = ingest_source_as_evidence(
-            case, title="Secret charge sheet", source_id="source:20240301:secret1"
+            case, title="Press release", source_id="source:20240301:public2"
+        )
+        mat = Material.objects.get(iri=iri)
+        assert mat.visibility == Visibility.LISTED
+
+    def test_ingest_honors_prior_embargo(self):
+        # The ingest-path recompute HONORS a caseworker embargo: once an @id is set
+        # CASE_GATED, a later ingest pass maps that policy against the DRAFT case's
+        # state → PRIVATE, rather than the born-PUBLIC default.
+        case = _case("draft-embargo")
+        iri = ingest_source_as_evidence(
+            case, title="Sensitive doc", source_id="source:20240301:embargo1"
+        )
+        Material.objects.filter(pk=iri).update(visibility_policy=Policy.CASE_GATED)
+        # Re-ingest the same @id; the upsert preserves the manual policy (INSERT-only
+        # birth default) and the ingest then recomputes from the DRAFT case.
+        ingest_source_as_evidence(
+            case, title="Sensitive doc", source_id="source:20240301:embargo1"
         )
         mat = Material.objects.get(iri=iri)
         assert mat.visibility == Visibility.PRIVATE


### PR DESCRIPTION
## Problem

Every document uploaded through a case (the case importer + the CIAA draft-case service) was minted at `/material/jawafdehi/<ident>` **regardless of its type** — `documentsource_to_jsonld` hardcoded `build_source_material_iri`, which forces `JAWAF_SOURCE`. That is the exact monolith the recent corpus re-home had to unwind by hand (744 mixed documents → 0). Without this fix, new cases would steadily refill the `jawafdehi` bucket.

## Fix

`documentsource_to_jsonld` now sources the material by its already-computed `material_type`:

| source_type | → material_type / source segment |
|---|---|
| `CIAA_PRESS_RELEASE` | `press_release` |
| `AG_ABHIYOG_PATRA` | `charge_sheet` |
| `OAG_AUDIT_REPORT` | `official_report` |
| `COURT_ORDER` | `court_order` |
| `LAW_OR_BILL` | `legal_corpus` |
| `NEWS` | `news` |
| `SOCIAL_MEDIA` | `social_media` |
| `COURT_FILING_OTHER` / `MISC` / unknown | `document` |

These are exactly the source tokens the re-home produced and that the Data-Quality "where the evidence comes from" table rolls up to issuing offices (companion FE PR: Jawafdehi/Jawafdehi#230).

`build_source_material_iri` gains a keyword-only `source` param (defaults to `JAWAF_SOURCE` for back-compat); the ident normalization is untouched, so re-ingest stays idempotent.

## Visibility (decision: public by default)

`default_policy_for` keys the draft embargo on `source == "jawafdehi"`. Once uploads stop being sourced `jawafdehi`, they are born **PUBLIC** (listed/searchable on ingest) — case uploads are public by default, consistent with the re-homed corpus. A caseworker embargoes a sensitive document by explicitly setting `CASE_GATED`/`PRIVATE` via the materials PATCH. The legacy `jawafdehi` source remains `CASE_GATED` for any residual rows.

Docstrings on `Policy` / `default_policy_for` and the ingest path are updated to describe the new model.

## Tests
- `test_source_material_shaper.py`: `@id` now sourced by material_type; new parametrized coverage across all source types + the caller-selectable `source=` param.
- `test_visibility.py::TestDefaultPolicyForSource`: shaper output is born PUBLIC; a residual hardcoded `jawafdehi` @id still births `CASE_GATED`.
- Verified: `pytest materials/tests/test_source_material_shaper.py` + `TestDefaultPolicyForSource` → **34 passed**; `ruff check` clean; 362 tests collect with no import errors.

> Note: no auto-migrate on deploy — this change has **no migration** (pure shaping/policy-default logic), so nothing to run post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Material identifiers now use paths based on their material type, such as news or documents, instead of a single legacy path.
  * Re-ingesting the same source remains idempotent, including when using a stable natural key.

* **Bug Fixes**
  * New case-upload materials are public by default, while legacy materials retain their gated behavior.
  * Visibility recalculation now correctly respects existing embargo and private-access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->