### PR TITLE
fix(stats): retry refresh_statistics on transient DB error, fall back to primary

### DIFF
--- a/cases/management/commands/refresh_statistics.py
+++ b/cases/management/commands/refresh_statistics.py
@@ -8,25 +8,50 @@ request ever pays the aggregation cost.
 
 from __future__ import annotations
 
+import time
+
 from django.core.management.base import BaseCommand
+from django.db import OperationalError
 
 from cases.services.statistics import refresh_statistics
 from config.db_router import route_reads_to_replica
+
+# The aggregation is read-only and idempotent, so a transient database error is
+# safe to retry. The motivating failure is a hot-standby cancelling a multi-second
+# scan mid-flight ("canceling statement due to conflict with recovery") when WAL
+# replay must remove row versions the query is still reading — transient, and gone
+# by the next attempt. On the FINAL attempt we read from the primary (never a
+# standby), which cannot self-conflict, so the snapshot still refreshes even if the
+# replica is under continuous replay pressure. Cold-start connection blips (the
+# same class the CronJob pre-flight wait guards against) are covered too.
+_MAX_ATTEMPTS = 3
 
 
 class Command(BaseCommand):
     help = "Recompute the /api/statistics/ payload and upsert the shared snapshot row."
 
     def handle(self, *args, **options):
