### PR TITLE
fix(courts): mute per-row indexing + bump updated_at in case_status backfill

### DIFF
--- a/courts/management/commands/backfill_case_status.py
+++ b/courts/management/commands/backfill_case_status.py
@@ -30,6 +30,8 @@ SAFETY: dry-run by default. It never writes unless BOTH ``--execute`` and
 
 from __future__ import annotations
 
+from contextlib import contextmanager, nullcontext
+
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.db.models import Q
@@ -38,6 +40,39 @@ from courts import case_status as cs
 from courts.models import CourtCase
 
 NGM_DB = "ngm"
+
+
+@contextmanager
+def _muted_indexing():
+    """Suppress the per-row OpenSearch upsert + audit log during the bulk write.
+
+    Every ``CourtCase`` save otherwise schedules an ``on_commit``
+    ``search_index.index()`` (``courts.signals``) and an auditlog ``LogEntry``. At
+    100k+ changed rows that per-row churn dominates runtime and hammers
+    OpenSearch, so we mute both here and (re)index once afterward via
+    ``reindex_courtcases --since`` — the write bumps ``updated_at`` so the
+    incremental pass re-indexes exactly the rows this backfill changed. Mirrors
+    the importer's ``_signals_muted`` but scoped to the only model we touch.
+    """
+    from auditlog.context import disable_auditlog
+    from django.db.models.signals import post_delete, post_save
+
+    from courts import signals as s
+
+    specs = [
+        (post_save, CourtCase, "ngm_courtcase_search_index", s._index_courtcase),
+        (post_delete, CourtCase, "ngm_courtcase_search_delete", s._delete_courtcase),
+    ]
+    disconnected = []
+    for sig, sender, uid, func in specs:
+        if sig.disconnect(dispatch_uid=uid, sender=sender):
+            disconnected.append((sig, sender, uid, func))
+    try:
+        with disable_auditlog():
+            yield
+    finally:
+        for sig, sender, uid, func in disconnected:
+            sig.connect(func, sender=sender, dispatch_uid=uid)
 
 # Columns loaded per row (composite PK + the scraper-owned typed columns this
 # pass may touch, plus extra_data for the hearing-based verdict fallback).
