### PR TITLE
fix(cases): drop the CORRUPTION-only "≥1 accused" publish gate

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -16,7 +16,6 @@ from .models import (
     ChatUserIdentity,
     Feedback,
     RelationshipType,
-    requires_accused,
 )
 from .rules.predicates import (
     can_manage_user,
@@ -321,28 +320,18 @@ class CaseEntityRelationshipInlineFormSet(BaseInlineFormSet):
             return
         if self.instance.state not in {CaseState.IN_REVIEW, CaseState.PUBLISHED}:
             return
-        # CORRUPTION cases require an ACCUSED entity; other case types (e.g.
-        # TAX_EVASION) only require a named subject — any non-location entity.
-        # The accepted relationship types and the error message differ, but the
-        # form-scanning loop is otherwise identical.
-        if requires_accused(self.instance.case_type):
+        # Every case type only requires a named SUBJECT — any non-location entity
+        # (person or organization). The former CORRUPTION-only "at least one
+        # ACCUSED" hard gate is retired so systemic / unsubstantiated cases (no
+        # charged individual) can publish; mirrors Case.validate(). Naming an
+        # accused remains a review-quality signal, not a publish blocker.
+        def is_required_entity(rel_type):
+            return rel_type != RelationshipType.LOCATION
 
-            def is_required_entity(rel_type):
-                return rel_type == RelationshipType.ACCUSED
-
-            error = (
-                "At least one accused entity relationship is required for IN_REVIEW or PUBLISHED state. "
-                "Please add accused entities using the 'Case Entity Relationships' section below."
-            )
-        else:
-
-            def is_required_entity(rel_type):
-                return rel_type != RelationshipType.LOCATION
-
-            error = (
-                "At least one non-location entity relationship is required for IN_REVIEW or PUBLISHED state. "
-                "Please add entities using the 'Case Entity Relationships' section below."
-            )
+        error = (
+            "At least one non-location entity relationship is required for IN_REVIEW or PUBLISHED state. "
+            "Please add entities using the 'Case Entity Relationships' section below."
+        )
         has_required_entity = any(
             form.cleaned_data
             and not form.cleaned_data.get("DELETE")

--- a/cases/models.py
+++ b/cases/models.py
@@ -952,23 +952,23 @@ class Case(models.Model):
 
         # Strict validation for IN_REVIEW and PUBLISHED states
         if self.state in [CaseState.IN_REVIEW, CaseState.PUBLISHED]:
-            # Entity requirement depends on case type. CORRUPTION cases must name
-            # at least one ACCUSED entity; other case types (e.g. TAX_EVASION)
-            # only require a named subject — any non-location entity. A
-            # location-only case is not a valid subject (the UI also excludes
-            # locations when naming a case's subject).
-            if requires_accused(self.case_type):
-                has_required_entity = self.entity_relationships.filter(
-                    relationship_type=RelationshipType.ACCUSED
-                ).exists()
-                entity_error = "At least one accused entity is required for IN_REVIEW or PUBLISHED state"
-            else:
-                has_required_entity = self.entity_relationships.exclude(
-                    relationship_type=RelationshipType.LOCATION
-                ).exists()
-                entity_error = "At least one non-location entity is required for IN_REVIEW or PUBLISHED state"
+            # Every case type requires a named SUBJECT — at least one non-location
+            # entity (a person or organization) — before it can leave DRAFT. The
+            # former CORRUPTION-only "at least one ACCUSED" hard gate is retired:
+            # systemic / unsubstantiated cases (e.g. a project-level irregularity
+            # with no charged individual, like budhigandaki) must be publishable,
+            # so the requirement is a named subject, not specifically an accused
+            # party. Naming an accused is still tracked as a review-quality signal
+            # (see cases.models.requires_accused / review.rules_engine), just no
+            # longer a publish blocker. A location-only case is not a valid subject
+            # (the UI also excludes locations when naming a case's subject).
+            has_required_entity = self.entity_relationships.exclude(
+                relationship_type=RelationshipType.LOCATION
+            ).exists()
             if not has_required_entity:
-                errors["entities"] = entity_error
+                errors["entities"] = (
+                    "At least one non-location entity is required for IN_REVIEW or PUBLISHED state"
+                )
 
             if not self.key_allegations or len(self.key_allegations) == 0:
                 errors["key_allegations"] = (

--- a/tests/test_case_model.py
+++ b/tests/test_case_model.py
@@ -423,10 +423,14 @@ def test_multiple_drafts_get_unique_auto_slugs():
 
 
 @pytest.mark.django_db
-def test_corruption_requires_accused_entity_for_review():
-    """CORRUPTION cases still need an ACCUSED entity to leave DRAFT.
+def test_corruption_does_not_require_accused_entity_for_review():
+    """CORRUPTION cases no longer require an ACCUSED entity to leave DRAFT.
 
-    A related-only entity does not satisfy the requirement.
+    Systemic / unsubstantiated cases (a project-level irregularity with no
+    charged individual, e.g. budhigandaki) must be publishable, so a non-location
+    subject — a related person or organization — satisfies the requirement. The
+    former CORRUPTION-only "at least one accused" hard gate is retired; naming an
+    accused is now a review-quality signal, not a publish blocker.
     """
     case = create_case_with_entities(
         title="Corruption Case",
@@ -437,9 +441,36 @@ def test_corruption_requires_accused_entity_for_review():
     )
     case.state = CaseState.IN_REVIEW
 
+    try:
+        case.validate()
+    except ValidationError as e:
+        pytest.fail(f"CORRUPTION should not require an accused entity: {e}")
+
+
+@pytest.mark.django_db
+def test_corruption_location_only_entity_is_insufficient():
+    """A CORRUPTION case with only a location entity has no named subject.
+
+    The non-location-subject requirement is type-agnostic, so a location-only
+    corruption case must still fail review validation (mirrors the TAX_EVASION
+    case below).
+    """
+    case = create_case_with_entities(
+        title="Corruption Case",
+        key_allegations=["Allegation"],
+        description="Description",
+        case_type=CaseType.CORRUPTION,
+    )
+    CaseEntityRelationship.objects.create(
+        case=case,
+        nes_id="https://jawafdehi.org/entity/location/district/kathmandu",
+        relationship_type=RelationshipType.LOCATION,
+    )
+    case.state = CaseState.IN_REVIEW
+
     with pytest.raises(ValidationError) as exc_info:
         case.validate()
-    assert "accused" in str(exc_info.value).lower()
+    assert "entity" in str(exc_info.value).lower()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

`Case.validate()` required at least one **ACCUSED** entity before a `CORRUPTION` case could leave `DRAFT` (move to `IN_REVIEW`/`PUBLISHED`). Systemic / unsubstantiated cases — a project-level irregularity with no charged individual — could therefore never be published, even when a named institutional subject was attached. Caseworkers hit a hard `422` on submit/publish for these cases.

## Change

Relax the entity requirement to be **case-type-agnostic**: every case now requires at least one **non-location subject** (a person or organization), matching what non-corruption case types already required. Naming an accused stays a **review-quality signal** (`cases.models.requires_accused` / `review.rules_engine`), not a hard publish blocker.

Applied in **both** enforcement paths so they stay consistent:
- `Case.validate()` — the API / state-machine gate
- the Wagtail/Django admin `CaseEntityRelationship` formset

## Tests

- `test_corruption_does_not_require_accused_entity_for_review` — a corruption case now passes review validation with a related-only subject
- `test_corruption_location_only_entity_is_insufficient` — a location-only corruption case still fails (no named subject), mirroring the tax-evasion case
- Existing allegation / empty-entity / state-transition / review-scoring tests unchanged and green

Verified end-to-end against a local Django+SQLite backend via the SPA editor: a corruption case with only a non-location subject now submits successfully (was `422`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)