### PR TITLE
feat(search): privacy-preserving per-query analytics event (data foundation for relevance tuning)

### DIFF
--- a/docs/search-analytics.md
+++ b/docs/search-analytics.md
@@ -1,0 +1,61 @@
+# Search analytics — the `search_query` event
+
+Instrumentation that collects the data a future ranking algorithm needs. It does **not** change ranking. Relevance-weight tuning is deferred (unified-search plan §8 Q3); tuning blind — with no record of what people search or which queries return nothing — is guesswork, so this closes the data gap first. When these events have adequate volume we build the algorithm from them.
+
+## What emits it
+
+`GET /api/search/` emits exactly one `search_query` event per request, server-side, in `search/analytics.py` (called from `UnifiedSearchView.get`). Server-side is deliberate: it is the **unbiased** denominator. GA4 is consent-gated (only ~a quarter of humans opt in) so it sees a fraction of traffic and no zero-result signal; this event sees every query.
+
+Emission is best-effort — `emit_search_event` swallows and logs any failure, so a telemetry bug can never turn a good search into a 500.
+
+## Fields
+
+One flat JSON line per query (rendered by the structlog JSON formatter; the log message `search_query` becomes the `event` field, logger name `jawafdehi.search.analytics`):
+
+| field | meaning |
+|---|---|
+| `search_id` | ephemeral per-response id (hex). The join key to a future client result-click beacon — **not** a user/session id. |
+| `q_normalized` | the query text, NFC + trimmed + lowercased + whitespace-collapsed. The demand signal. `""` for a browse. |
+| `q_len` | length of `q_normalized`. |
+| `has_query` | false for a browse (no query term). |
+| `lang` | requested `ne` / `en` / `both`. |
+| `types` | requested type filter, sorted; `[]` means all types. |
+| `sort` | `relevance` / `newest` / `oldest` / `title`. |
+| `page`, `page_size` | paging. |
+| `filters` | active refine facets (`case_type` / `entity_type` / `tags` / `status`), taxonomy tokens only; `null` when none. |
+| `result_count` | total hits. |
+| `zero_result` | **the key gap signal** — a real query (`has_query`) that returned nothing. A browse returning nothing is not a miss. |
+| `counts_by_type` | per-type hit counts — which index satisfied the demand. |
+| `returned` | hits on this page. |
+| `took_ms` | wall-clock of the OpenSearch call. |
+| `top_type`, `top_score` | type + score of the first hit, **first page only** — the click-through anchor (the best answer shown). |
+
+## Privacy
+
+No user identity — no id, IP, user-agent, session, or referer. `q_normalized` is normalized, not hashed (the query text *is* the signal), and is never attached to a person. Aggregate product telemetry, not an audit trail — route the `jawafdehi.search.analytics` stream to **short retention** (shorter than the general 365-day archive).
+
+## The click loop (next step, not yet built)
+
+`search_id` is echoed in the response envelope so the SPA can send it back on a result click. A tiny beacon — `(search_id, rank, result_type, iri)` → a `search_click` event — closes the loop into `(query → shown → clicked)` learning-to-rank judgments, unbiased and consent-free, without ever identifying who clicked. The GA4 `select_search_result` event (rank + term, shipped) is the consent-gated mirror; the beacon is the ground truth.
+
+## Using it to tune relevance (later)
+
+Once volume is adequate:
+
+- **Zero-result queries** (`zero_result:true`, ranked by frequency) → the highest-value backlog: missing synonyms/spellings, analyzer gaps, or genuinely absent corpus. This is what should drive the deferred synonym/fuzziness work — measured, not guessed.
+- **`counts_by_type` vs clicks** → whether the cross-type `indices_boost` matches real preference.
+- **`top_score` distribution on clicked vs abandoned searches** → a score threshold for "no confident answer".
+- **`search_id`-joined clicks by rank** → CTR@k, the training signal for learning-to-rank.
+
+### LogsQL sketches (VictoriaLogs)
+
+```
+# top zero-result queries (28d)
+event:search_query zero_result:true | stats by (q_normalized) count() hits | sort by (hits) desc | limit 50
+
+# demand by type filter
+event:search_query has_query:true | stats by (types) count()
+
+# slow queries
+event:search_query took_ms:>500 | fields q_normalized, took_ms, result_count
+```