@@ -84,9 +119,13 @@ def run_backfill(*, batch_size=2000, limit=None, execute=False, using=NGM_DB, on
 
     Keyset pagination on the composite natural key ``(court, case_number)`` keeps
     memory bounded over 1.6M rows. In ``execute`` mode each changed row is saved
-    with ``update_fields`` (only the columns that changed) inside a per-batch
-    transaction; ``updated_at`` is intentionally left untouched — a backfill is
-    not a fresh scrape.
+    with ``update_fields`` (only the changed columns + ``updated_at``) inside a
+    per-batch transaction, with the live OpenSearch/auditlog signals muted for the
+    whole run (see :func:`_muted_indexing`). ``updated_at`` IS bumped so a later
+    ``reindex_courtcases --since`` re-indexes exactly the changed rows; the keyset
+    is on ``(court, case_number)`` (never mutated) so it stays stable across writes.
+    Idempotent and re-runnable: extend the parser, re-run, and only newly-derivable
+    rows change.
     """
     stats = {
         "scanned": 0,
@@ -96,56 +135,57 @@ def run_backfill(*, batch_size=2000, limit=None, execute=False, using=NGM_DB, on
         "verdict_date_set": 0,
         "unmapped": 0,
     }
-    last_key = None
-    while True:
-        qs = (
-            CourtCase.objects.using(using)
-            .only(*_LOAD)
-            .order_by("court", "case_number")
-        )
-        if last_key is not None:
-            court, number = last_key
-            qs = qs.filter(
-                Q(court_id__gt=court)
-                | (Q(court_id=court) & Q(case_number__gt=number))
+    with (_muted_indexing() if execute else nullcontext()):
+        last_key = None
+        while True:
+            qs = (
+                CourtCase.objects.using(using)
+                .only(*_LOAD)
+                .order_by("court", "case_number")
             )
-        rows = list(qs[:batch_size])
-        if not rows:
-            break
+            if last_key is not None:
+                court, number = last_key
+                qs = qs.filter(
+                    Q(court_id__gt=court)
+                    | (Q(court_id=court) & Q(case_number__gt=number))
+                )
+            rows = list(qs[:batch_size])
+            if not rows:
+                break
 
-        changed: list[tuple[CourtCase, list[str]]] = []
-        for case in rows:
-            stats["scanned"] += 1
-            updates, parsed = compute_case_updates(
-                case.case_status, case.verdict_type,
-                case.verdict_date_bs, case.verdict_date_ad, _hearings_of(case),
-            )
-            if parsed.unmapped:
-                stats["unmapped"] += 1
-            if not updates:
-                continue
+            changed: list[tuple[CourtCase, list[str]]] = []
+            for case in rows:
+                stats["scanned"] += 1
+                updates, parsed = compute_case_updates(
+                    case.case_status, case.verdict_type,
+                    case.verdict_date_bs, case.verdict_date_ad, _hearings_of(case),
+                )
+                if parsed.unmapped:
+                    stats["unmapped"] += 1
+                if not updates:
+                    continue
 
-            stats["rows_changed"] += 1
-            if "case_status" in updates:
-                stats["header_cleared"] += 1
-            if "verdict_type" in updates:
-                stats["verdict_type_set"] += 1
-            if "verdict_date_bs" in updates:
-                stats["verdict_date_set"] += 1
-            for key, value in updates.items():
-                setattr(case, key, value)
-            changed.append((case, list(updates)))
+                stats["rows_changed"] += 1
+                if "case_status" in updates:
+                    stats["header_cleared"] += 1
+                if "verdict_type" in updates:
+                    stats["verdict_type_set"] += 1
+                if "verdict_date_bs" in updates:
+                    stats["verdict_date_set"] += 1
+                for key, value in updates.items():
+                    setattr(case, key, value)
+                changed.append((case, [*updates, "updated_at"]))
 
-        if execute and changed:
-            with transaction.atomic(using=using):
-                for case, fields in changed:
-                    case.save(using=using, update_fields=fields)
+            if execute and changed:
+                with transaction.atomic(using=using):
+                    for case, fields in changed:
+                        case.save(using=using, update_fields=fields)
 
-        last_key = (rows[-1].court_id, rows[-1].case_number)
-        if on_batch is not None:
-            on_batch(stats)
-        if limit and stats["scanned"] >= limit:
-            break
+            last_key = (rows[-1].court_id, rows[-1].case_number)
+            if on_batch is not None:
+                on_batch(stats)
+            if limit and stats["scanned"] >= limit:
+                break
 
     return stats
 

--- a/courts/tests/test_backfill_case_status.py
+++ b/courts/tests/test_backfill_case_status.py
@@ -146,6 +146,36 @@ class RunBackfillDBTests(TestCase):
         c = CourtCase.objects.using("ngm").get(case_number="082-CR-0004")
         self.assertEqual(c.verdict_date_bs, "2081-01-01")
 
+    def test_execute_bumps_updated_at_only_on_changed_rows(self):
+        # updated_at IS bumped on changed rows so `reindex_courtcases --since`
+        # finds exactly them; an unchanged row is never saved, so it's untouched.
+        _mk("082-CR-0050", "आदेश /फैसलाको किसिम")  # header → changes
+        _mk("082-CR-0051", "चालु")  # pending → no change
+        changed_before = CourtCase.objects.using("ngm").get(case_number="082-CR-0050").updated_at
+        same_before = CourtCase.objects.using("ngm").get(case_number="082-CR-0051").updated_at
+        run_backfill(execute=True)
+        self.assertGreater(
+            CourtCase.objects.using("ngm").get(case_number="082-CR-0050").updated_at, changed_before
+        )
+        self.assertEqual(
+            CourtCase.objects.using("ngm").get(case_number="082-CR-0051").updated_at, same_before
+        )
+
+    def test_muted_indexing_disconnects_then_restores_signal(self):
+        from django.db.models.signals import post_save
+
+        from courts import signals as s
+        from courts.management.commands.backfill_case_status import _muted_indexing
+
+        uid = "ngm_courtcase_search_index"
+        with _muted_indexing():
+            # already disconnected inside the context → a disconnect returns False
+            self.assertFalse(post_save.disconnect(dispatch_uid=uid, sender=CourtCase))
+        # restored on exit; put it back unconditionally before asserting
+        restored = post_save.disconnect(dispatch_uid=uid, sender=CourtCase)
+        post_save.connect(s._index_courtcase, sender=CourtCase, dispatch_uid=uid)
+        self.assertTrue(restored)
+
     def test_keyset_paginates_every_row_across_courts(self):
         for i in range(1, 4):
             _mk(f"082-CR-000{i}", "आदेश /फैसलाको किसिम", court="special")


### PR DESCRIPTION
### **User description**
Prep to run `backfill_case_status` against the **1.6M-row prod corpus** (migration 0005 is applied; `scraped_dates` empty; live target counts: 103,212 header artifacts, `verdict_type` populated on only 3 rows).

## Problem
As merged, the backfill's per-row `.save()` fires the `courts.signals` `post_save` receiver — which schedules an `on_commit` OpenSearch index — plus an auditlog `LogEntry`. Over 100k+ changed rows that per-row churn dominates runtime and hammers OpenSearch. The importer already avoids this (`_signals_muted` + one bulk reindex after); the backfill didn't.

## Fix
- **Mute** the `CourtCase` index signal + auditlog for the whole `--execute` run (`_muted_indexing`, scoped to the only model this pass touches; dry-run unaffected via `nullcontext`).
- **Bump `updated_at`** on changed rows so a later `reindex_courtcases --since <T>` re-indexes *exactly* the rows the backfill changed — the intended incremental-reindex seam (the importer's own note at `importer.py:531` describes this pattern). The keyset is on `(court, case_number)` — never mutated — so it stays stable across writes.

Idempotent + re-runnable is preserved (extend the parser, re-run, only newly-derivable rows change).

## Operational sequence this enables
1. deploy → `backfill_case_status` **dry-run** (real projection)
2. `backfill_case_status --execute --i-understand-this-writes-prod` (one-shot exec, signals muted)
3. `reindex_courtcases --since <T>` (incremental — only the changed rows)
4. verify → `reindex_courtcases --rebuild` (full 1.6M)
5. **pause** for further data-quality analysis (ready to re-backfill if more issues surface)

## Tests
+2 (`updated_at` bumped only on changed rows; mute disconnects then restores the signal). Full courts suite: **202 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Mute bulk backfill side effects

- Bump changed rows `updated_at`

- Preserve dry-run behavior

- Cover timestamp, signal restoration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backfill execute"] -- "mute" --> B["Signals auditlog"]
  A -- "save changed rows" --> C["updated_at bumped"]
  C -- "enables" --> D["reindex_courtcases --since"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backfill_case_status.py</strong><dd><code>Mute indexing during executable backfill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/management/commands/backfill_case_status.py

<ul><li>Add <code>_muted_indexing</code> context manager<br> <li> Disable CourtCase search signals, auditlog<br> <li> Wrap execute runs only<br> <li> Include <code>updated_at</code> in changed saves</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/356/files#diff-10a8192368ae1e5449fc2a3195157fb012e14939499b3ccd906c94d55497db64">+92/-52</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_backfill_case_status.py</strong><dd><code>Validate timestamp and signal muting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_backfill_case_status.py

<ul><li>Test changed rows bump <code>updated_at</code><br> <li> Test unchanged rows stay untouched<br> <li> Test signal disconnect, restoration behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/356/files#diff-f9fb36da75471ef1944063b1c2bec232f4ebffcaecc60218908f511065610cec">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

fallback_models: ['openai/cx/gpt-5.4-mini']
custom_reasoning_model: False
custom_model_max_tokens: 200000
output_relevant_configurations: True
model: openai/cx/gpt-5.5
git_provider: github
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
