### PR TITLE
fix(observability): report search-backend 503s to Sentry

### DIFF
--- a/search/tests/test_search_api.py
+++ b/search/tests/test_search_api.py
@@ -88,6 +88,25 @@ def test_search_api_503_when_cluster_down():
 
 
 @pytest.mark.django_db
+def test_search_api_503_reports_to_sentry():
+    """A search-backend outage returns a *handled* 503, so it must be reported to
+    Sentry explicitly (the Django integration only sees unhandled exceptions, and
+    the service logs the transport error at warning level, below Sentry's ERROR
+    event threshold). Without this, search outages are invisible in Sentry."""
+    client = MagicMock()
+    client.search.side_effect = ConnectionError("down")
+    with patch("search.service.make_client", return_value=client), patch(
+        "search.views.sentry_sdk.capture_exception"
+    ) as capture:
+        resp = APIClient().get("/api/search/", {"q": "x"})
+    assert resp.status_code == 503
+    capture.assert_called_once()
+    # The captured exception chains back to the underlying transport error.
+    captured = capture.call_args.args[0]
+    assert isinstance(captured.__cause__, ConnectionError)
+
+
+@pytest.mark.django_db
 def test_search_api_allows_empty_q_as_browse():
     """``q`` is optional: no query term is a browse (match-all), not a 400."""
     client = MagicMock()

--- a/search/views.py
+++ b/search/views.py
@@ -15,6 +15,7 @@ import json
 import time
 import uuid
 
+import sentry_sdk
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, status
@@ -216,7 +217,17 @@ class UnifiedSearchView(APIView):
             return Response(
                 {"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST
             )
-        except SearchUnavailable:
+        except SearchUnavailable as exc:
+            # This is a *handled* 503, so neither the Django integration (which only
+            # reports unhandled exceptions) nor the service's warning-level log
+            # (below Sentry's ERROR event_level) would surface a search-backend
+            # outage. Report it explicitly — with the chained transport error — so
+            # these 503s are visible and alertable in Sentry. The request/transaction
+            # context is inherited from the current scope; ``before_send`` keeps it
+            # (a real request has real filenames, not <string>/<stdin>/<console>).
+            with sentry_sdk.new_scope() as scope:
+                scope.set_tag("search_unavailable", True)
+                sentry_sdk.capture_exception(exc)
             return Response(
                 {"detail": "Search is temporarily unavailable."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,


### PR DESCRIPTION
### **User description**
## Why

Today the `/api/search/` endpoint served **22× HTTP 503** in a ~2-minute burst during a `jawafdehi-platform` rollout — the freshly-started pods briefly couldn't reach `opensearch.app.svc.cluster.local:9200` (`[Errno 111] Connection refused`), and search is a hard dependency with no fallback. **None of it showed up in Sentry.**

Root cause of the blind spot: the endpoint catches the transport error, logs it at **`warning`** level, and returns a *handled* 503 `Response`. So:
- `DjangoIntegration` never sees an unhandled exception (nothing to auto-capture), and
- the log is below Sentry's default `event_level=ERROR`.

The 503 was only visible in the pod access logs + the `django.request` structlog line — not in the Sentry Issues stream.

## What

Capture the exception explicitly in the `except SearchUnavailable` branch:
- `sentry_sdk.capture_exception(exc)` on a forked scope, tagged `search_unavailable`.
- The chained transport error (`raise SearchUnavailable(...) from exc`) is preserved, so Sentry groups by the real cause (e.g. `ConnectionError: Connection refused`) and shows the full chain.
- The existing `before_send` (`_drop_exec_originated_events`) keeps the event — a real HTTP request has real filenames, not `<string>`/`<stdin>`/`<console>`.
- Request/transaction context is inherited from the current scope; the tag is scoped to this event only (no leak).

Client behaviour is unchanged — still a 503 with `{"detail": "Search is temporarily unavailable."}`.

## Tests

- Extended `test_search_api_503_when_cluster_down` with a new `test_search_api_503_reports_to_sentry` asserting `capture_exception` is called once and the captured exception chains back to the transport error.
- Full `search/tests/test_search_api.py` suite: **16 passed**. `ruff check` clean.

## Follow-ups (not in this PR)
- The rollout-induced blip itself: a startup readiness gate on OpenSearch reachability, or a short connect-retry/backoff in `make_client()`, so a deploy doesn't surface as user-facing 503s.
- Wire a Sentry alert on the new `search_unavailable` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Search 503s sent to Sentry

- Event scoped with `search_unavailable`

- Transport cause chain verified


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OpenSearch failure"] -- "raises" --> B["SearchUnavailable"]
  B -- "handled 503" --> C["API response"]
  B -- "captured" --> D["Sentry event"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Capture handled search outages in Sentry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/views.py

<ul><li>Imports <code>sentry_sdk</code><br> <li> Captures handled <code>SearchUnavailable</code> exceptions<br> <li> Tags scoped Sentry events <code>search_unavailable</code><br> <li> Keeps 503 response unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/362/files#diff-7f3465c740a25f0dc3298c912c7684f213f4c42d69abc39f21e1ebe54e4652e8">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_search_api.py</strong><dd><code>Test Sentry capture for search 503</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/tests/test_search_api.py

<ul><li>Adds Sentry reporting regression test<br> <li> Mocks <code>capture_exception</code><br> <li> Asserts one capture per 503<br> <li> Verifies chained <code>ConnectionError</code> cause</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/362/files#diff-e48bee009ce8797be684a85f7a0570d8afea9d5b65cbd6331464b373aa1fda3c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