--- a/docs/unified-search-plan.md
+++ b/docs/unified-search-plan.md
@@ -536,7 +536,10 @@ Genuinely remaining:
    it into `shared/jawafdehi_shared/search/` so all indexers use one implementation?
    (Pending the bilingual deep-research result, which may change the approach entirely.)
 3. **Relevance weights:** initial cross-type boost defaults (entities-first?
-   identifier-exact-first?) and who owns tuning them.
+   identifier-exact-first?) and who owns tuning them. Tuning stays DEFERRED until
+   data justifies it — the `search_query` analytics event (`search/analytics.py`,
+   see `docs/search-analytics.md`) now records the demand + zero-result + click-anchor
+   signals that will DRIVE this tuning, so it is measured rather than guessed.
 4. ~~**The "internal" role mechanics.**~~ RESOLVED — the "internal" role idea was
    dropped. Draft/in-review view is granted to the **readonly+ roles** (readonly/
    caseworker/moderator/admin) via the shared role→group map

--- a/search/analytics.py
+++ b/search/analytics.py
@@ -1,0 +1,141 @@
+"""Server-side search analytics: one structured event per ``/api/search`` call.
+
+This is INSTRUMENTATION ONLY — it does not change ranking. Its purpose is to
+accumulate the demand + result-quality signals we need to build a data-driven
+ranking algorithm LATER, once these events have adequate volume (the plan's
+"relevance-weight tuning DEFERRED to future"). Tuning the query blind — with no
+record of what people actually search or which queries return nothing — would be
+guesswork; this closes that gap first.
+
+What each event captures:
+
+* **demand** — the normalized query text and its length, the requested type
+  filter / language / sort / paging, and the active refine facets. This is the
+  UNBIASED denominator: it is emitted for every request server-side, unlike GA4
+  (consent-gated to ~a quarter of humans) which only sees a fraction of traffic.
+* **result quality** — the total hit count, a ``zero_result`` flag (the single
+  most actionable gap signal — a real query the corpus/analyzers could not
+  answer), the per-type counts (which index satisfied the demand), and the top
+  hit's type/score on the first page (a coarse "was the best answer strong"
+  signal, and the join target for click-through analysis).
+* **latency** — wall-clock time of the OpenSearch call, so slow queries surface.
+
+Privacy: NO user identity is recorded — no id, IP, user-agent, session, or
+referer. The query text is normalized (case/whitespace) but not hashed, because
+the query text IS the signal being collected; it is never attached to a person.
+Each event carries an ephemeral ``search_id`` so a future client-side
+result-click beacon can be correlated into (query -> shown -> clicked)
+learning-to-rank judgments WITHOUT ever identifying who searched. The events are
+meant for a SHORT-retention stream (route by the ``jawafdehi.search.analytics``
+logger name); they are aggregate product telemetry, not an audit trail.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from typing import Any
+
+# A dedicated logger (distinct from ``jawafdehi.search``, which carries the 503
+# transport warnings) so the log pipeline can route these product-telemetry events
+# to their own short-retention stream by logger name.
+logger = logging.getLogger("jawafdehi.search.analytics")
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_query(q: str | None) -> str:
+    """Normalize a raw query for aggregation: NFC + trim + lowercase + collapse
+    internal whitespace. Returns ``""`` for a blank/browse query.
+
+    NFC so a Devanagari term typed composed vs decomposed aggregates as one; lower
+    + whitespace-collapse so ``"  Sher   Deuba "`` and ``"sher deuba"`` are the
+    same demand bucket. Not hashed — the query text is the signal we collect.
+    """
+    if not q:
+        return ""
+    normalized = unicodedata.normalize("NFC", q).strip().lower()
+    return _WHITESPACE_RE.sub(" ", normalized)
+
+
+def build_search_event(
+    *,
+    search_id: str,
+    params: dict[str, Any],
+    response: dict[str, Any],
+    took_ms: float,
+) -> dict[str, Any]:
+    """Build the ``search_query`` event payload (a flat, JSON-serializable dict).
+
+    Pure/inspectable so the field contract is unit-tested without touching the log
+    pipeline. ``params`` carries the validated request inputs (``q``, ``lang``,
+    ``types``, ``sort``, ``page``, ``page_size``, ``filters``); ``response`` is the
+    :class:`SearchService` envelope (``count``, ``counts``, ``results``).
+
+    ``types`` is emitted as a sorted list; an empty list means "all types" (no
+    filter). ``top_type``/``top_score`` are recorded only for the FIRST page with
+    at least one hit — they anchor click-through analysis to the best answer shown.
+    """
+    q_normalized = normalize_query(params.get("q"))
+    has_query = bool(q_normalized)
+    count = int(response.get("count") or 0)
+    results = response.get("results") or []
+    page = params.get("page", 1)
+    active_filters = {
+        facet: values for facet, values in (params.get("filters") or {}).items() if values
+    }
+
+    event: dict[str, Any] = {
+        "search_id": search_id,
+        "q_normalized": q_normalized,
+        "q_len": len(q_normalized),
+        "has_query": has_query,
+        "lang": params.get("lang"),
+        "types": sorted(params.get("types") or []),
+        "sort": params.get("sort"),
+        "page": page,
+        "page_size": params.get("page_size"),
+        "filters": active_filters or None,
+        "result_count": count,
+        # The key gap signal: a real query the corpus/analyzers could not answer.
+        # A browse (no query term) that returns nothing is NOT a zero-result miss.
+        "zero_result": has_query and count == 0,
+        "counts_by_type": response.get("counts") or {},
+        "returned": len(results),
+        "took_ms": round(took_ms, 1),
+    }
+
+    if page == 1 and results:
+        top = results[0]
+        event["top_type"] = top.get("type")
+        event["top_score"] = top.get("score")
+
+    return event
+
+
+def emit_search_event(
+    *,
+    search_id: str,
+    params: dict[str, Any],
+    response: dict[str, Any],
+    took_ms: float,
+) -> None:
+    """Emit one ``search_query`` analytics event. Never raises.
+
+    Analytics is best-effort: a bug here must NEVER turn a good search response
+    into an error, so payload construction and logging are wrapped — a failure is
+    logged and swallowed. The event fields ride in ``extra`` so the structlog JSON
+    formatter renders them as top-level keys (the log message ``"search_query"``
+    becomes the ``event`` field).
+    """
+    try:
+        event = build_search_event(
+            search_id=search_id,
+            params=params,
+            response=response,
+            took_ms=took_ms,
+        )
+        logger.info("search_query", extra=event)
+    except Exception:  # noqa: BLE001 — telemetry must never break the response.
+        logger.warning("search analytics emit failed", exc_info=True)

--- a/search/analytics.py
+++ b/search/analytics.py
@@ -74,8 +74,11 @@ def build_search_event(
     :class:`SearchService` envelope (``count``, ``counts``, ``results``).
 
     ``types`` is emitted as a sorted list; an empty list means "all types" (no
-    filter). ``top_type``/``top_score`` are recorded only for the FIRST page with
-    at least one hit — they anchor click-through analysis to the best answer shown.
+    filter). ``top_type``/``top_score`` are recorded only for the TRUE first page
+    with at least one hit (offset ``page==1`` AND no ``cursor``) — they anchor
+    click-through analysis to the best answer shown, and a cursor-paginated deep
+    page keeps ``page==1`` (the service ignores ``page`` under a cursor), so it
+    must be excluded or the anchor would misattribute to a deep page.
     """
     q_normalized = normalize_query(params.get("q"))
     has_query = bool(q_normalized)
