### PR TITLE
fix(courts): normalise case_type in the importer DQ pass

### DIFF
--- a/courts/importer.py
+++ b/courts/importer.py
@@ -41,7 +41,11 @@ from django.utils import timezone
 from jawafdehi_shared.entities.ids import build_courtcase_iri
 from courts import search_index
 from courts.models import CaseEntity, Court, CourtCase, CourtCaseHearing
-from courts.normalize import best_effort_normalize, is_verdict_sentinel
+from courts.normalize import (
+    best_effort_normalize,
+    is_verdict_sentinel,
+    normalize_case_type,
+)
 from materials.jsonld import (
     MaterialType,
     case_order_sources,
@@ -114,6 +118,7 @@ class ImportResult:
     dq_verdict_nulled: int = 0
     dq_hc_recovered: int = 0
     dq_special_flagged: int = 0
+    dq_case_type_normalized: int = 0
     skipped: int = 0
     failed: int = 0
     errors: list[dict[str, Any]] = field(default_factory=list)
@@ -126,6 +131,7 @@ class ImportResult:
             "dq_verdict_nulled": self.dq_verdict_nulled,
             "dq_hc_recovered": self.dq_hc_recovered,
             "dq_special_flagged": self.dq_special_flagged,
+            "dq_case_type_normalized": self.dq_case_type_normalized,
             "skipped": self.skipped,
             "failed": self.failed,
             "errors": list(self.errors),
@@ -544,6 +550,11 @@ class CourtCaseImporter:
         if self._court_type(case, row) == "high":
             self._recover_high_court_fields(case)
 
+        # (4) case_type free-text noise — canonicalise in place (conservative;
+        # preserves statute/section labels), archiving the raw value once. Runs
+        # after (3) so a just-recovered high-court case_type is normalised too.
+        self._normalize_case_type(case)
+
     def _flag_special_defendants(self, case: CourtCase, row: Any) -> None:
         if self._read_only and not isinstance(row, CourtCase):
             has_defendant = any(
@@ -581,6 +592,24 @@ class CourtCaseImporter:
             return
         self._update_case(case, **updates)
         self.res.dq_hc_recovered += 1
+
+    def _normalize_case_type(self, case: CourtCase) -> None:
+        """Canonicalise ``case_type`` in place (structural noise only), archiving
+        the raw value under ``extra_data._dq.case_type_raw`` so the rewrite is
+        reversible. Conservative by design — statute citations and section
+        references are preserved (see ``courts.normalize.normalize_case_type``).
+        Idempotent: a re-run finds the value already canonical and does nothing."""
+        if not case.case_type:
+            return
+        canonical = normalize_case_type(case.case_type)
+        if not canonical or canonical == case.case_type:
+            return
+        extra = dict(case.extra_data or {})
+        dq = dict(extra.get("_dq") or {})
+        dq.setdefault("case_type_raw", case.case_type)
+        extra["_dq"] = dq
+        self._update_case(case, case_type=canonical, extra_data=extra)
+        self.res.dq_case_type_normalized += 1
 
     @staticmethod
     def _court_type(case: CourtCase, row: Any) -> str | None:

--- a/courts/importer.py
+++ b/courts/importer.py
@@ -610,7 +610,10 @@ class CourtCaseImporter:
         # _recover_high_court_fields' isinstance guard.
         if case.extra_data is None or isinstance(case.extra_data, dict):
             extra = dict(case.extra_data or {})
-            dq = dict(extra.get("_dq") or {})
+            # Guard the nested _dq shape too — a malformed non-dict _dq would
+            # otherwise crash the row on dict(<non-dict>).
+            existing_dq = extra.get("_dq")
+            dq = dict(existing_dq) if isinstance(existing_dq, dict) else {}
             dq.setdefault("case_type_raw", case.case_type)
             extra["_dq"] = dq
             self._update_case(case, case_type=canonical, extra_data=extra)

--- a/courts/importer.py
+++ b/courts/importer.py
@@ -604,11 +604,18 @@ class CourtCaseImporter:
         canonical = normalize_case_type(case.case_type)
         if not canonical or canonical == case.case_type:
             return
-        extra = dict(case.extra_data or {})
-        dq = dict(extra.get("_dq") or {})
-        dq.setdefault("case_type_raw", case.case_type)
-        extra["_dq"] = dq
-        self._update_case(case, case_type=canonical, extra_data=extra)
+        # Archive the raw value for reversibility. Only merge into a dict-shaped
+        # (or absent) extra_data — a non-dict/non-None value is malformed, so skip
+        # the archive rather than crash the row on dict(<non-dict>), matching
+        # _recover_high_court_fields' isinstance guard.
+        if case.extra_data is None or isinstance(case.extra_data, dict):
+            extra = dict(case.extra_data or {})
+            dq = dict(extra.get("_dq") or {})
+            dq.setdefault("case_type_raw", case.case_type)
+            extra["_dq"] = dq
+            self._update_case(case, case_type=canonical, extra_data=extra)
+        else:
+            self._update_case(case, case_type=canonical)
         self.res.dq_case_type_normalized += 1
 
     @staticmethod

--- a/courts/normalize.py
+++ b/courts/normalize.py
@@ -154,17 +154,26 @@ def normalize_case_type(case_type: str | None) -> str | None:
     Reversible and safe to run in place over the whole corpus: it unwraps the
     ``भ्रष्टाचार ( X )`` wrapper and strips a leading/trailing STRUCTURED
     case-number token (``NNN-XX-NNNN``), and NOTHING else. Statute citations,
-    section references and free-text descriptions are preserved verbatim. If
-    cleaning would strip the last Devanagari letter (a value that is ONLY a case
-    number), the original is returned unchanged, so a value is never emptied.
+    section references and free-text descriptions are preserved verbatim.
+
+    Matching runs on a whitespace-collapsed, quote-stripped copy (so the tokens
+    match regardless of incidental spacing/quotes), but a value is only reported
+    as CHANGED when a structural transform actually fires. A value that differs
+    from the input by whitespace or surrounding quotes ALONE is returned verbatim
+    — so the importer never rewrites (and re-archives / re-counts) it for
+    cosmetics. If cleaning would strip the last Devanagari letter (a value that is
+    ONLY a case number), the original is returned unchanged, so a value is never
+    emptied.
     """
     if not case_type:
         return case_type
-    original = _WHITESPACE.sub(" ", case_type).strip().strip("\"'")
-    if not original:
-        return original
+    # Whitespace/quote-collapsed working copy — used ONLY for matching, not
+    # returned unless a structural transform below actually changes it.
+    collapsed = _WHITESPACE.sub(" ", case_type).strip().strip("\"'")
+    if not collapsed:
+        return case_type
 
-    s = original
+    s = collapsed
     wrapper = _BHRASHTACHAR_WRAPPER.match(s)
     if wrapper and _has_devanagari_letter(wrapper.group(1)):
         s = wrapper.group(1).strip()
@@ -177,8 +186,9 @@ def normalize_case_type(case_type: str | None) -> str | None:
     if candidate != s and _has_devanagari_letter(candidate):
         s = candidate
 
-    # Whitespace only — the token regexes already consume adjacent separators, and
-    # stripping punctuation here would break balanced parens in statute labels
-    # like "चोरी गरेको (दफा 241)".
     s = s.strip()
-    return s if _has_devanagari_letter(s) else original
+    cleaned = s if _has_devanagari_letter(s) else collapsed
+
+    # Persist only a STRUCTURAL change; a whitespace/quote/Unicode-form-only diff
+    # returns the raw input so the importer sees no change.
+    return cleaned if cleaned != collapsed else case_type

--- a/courts/normalize.py
+++ b/courts/normalize.py
@@ -174,17 +174,28 @@ def normalize_case_type(case_type: str | None) -> str | None:
         return case_type
 
     s = collapsed
-    wrapper = _BHRASHTACHAR_WRAPPER.match(s)
-    if wrapper and _has_devanagari_letter(wrapper.group(1)):
-        s = wrapper.group(1).strip()
+    # Apply the strips repeatedly until the value stops changing, so a value
+    # carrying MORE THAN ONE kind of noise (e.g. a leading case number AND a
+    # भ्रष्टाचार(X) wrapper, where stripping the number first re-exposes the
+    # wrapper) is fully normalised in ONE call and the result is a fixed point
+    # (idempotent). Each pass can only shrink s, so this always converges; the cap
+    # is a belt-and-suspenders guard, not a real bound.
+    for _ in range(5):
+        before = s
+        wrapper = _BHRASHTACHAR_WRAPPER.match(s)
+        if wrapper and _has_devanagari_letter(wrapper.group(1)):
+            s = wrapper.group(1).strip()
 
-    candidate = _LEADING_CASE_NUMBER.sub("", s, count=1).strip()
-    if candidate != s and _has_devanagari_letter(candidate):
-        s = candidate
+        candidate = _LEADING_CASE_NUMBER.sub("", s, count=1).strip()
+        if candidate != s and _has_devanagari_letter(candidate):
+            s = candidate
 
-    candidate = _TRAILING_CASE_NUMBER.sub("", s, count=1).strip()
-    if candidate != s and _has_devanagari_letter(candidate):
-        s = candidate
+        candidate = _TRAILING_CASE_NUMBER.sub("", s, count=1).strip()
+        if candidate != s and _has_devanagari_letter(candidate):
+            s = candidate
+
+        if s == before:
+            break
 
     s = s.strip()
     cleaned = s if _has_devanagari_letter(s) else collapsed

--- a/courts/normalize.py
+++ b/courts/normalize.py
@@ -130,8 +130,12 @@ _CASE_NUMBER_TOKEN = r"[\d०-९]{2,4}-[A-Za-z][A-Za-z\d०-९]{0,4}(?:-[\d०
 _LEADING_CASE_NUMBER = re.compile(
     r"^\(?\s*(?:" + _CASE_NUMBER_TOKEN + r")\s*\)?[\s,.:;/।\-]*"
 )
+# Mirror the leading pattern's separator class BEFORE the token, so a token
+# preceded by a comma/danda/slash (e.g. "लेनदेन, 080-cp-1852") is consumed whole
+# and never leaves a dangling separator. The token itself is still the strict
+# NNN-XX-NNNN shape, so statute labels ending in "(दफा 241)" are unaffected.
 _TRAILING_CASE_NUMBER = re.compile(
-    r"\s*[(（]?\s*(?:" + _CASE_NUMBER_TOKEN + r")\s*[)）]?\s*$"
+    r"[\s,.:;/।\-]*[(（]?\s*(?:" + _CASE_NUMBER_TOKEN + r")\s*[)）]?\s*$"
 )
 # भ्रष्टाचार ( X ) — the "corruption ( offense )" wrapper; capture the inner offense.
 _BHRASHTACHAR_WRAPPER = re.compile(r"^भ्रष्टाचार\s*\(\s*(.+?)\s*\)\s*$")

--- a/courts/normalize.py
+++ b/courts/normalize.py
@@ -113,3 +113,68 @@ def is_verdict_sentinel(value: object) -> bool:
         return True
     stripped = str(value).replace("*", "").replace(" ", "").replace("-", "")
     return stripped == ""
+
+
+# ── case_type canonicalisation ───────────────────────────────────────────────
+# case_type is scraped free text (the मुद्दाको किसिम cause-list / detail cell), so
+# clerks paste case numbers, dates and whole sentences into it. The cleaner below
+# is deliberately HIGH-PRECISION: it removes only the unambiguous structural noise
+# and preserves the label — crucially the statute citations (``चोरी गरेको (दफा 241)``)
+# and section references (``१५५ बमोजिम``) that are the MOST useful case_type values
+# and merely happen to contain digits. Aggressive rewriting of those would destroy
+# real information, so it is intentionally NOT done here.
+
+# A STRUCTURED court case-number token, e.g. "080-C1-0199", "०७९-CP-२३४२". The
+# letter segment (C1/CP/CR/WO/OA/FN…) is Latin even when the digits are Devanagari.
+_CASE_NUMBER_TOKEN = r"[\d०-९]{2,4}-[A-Za-z][A-Za-z\d०-९]{0,4}(?:-[\d०-९]{1,6})?"
+_LEADING_CASE_NUMBER = re.compile(
+    r"^\(?\s*(?:" + _CASE_NUMBER_TOKEN + r")\s*\)?[\s,.:;/।\-]*"
+)
+_TRAILING_CASE_NUMBER = re.compile(
+    r"\s*[(（]?\s*(?:" + _CASE_NUMBER_TOKEN + r")\s*[)）]?\s*$"
+)
+# भ्रष्टाचार ( X ) — the "corruption ( offense )" wrapper; capture the inner offense.
+_BHRASHTACHAR_WRAPPER = re.compile(r"^भ्रष्टाचार\s*\(\s*(.+?)\s*\)\s*$")
+# Any Devanagari vowel/consonant (excludes the digit block ०-९ at U+0966–U+096F).
+_DEVANAGARI_LETTER = re.compile(r"[ऄ-ह]")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _has_devanagari_letter(text: str) -> bool:
+    return bool(_DEVANAGARI_LETTER.search(text or ""))
+
+
+def normalize_case_type(case_type: str | None) -> str | None:
+    """Canonicalise a scraped ``case_type`` toward its semantic charge/matter label.
+
+    Reversible and safe to run in place over the whole corpus: it unwraps the
+    ``भ्रष्टाचार ( X )`` wrapper and strips a leading/trailing STRUCTURED
+    case-number token (``NNN-XX-NNNN``), and NOTHING else. Statute citations,
+    section references and free-text descriptions are preserved verbatim. If
+    cleaning would strip the last Devanagari letter (a value that is ONLY a case
+    number), the original is returned unchanged, so a value is never emptied.
+    """
+    if not case_type:
+        return case_type
+    original = _WHITESPACE.sub(" ", case_type).strip().strip("\"'")
+    if not original:
+        return original
+
+    s = original
+    wrapper = _BHRASHTACHAR_WRAPPER.match(s)
+    if wrapper and _has_devanagari_letter(wrapper.group(1)):
+        s = wrapper.group(1).strip()
+
+    candidate = _LEADING_CASE_NUMBER.sub("", s, count=1).strip()
+    if candidate != s and _has_devanagari_letter(candidate):
+        s = candidate
+
+    candidate = _TRAILING_CASE_NUMBER.sub("", s, count=1).strip()
+    if candidate != s and _has_devanagari_letter(candidate):
+        s = candidate
+
+    # Whitespace only — the token regexes already consume adjacent separators, and
+    # stripping punctuation here would break balanced parens in statute labels
+    # like "चोरी गरेको (दफा 241)".
+    s = s.strip()
+    return s if _has_devanagari_letter(s) else original

--- a/courts/tests/test_import_courtcases.py
+++ b/courts/tests/test_import_courtcases.py
@@ -167,6 +167,30 @@ class CopyModeLoadTests(_NgmTestCase):
         self.assertEqual(case.case_status, "फैसला")
         self.assertEqual(res.dq_hc_recovered, 1)
 
+    def test_case_type_normalized_and_raw_archived(self):
+        # A leading case-number token is stripped in place; the raw value is kept
+        # under extra_data._dq for reversibility, and the guard is counted.
+        row = _src_row(case="081-CR-0300", case_type="080-cp-1852 लेनदेन")
+        res = _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="081-CR-0300"
+        )
+        self.assertEqual(case.case_type, "लेनदेन")
+        self.assertEqual(case.extra_data["_dq"]["case_type_raw"], "080-cp-1852 लेनदेन")
+        self.assertEqual(res.dq_case_type_normalized, 1)
+
+    def test_case_type_statute_label_preserved(self):
+        # A charge label with its statute section is meaningful, not noise — it
+        # must pass through untouched (no rewrite, no raw archived, not counted).
+        row = _src_row(case="081-CR-0301", case_type="चोरी गरेको (दफा 241)")
+        res = _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="081-CR-0301"
+        )
+        self.assertEqual(case.case_type, "चोरी गरेको (दफा 241)")
+        self.assertEqual(res.dq_case_type_normalized, 0)
+        self.assertNotIn("_dq", case.extra_data or {})
+
     def test_verdict_sentinel_not_surfaced(self):
         row = _src_row(case="081-CR-0042", verdict_date_bs="**** ** **")
         res = _copy([row]).run()

--- a/courts/tests/test_import_courtcases.py
+++ b/courts/tests/test_import_courtcases.py
@@ -191,6 +191,21 @@ class CopyModeLoadTests(_NgmTestCase):
         self.assertEqual(res.dq_case_type_normalized, 0)
         self.assertNotIn("_dq", case.extra_data or {})
 
+    def test_case_type_normalized_with_non_dict_extra_data(self):
+        # A malformed (non-dict) extra_data must not crash the row: case_type is
+        # still normalised, the raw archive is skipped, and extra_data is untouched.
+        row = _src_row(
+            case="081-CR-0302", case_type="080-cp-1852 लेनदेन", extra_data=["junk"]
+        )
+        res = _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="081-CR-0302"
+        )
+        self.assertEqual(case.case_type, "लेनदेन")
+        self.assertEqual(case.extra_data, ["junk"])
+        self.assertEqual(res.failed, 0)
+        self.assertEqual(res.dq_case_type_normalized, 1)
+
     def test_verdict_sentinel_not_surfaced(self):
         row = _src_row(case="081-CR-0042", verdict_date_bs="**** ** **")
         res = _copy([row]).run()

--- a/courts/tests/test_import_courtcases.py
+++ b/courts/tests/test_import_courtcases.py
@@ -290,6 +290,32 @@ class InplaceModeTests(_NgmTestCase):
         ent = CaseEntity.objects.using("ngm").get(name="Shyam")
         self.assertEqual(ent.nes_id, "entity:person/shyam")
 
+    def test_inplace_case_type_normalization_is_idempotent(self):
+        court = Court.objects.using("ngm").create(
+            identifier="supreme", court_type="supreme", full_name_nepali="स"
+        )
+        CourtCase.objects.using("ngm").create(
+            court=court, case_number="081-CR-0400", status="enriched",
+            case_type="080-cp-1852 लेनदेन",
+        )
+        cfg = dict(mode=ImportMode.INPLACE, courts=["supreme"])
+        first = CourtCaseImporter(ImportConfig(**cfg)).run()
+        self.assertEqual(first.dq_case_type_normalized, 1)
+        case = CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="081-CR-0400"
+        )
+        self.assertEqual(case.case_type, "लेनदेन")
+        self.assertEqual(case.extra_data["_dq"]["case_type_raw"], "080-cp-1852 लेनदेन")
+
+        # Second pass: already canonical → no rewrite, no re-archive, not re-counted.
+        second = CourtCaseImporter(ImportConfig(**cfg)).run()
+        self.assertEqual(second.dq_case_type_normalized, 0)
+        case = CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="081-CR-0400"
+        )
+        self.assertEqual(case.case_type, "लेनदेन")
+        self.assertEqual(case.extra_data["_dq"]["case_type_raw"], "080-cp-1852 लेनदेन")
+
 
 class SignalAndReindexTests(_NgmTestCase):
     def test_signals_muted_then_restored(self):

--- a/courts/tests/test_import_courtcases.py
+++ b/courts/tests/test_import_courtcases.py
@@ -206,6 +206,23 @@ class CopyModeLoadTests(_NgmTestCase):
         self.assertEqual(res.failed, 0)
         self.assertEqual(res.dq_case_type_normalized, 1)
 
+    def test_case_type_normalized_with_non_dict_dq(self):
+        # A malformed non-dict _dq must not crash the row: it is replaced with a
+        # proper dict carrying the archived raw value.
+        row = _src_row(
+            case="081-CR-0303", case_type="080-cp-1852 लेनदेन",
+            extra_data={"_dq": "junk", "keep": 1},
+        )
+        res = _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="081-CR-0303"
+        )
+        self.assertEqual(case.case_type, "लेनदेन")
+        self.assertEqual(case.extra_data["_dq"]["case_type_raw"], "080-cp-1852 लेनदेन")
+        self.assertEqual(case.extra_data["keep"], 1)  # other keys preserved
+        self.assertEqual(res.failed, 0)
+        self.assertEqual(res.dq_case_type_normalized, 1)
+
     def test_verdict_sentinel_not_surfaced(self):
         row = _src_row(case="081-CR-0042", verdict_date_bs="**** ** **")
         res = _copy([row]).run()

--- a/courts/tests/test_normalize.py
+++ b/courts/tests/test_normalize.py
@@ -46,6 +46,10 @@ def test_parse_stated_count_no_signal():
         ("(079-C1-0427) अपराधिक उपद्रव", "अपराधिक उपद्रव"),
         ("०७९-CP-२३४२ लेनदेन", "लेनदेन"),  # Devanagari-digit case number
         ("अपराधिक उपद्रव (079-C1-0427)", "अपराधिक उपद्रव"),
+        # A separator (comma) before a trailing token is consumed whole — no
+        # dangling "लेनदेन," left behind.
+        ("लेनदेन, 080-cp-1852", "लेनदेन"),
+        ("भुल सुधार; 074-CP-1181", "भुल सुधार"),
     ],
 )
 def test_normalize_case_type_strips_case_numbers(raw, expected):

--- a/courts/tests/test_normalize.py
+++ b/courts/tests/test_normalize.py
@@ -85,6 +85,22 @@ def test_normalize_case_type_is_idempotent():
         assert normalize_case_type(once) == once
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "चेक  अनादर",  # internal double space
+        " चेक अनादर ",  # leading/trailing whitespace
+        '"लेनदेन"',  # surrounding quotes
+        "  080-c1-0199  ",  # pure case number with padding
+    ],
+)
+def test_normalize_case_type_cosmetic_only_returns_input_verbatim(value):
+    # Whitespace / surrounding quotes are NOT structural noise: with no
+    # case-number token or wrapper to strip, the raw input is returned unchanged,
+    # so the importer does not rewrite / re-archive / re-count it for cosmetics.
+    assert normalize_case_type(value) == value
+
+
 @pytest.mark.parametrize("value", ["", None])
 def test_normalize_case_type_empty(value):
     assert normalize_case_type(value) == value

--- a/courts/tests/test_normalize.py
+++ b/courts/tests/test_normalize.py
@@ -50,6 +50,9 @@ def test_parse_stated_count_no_signal():
         # dangling "लेनदेन," left behind.
         ("लेनदेन, 080-cp-1852", "लेनदेन"),
         ("भुल सुधार; 074-CP-1181", "भुल सुधार"),
+        # Combined noise (leading case number AND भ्रष्टाचार wrapper): stripping the
+        # number re-exposes the wrapper, so both are resolved in a single call.
+        ("080-cp-1852 भ्रष्टाचार ( रकम हिनामिना )", "रकम हिनामिना"),
     ],
 )
 def test_normalize_case_type_strips_case_numbers(raw, expected):
@@ -80,7 +83,12 @@ def test_normalize_case_type_preserves_meaningful_values(value):
 
 
 def test_normalize_case_type_is_idempotent():
-    for raw in ("भ्रष्टाचार ( रकम हिनामिना )", "080-cp-1852 लेनदेन", "चोरी गरेको (दफा 241)"):
+    for raw in (
+        "भ्रष्टाचार ( रकम हिनामिना )",
+        "080-cp-1852 लेनदेन",
+        "चोरी गरेको (दफा 241)",
+        "080-cp-1852 भ्रष्टाचार ( रकम हिनामिना )",  # combined noise
+    ):
         once = normalize_case_type(raw)
         assert normalize_case_type(once) == once
 

--- a/courts/tests/test_normalize.py
+++ b/courts/tests/test_normalize.py
@@ -1,6 +1,8 @@
 """Unit tests for ``courts.normalize`` helpers."""
 
-from courts.normalize import parse_stated_defendant_count
+import pytest
+
+from courts.normalize import normalize_case_type, parse_stated_defendant_count
 
 
 def test_parse_stated_count_ascii_and_devanagari():
@@ -31,3 +33,54 @@ def test_parse_stated_count_no_signal():
     assert parse_stated_defendant_count("प्रमुख प्रतिवादी") == (None, False)
     assert parse_stated_defendant_count("") == (None, False)
     assert parse_stated_defendant_count(None) == (None, False)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # भ्रष्टाचार ( X ) wrapper -> inner offense.
+        ("भ्रष्टाचार ( रकम हिनामिना )", "रकम हिनामिना"),
+        # Leading/trailing structured case-number token stripped, label kept.
+        ("080-cp-1852 लेनदेन", "लेनदेन"),
+        ("074-CP-1181, भुल वा त्रुटि शंशोधन", "भुल वा त्रुटि शंशोधन"),
+        ("(079-C1-0427) अपराधिक उपद्रव", "अपराधिक उपद्रव"),
+        ("०७९-CP-२३४२ लेनदेन", "लेनदेन"),  # Devanagari-digit case number
+        ("अपराधिक उपद्रव (079-C1-0427)", "अपराधिक उपद्रव"),
+    ],
+)
+def test_normalize_case_type_strips_case_numbers(raw, expected):
+    assert normalize_case_type(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Statute citations are the MOST useful case_type values — never touched,
+        # even though they contain digits and parentheses.
+        "चोरी गरेको (दफा 241)",
+        "जबरजस्ती करणी गरेको (दफा 219)",
+        "अंशबण्डा गरिपाऊँ (दफा २०५), (२१५)",
+        "मु.फौ.सं. को दफा 155 बमोजिमको निवेदन",
+        # Section references and clean labels pass through.
+        "१५५ को सुविधा पाउँ",
+        "155 बमोजिमको निवेदन",
+        "चेक अनादर",
+        # A value that is ONLY a case number has no label to keep -> unchanged
+        # (never emptied to something misleading).
+        "080-c1-0199",
+        "3942",
+    ],
+)
+def test_normalize_case_type_preserves_meaningful_values(value):
+    assert normalize_case_type(value) == value
+
+
+def test_normalize_case_type_is_idempotent():
+    for raw in ("भ्रष्टाचार ( रकम हिनामिना )", "080-cp-1852 लेनदेन", "चोरी गरेको (दफा 241)"):
+        once = normalize_case_type(raw)
+        assert normalize_case_type(once) == once
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_normalize_case_type_empty(value):
+    assert normalize_case_type(value) == value


### PR DESCRIPTION
### **User description**
## What

Fills the one remaining gap in the court-case data-quality pass: **`case_type` normalisation**. The importer already handles the verdict sentinel, high-court `extra_data` field recovery, and special-defendant truncation — but `case_type` was imported as raw free text.

`case_type` is the scraped `मुद्दाको किसिम` cause-list/detail cell, so clerks paste case numbers, dates and whole sentences into it. This adds:

- **`courts.normalize.normalize_case_type`** — conservative, reversible, idempotent. Unwraps the `भ्रष्टाचार ( X )` wrapper and strips a leading/trailing **structured** case-number token (`NNN-XX-NNNN`); preserves everything else. A value that is *only* a case number is returned unchanged (never emptied).
- **importer DQ guard `_normalize_case_type`** — rewrites `case_type` in place, archives the raw value under `extra_data._dq.case_type_raw` (reversible), counts it as `dq_case_type_normalized`, and bumps `updated_at` so `reindex_courtcases --since` propagates it. Runs after high-court recovery so a just-recovered `case_type` is normalised too.

## Why conservative (not an aggressive rewrite)

Profiling flagged ~15% of `case_type` as "non-canonical", but that was mostly a measurement artifact: **~62k rows explicitly cite a statute** (`दफा`/`ऐन`) and only **56 rows are truly label-less**. The most common "dirty" values are actually the *best* labels — `चोरी गरेको (दफा 241)`, `जबरजस्ती करणी गरेको (दफा 219)` — that merely contain digits. Aggressively overwriting those would destroy the statutory reference, so the cleaner is deliberately high-precision and leaves them untouched.

## Tests

Unit coverage for the normaliser (strip cases + statute/section preservation + idempotency) and two importer tests (rewrite+archive, statute label left untouched). **44 tests pass** (`courts/tests/test_normalize.py`, `courts/tests/test_import_courtcases.py`).

## Rollout

Code-only; no schema change. Effect lands when the standard inplace import + `reindex_courtcases --since` runs. Reversible via the archived `extra_data._dq.case_type_raw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Normalize court `case_type`

- Archive raw values reversibly

- Count importer DQ rewrites

- Add normalization tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  raw["Raw case_type"] -- "normalize" --> canonical["Canonical label"]
  canonical["Canonical label"] -- "archive raw" --> dq["extra_data._dq"]
  dq["extra_data._dq"] -- "count" --> result["ImportResult"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>importer.py</strong><dd><code>Importer normalizes and tracks case_type rewrites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/importer.py

<ul><li>Imports <code>normalize_case_type</code><br> <li> Adds <code>dq_case_type_normalized</code> result counter<br> <li> Runs <code>_normalize_case_type</code> after high-court recovery<br> <li> Archives raw <code>case_type</code> under <code>extra_data._dq.case_type_raw</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/359/files#diff-a2ea0a5ee9a8aac5012f08c2d0ff48c202ab0e3730b10429974f63d10c931416">+30/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>normalize.py</strong><dd><code>Conservative case_type canonicalization helper added</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/normalize.py

<ul><li>Adds conservative <code>normalize_case_type</code><br> <li> Strips <code>भ्रष्टाचार ( X )</code> wrapper<br> <li> Removes structured leading/trailing case-number tokens<br> <li> Preserves statute labels, sections, case-number-only values</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/359/files#diff-c0ccd8f919124f54bb87e844d9ff23f5994b790ac80add5c10b9124fe5ea0396">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_import_courtcases.py</strong><dd><code>Importer tests cover case_type DQ behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_import_courtcases.py

<ul><li>Tests importer <code>case_type</code> rewrite<br> <li> Verifies raw value archiving<br> <li> Verifies statute label preservation<br> <li> Checks DQ normalization counter</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/359/files#diff-60700ab5ba12ea6b7819beb0b7385999396a899b945dd2025ec9628892f9aab5">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_normalize.py</strong><dd><code>Unit tests cover case_type normalization rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_normalize.py

<ul><li>Adds <code>normalize_case_type</code> unit tests<br> <li> Covers wrapper and case-number stripping<br> <li> Covers meaningful value preservation<br> <li> Verifies idempotency and empty handling</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/359/files#diff-4113eafcb356ee8f89543a0b188a990ba7a5e51aeb671dffa6bf815cbe9e29ff">+54/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
