### PR TITLE
fix(courts): drop orphaned open paren when a case number is stripped from inside a parenthetical

### DIFF
--- a/courts/normalize.py
+++ b/courts/normalize.py
@@ -153,8 +153,10 @@ def normalize_case_type(case_type: str | None) -> str | None:
 
     Reversible and safe to run in place over the whole corpus: it unwraps the
     ``भ्रष्टाचार ( X )`` wrapper and strips a leading/trailing STRUCTURED
-    case-number token (``NNN-XX-NNNN``), and NOTHING else. Statute citations,
-    section references and free-text descriptions are preserved verbatim.
+    case-number token (``NNN-XX-NNNN``) — dropping an opening paren left orphaned
+    when that token sat inside a parenthetical alongside real text — and NOTHING
+    else. Statute citations, section references and free-text descriptions are
+    preserved verbatim.
 
     Matching runs on a whitespace-collapsed, quote-stripped copy (so the tokens
     match regardless of incidental spacing/quotes), but a value is only reported
@@ -193,6 +195,20 @@ def normalize_case_type(case_type: str | None) -> str | None:
         candidate = _TRAILING_CASE_NUMBER.sub("", s, count=1).strip()
         if candidate != s and _has_devanagari_letter(candidate):
             s = candidate
+
+        # A structured case number can sit INSIDE a parenthetical that also holds
+        # real descriptive text, e.g. "हाजिर गराई पाउ ( ज्यान मार्ने उद्योग, 079-C1-0213)".
+        # Stripping the trailing ", 079-C1-0213)" removes the CLOSING paren but leaves
+        # the opening "(" dangling. Drop that now-orphaned opening paren (keeping the
+        # description) so we never emit an unbalanced "(". Guarded on ``s != before``
+        # so it fires ONLY as a consequence of a strip this pass — a value's own
+        # pre-existing unbalanced parens are never rebalanced when nothing else changed.
+        if s != before and (s.count("(") + s.count("（")) > (s.count(")") + s.count("）")):
+            idx = max(s.rfind("("), s.rfind("（"))
+            if idx != -1 and ")" not in s[idx:] and "）" not in s[idx:]:
+                candidate = _WHITESPACE.sub(" ", s[:idx] + " " + s[idx + 1:]).strip()
+                if _has_devanagari_letter(candidate):
+                    s = candidate
 
         if s == before:
             break

--- a/courts/tests/test_normalize.py
+++ b/courts/tests/test_normalize.py
@@ -53,6 +53,14 @@ def test_parse_stated_count_no_signal():
         # Combined noise (leading case number AND भ्रष्टाचार wrapper): stripping the
         # number re-exposes the wrapper, so both are resolved in a single call.
         ("080-cp-1852 भ्रष्टाचार ( रकम हिनामिना )", "रकम हिनामिना"),
+        # A case number sits INSIDE a parenthetical alongside real text: the trailing
+        # ", TOKEN)" is stripped AND the now-orphaned opening "(" is dropped, so no
+        # unbalanced paren is left behind while the description is preserved.
+        ("हाजिर गराई पाउ ( ज्यान मार्ने उद्योग, 079-C1-0213)", "हाजिर गराई पाउ ज्यान मार्ने उद्योग"),
+        ("हाजिर गराई पाउ ( ज्यान मार्ने उद्योग, 079-C1-0229)", "हाजिर गराई पाउ ज्यान मार्ने उद्योग"),
+        # A BALANCED inner paren (here from the भ्रष्टाचार wrapper unwrap) is preserved
+        # verbatim — only a genuinely orphaned opening paren is removed.
+        ("भ्रष्टाचार ( रिसवत(घुस) )", "रिसवत(घुस)"),
     ],
 )
 def test_normalize_case_type_strips_case_numbers(raw, expected):
@@ -76,6 +84,10 @@ def test_normalize_case_type_strips_case_numbers(raw, expected):
         # (never emptied to something misleading).
         "080-c1-0199",
         "3942",
