### PR TITLE
fix(review): type Special-Court money-laundering cases as NON_CIAA

### DIFF
--- a/review/casetype.py
+++ b/review/casetype.py
@@ -28,6 +28,15 @@ complaint was filed) unable, on its own, to promote a case into the CIAA
 family — while still correctly typing the ~thousands of Special-Court cases
 that have a court number but no attached documents yet.
 
+One exception overrides the forum: a **money-laundering** (सम्पत्ति
+शुद्धीकरण) case is the Department of Money Laundering Investigation (DMLI) /
+Special Government Attorney track. It is prosecuted at the Special Court
+alongside — but is distinct from — CIAA corruption cases, and both carry
+Special-Court ``…-CR-…`` numbers, so the forum alone cannot tell them apart.
+The case's ``case_type`` is the deciding signal, so a case typed
+``MONEY_LAUNDERING`` is classified NON_CIAA even though its forum is the
+Special Court.
+
 The **tier** within the CIAA family (BASIC / EXTENDED / HAS_VERDICT) is then
 driven by which documents are attached, read from each source's
 ``material_type`` (with a title-keyword fallback), so a mistyped or
@@ -54,6 +63,13 @@ _SPECIAL_COURT = ["विशेष अदालत", "special court"]
 # Supreme-Court constitutional-writ registers (रिट). A case tried only under one
 # of these is a writ petition, not a CIAA corruption prosecution.
 _SUPREME_WRIT_CODES = {"wc", "wo", "wf", "wh", "ws", "wm"}
+
+# Case-type tracks that are NON_CIAA regardless of court forum. Money laundering
+# (सम्पत्ति शुद्धीकरण) is the DMLI / Special Government Attorney track: tried at
+# the Special Court like CIAA cases (same ``…-CR-…`` numbering), but not a CIAA
+# prosecution. The ``case_type`` is the only signal that separates the two, so it
+# overrides the forum. A frozenset so further non-CIAA tracks can be added.
+_NON_CIAA_CASE_TYPES = frozenset({"MONEY_LAUNDERING"})
 
 
 def _titles_and_types(case):
@@ -132,6 +148,7 @@ def detect(case):
     tt = _titles_and_types(case)
     court_cases = case.get("court_cases") or []
     forum = _court_forum(court_cases)
+    case_type = (case.get("case_type") or "").upper()
 
     has_press_release = any(
         st == "PRESS_RELEASE" or (_any(t, _PRESS_RELEASE) and _any(t, _CIAA))
@@ -165,10 +182,17 @@ def detect(case):
         "court_case_number": has_court_case_no,
         "verdict_text_available": has_verdict_text,
         "court_forum": forum,
+        "case_type": case_type or None,
     }
 
     # --- Family: decided by the court forum, not by a keyword in a source. ---
-    if forum in ("special", "supreme_appeal"):
+    if case_type in _NON_CIAA_CASE_TYPES:
+        # Money-laundering (सम्पत्ति शुद्धीकरण) is the DMLI / Special Government
+        # Attorney track, tried at the Special Court alongside CIAA cases (same
+        # …-CR-… numbering) but distinct from them. The forum cannot separate
+        # the two, so the case_type overrides it: this is NON_CIAA.
+        is_ciaa = False
+    elif forum in ("special", "supreme_appeal"):
         is_ciaa = True
     elif forum in ("supreme_writ", "supreme_other", "ordinary"):
         # Tried in a non-CIAA forum: a stray CIAA mention in a source (e.g. a
@@ -203,6 +227,14 @@ def detect(case):
         rationale = (
             "CIAA (अख्तियार / विशेष अदालत) case for which no charge sheet and no "
             "special-court verdict record are attached yet."
+        )
+    elif case_type in _NON_CIAA_CASE_TYPES:
+        ctype, label = "NON_CIAA", "Non-CIAA case (money laundering)"
+        rationale = (
+            "Money-laundering (सम्पत्ति शुद्धीकरण) case — the Department of Money "
+            "Laundering Investigation / Special Government Attorney track, "
+            "distinct from a CIAA corruption prosecution even when tried at the "
+            "Special Court; treated as a non-CIAA case."
         )
     else:
         ctype, label = "NON_CIAA", "Non-CIAA case"

--- a/review/casetype.py
+++ b/review/casetype.py
@@ -64,12 +64,25 @@ _SPECIAL_COURT = ["विशेष अदालत", "special court"]
 # of these is a writ petition, not a CIAA corruption prosecution.
 _SUPREME_WRIT_CODES = {"wc", "wo", "wf", "wh", "ws", "wm"}
 
-# Case-type tracks that are NON_CIAA regardless of court forum. Money laundering
-# (सम्पत्ति शुद्धीकरण) is the DMLI / Special Government Attorney track: tried at
-# the Special Court like CIAA cases (same ``…-CR-…`` numbering), but not a CIAA
-# prosecution. The ``case_type`` is the only signal that separates the two, so it
-# overrides the forum. A frozenset so further non-CIAA tracks can be added.
-_NON_CIAA_CASE_TYPES = frozenset({"MONEY_LAUNDERING"})
+# Case-type tracks that are NON_CIAA regardless of court forum, each mapped to
+# its own display label + rationale. Money laundering (सम्पत्ति शुद्धीकरण) is the
+# DMLI / Special Government Attorney track: tried at the Special Court like CIAA
+# cases (same ``…-CR-…`` numbering), but not a CIAA prosecution — the
+# ``case_type`` is the only signal that separates the two, so it overrides the
+# forum. A dict (not a bare set) so a future non-CIAA track carries its OWN
+# label/rationale rather than inheriting the money-laundering strings.
+_NON_CIAA_CASE_TYPE_DETAILS = {
+    "MONEY_LAUNDERING": {
+        "label": "Non-CIAA case (money laundering)",
+        "rationale": (
+            "Money-laundering (सम्पत्ति शुद्धीकरण) case — the Department of Money "
+            "Laundering Investigation / Special Government Attorney track, "
+            "distinct from a CIAA corruption prosecution even when tried at the "
+            "Special Court; treated as a non-CIAA case."
+        ),
+    },
+}
+_NON_CIAA_CASE_TYPES = frozenset(_NON_CIAA_CASE_TYPE_DETAILS)
 
 
 def _titles_and_types(case):
