### PR TITLE
chore(observability): drop shell/exec-originated events from Sentry

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -51,6 +51,33 @@ configure_structlog()
 
 _sentry_dsn = os.getenv("SENTRY_DSN")
 _sentry_environment = os.getenv("SENTRY_ENVIRONMENT", "production")
+
+# Filenames the interpreter assigns to code that has no source file: `manage.py
+# shell -c "..."` and any exec()/eval() compile to "<string>", the interactive
+# shell REPL to "<console>", piped stdin to "<stdin>". Real app code — HTTP
+# request handlers, mgmt-command bodies, tasks — always has a real filename, so a
+# stack that passes through any of these came from an operator one-off or a
+# health-check probe, never the running service.
+_EXEC_PSEUDO_FILENAMES = {"<string>", "<stdin>", "<console>"}
+
+
+def _drop_exec_originated_events(event, _hint):
+    """Sentry ``before_send``: drop events raised from exec'd / interactive code.
+
+    This kills the dominant source of API Sentry noise: exceptions from ad-hoc
+    ``manage.py shell -c "..."`` sessions and the CronJob pre-flight readiness
+    probes (e.g. reindex-cases' ``shell -c "... assert make_client().ping()"``,
+    which fires an ``AssertionError`` on every cold start until deps are
+    reachable). Any event whose stack passes through a ``<string>``/``<stdin>``/
+    ``<console>`` frame is such noise; everything with a real filename is kept.
+    """
+    for value in (event.get("exception") or {}).get("values") or []:
+        for frame in (value.get("stacktrace") or {}).get("frames") or []:
+            if frame.get("filename") in _EXEC_PSEUDO_FILENAMES:
+                return None
+    return event
+
+
 # Belt-and-suspenders: never ship events from local / dev runs even if a DSN
 # leaked into a developer's .env. Prod sets SENTRY_ENVIRONMENT=production.
 if _sentry_dsn and _sentry_environment.strip().lower() not in {
@@ -65,6 +92,7 @@ if _sentry_dsn and _sentry_environment.strip().lower() not in {
         traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "1.0")),
         send_default_pii=False,
         environment=_sentry_environment,
+        before_send=_drop_exec_originated_events,
     )
 
 


### PR DESCRIPTION
### **User description**
## What

The API Sentry project's top "errors" never came from the running service — they come from `manage.py shell` and CronJob pre-flight probes, which the SDK still captures:

- **`AssertionError` ×39 (the #1 issue by volume)** — the `reindex-cases` CronJob pre-flight loop runs `manage.py shell -c "... assert make_client().ping()"`; the assert fires on every OpenSearch cold start until deps are reachable. `2>/dev/null` hides it from logs but not from Sentry (the SDK hooks the exception, not stderr).
- **~13 one-off `AttributeError`/`FieldError`/`ImportError`/`SyntaxError`** — all from ad-hoc `manage.py shell -c "..."` sessions (every frame is `<string>`).

## Fix

Add a Sentry `before_send` that drops any event whose stack passes through a `<string>`/`<stdin>`/`<console>` frame — i.e. code with no source file (exec'd, piped, or the interactive REPL). Real request handlers and management-command bodies always have real filenames and are unaffected.

This removes ~50 events/week of pure noise so the dashboard actually signals. No functional behaviour changes; `ruff check` clean, `before_send` unit-verified (drops `<string>` events, keeps real ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Filter exec-originated Sentry noise

- Drop `<string>`/`<stdin>`/`<console>` events

- Keep real source-file exceptions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sentry event"] -- "inspect frames" --> B["Pseudo filename?"]
  B -- "yes" --> C["Drop event"]
  B -- "no" --> D["Send event"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Filter shell-originated Sentry events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/settings.py

<ul><li>Adds <code>_EXEC_PSEUDO_FILENAMES</code><br> <li> Adds <code>_drop_exec_originated_events</code><br> <li> Wires filter into <code>sentry_sdk.init</code><br> <li> Drops shell, exec, stdin Sentry events</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/361/files#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