+        # A value carrying its OWN unbalanced paren but NO case-number token is left
+        # verbatim: the orphan-paren cleanup only fires as a consequence of a strip,
+        # so a value nothing else touched is never rebalanced.
+        "जाँच बुझ ( अपुरो विवरण",
     ],
 )
 def test_normalize_case_type_preserves_meaningful_values(value):
@@ -88,6 +100,7 @@ def test_normalize_case_type_is_idempotent():
         "080-cp-1852 लेनदेन",
         "चोरी गरेको (दफा 241)",
         "080-cp-1852 भ्रष्टाचार ( रकम हिनामिना )",  # combined noise
+        "हाजिर गराई पाउ ( ज्यान मार्ने उद्योग, 079-C1-0213)",  # dangling-paren cleanup
     ):
         once = normalize_case_type(raw)
         assert normalize_case_type(once) == once


### PR DESCRIPTION
### **User description**
## Why

Follow-up to #359. A full-corpus **dry-run** of the merged `normalize_case_type` over all **1,610,771** rows projected **26,020** rewrites (24,554 distinct) — ~30× the earlier ~856 estimate. The composition is sound (भ्रष्टाचार(X) wrapper unwraps + case-number-suffixed procedural labels), but it surfaced one cosmetic edge worth fixing **before** the backfill.

When a structured case number sits **inside** a parenthetical alongside real text, stripping the trailing `", TOKEN)"` removes the closing paren but leaves the opening `(` dangling:

```
हाजिर गराई पाउ ( ज्यान मार्ने उद्योग, 079-C1-0213)
  ->  हाजिर गराई पाउ ( ज्यान मार्ने उद्योग        # before: unbalanced "("
  ->  हाजिर गराई पाउ ज्यान मार्ने उद्योग          # after this PR
```

The value was always reversible (raw archived to `_dq.case_type_raw`) and never lost content — this just avoids emitting an unbalanced `(` into `case_type` (which is user-facing in search facets). Doing it now means the one-shot backfill writes the clean form; a second pass would **not** re-clean an already-rewritten value.

## What

- Drop the now-orphaned opening paren (keeping the description) inside the existing fixed-point loop.
- **Scoped**: guarded on `s != before`, so it fires ONLY as a consequence of a strip this pass — a value's own pre-existing unbalanced parens are never rebalanced.
- **Balanced inner parens preserved**: `भ्रष्टाचार ( रिसवत(घुस) )` → `रिसवत(घुस)` is untouched.

## Tests

New cases: dangling-paren strip (2 real examples), balanced-inner-paren preservation (regression), scoping guard (own unbalanced paren left verbatim when nothing else fires), and idempotency. **34 normalize + 5 importer `case_type` tests pass; `ruff check` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix dangling parenthesis cleanup

- Preserve scoped normalization behavior

- Add regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Case type input"] -- "strip case number" --> B["Possible orphaned paren"]
  B -- "remove only if strip changed text" --> C["Balanced normalized label"]
  C -- "verify" --> D["Regression tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>normalize.py</strong><dd><code>Scoped orphan parenthesis cleanup in normalizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/normalize.py

<ul><li>Documents orphaned parenthesis handling in <code>normalize_case_type</code><br> <li> Removes unmatched opening <code>(</code> or <code>（</code> after same-pass case-number stripping<br> <li> Guards cleanup with <code>s != before</code> to avoid rebalancing untouched values<br> <li> Preserves candidates only when Devanagari content remains</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/363/files#diff-c0ccd8f919124f54bb87e844d9ff23f5994b790ac80add5c10b9124fe5ea0396">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_normalize.py</strong><dd><code>Regression tests for parenthesis normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_normalize.py

<ul><li>Adds real dangling-parenthesis normalization examples<br> <li> Covers balanced inner parenthesis preservation<br> <li> Verifies pre-existing unbalanced values stay unchanged<br> <li> Extends idempotency coverage for cleanup path</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/363/files#diff-4113eafcb356ee8f89543a0b188a990ba7a5e51aeb671dffa6bf815cbe9e29ff">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