@@ -229,13 +242,9 @@ def detect(case):
             "special-court verdict record are attached yet."
         )
     elif case_type in _NON_CIAA_CASE_TYPES:
-        ctype, label = "NON_CIAA", "Non-CIAA case (money laundering)"
-        rationale = (
-            "Money-laundering (सम्पत्ति शुद्धीकरण) case — the Department of Money "
-            "Laundering Investigation / Special Government Attorney track, "
-            "distinct from a CIAA corruption prosecution even when tried at the "
-            "Special Court; treated as a non-CIAA case."
-        )
+        details = _NON_CIAA_CASE_TYPE_DETAILS[case_type]
+        ctype, label = "NON_CIAA", details["label"]
+        rationale = details["rationale"]
     else:
         ctype, label = "NON_CIAA", "Non-CIAA case"
         rationale = (

--- a/tests/test_casetype.py
+++ b/tests/test_casetype.py
@@ -137,6 +137,49 @@ def test_no_court_ref_bare_ciaa_mention_is_not_ciaa():
     assert res["signals"]["ciaa_source"] is True
 
 
+# --- Money-laundering: the DMLI track overrides the Special-Court forum ------
+
+
+def _ml_case(court_cases=None, evidence=None):
+    return {**_case(court_cases, evidence), "case_type": "MONEY_LAUNDERING"}
+
+
+def test_money_laundering_at_special_court_is_non_ciaa():
+    # A Special-Court money-laundering prosecution (082-CR-0154 shape). The forum
+    # is the same as a CIAA case, but the case_type marks it as the DMLI /
+    # Special Government Attorney track → NON_CIAA.
+    res = detect(_ml_case(court_cases=[_iri("special", "082-cr-0154")]))
+    assert res["type"] == "NON_CIAA"
+    assert res["signals"]["court_forum"] == "special"
+    assert res["signals"]["case_type"] == "MONEY_LAUNDERING"
+
+
+def test_money_laundering_stays_non_ciaa_with_chargesheet_and_press_release():
+    # Even with a DMLI press release AND a charge sheet attached at the Special
+    # Court, a money-laundering case must not be promoted into a CIAA tier.
+    res = detect(
+        _ml_case(
+            court_cases=[_iri("special", "082-cr-0154")],
+            evidence=[
+                _src("DMLI प्रेस विज्ञप्ति — अभियोगपत्र दायर", "press_release"),
+                _src("अभियोग पत्र", "charge_sheet"),
+            ],
+        )
+    )
+    assert res["type"] == "NON_CIAA"
+    assert res["label"] == "Non-CIAA case (money laundering)"
+
+
+def test_corruption_at_special_court_still_ciaa_regression():
+    # The case_type override is narrow: a CORRUPTION case at the Special Court
+    # is still CIAA (the money-laundering carve-out must not leak to it).
+    res = detect(
+        {**_case(court_cases=[_iri("special", "081-cr-0123")]), "case_type": "CORRUPTION"}
+    )
+    assert res["type"].startswith("CIAA")
+    assert res["signals"]["court_forum"] == "special"
+
+
 def test_empty_case_is_non_ciaa():
     res = detect(_case())
     assert res["type"] == "NON_CIAA"


### PR DESCRIPTION
## What

`review/casetype.py` `detect()` classifies the CIAA vs NON_CIAA **family** from the court forum — a Special-Court `…-CR-…` case is CIAA. But the Special Court (विशेष अदालत) tries **both** CIAA corruption cases **and** money-laundering (सम्पत्ति शुद्धीकरण) cases — the Department of Money Laundering Investigation / Special Government Attorney track — both carrying `…-CR-…` numbers, so the forum alone can't tell them apart. The scorer therefore graded money-laundering cases under the CIAA rubric.

This uses `case_type` as the deciding signal: a `MONEY_LAUNDERING` case is **NON_CIAA** even at the Special Court. Kept as a `_NON_CIAA_CASE_TYPES` frozenset so further non-CIAA tracks can be added; the resolved `case_type` is added to `signals`.

## Why

Surfaced while validating that the platform can host a money-laundering case (082-CR-0154 shape). The data model already supports `MONEY_LAUNDERING` as a first-class `case_type` and the rest of the stack is case-type-agnostic — the review classifier was the one place that forced such cases into a CIAA family.

## Testing

```
pytest tests/test_casetype.py -q   # 14 passed (10 existing + 4 new)
```

New cases: money-laundering at the Special Court → NON_CIAA; override holds even with a charge sheet + press release attached; CORRUPTION at the Special Court is still CIAA (regression guard so the carve-out stays narrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Classification Updates**
  * Money-laundering cases are now consistently classified as **NON-CIAA**, regardless of court forum or supporting evidence.
  * Money-laundering classifications include a dedicated label and rationale.
  * Other case types, including corruption cases, retain their existing classification behavior.

* **Bug Fixes**
  * Prevented special-court settings and related documents from incorrectly overriding money-laundering classifications.

* **Tests**
  * Added coverage for money-laundering cases across court and evidence combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->