### PR TITLE
feat(search): result-click beacon (POST /api/search/click) — closes the click loop

### DIFF
--- a/docs/search-analytics.md
+++ b/docs/search-analytics.md
@@ -34,9 +34,25 @@ One flat JSON line per query (rendered by the structlog JSON formatter; the log 
 
 No user identity — no id, IP, user-agent, session, or referer. `q_normalized` is normalized, not hashed (the query text *is* the signal), and is never attached to a person. Aggregate product telemetry, not an audit trail — route the `jawafdehi.search.analytics` stream to **short retention** (shorter than the general 365-day archive).
 
-## The click loop (next step, not yet built)
+## The click loop — `search_click`
 
-`search_id` is echoed in the response envelope so the SPA can send it back on a result click. A tiny beacon — `(search_id, rank, result_type, iri)` → a `search_click` event — closes the loop into `(query → shown → clicked)` learning-to-rank judgments, unbiased and consent-free, without ever identifying who clicked. The GA4 `select_search_result` event (rank + term, shipped) is the consent-gated mirror; the beacon is the ground truth.
+`search_id` is echoed in the search response envelope so the SPA can send it back on a result click. `POST /api/search/click` (public, unauthenticated, `SearchClickView`) records that click as a `search_click` event, join-keyed by `search_id` — closing the loop into `(query → shown → clicked)` learning-to-rank judgments, unbiased and consent-free, without ever identifying who clicked. The GA4 `select_search_result` event (rank + term) is the consent-gated mirror; this beacon is the ground truth.
+
+Transport: the SPA uses `navigator.sendBeacon`, which posts `text/plain` (a CORS-safelisted content type → no preflight, survives the click-then-navigate). The view therefore parses the raw request body directly rather than via DRF content negotiation. It is **best-effort**: it always returns `204` (a beacon cannot read the response), emits nothing on a malformed/garbage payload, and never raises.
+
+`search_click` fields:
+
+| field | meaning |
+|---|---|
+| `search_id` | the id from the search response that produced the clicked list — the join key to its `search_query` event. Not a user/session id. |
+| `rank` | 1-based position of the clicked result in the full order (page offset applied). |
+| `result_type` | `entity` / `material` / `courtcase` / `case`. |
+| `result_id` | the clicked result's public IRI (the envelope `id`). |
+| `result_score` | the relevance score it was shown with (optional) — the label side of the LTR signal. |
+
+Same logger/stream/privacy stance as `search_query` (no identity, short retention). Filter the two apart by `event:search_query` vs `event:search_click`.
+
+**Remaining:** the SPA-side `sendBeacon` call on result click (wires `search_id` from the response into the existing click handler that already fires the GA `select_search_result` event).
 
 ## Using it to tune relevance (later)
 
@@ -58,4 +74,9 @@ event:search_query has_query:true | stats by (types) count()
 
 # slow queries
 event:search_query took_ms:>500 | fields q_normalized, took_ms, result_count
+
+# clicks by rank → CTR@k shape (are people clicking rank 1, or scrolling?)
+event:search_click | stats by (rank) count() clicks | sort by (rank)
 ```
+
+Joining the two streams by `search_id` (in an offline notebook, not LogsQL) yields the `(query, shown, clicked-rank)` tuples that train a ranking model.

--- a/search/analytics.py
+++ b/search/analytics.py
@@ -144,3 +144,53 @@ def emit_search_event(
         logger.info("search_query", extra=event)
     except Exception:  # noqa: BLE001 — telemetry must never break the response.
         logger.warning("search analytics emit failed", exc_info=True)
+
+
+def build_click_event(
+    *,
+    search_id: str,
+    rank: int,
+    result_type: str,
+    result_id: str,
+    result_score: float | None = None,
+) -> dict[str, Any]:
+    """Build the ``search_click`` event payload (a flat, JSON-serializable dict).
+
+    The other half of the click loop: it join-keys back to a ``search_query`` event
+    by ``search_id``, so ``(query -> shown -> clicked)`` learning-to-rank judgments
+    can be reconstructed WITHOUT any user identity. ``rank`` is the clicked result's
+    1-based position in the full result order (page offset applied), ``result_type``
+    the index it came from, ``result_id`` its public IRI, and ``result_score`` the
+    relevance score it was shown with (the label side of the training signal).
+    """
+    event: dict[str, Any] = {
+        "search_id": search_id,
+        "rank": rank,
+        "result_type": result_type,
+        "result_id": result_id,
+    }
+    if result_score is not None:
+        event["result_score"] = result_score
+    return event
+
+
+def emit_search_click_event(
+    *,
+    search_id: str,
+    rank: int,
+    result_type: str,
+    result_id: str,
+    result_score: float | None = None,
+) -> None:
+    """Emit one ``search_click`` analytics event. Never raises (best-effort)."""
+    try:
+        event = build_click_event(
+            search_id=search_id,
+            rank=rank,
+            result_type=result_type,
+            result_id=result_id,
+            result_score=result_score,
+        )
+        logger.info("search_click", extra=event)
+    except Exception:  # noqa: BLE001 — telemetry must never break the response.
+        logger.warning("search click emit failed", exc_info=True)

--- a/search/tests/test_search_analytics.py
+++ b/search/tests/test_search_analytics.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from search.analytics import build_search_event, emit_search_event, normalize_query
+from search.analytics import (
+    build_click_event,
+    build_search_event,
+    emit_search_click_event,
+    emit_search_event,
+    normalize_query,
+)
 
 
 def test_normalize_query_lowercases_trims_and_collapses_whitespace():
@@ -147,5 +153,43 @@ def test_emit_search_event_never_raises():
             params=_params(),
             response={"count": 0, "counts": {}, "results": []},
             took_ms=1.0,
+        )
+
+
+# ── click event (the other half of the loop) ────────────────────────────────────
+
+
+def test_build_click_event_join_keys_and_carries_no_identity():
+    event = build_click_event(
+        search_id="abc123",
+        rank=3,
+        result_type="entity",
+        result_id="https://jawafdehi.org/entity/person/x",
+        result_score=9.5,
+    )
+    # Joins back to the query by search_id; carries the clicked result + its rank.
+    assert event["search_id"] == "abc123"
+    assert event["rank"] == 3
+    assert event["result_type"] == "entity"
+    assert event["result_id"] == "https://jawafdehi.org/entity/person/x"
+    assert event["result_score"] == 9.5
+    # No identity, ever.
+    forbidden = {"user", "user_id", "ip", "session", "user_agent", "referer"}
+    assert forbidden.isdisjoint(event.keys())
+
+
+def test_build_click_event_omits_absent_score():
+    event = build_click_event(
+        search_id="x", rank=1, result_type="case", result_id="case:1"
+    )
+    assert "result_score" not in event
+
+
+def test_emit_search_click_event_never_raises():
+    with patch(
+        "search.analytics.build_click_event", side_effect=RuntimeError("boom")
+    ):
+        emit_search_click_event(
+            search_id="x", rank=1, result_type="case", result_id="case:1"
         )
 

--- a/search/tests/test_search_api.py
+++ b/search/tests/test_search_api.py
@@ -6,6 +6,7 @@ cluster is down (hard dependency), and 400 when ``q`` is missing.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -197,3 +198,63 @@ def test_search_api_type_all_searches_every_type():
 def test_search_api_400_on_invalid_type():
     resp = APIClient().get("/api/search/", {"q": "x", "type": "bogus"})
     assert resp.status_code == 400
+
+
+# ── POST /api/search/click (the result-click beacon) ────────────────────────────
+
+
+@pytest.mark.django_db
+def test_search_click_beacon_emits_event():
+    """A valid click beacon is accepted (204) and emits one ``search_click`` event
+    carrying the join key + clicked result."""
+    payload = {
+        "search_id": "sid-1",
+        "rank": 4,
+        "result_type": "case",
+        "result_id": "/case/some-slug",
+        "result_score": 8.1,
+    }
+    with patch("search.views.emit_search_click_event") as emit:
+        resp = APIClient().post("/api/search/click", payload, format="json")
+    assert resp.status_code == 204
+    emit.assert_called_once_with(
+        search_id="sid-1",
+        rank=4,
+        result_type="case",
+        result_id="/case/some-slug",
+        result_score=8.1,
+    )
+
+
+@pytest.mark.django_db
+def test_search_click_beacon_accepts_text_plain_body():
+    """navigator.sendBeacon posts text/plain (CORS-safelisted, no preflight); the
+    view parses the raw body rather than 415-ing on the media type."""
+    body = json.dumps(
+        {"search_id": "sid-2", "rank": 1, "result_type": "entity", "result_id": "e:1"}
+    )
+    with patch("search.views.emit_search_click_event") as emit:
+        resp = APIClient().post(
+            "/api/search/click", data=body, content_type="text/plain"
+        )
+    assert resp.status_code == 204
+    emit.assert_called_once()
+    assert emit.call_args.kwargs["search_id"] == "sid-2"
+
+
+@pytest.mark.django_db
+def test_search_click_beacon_swallows_invalid_payload():
+    """Best-effort: an invalid or garbage beacon still returns 204 and emits
+    nothing (a beacon cannot read the response, so a 400 would be pointless)."""
+    with patch("search.views.emit_search_click_event") as emit:
+        # Missing required fields.
+        r1 = APIClient().post(
+            "/api/search/click", {"rank": 1}, format="json"
+        )
+        # Not even JSON.
+        r2 = APIClient().post(
+            "/api/search/click", data="not json", content_type="text/plain"
+        )
+    assert r1.status_code == 204
+    assert r2.status_code == 204
+    emit.assert_not_called()

--- a/search/urls.py
+++ b/search/urls.py
@@ -2,10 +2,13 @@
 
 from django.urls import path
 
-from .views import UnifiedSearchView
+from .views import SearchClickView, UnifiedSearchView
 
 app_name = "search"
 
 urlpatterns = [
     path("", UnifiedSearchView.as_view(), name="unified-search"),
+    # No trailing slash: the SPA beacons to exactly /api/search/click, and
+    # APPEND_SLASH cannot redirect a POST (it would error instead of redirecting).
+    path("click", SearchClickView.as_view(), name="search-click"),
 ]

--- a/search/views.py
+++ b/search/views.py
@@ -1,4 +1,5 @@
-"""The unified platform search API: ``GET /api/search/``.
+"""The unified platform search API: ``GET /api/search/`` and the click beacon
+``POST /api/search/click``.
 
 Public read. One query across entities, materials, court cases, and PUBLISHED
 cases (the index is all-public — no ACL filter). OpenSearch is a hard dependency:
@@ -10,6 +11,7 @@ This REPLACES the old Jawafdehi-scoped ``cases.UnifiedSearchView`` and the NGM
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
 
@@ -20,7 +22,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .analytics import emit_search_event
+from .analytics import emit_search_click_event, emit_search_event
 from .service import (
     ALL_SORTS,
     ALL_TYPES,
@@ -240,3 +242,54 @@ class UnifiedSearchView(APIView):
             took_ms=took_ms,
         )
         return Response(response)
+
+
+class SearchClickSerializer(serializers.Serializer):
+    """Validates a result-click beacon. ``search_id`` joins back to the
+    ``search_query`` event that produced the clicked result list."""
+
+    search_id = serializers.CharField(max_length=64)
+    # 1-based position in the full result order (page offset already applied).
+    rank = serializers.IntegerField(min_value=1)
+    result_type = serializers.ChoiceField(choices=list(ALL_TYPES))
+    # The clicked result's public IRI (the envelope ``id``).
+    result_id = serializers.CharField(max_length=1024)
+    # The relevance score the result was shown with (optional — the label side of
+    # the future learning-to-rank signal).
+    result_score = serializers.FloatField(required=False)
+
+
+@extend_schema(
+    summary="Search result-click beacon",
+    description=(
+        "Fire-and-forget beacon recording that a search result was clicked, "
+        "join-keyed by 'search_id' to the query that produced it — the other half "
+        "of the click loop for future relevance tuning. Public, unauthenticated, "
+        "and best-effort: it records NO user identity and always returns 204 (a "
+        "beacon cannot read the response). Sent by the SPA via navigator.sendBeacon "
+        "(text/plain), so the body is parsed directly rather than via content "
+        "negotiation."
+    ),
+    request=SearchClickSerializer,
+    responses={204: None},
+    tags=["search"],
+)
+class SearchClickView(APIView):
+    """Ingest a search result-click beacon → one ``search_click`` analytics event."""
+
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        # sendBeacon sends text/plain (CORS-safelisted, no preflight), so read the
+        # raw body instead of request.data — DRF would 415 on a non-JSON media type.
+        try:
+            payload = json.loads(request.body or b"{}")
+        except (ValueError, TypeError):
+            payload = None
+        if isinstance(payload, dict):
+            serializer = SearchClickSerializer(data=payload)
+            if serializer.is_valid():
+                emit_search_click_event(**serializer.validated_data)
+        # Always 204: a beacon never reads the response, and a malformed/garbage
+        # click is not worth surfacing an error for on best-effort telemetry.
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### **User description**
## Why

Follow-up to #349 (server-side `search_query` log). #349 mints an ephemeral `search_id` per search and echoes it in the response envelope; this PR adds the endpoint that consumes it. Together they close the loop into **`(query → shown → clicked)`** learning-to-rank judgments — the ground-truth signal that will drive the deferred relevance tuning (unified-search plan §8 Q3), **unbiased and consent-free**. The GA4 `select_search_result` event (FE, merged) is the consent-gated (~24%) mirror; this beacon is the full-traffic truth.

Still instrumentation only — no ranking change.

## What

`POST /api/search/click` (`SearchClickView`, public/unauthenticated) → one `search_click` event:

| field | meaning |
|---|---|
| `search_id` | join key back to the query's `search_query` event (not a user/session id) |
| `rank` | 1-based position of the clicked result (page offset applied) |
| `result_type` | `entity` / `material` / `courtcase` / `case` |
| `result_id` | clicked result's public IRI |
| `result_score` | score it was shown with (optional) — the LTR label |

## Design notes

- **`AllowAny`** — the default permission is `ReadOnlyOrAuthenticatedWrite` (writes need auth); the beacon is public, so it opts in explicitly (like the search GET).
- **Raw-body parse** — `navigator.sendBeacon` posts `text/plain` (CORS-safelisted → no preflight, survives click-then-navigate). The view reads `request.body` directly instead of `request.data`, so DRF doesn't `415` on the media type.
- **Best-effort** — always returns `204` (a beacon can't read the response), emits nothing on a malformed/garbage payload, and `emit_search_click_event` never raises.
- **Throttled** — inherits the default `AnonRateThrottle` (baseline abuse dampening for a public write).
- **No trailing slash** on the route — `APPEND_SLASH` can't redirect a POST.
- **Privacy** — same stance/stream as `search_query`: no id/IP/UA/session/referer; short retention. Distinguish the two by `event:search_query` vs `event:search_click`.

## Tests

`search/` suite **94 passed**, `ruff check .` clean. New:
- builder — join key + no identity, optional score omitted, never-raises.
- endpoint — valid JSON emits with the right fields; **text/plain (sendBeacon) body** accepted; invalid/garbage payload → 204 + no emit.

## Docs

`docs/search-analytics.md` — `search_click` schema, transport rationale, and a CTR-by-rank LogsQL sketch. **Remaining:** the SPA `sendBeacon` call on result click (wires `search_id` into the existing handler that already fires GA `select_search_result`) — separate FE PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add search click beacon endpoint

- Emit identity-free `search_click` events

- Accept `sendBeacon` text/plain payloads

- Cover analytics, API, docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  spa["SPA click beacon"] 
  endpoint["POST /api/search/click"]
  validator["SearchClickSerializer"]
  logger["search_click analytics log"]
  spa -- "text/plain or JSON" --> endpoint
  endpoint -- "validates" --> validator
  validator -- "emits" --> logger
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Add search click analytics events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/analytics.py

<ul><li>Add <code>build_click_event</code> payload builder<br> <li> Add optional <code>result_score</code> support<br> <li> Add non-raising <code>emit_search_click_event</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/353/files#diff-6bcb36bf3950897b3507efb046a72512087b09c216e504a5bc989a83cd702105">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>urls.py</strong><dd><code>Route click beacon endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/urls.py

<ul><li>Import <code>SearchClickView</code><br> <li> Register <code>/api/search/click</code><br> <li> Avoid trailing slash for POST beacons</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/353/files#diff-a0d61804067ea5644a3908b25d08548aa7deb3b4a29b49b22161f8b0f76c5fd6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Implement public click beacon view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/views.py

<ul><li>Add <code>SearchClickSerializer</code><br> <li> Add public <code>SearchClickView</code><br> <li> Parse raw JSON body for <code>sendBeacon</code><br> <li> Always return <code>204</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/353/files#diff-7f3465c740a25f0dc3298c912c7684f213f4c42d69abc39f21e1ebe54e4652e8">+55/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_search_analytics.py</strong><dd><code>Test search click analytics helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/tests/test_search_analytics.py

<ul><li>Import click analytics helpers<br> <li> Test click payload fields<br> <li> Assert no identity fields<br> <li> Test score omission, emit swallowing</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/353/files#diff-40a9d00e93dbaaa3dd4c7fff561dac8e4f5c8897c81f3cc751ff9d93536ac36e">+45/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_search_api.py</strong><dd><code>Test click beacon API behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/tests/test_search_api.py

<ul><li>Test valid beacon emits event<br> <li> Test <code>text/plain</code> raw body support<br> <li> Test invalid payload returns <code>204</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/353/files#diff-e48bee009ce8797be684a85f7a0570d8afea9d5b65cbd6331464b373aa1fda3c">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search-analytics.md</strong><dd><code>Document search click analytics loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/search-analytics.md

<ul><li>Document <code>search_click</code> loop<br> <li> Describe beacon transport behavior<br> <li> List click event fields<br> <li> Add CTR LogsQL example</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/353/files#diff-7cb799355eeb06ee6a48f92d62ee2bfbb25f7003be8416e0b4c9df1fce6c2f06">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

model: openai/cx/gpt-5.5
git_provider: github
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
custom_model_max_tokens: 200000
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
