### PR TITLE
chore(cases): 400 tripwire — log the offending body on a non-array case PATCH

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -799,6 +799,26 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
 
         patch_ops = request.data
         if not isinstance(patch_ops, list):
+            # Tripwire: a valid client (the SPA) always sends a bare RFC-6902
+            # array here, so a non-list body is anomalous. An intermittent
+            # empty/object body was seen in prod publish traffic but could not be
+            # reproduced from the SPA — capture enough to identify the culprit if
+            # it recurs. The body is not a valid patch (so it carries no case
+            # content worth redacting); still truncate + type-tag it defensively.
+            body_repr = repr(request.data)
+            if len(body_repr) > 500:
+                body_repr = body_repr[:500] + "…"
+            logger.warning(
+                "cases.partial_update rejected a non-array PATCH body: "
+                "type=%s content_type=%r content_length=%s user=%s case=%s ua=%r body=%s",
+                type(request.data).__name__,
+                request.content_type,
+                request.META.get("CONTENT_LENGTH"),
+                getattr(request.user, "username", None) or "anon",
+                case.slug,
+                request.META.get("HTTP_USER_AGENT", "")[:200],
+                body_repr,
+            )
             return Response(
                 {"detail": "Request body must be a JSON array of patch operations."},
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Why

`PATCH /api/cases/{slug}/` returns `400 "Request body must be a JSON array of patch operations"` whenever the body isn't a list. Prod publish traffic hit this **intermittently** on 2026-07-17 (~6am PT) — a real browser sent an empty/object body — but it **could not be reproduced** from the current SPA, which always sends a bare RFC-6902 array (verified end-to-end against a real Django backend). So the offending body shape/client is unknown.

## What

Adds a `WARNING`-level tripwire on that 400 branch capturing:
- body **type** and a truncated `repr` (≤500 chars)
- `content-type`, `content-length`
- `user`, case `slug`
- `user-agent`

The body is not a valid patch (carries no case content worth redacting) and is truncated defensively. A future recurrence becomes one greppable log line in VictoriaLogs instead of a guessing game.

Pure diagnostics — no behaviour change; the 400 response is unchanged. `test_patch_400_for_malformed_patch_body` and the other malformed-body tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)