@@ -106,7 +109,9 @@ def build_search_event(
         "took_ms": round(took_ms, 1),
     }
 
-    if page == 1 and results:
+    # Only the TRUE first page anchors the click-through analysis. A cursor page
+    # keeps page==1 (the service ignores page under a cursor), so exclude it.
+    if page == 1 and not params.get("cursor") and results:
         top = results[0]
         event["top_type"] = top.get("type")
         event["top_score"] = top.get("score")

--- a/search/tests/test_search_analytics.py
+++ b/search/tests/test_search_analytics.py
@@ -1,0 +1,133 @@
+"""Unit tests for the server-side search-analytics event builder.
+
+Pure functions (no DB, no cluster, no log pipeline): assert the ``search_query``
+event contract that a future ranking algorithm will consume — normalized query,
+the zero-result gap flag, per-type counts, the top-hit anchor, and that NO user
+identity is ever included.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from search.analytics import build_search_event, emit_search_event, normalize_query
+
+
+def test_normalize_query_lowercases_trims_and_collapses_whitespace():
+    assert normalize_query("  Sher   Bahadur  Deuba ") == "sher bahadur deuba"
+
+
+def test_normalize_query_blank_is_empty_string():
+    assert normalize_query(None) == ""
+    assert normalize_query("") == ""
+    assert normalize_query("   ") == ""
+
+
+def _params(**over):
+    base = {
+        "q": "akhtiyar",
+        "lang": "both",
+        "types": None,
+        "sort": "relevance",
+        "page": 1,
+        "page_size": 10,
+        "filters": {},
+    }
+    base.update(over)
+    return base
+
+
+def test_build_event_captures_demand_and_result_shape():
+    response = {
+        "count": 42,
+        "counts": {"case": 2, "entity": 40},
+        "results": [{"type": "entity", "score": 12.5}],
+    }
+    event = build_search_event(
+        search_id="abc123", params=_params(), response=response, took_ms=7.04
+    )
+    assert event["search_id"] == "abc123"
+    assert event["q_normalized"] == "akhtiyar"
+    assert event["q_len"] == len("akhtiyar")
+    assert event["has_query"] is True
+    assert event["result_count"] == 42
+    assert event["zero_result"] is False
+    assert event["counts_by_type"] == {"case": 2, "entity": 40}
+    assert event["returned"] == 1
+    assert event["took_ms"] == 7.0
+    # First-page top hit is recorded as the click-through anchor.
+    assert event["top_type"] == "entity"
+    assert event["top_score"] == 12.5
+
+
+def test_build_event_flags_zero_result_only_for_real_queries():
+    empty = {"count": 0, "counts": {}, "results": []}
+    # A real query that returned nothing is the actionable gap signal.
+    hit = build_search_event(
+        search_id="x", params=_params(q="obscure name"), response=empty, took_ms=1.0
+    )
+    assert hit["zero_result"] is True
+    # A browse (no query term) that returns nothing is NOT a zero-result miss.
+    browse = build_search_event(
+        search_id="x", params=_params(q=""), response=empty, took_ms=1.0
+    )
+    assert browse["has_query"] is False
+    assert browse["zero_result"] is False
+
+
+def test_build_event_omits_top_hit_beyond_first_page():
+    response = {
+        "count": 99,
+        "counts": {"entity": 99},
+        "results": [{"type": "entity", "score": 3.0}],
+    }
+    event = build_search_event(
+        search_id="x", params=_params(page=2), response=response, took_ms=1.0
+    )
+    # top_* anchors click-through to the best answer SHOWN FIRST; deeper pages
+    # would misattribute, so they are omitted there.
+    assert "top_type" not in event
+    assert "top_score" not in event
+
+
+def test_build_event_records_active_facets_and_sorted_types():
+    event = build_search_event(
+        search_id="x",
+        params=_params(
+            types=["entity", "case"],
+            filters={"case_type": ["CORRUPTION"], "tags": []},
+        ),
+        response={"count": 1, "counts": {}, "results": []},
+        took_ms=1.0,
+    )
+    # Types are sorted for stable aggregation; empty facet lists are dropped.
+    assert event["types"] == ["case", "entity"]
+    assert event["filters"] == {"case_type": ["CORRUPTION"]}
+
+
+def test_build_event_carries_no_user_identity():
+    """The event is aggregate product telemetry — it must never carry identity."""
+    event = build_search_event(
+        search_id="x",
+        params=_params(),
+        response={"count": 1, "counts": {}, "results": []},
+        took_ms=1.0,
+    )
+    forbidden = {"user", "user_id", "ip", "ip_address", "session", "user_agent", "referer"}
+    assert forbidden.isdisjoint(event.keys())
+
+
+def test_emit_search_event_never_raises():
+    """The never-raise contract the view depends on: a builder failure is
+    swallowed (logged), so telemetry can never turn a good search into a 500."""
+    with patch(
+        "search.analytics.build_search_event", side_effect=RuntimeError("boom")
+    ):
+        # Must NOT propagate.
+        emit_search_event(
+            search_id="x",
+            params=_params(),
+            response={"count": 0, "counts": {}, "results": []},
+            took_ms=1.0,
+        )
+

--- a/search/tests/test_search_analytics.py
+++ b/search/tests/test_search_analytics.py
@@ -90,6 +90,24 @@ def test_build_event_omits_top_hit_beyond_first_page():
     assert "top_score" not in event
 
 
+def test_build_event_omits_top_hit_on_cursor_pages():
+    """A cursor-paginated deep page keeps page==1 (the service ignores page under
+    a cursor), so it must NOT be treated as the first page for the click anchor."""
+    response = {
+        "count": 99,
+        "counts": {"entity": 99},
+        "results": [{"type": "entity", "score": 3.0}],
+    }
+    event = build_search_event(
+        search_id="x",
+        params=_params(page=1, cursor="opaque-token"),
+        response=response,
+        took_ms=1.0,
+    )
+    assert "top_type" not in event
+    assert "top_score" not in event
+
+
 def test_build_event_records_active_facets_and_sorted_types():
     event = build_search_event(
         search_id="x",

--- a/search/tests/test_search_api.py
+++ b/search/tests/test_search_api.py
@@ -57,6 +57,27 @@ def test_search_api_returns_envelope():
 
 
 @pytest.mark.django_db
+def test_search_api_echoes_search_id_and_emits_analytics():
+    """Every search echoes an ephemeral ``search_id`` (the click-loop join seam)
+    and emits ONE server-side analytics event carrying that same id + the query."""
+    client = MagicMock()
+    client.search.return_value = _canned()
+    with patch("search.service.make_client", return_value=client), patch(
+        "search.views.emit_search_event"
+    ) as emit:
+        resp = APIClient().get("/api/search/", {"q": "Akhtiyar"})
+    assert resp.status_code == 200
+    search_id = resp.json()["search_id"]
+    assert search_id
+    emit.assert_called_once()
+    kwargs = emit.call_args.kwargs
+    assert kwargs["search_id"] == search_id
+    assert kwargs["params"]["q"] == "Akhtiyar"
+    assert kwargs["response"]["count"] == 1
+    assert kwargs["took_ms"] >= 0
+
+
+@pytest.mark.django_db
 def test_search_api_503_when_cluster_down():
     client = MagicMock()
     client.search.side_effect = ConnectionError("down")

--- a/search/views.py
+++ b/search/views.py
@@ -10,6 +10,9 @@ This REPLACES the old Jawafdehi-scoped ``cases.UnifiedSearchView`` and the NGM
 
 from __future__ import annotations
 
+import time
+import uuid
+
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, status
@@ -17,6 +20,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .analytics import emit_search_event
 from .service import (
     ALL_SORTS,
     ALL_TYPES,
@@ -188,13 +192,19 @@ class UnifiedSearchView(APIView):
             "tags": data["tags"],
             "status": data["status"],
         }
+        active_filters = {k: v for k, v in filters.items() if v}
+        # Ephemeral per-response id: it join-keys the server-side analytics event to
+        # a future client result-click beacon (query -> shown -> clicked) WITHOUT
+        # attaching any identity. Echoed in the envelope so the SPA can send it back.
+        search_id = uuid.uuid4().hex
+        started = time.perf_counter()
         try:
             response = SearchService().search(
                 q=data["q"],
                 types=data["type"] or None,
                 lang=data["lang"],
                 sort=data["sort"],
-                filters={k: v for k, v in filters.items() if v},
+                filters=active_filters,
                 page=data["page"],
                 page_size=data["page_size"],
                 cursor=data.get("cursor"),
@@ -209,4 +219,21 @@ class UnifiedSearchView(APIView):
                 {"detail": "Search is temporarily unavailable."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
+        took_ms = (time.perf_counter() - started) * 1000.0
+        response["search_id"] = search_id
+        # Best-effort product telemetry (never raises); see search/analytics.py.
+        emit_search_event(
+            search_id=search_id,
+            params={
+                "q": data["q"],
+                "lang": data["lang"],
+                "types": data["type"] or None,
+                "sort": data["sort"],
+                "page": data["page"],
+                "page_size": data["page_size"],
+                "filters": active_filters,
+            },
+            response=response,
+            took_ms=took_ms,
+        )
         return Response(response)

--- a/search/views.py
+++ b/search/views.py
@@ -232,6 +232,9 @@ class UnifiedSearchView(APIView):
                 "page": data["page"],
                 "page_size": data["page_size"],
                 "filters": active_filters,
+                # Under a cursor the service ignores ``page`` (stays 1); pass it so
+                # the builder doesn't mistake a deep cursor page for the first page.
+                "cursor": data.get("cursor"),
             },
             response=response,
             took_ms=took_ms,


### PR DESCRIPTION
## Why

We want to improve search *relevance*, but we have **no record of what people actually search** or which queries return nothing — so tuning ranking now would be guesswork. This PR is **instrumentation only** (no ranking change): it starts collecting the demand + result-quality signals that a future data-driven ranking algorithm will consume. Relevance-weight tuning stays deferred (unified-search plan §8 Q3) until this data reaches adequate volume.

## What

Every `GET /api/search/` emits one structured `search_query` event (`search/analytics.py`, called from `UnifiedSearchView.get`):

- **demand** — `q_normalized` (NFC + lowercased + whitespace-collapsed), `q_len`, `has_query`, `lang`, `types`, `sort`, paging, active refine `filters`.
- **result quality** — `result_count`, **`zero_result`** (the key gap signal: a real query the corpus/analyzers couldn't answer), `counts_by_type` (which index satisfied the demand), `returned`, and first-page `top_type`/`top_score` (the click-through anchor).
- **latency** — `took_ms` (wall-clock of the OpenSearch call).

Server-side on purpose: it's the **unbiased** denominator. GA4 is consent-gated (~a quarter of humans opt in) and has no zero-result signal; this sees every query.

## Privacy

**No user identity** — no id, IP, user-agent, session, or referer. `q_normalized` is normalized (not hashed — the query text *is* the signal) and never attached to a person. Aggregate product telemetry, not an audit trail; route the `jawafdehi.search.analytics` logger to **short retention**. A dedicated no-identity test guards this.

## Click-loop seam (next PR, not built here)

The response envelope now echoes an ephemeral `search_id`. A future FE beacon — `(search_id, rank, result_type, iri)` → a `search_click` event — closes the loop into `(query → shown → clicked)` learning-to-rank judgments, unbiased and consent-free, without identifying who clicked. (The GA4 `select_search_result` event shipped in the FE is the consent-gated mirror.)

## Safety

`emit_search_event` swallows and logs any failure — a telemetry bug can **never** turn a good search into a 500. Covered by a never-raise test.

## Tests

- `search/tests/test_search_analytics.py` — builder contract: normalization, `zero_result` (real query vs browse), sorted `types` / active facets, first-page-only top hit, **no identity**, never-raise.
- `search/tests/test_search_api.py` — envelope echoes `search_id`; exactly one event emits with the same id + query.
- Full `search/` suite: **87 passed**; `ruff check .` clean.

## Docs

`docs/search-analytics.md` — event schema, privacy stance, click-loop plan, and LogsQL sketches (top zero-result queries, demand by type, slow queries) for when we build the algorithm. Pointer added at unified-search plan §8 Q3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side search analytics covering demand, result quality signals (including zero-result), active filters, pagination shape, and search latency.
  * Search responses now include a temporary `search_id` to correlate analytics and support future learning from interactions.
* **Documentation**
  * Documented the emitted analytics fields, privacy constraints, retention expectations, and example query analyses.
* **Bug Fixes**
  * Analytics collection is best-effort and will never fail the search request.
* **Tests**
  * Added unit and API tests to validate event correctness, `search_id` correlation, and the never-raise behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->