-        # The aggregation is read-only and tolerant of replica lag, so opt its
-        # reads into the read replicas (where configured) to keep the heavy
-        # counts off the primaries. The snapshot upsert is a pure write and is
-        # always routed to the primary regardless of this flag.
-        route_reads_to_replica(True)
-        try:
-            stats = refresh_statistics()
-        finally:
-            route_reads_to_replica(False)
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            # Route the heavy counts onto the read replicas (where configured) to
+            # keep them off the primaries — except on the last attempt, where we
+            # fall back to the primary to guarantee the job completes. The snapshot
+            # upsert is a pure write and is always routed to the primary regardless
+            # of this flag.
+            route_reads_to_replica(attempt < _MAX_ATTEMPTS)
+            try:
+                stats = refresh_statistics()
+                break
+            except OperationalError as exc:
+                if attempt == _MAX_ATTEMPTS:
+                    raise
+                backoff = 2**attempt
+                self.stderr.write(
+                    f"refresh_statistics: transient database error on attempt "
+                    f"{attempt}/{_MAX_ATTEMPTS} ({exc}); retrying in {backoff}s"
+                )
+                time.sleep(backoff)
+            finally:
+                route_reads_to_replica(False)
         self.stdout.write(
             self.style.SUCCESS(
                 f"Statistics snapshot refreshed (last_updated={stats['last_updated']})"

--- a/tests/commands/test_refresh_statistics_retry.py
+++ b/tests/commands/test_refresh_statistics_retry.py
@@ -1,0 +1,88 @@
+"""Retry + primary-fallback behaviour of the ``refresh_statistics`` command.
+
+The nightly snapshot job routes its heavy reads onto the NGM read replica to keep
+the counts off the primary. A hot standby can cancel a multi-second aggregation
+mid-flight ("canceling statement due to conflict with recovery") when WAL replay
+must remove row versions the query is still reading — a transient error that was
+crashing the CronJob (and paging Sentry). The command must retry, and on its
+FINAL attempt read from the primary (which never self-conflicts) so the snapshot
+still refreshes even under continuous replay pressure.
+
+These tests mock the aggregation itself, so they need no database — they assert
+the retry count, the backoff sleeps, and (the crux) that the last attempt runs
+with replica routing OFF.
+"""
+
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+from django.db import OperationalError
+
+from config.db_router import _reads_use_replica
+
+COMMAND = "cases.management.commands.refresh_statistics"
+
+
+def _run_with(side_effects, monkeypatch):
+    """Invoke the command with ``refresh_statistics`` yielding ``side_effects``.
+
+    Records the live replica-routing flag at each attempt and the backoff sleeps.
+    Each side effect is either an exception instance (raised) or a return value.
+    """
+    seen_replica_flags = []
+    sleeps = []
+
+    def fake_refresh():
+        seen_replica_flags.append(_reads_use_replica())
+        effect = side_effects[len(seen_replica_flags) - 1]
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
+
+    monkeypatch.setattr(f"{COMMAND}.time.sleep", lambda s: sleeps.append(s))
+    with mock.patch(f"{COMMAND}.refresh_statistics", side_effect=fake_refresh):
+        call_command("refresh_statistics")
+    return seen_replica_flags, sleeps
+
+
+def test_succeeds_first_try_uses_replica(monkeypatch):
+    flags, sleeps = _run_with([{"last_updated": "now"}], monkeypatch)
+    assert flags == [True]  # single attempt, on the replica
+    assert sleeps == []  # no retry, no backoff
+
+
+def test_retries_then_succeeds_still_on_replica(monkeypatch):
+    flags, sleeps = _run_with(
+        [OperationalError("conflict with recovery"), {"last_updated": "now"}],
+        monkeypatch,
+    )
+    assert flags == [True, True]  # attempts 1 and 2 are both < MAX → replica
+    assert sleeps == [2]  # one exponential backoff before the retry
+
+
+def test_final_attempt_falls_back_to_primary(monkeypatch):
+    # Fails on the replica twice; only the 3rd (final) attempt, on the PRIMARY,
+    # succeeds — proving the fallback is what lets the job complete.
+    flags, sleeps = _run_with(
+        [
+            OperationalError("conflict with recovery"),
+            OperationalError("conflict with recovery"),
+            {"last_updated": "now"},
+        ],
+        monkeypatch,
+    )
+    assert flags == [True, True, False]  # last attempt reads the primary
+    assert sleeps == [2, 4]  # exponential backoff between attempts
+
+
+def test_persistent_failure_propagates_after_max_attempts(monkeypatch):
+    with pytest.raises(OperationalError):
+        _run_with([OperationalError("boom")] * 3, monkeypatch)
+
+
+def test_replica_routing_is_reset_after_run(monkeypatch):
+    _run_with([{"last_updated": "now"}], monkeypatch)
+    # The command's finally-block must always clear the flag so it never leaks
+    # into a later in-process caller.
+    assert _reads_use_replica() is False


### PR DESCRIPTION
### **User description**
## What

The nightly `platform-refresh-statistics` CronJob deliberately routes its heavy NGM aggregations onto the read replica (`route_reads_to_replica(True)`) to keep the counts off the primary. A hot standby, however, cancels a multi-second scan mid-flight when WAL replay must vacuum row versions the query is still reading:

```
OperationalError: canceling statement due to conflict with recovery
  at cases/services/statistics.py:342 _ngm_metrics
  → refresh_statistics.py:27 handle
```

This was crashing the job (Sentry `JAWAFDEHI-API-3N`/`-3P`, recurring on scheduled runs) so the statistics snapshot silently went stale.

## Fix

Retry the read-only, idempotent aggregation up to 3× with exponential backoff. On the **final** attempt, reads go to the **primary** (which cannot self-conflict), so the snapshot always refreshes even under continuous replay pressure. The same retry also absorbs cold-start connection blips. The replica-offload benefit is preserved for the common (non-conflicting) case.

## Tests

New DB-free unit test (`tests/commands/test_refresh_statistics_retry.py`, 5 cases): single-try-on-replica, retry-then-succeed, **primary fallback on the last attempt**, propagation after max attempts, and flag reset in the `finally`. All pass locally; `ruff check` clean.

Found via a Sentry deep-dive; this is the only genuine recurring bug of the batch — the sibling PRs are telemetry-noise suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Retry transient statistics DB failures

- Fallback to primary on final attempt

- Reset replica routing after attempts

- Add retry behavior unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["refresh_statistics command"] -- "tries replica reads" --> B["attempts 1-2"]
  B -- "OperationalError" --> C["exponential backoff"]
  C -- "final retry" --> D["primary reads"]
  D -- "success" --> E["snapshot refreshed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>refresh_statistics.py</strong><dd><code>Add retry and primary fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cases/management/commands/refresh_statistics.py

<ul><li>Imports <code>time</code> and <code>OperationalError</code>.<br> <li> Adds <code>_MAX_ATTEMPTS = 3</code>.<br> <li> Retries <code>refresh_statistics()</code> on <code>OperationalError</code>.<br> <li> Uses primary reads on final attempt, resets routing.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/360/files#diff-af674569a5fe811fbfe8a0601fbe431bc80425270f026a932fcf2b77a3ff5b76">+34/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_refresh_statistics_retry.py</strong><dd><code>Cover statistics refresh retry behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_refresh_statistics_retry.py

<ul><li>Adds DB-free command tests.<br> <li> Verifies replica routing per attempt.<br> <li> Checks exponential backoff sleeps.<br> <li> Ensures persistent failures propagate.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/360/files#diff-6dac99592f167be335cd986f805b3ae833da89675d691578140ec09ae5fe0b74">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
