### PR TITLE
feat(courts): run the court-case scraper as a court_scrape queue job

### DIFF
--- a/courts/job_handlers.py
+++ b/courts/job_handlers.py
@@ -1,0 +1,89 @@
+"""Worker-side job handlers owned by the courts app.
+
+One kind so far: ``court_scrape`` — crawl one court's recent cause-lists into the
+ngm lake. Unlike the review/materials handlers (DB-free, run by the external HTTP
+poller), the scrape handler WRITES court cases + hearings through the courts ORM,
+so it runs in-process in a consumer that has ngm DB access (see
+``courts/management/commands/scrape_worker.py``). It still rides the central job
+queue (claim/lease/retry/backoff/dedup + the ``/api/jobs`` dashboard) for crash
+safety and observability.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from django.utils import timezone
+
+from courts.scraper import registry
+from courts.scraper.crawl import run_crawl
+from courts.scraper.fetch import Fetcher
+
+
+def _anchor(value) -> date:
+    """Resolve the optional ``today`` payload key (YYYY-MM-DD) to a date."""
+    if not value:
+        return timezone.localdate()
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def handle_court_scrape(payload, on_stage=None, fetch=None) -> dict:
+    """Crawl the court in ``payload['court']`` into the ngm lake (write mode).
+
+    Payload keys: ``court`` (required registry key — normally one leaf court, as
+    the enqueuer posts one job per court), ``lookback_days``, ``limit_dates``,
+    ``enrich``, ``today``. Returns aggregate + per-court stats (also stored as
+    ``job.result``). Raises ``ValueError``/``KeyError`` on a missing/unknown court
+    (the worker treats these as non-retryable) and propagates fetch/parse errors
+    (retryable).
+
+    ``fetch`` is injectable for tests; production passes ``None`` and a live
+    ``Fetcher`` is built.
+    """
+    court = (payload or {}).get("court")
+    if not court:
+        raise ValueError("court_scrape job payload is missing 'court'.")
+
+    keys = registry.resolve(court)  # KeyError on an unknown court
+    today = _anchor((payload or {}).get("today"))
+    enrich = bool((payload or {}).get("enrich"))
+    lookback_days = (payload or {}).get("lookback_days")
+    limit_dates = (payload or {}).get("limit_dates")
+
+    fetch = fetch or Fetcher()
+    totals = {"courts": 0, "dates": 0, "cases": 0, "hearings": 0, "enriched": 0}
+    per_court: list[dict] = []
+    for key in keys:
+        if on_stage is not None:
+            on_stage(f"scrape:{key}")
+        spec = registry.REGISTRY[key]
+        for s in run_crawl(
+            spec,
+            fetch=fetch,
+            today=today,
+            lookback_days=lookback_days,
+            limit_dates=limit_dates,
+            write=True,
+            enrich=enrich,
+        ):
+            totals["courts"] += 1
+            totals["dates"] += s.dates
+            totals["cases"] += s.cases
+            totals["hearings"] += s.hearings
+            totals["enriched"] += s.enriched
+            per_court.append({
+                "court": key,
+                "court_id": s.court_id,
+                "dates": s.dates,
+                "cases": s.cases,
+                "hearings": s.hearings,
+                "enriched": s.enriched,
+            })
+    return {**totals, "per_court": per_court}
+
+
+#: Kind → worker handler, mirroring review/materials ``job_handlers.HANDLERS`` so
+#: a consumer can dispatch by kind. The in-process ``scrape_worker`` reads this;
+#: the DB-free HTTP poller deliberately does NOT aggregate it (``court_scrape``
+#: needs ngm DB access, which that poller doesn't carry).
+HANDLERS = {"court_scrape": handle_court_scrape}

--- a/courts/job_handlers.py
+++ b/courts/job_handlers.py
@@ -1,9 +1,9 @@
 """Worker-side job handlers owned by the courts app.
 
-One kind so far: ``court_scrape`` — crawl one court's recent cause-lists into the
-ngm lake. Unlike the review/materials handlers (DB-free, run by the external HTTP
-poller), the scrape handler WRITES court cases + hearings through the courts ORM,
-so it runs in-process in a consumer that has ngm DB access (see
+One kind so far: ``court_scrape`` — crawl one leaf court's recent cause-lists into
+the ngm lake. Unlike the review/materials handlers (DB-free, run by the external
+HTTP poller), the scrape handler WRITES court cases + hearings through the courts
+ORM, so it runs in-process in a consumer that has ngm DB access (see
 ``courts/management/commands/scrape_worker.py``). It still rides the central job
 queue (claim/lease/retry/backoff/dedup + the ``/api/jobs`` dashboard) for crash
 safety and observability.
@@ -11,51 +11,68 @@ safety and observability.
 
 from __future__ import annotations
 
-from datetime import date, datetime
-
-from django.utils import timezone
-
 from courts.scraper import registry
+from courts.scraper.base import anchor
 from courts.scraper.crawl import run_crawl
 from courts.scraper.fetch import Fetcher
 
 
-def _anchor(value) -> date:
-    """Resolve the optional ``today`` payload key (YYYY-MM-DD) to a date."""
-    if not value:
-        return timezone.localdate()
-    return datetime.strptime(value, "%Y-%m-%d").date()
+class BadCourtScrapePayload(ValueError):
+    """The payload names a missing/unknown court (or a malformed ``today``).
+
+    A permanent error: the worker treats it as non-retryable rather than
+    re-queuing (a bad payload never succeeds on retry). Subclasses ``ValueError``
+    so callers/tests catching ``ValueError`` still match. Everything raised from
+    inside the crawl (portal flakes, parse hiccups, DB errors) is a DIFFERENT,
+    retryable class — so a transient parser ValueError/KeyError is retried, not
+    dead-lettered.
+    """
 
 
 def handle_court_scrape(payload, on_stage=None, fetch=None) -> dict:
-    """Crawl the court in ``payload['court']`` into the ngm lake (write mode).
+    """Crawl the court in the payload into the ngm lake (write mode).
 
-    Payload keys: ``court`` (required registry key — normally one leaf court, as
-    the enqueuer posts one job per court), ``lookback_days``, ``limit_dates``,
-    ``enrich``, ``today``. Returns aggregate + per-court stats (also stored as
-    ``job.result``). Raises ``ValueError``/``KeyError`` on a missing/unknown court
-    (the worker treats these as non-retryable) and propagates fetch/parse errors
-    (retryable).
+    Payload keys: ``court`` (required registry/tier key — special/district/high/
+    supreme), ``court_id`` (optional leaf court to restrict to — the enqueuer
+    posts one job per leaf court), ``lookback_days``, ``limit_dates``, ``enrich``,
+    ``today``. Returns aggregate + per-court stats (also stored as ``job.result``).
+    Raises ``BadCourtScrapePayload`` on a missing/unknown court or malformed
+    ``today`` (non-retryable); propagates fetch/parse/DB errors (retryable).
 
-    ``fetch`` is injectable for tests; production passes ``None`` and a live
-    ``Fetcher`` is built.
+    ``on_stage`` is called per crawled date so the consumer can heartbeat the job
+    lease during a long crawl. ``fetch`` is injectable for tests; production
+    passes ``None`` and a live ``Fetcher`` is built.
     """
-    court = (payload or {}).get("court")
+    payload = payload or {}
+    court = payload.get("court")
     if not court:
-        raise ValueError("court_scrape job payload is missing 'court'.")
+        raise BadCourtScrapePayload("court_scrape job payload is missing 'court'.")
+    try:
+        keys = registry.resolve(court)
+    except KeyError as exc:
+        raise BadCourtScrapePayload(str(exc)) from exc
+    try:
+        today = anchor(payload.get("today"))
+    except ValueError as exc:
+        raise BadCourtScrapePayload(f"bad 'today' in payload: {exc}") from exc
 
-    keys = registry.resolve(court)  # KeyError on an unknown court
-    today = _anchor((payload or {}).get("today"))
-    enrich = bool((payload or {}).get("enrich"))
-    lookback_days = (payload or {}).get("lookback_days")
-    limit_dates = (payload or {}).get("limit_dates")
+    court_id = payload.get("court_id")  # optional: restrict to one leaf court
+    enrich = bool(payload.get("enrich"))
+    lookback_days = payload.get("lookback_days")
+    limit_dates = payload.get("limit_dates")
+
+    # Heartbeat the job lease per crawled date so a long single-court crawl does
+    # not outlive its lease and get reaped mid-run.
+    on_progress = (
+        (lambda cid, date_bs: on_stage(f"{cid} {date_bs}"))
+        if on_stage is not None
+        else None
+    )
 
     fetch = fetch or Fetcher()
     totals = {"courts": 0, "dates": 0, "cases": 0, "hearings": 0, "enriched": 0}
     per_court: list[dict] = []
     for key in keys:
-        if on_stage is not None:
-            on_stage(f"scrape:{key}")
         spec = registry.REGISTRY[key]
         for s in run_crawl(
             spec,
@@ -65,6 +82,8 @@ def handle_court_scrape(payload, on_stage=None, fetch=None) -> dict:
             limit_dates=limit_dates,
             write=True,
             enrich=enrich,
+            only_court_id=court_id,
+            on_progress=on_progress,
         ):
             totals["courts"] += 1
             totals["dates"] += s.dates

--- a/courts/management/commands/enqueue_scrape.py
+++ b/courts/management/commands/enqueue_scrape.py
@@ -1,11 +1,15 @@
 """Enqueue ``court_scrape`` jobs — the thin recurring trigger for the scraper.
 
 The central queue owns execution (lease/retry/backoff/dedup); this command only
-posts one job per court, so a small CronJob can drive recurring scrapes without
-the queue growing its own scheduler (see ``docs/jobs-queue-design.md`` §6.3). The
-``court_scrape:<court>`` dedup key means re-enqueuing a court whose scrape is
-still queued or running is a no-op — no pile-ups, no two overlapping crawls of
-one court.
+posts jobs, so a small CronJob can drive recurring scrapes without the queue
+growing its own scheduler (see ``docs/jobs-queue-design.md`` §6.3).
+
+One job per LEAF court (not per tier): a `district` tier has ~77 courts, so
+posting one job each keeps every job small (bounded dates, one lease, per-court
+dedup/retry) instead of one giant job crawling all 77 under a single lease. The
+``court_scrape:<tier>:<court_id>`` dedup key means re-enqueuing a court whose
+scrape is still queued or running is a no-op — no pile-ups, no two overlapping
+crawls of one court.
 
     manage.py enqueue_scrape --court all
     manage.py enqueue_scrape --court special --lookback-days 30 --enrich
@@ -18,7 +22,7 @@ from jobs import queue as jobs_queue
 
 
 class Command(BaseCommand):
-    help = "Enqueue one court_scrape job per court onto the central queue."
+    help = "Enqueue one court_scrape job per leaf court onto the central queue."
 
     def add_arguments(self, parser):
         parser.add_argument("--court", default="all",
@@ -34,20 +38,27 @@ class Command(BaseCommand):
 
     def handle(self, *args, **o):
         try:
-            keys = registry.resolve(o["court"])
+            tiers = registry.resolve(o["court"])
         except KeyError as exc:
             raise CommandError(str(exc)) from exc
 
-        for key in keys:
-            payload = {"court": key, "enrich": o["enrich"]}
-            if o["lookback_days"] is not None:
-                payload["lookback_days"] = o["lookback_days"]
-            if o["limit_dates"] is not None:
-                payload["limit_dates"] = o["limit_dates"]
-            job = jobs_queue.enqueue(
-                kind="court_scrape",
-                payload=payload,
-                dedup_key=f"court_scrape:{key}",
-                priority=o["priority"],
-            )
-            self.stdout.write(f"  {key}: job {job.pk} [{job.status}]")
+        enqueued = 0
+        for tier in tiers:
+            module = registry.REGISTRY[tier]
+            # court_ids(None): every module enumerates its courts statically
+            # (fetch-free), so the enqueuer never touches the network.
+            for court_id in module.court_ids(None):
+                payload = {"court": tier, "court_id": court_id, "enrich": o["enrich"]}
+                if o["lookback_days"] is not None:
+                    payload["lookback_days"] = o["lookback_days"]
+                if o["limit_dates"] is not None:
+                    payload["limit_dates"] = o["limit_dates"]
+                job = jobs_queue.enqueue(
+                    kind="court_scrape",
+                    payload=payload,
+                    dedup_key=f"court_scrape:{tier}:{court_id}",
+                    priority=o["priority"],
+                )
+                self.stdout.write(f"  {tier}/{court_id}: job {job.pk} [{job.status}]")
+                enqueued += 1
+        self.stdout.write(f"enqueued {enqueued} court_scrape job(s).")

--- a/courts/management/commands/enqueue_scrape.py
+++ b/courts/management/commands/enqueue_scrape.py
@@ -1,0 +1,53 @@
+"""Enqueue ``court_scrape`` jobs — the thin recurring trigger for the scraper.
+
+The central queue owns execution (lease/retry/backoff/dedup); this command only
+posts one job per court, so a small CronJob can drive recurring scrapes without
+the queue growing its own scheduler (see ``docs/jobs-queue-design.md`` §6.3). The
+``court_scrape:<court>`` dedup key means re-enqueuing a court whose scrape is
+still queued or running is a no-op — no pile-ups, no two overlapping crawls of
+one court.
+
+    manage.py enqueue_scrape --court all
+    manage.py enqueue_scrape --court special --lookback-days 30 --enrich
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from courts.scraper import registry
+from jobs import queue as jobs_queue
+
+
+class Command(BaseCommand):
+    help = "Enqueue one court_scrape job per court onto the central queue."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--court", default="all",
+                            help="special | district | high | supreme | all")
+        parser.add_argument("--lookback-days", type=int, default=None,
+                            help="override the court's default lookback window")
+        parser.add_argument("--limit-dates", type=int, default=None,
+                            help="cap dates per court (smoke/testing)")
+        parser.add_argument("--enrich", action="store_true",
+                            help="follow each touched case's detail page")
+        parser.add_argument("--priority", type=int, default=100,
+                            help="queue priority (lower runs sooner)")
+
+    def handle(self, *args, **o):
+        try:
+            keys = registry.resolve(o["court"])
+        except KeyError as exc:
+            raise CommandError(str(exc)) from exc
+
+        for key in keys:
+            payload = {"court": key, "enrich": o["enrich"]}
+            if o["lookback_days"] is not None:
+                payload["lookback_days"] = o["lookback_days"]
+            if o["limit_dates"] is not None:
+                payload["limit_dates"] = o["limit_dates"]
+            job = jobs_queue.enqueue(
+                kind="court_scrape",
+                payload=payload,
+                dedup_key=f"court_scrape:{key}",
+                priority=o["priority"],
+            )
+            self.stdout.write(f"  {key}: job {job.pk} [{job.status}]")

--- a/courts/management/commands/scrape_courtcases.py
+++ b/courts/management/commands/scrape_courtcases.py
@@ -21,46 +21,7 @@ from django.utils import timezone
 
 from courts.scraper import registry
 from courts.scraper.crawl import run_crawl
-
-_UA = "Mozilla/5.0 (X11; Linux x86_64) Jawafdehi-courts-crawler"
-
-
-class _Fetcher:
-    """``fetch(url, data=None) -> html``: POST when ``data`` is given, else GET."""
-
-    def __init__(self, timeout: int = 60):
-        import requests
-
-        self._s = requests.Session()
-        self._s.headers.update({
-            "User-Agent": _UA,
-            "Referer": "https://supremecourt.gov.np/",
-            "Origin": "https://supremecourt.gov.np",
-        })
-        self._timeout = timeout
-
-    def __call__(self, url, data=None):
-        resp = (
-            self._s.post(url, data=data, timeout=self._timeout)
-            if data is not None
-            else self._s.get(url, timeout=self._timeout)
-        )
-        resp.raise_for_status()
-        return _decode(resp)
-
-
-def _decode(resp) -> str:
-    """Body as text, forcing UTF-8 when the portal omits the charset.
-
-    supremecourt.gov.np serves UTF-8 Devanagari but sends ``Content-Type:
-    text/html`` with NO charset, so ``requests`` falls back to ISO-8859-1 and
-    mojibakes every page (the parsers then see zero Devanagari). Honor an
-    explicit header charset when present; otherwise decode as UTF-8 —
-    ``utf-8-sig`` also strips the BOM some endpoints emit.
-    """
-    if "charset=" not in resp.headers.get("content-type", "").lower():
-        resp.encoding = "utf-8-sig"
-    return resp.text
+from courts.scraper.fetch import Fetcher
 
 
 class Command(BaseCommand):
@@ -89,7 +50,7 @@ class Command(BaseCommand):
         today = self._anchor(o["today"])
         enrich = o["enrich"]
         write = o["write"] or enrich
-        fetch = _Fetcher()
+        fetch = Fetcher()
         mode = "WRITE" if write else "DRY-RUN"
         self.stdout.write(f"scrape_courtcases [{mode}] courts={keys} today={today}")
 

--- a/courts/management/commands/scrape_courtcases.py
+++ b/courts/management/commands/scrape_courtcases.py
@@ -14,12 +14,12 @@ also follows each case's detail page.
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
 
 from courts.scraper import registry
+from courts.scraper.base import anchor
 from courts.scraper.crawl import run_crawl
 from courts.scraper.fetch import Fetcher
 
@@ -69,9 +69,7 @@ class Command(BaseCommand):
 
     @staticmethod
     def _anchor(value: str | None) -> date:
-        if not value:
-            return timezone.localdate()
         try:
-            return datetime.strptime(value, "%Y-%m-%d").date()
+            return anchor(value)
         except ValueError as exc:
             raise CommandError(f"--today must be YYYY-MM-DD, got {value!r}") from exc

--- a/courts/management/commands/scrape_worker.py
+++ b/courts/management/commands/scrape_worker.py
@@ -1,0 +1,112 @@
+"""In-process consumer for ``court_scrape`` jobs.
+
+The court scraper writes court cases + hearings into the ngm lake via the courts
+ORM, so — unlike the DB-free review/material poller — its consumer must run with
+ngm DB access. This command claims ``court_scrape`` jobs straight off the queue
+engine (``jobs.queue``, in-process: no HTTP/OIDC hop), runs the crawl, and
+finalizes each job, inheriting the queue's lease/retry/backoff/dedup and the
+``/api/jobs`` dashboard. Run it inside the platform image (has
+``NGM_DATABASE_URL``).
+
+Read-only by default (reports how many ``court_scrape`` jobs are queued);
+``--apply`` claims, runs and finalizes.
+
+    manage.py scrape_worker                     # READ-ONLY: report queued, exit
+    manage.py scrape_worker --apply --once      # drain queued scrapes, exit (CronJob)
+    manage.py scrape_worker --apply             # poll forever (daemon)
+"""
+
+import time
+import traceback
+
+from django.core.management.base import BaseCommand
+
+from courts.job_handlers import HANDLERS
+from jobs import queue as jobs_queue
+from jobs.models import Job
+
+KIND = "court_scrape"
+
+#: Exceptions that will never succeed on retry (a bad/unknown court in the
+#: payload) vs. transient portal/network failures (retried with backoff).
+_NON_RETRYABLE = (ValueError, KeyError)
+
+
+class Command(BaseCommand):
+    help = "Drain court_scrape jobs from the central queue (in-process, ngm DB)."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true",
+                            help="claim/run/finalize (mutates the queue + ngm "
+                                 "lake); without it the worker only reports the "
+                                 "queued count")
+        parser.add_argument("--once", action="store_true",
+                            help="with --apply: drain currently-available jobs "
+                                 "then exit (the CronJob mode)")
+        parser.add_argument("--poll", type=float, default=5.0,
+                            help="seconds between polls when idle (daemon mode)")
+        parser.add_argument("--max-jobs", type=int, default=None,
+                            help="finalize at most this many jobs, then exit")
+
+    def handle(self, *args, **o):
+        if not o["apply"]:
+            queued = Job.objects.filter(kind=KIND, status=Job.QUEUED).count()
+            self.stdout.write(
+                f"scrape_worker (read-only): {queued} queued {KIND} job(s); "
+                "use --apply to drain."
+            )
+            return
+
+        once = o["once"]
+        poll = float(o["poll"])
+        max_jobs = o["max_jobs"]
+        finalized = 0
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(f"scrape_worker up: kind={KIND} once={once}")
+        )
+        while True:
+            job = jobs_queue.claim_next([KIND])
+            if job is None:
+                if once:
+                    break
+                time.sleep(poll)
+                continue
+            self._run(job)
+            finalized += 1
+            if max_jobs and finalized >= max_jobs:
+                self.stdout.write(f"scrape_worker: hit --max-jobs={max_jobs}.")
+                break
+        self.stdout.write(
+            self.style.SUCCESS(f"scrape_worker: finalized {finalized} job(s).")
+        )
+
+    def _run(self, job):
+        self.stdout.write(f"  claimed job {job.pk} payload={job.payload}")
+        handler = HANDLERS[KIND]
+        try:
+            result = handler(
+                job.payload, on_stage=lambda s: jobs_queue.touch(job, stage=s)
+            )
+        except Exception as exc:  # noqa: BLE001 - report failure to the queue
+            retryable = not isinstance(exc, _NON_RETRYABLE)
+            err = f"{exc}\n{traceback.format_exc()[:2000]}"
+            self._finalize_failed(job, err, retryable)
+            self.stderr.write(f"  job {job.pk} failed (retryable={retryable}): {exc}")
+            return
+        try:
+            jobs_queue.finalize(job, status=Job.DONE, result=result)
+        except jobs_queue.JobNotRunning:
+            self.stderr.write(f"  job {job.pk}: lease lost mid-run; result dropped.")
+            return
+        self.stdout.write(self.style.SUCCESS(
+            f"  finished job {job.pk}: {result['cases']} cases / "
+            f"{result['hearings']} hearings across {result['courts']} court(s)"
+        ))
+
+    def _finalize_failed(self, job, err, retryable):
+        try:
+            jobs_queue.finalize(
+                job, status=Job.FAILED, error=err, retryable=retryable
+            )
+        except jobs_queue.JobNotRunning:
+            self.stderr.write(f"  job {job.pk}: lease lost; not finalizing failure.")

--- a/courts/management/commands/scrape_worker.py
+++ b/courts/management/commands/scrape_worker.py
@@ -21,15 +21,16 @@ import traceback
 
 from django.core.management.base import BaseCommand
 
-from courts.job_handlers import HANDLERS
+from courts.job_handlers import HANDLERS, BadCourtScrapePayload
 from jobs import queue as jobs_queue
 from jobs.models import Job
 
 KIND = "court_scrape"
 
-#: Exceptions that will never succeed on retry (a bad/unknown court in the
-#: payload) vs. transient portal/network failures (retried with backoff).
-_NON_RETRYABLE = (ValueError, KeyError)
+#: The only non-retryable failure: a bad/unknown court in the payload (raised as
+#: BadCourtScrapePayload up-front, before any crawl). Everything else — portal
+#: flakes, parse hiccups, DB errors — is retried with backoff, then dead-lettered.
+_NON_RETRYABLE = (BadCourtScrapePayload,)
 
 
 class Command(BaseCommand):
@@ -64,7 +65,9 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.MIGRATE_HEADING(f"scrape_worker up: kind={KIND} once={once}")
         )
-        while True:
+        # `max_jobs is None` = unlimited; the `< max_jobs` guard also makes
+        # `--max-jobs 0` a no-op-and-exit rather than (falsy-zero) unlimited.
+        while max_jobs is None or finalized < max_jobs:
             job = jobs_queue.claim_next([KIND])
             if job is None:
                 if once:
@@ -73,9 +76,6 @@ class Command(BaseCommand):
                 continue
             self._run(job)
             finalized += 1
-            if max_jobs and finalized >= max_jobs:
-                self.stdout.write(f"scrape_worker: hit --max-jobs={max_jobs}.")
-                break
         self.stdout.write(
             self.style.SUCCESS(f"scrape_worker: finalized {finalized} job(s).")
         )

--- a/courts/scraper/base.py
+++ b/courts/scraper/base.py
@@ -11,7 +11,7 @@ via :mod:`courts.case_status`. All writes go through here so the extra_data-unio
 from __future__ import annotations
 
 from collections.abc import Iterator
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from django.db import transaction
 from django.utils import timezone
@@ -28,6 +28,16 @@ _ENRICH_COLUMNS = {
     "case_status", "verdict_type", "verdict_date_bs", "verdict_date_ad",
     "verdict_judge", "case_subject", "hearing_count", "registration_number",
 }
+
+
+def anchor(value: str | None) -> date:
+    """Resolve an optional ``YYYY-MM-DD`` AD anchor date; default to today (KTM
+    localdate). Raises ``ValueError`` on a malformed string. Shared by the
+    scrape_courtcases command and the court_scrape job handler.
+    """
+    if not value:
+        return timezone.localdate()
+    return datetime.strptime(value, "%Y-%m-%d").date()
 
 
 def iter_bs_dates(lookback_days: int, *, today: date, offset_days: int = 1) -> Iterator[tuple[date, str]]:

--- a/courts/scraper/base.py
+++ b/courts/scraper/base.py
@@ -60,6 +60,11 @@ def scraped_dates_for(court_id: str, *, using: str = NGM_DB) -> set[str]:
 
 
 def mark_scraped(court_id: str, date_bs: str, note: str | None = None, *, using: str = NGM_DB) -> None:
+    # Marking a date scraped for a court implies the court exists. Ensure it here
+    # so a date with an EMPTY cause-list (no cases → upsert_causelist never ran
+    # _ensure_court) doesn't fail the ScrapedDate → Court FK. Real courts already
+    # exist (bulk-COPY'd); this only creates a stub for a court not yet in the DB.
+    _ensure_court(court_id, using=using)
     ScrapedDate.objects.using(using).get_or_create(
         court_id=court_id, date_bs=date_bs, defaults={"note": note}
     )

--- a/courts/scraper/crawl.py
+++ b/courts/scraper/crawl.py
@@ -32,12 +32,19 @@ def run_crawl(
     limit_dates: int | None = None,
     write: bool = False,
     enrich: bool = False,
+    only_court_id: str | None = None,
+    on_progress=None,
 ) -> list[CrawlStats]:
     """Crawl every court the ``module`` covers. ``module`` exposes ``court_ids``,
     ``LOOKBACK_DAYS``, ``crawl_date`` and (optionally) ``crawl_detail``.
 
     Dry-run by default: fetch + parse run, but nothing is written unless
     ``write=True``. Returns per-court stats.
+
+    ``only_court_id`` restricts the crawl to that single court (the court_scrape
+    job posts one job per leaf court). ``on_progress(court_id, date_bs)`` is
+    called before each date is fetched, so a consumer can heartbeat a job lease
+    during a long crawl.
     """
     from nepali.datetime import nepalidate
 
@@ -45,12 +52,16 @@ def run_crawl(
     results: list[CrawlStats] = []
 
     for court_id in module.court_ids(fetch):
+        if only_court_id is not None and court_id != only_court_id:
+            continue
         stats = CrawlStats(court_id=court_id)
         done = base.scraped_dates_for(court_id) if write else set()
         touched: set[str] = set()
         for ad_date, date_bs in base.iter_bs_dates(lookback, today=today):
             if date_bs in done:
                 continue
+            if on_progress is not None:
+                on_progress(court_id, date_bs)
             rows = module.crawl_date(fetch, court_id, date_bs, nepalidate.from_date(ad_date))
             stats.dates += 1
             stats.per_date.append(date_bs)

--- a/courts/scraper/district.py
+++ b/courts/scraper/district.py
@@ -80,7 +80,7 @@ def parse_daily_list(
                 bench_td = bench_row.find("td", align="right")
                 judge_td = bench_row.find("td", class_="judge")
                 if bench_td:
-                    current_bench = normalize_whitespace(bench_td.get_text()) or None
+                    current_bench = normalize_whitespace(bench_td.get_text())[:100] or None
                 if judge_td:
                     current_judge = normalize_whitespace(judge_td.get_text()) or None
 
@@ -153,7 +153,7 @@ def _parse_row(
         court_identifier=court_identifier,
         registration_date_bs=registration_date or None,
         registration_date_ad=bs_to_ad(registration_date),
-        case_type=normalize_whitespace(cells[3].get_text()) or None,
+        case_type=normalize_whitespace(cells[3].get_text())[:200] or None,
         plaintiff=normalize_whitespace(cells[4].get_text()) or None,
         defendant=normalize_whitespace(cells[5].get_text()) or None,
         extra_data=extra_data,
@@ -167,7 +167,7 @@ def _parse_row(
         bench=bench,
         serial_no=serial_no or None,
         judge_names=judge,
-        decision_type=normalize_whitespace(cells[9].get_text()) or None,
+        decision_type=normalize_whitespace(cells[9].get_text())[:200] or None,
         remarks=normalize_whitespace(cells[8].get_text()) or None,
     )
     return case, hearing
@@ -236,19 +236,19 @@ def _extract_detail_fields(soup: BeautifulSoup) -> dict[str, object]:
                 if not value:
                     continue
                 if label == "रजिष्ट्रेशन नं":
-                    data["registration_number"] = value
+                    data["registration_number"] = value[:100]
                 elif label == "मुद्दाको किसिम":
-                    data["case_type"] = value
+                    data["case_type"] = value[:200]
                 elif label == "मुद्दाको बिषय":
-                    data["case_subject"] = value
+                    data["case_subject"] = value  # CourtCase.case_subject is TextField
                 elif label == "मुद्दाको स्थिति":
-                    data["case_status"] = value
+                    data["case_status"] = value[:100]
                 elif label == "फैसला मिति" and value != _VERDICT_DATE_SENTINEL:
                     date_bs = normalize_date(value)
                     data["verdict_date_bs"] = date_bs
                     data["verdict_date_ad"] = bs_to_ad(date_bs)
                 elif label == "फैसला गर्ने मा. न्यायाधीश":
-                    data["verdict_judge"] = value
+                    data["verdict_judge"] = value[:500]
                 elif label == "पेशी चढेको संख्या":
                     data["hearing_count"] = value
 
@@ -258,7 +258,7 @@ def _extract_detail_fields(soup: BeautifulSoup) -> dict[str, object]:
             if "रजिष्ट्रेशन नं" in text:
                 reg_num = text.split(":")[-1].strip()
                 if reg_num:
-                    data["registration_number"] = reg_num
+                    data["registration_number"] = reg_num[:100]
     return data
 
 
@@ -306,7 +306,9 @@ def _parse_party_table(table) -> list[dict[str, object]]:
             name = cells[0].get_text(strip=True)
             address = cells[1].get_text(strip=True)
             if name:
-                parties.append({"name": name, "address": address or None})
+                parties.append(
+                    {"name": name[:500], "address": address[:500] if address else None}
+                )
     return parties
 
 

--- a/courts/scraper/fetch.py
+++ b/courts/scraper/fetch.py
@@ -1,0 +1,49 @@
+"""HTTP fetcher for the court-portal crawlers.
+
+Extracted from the ``scrape_courtcases`` command so both that command and the
+``court_scrape`` job handler share one fetch + decode path. ``Fetcher`` is a
+callable: ``fetch(url, data=None) -> html`` — POST when ``data`` is given, else
+GET.
+"""
+
+from __future__ import annotations
+
+_UA = "Mozilla/5.0 (X11; Linux x86_64) Jawafdehi-courts-crawler"
+
+
+def decode(resp) -> str:
+    """Body as text, forcing UTF-8 when the portal omits the charset.
+
+    supremecourt.gov.np serves UTF-8 Devanagari but sends ``Content-Type:
+    text/html`` with NO charset, so ``requests`` falls back to ISO-8859-1 and
+    mojibakes every page (the parsers then see zero Devanagari). Honor an
+    explicit header charset when present; otherwise decode as UTF-8 —
+    ``utf-8-sig`` also strips the BOM some endpoints emit.
+    """
+    if "charset=" not in resp.headers.get("content-type", "").lower():
+        resp.encoding = "utf-8-sig"
+    return resp.text
+
+
+class Fetcher:
+    """``fetch(url, data=None) -> html``: POST when ``data`` is given, else GET."""
+
+    def __init__(self, timeout: int = 60):
+        import requests
+
+        self._s = requests.Session()
+        self._s.headers.update({
+            "User-Agent": _UA,
+            "Referer": "https://supremecourt.gov.np/",
+            "Origin": "https://supremecourt.gov.np",
+        })
+        self._timeout = timeout
+
+    def __call__(self, url, data=None):
+        resp = (
+            self._s.post(url, data=data, timeout=self._timeout)
+            if data is not None
+            else self._s.get(url, timeout=self._timeout)
+        )
+        resp.raise_for_status()
+        return decode(resp)

--- a/courts/tests/test_job_scrape.py
+++ b/courts/tests/test_job_scrape.py
@@ -89,18 +89,32 @@ class HandlerTests(_NgmTestCase):
         with self.assertRaises(ValueError):
             handle_court_scrape({}, fetch=_fake_fetch)
 
+    def test_handler_heartbeats_once_per_crawled_date(self):
+        from courts.job_handlers import handle_court_scrape
+
+        stages = []
+        handle_court_scrape(_SPECIAL_PAYLOAD, on_stage=stages.append, fetch=_fake_fetch)
+        # on_stage fires per crawled date so the worker can extend the lease.
+        self.assertTrue(stages)
+        self.assertTrue(stages[0].startswith("special "))
+
 
 class EnqueueTests(_NgmTestCase):
-    def test_enqueue_all_posts_one_job_per_court_and_dedups(self):
+    def test_enqueue_all_posts_one_job_per_leaf_court_and_dedups(self):
         from courts.scraper import registry
 
         call_command("enqueue_scrape", "--court", "all")
-        n_courts = len(registry.REGISTRY)
-        self.assertEqual(Job.objects.filter(kind="court_scrape").count(), n_courts)
+        # one job per LEAF court_id across all tiers (district ~77, high ~18, ...)
+        expected = sum(len(m.court_ids(None)) for m in registry.REGISTRY.values())
+        self.assertEqual(Job.objects.filter(kind="court_scrape").count(), expected)
+        # dedup key is per leaf court: <tier>:<court_id>
+        self.assertTrue(
+            Job.objects.filter(dedup_key="court_scrape:special:special").exists()
+        )
 
         # Re-enqueuing while the jobs are still QUEUED is a no-op (dedup key).
         call_command("enqueue_scrape", "--court", "all")
-        self.assertEqual(Job.objects.filter(kind="court_scrape").count(), n_courts)
+        self.assertEqual(Job.objects.filter(kind="court_scrape").count(), expected)
 
     def test_enqueue_unknown_court_errors(self):
         from django.core.management.base import CommandError
@@ -136,8 +150,8 @@ class ScrapeWorkerTests(_NgmTestCase):
         )
 
     def test_unknown_court_fails_terminally_not_retried(self):
-        # A KeyError (unknown court) is non-retryable: the worker finalizes it
-        # FAILED on the first attempt rather than re-queuing.
+        # An unknown court is a BadCourtScrapePayload (non-retryable): the worker
+        # finalizes it FAILED on the first attempt rather than re-queuing.
         jobs_queue.enqueue(
             kind="court_scrape", payload={"court": "bogus"},
             dedup_key="court_scrape:bogus",
@@ -147,3 +161,13 @@ class ScrapeWorkerTests(_NgmTestCase):
         job = Job.objects.get(kind="court_scrape")
         self.assertEqual(job.status, Job.FAILED)
         self.assertEqual(job.attempts, 1)
+
+    def test_max_jobs_zero_finalizes_nothing(self):
+        jobs_queue.enqueue(
+            kind="court_scrape", payload=_SPECIAL_PAYLOAD,
+            dedup_key="court_scrape:special",
+        )
+        with patch("courts.job_handlers.Fetcher", lambda: _fake_fetch):
+            call_command("scrape_worker", "--apply", "--once", "--max-jobs", "0")
+        # --max-jobs 0 is a no-op-and-exit (not falsy-unlimited): job stays QUEUED.
+        self.assertEqual(Job.objects.get(kind="court_scrape").status, Job.QUEUED)

--- a/courts/tests/test_job_scrape.py
+++ b/courts/tests/test_job_scrape.py
@@ -1,0 +1,149 @@
+"""court_scrape job wiring: kind registration, handler, enqueuer, and the
+in-process scrape_worker consumer — all against a FAKE fetch (no network).
+
+Mirrors test_scraper_crawl.py's fake-fetcher approach; the crawl parse/write is
+proven there, so these tests focus on the queue wiring: enqueue+dedup, the
+handler's write + stats, and the worker's claim → run → finalize lifecycle
+(including retryable vs. terminal failure classification).
+"""
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from courts.models import CourtCase
+from jobs import queue as jobs_queue
+from jobs.models import Job
+from jobs.registry import get as get_kind
+
+_BENCH_SELECT = """<select name="bench_type">
+  <option value="">--</option><option value="1">इजलास १</option></select>"""
+
+_BENCH_PAGE = """<table width="100%" border="1">
+  <tr><th>क्र</th><th>फाँट</th><th>मिति</th><th>मुद्दा</th><th>नं</th><th>वादी</th>
+      <th>प्रतिवादी</th><th>मूल</th><th>कैफियत</th><th>स्थिति</th><th>किसिम</th></tr>
+  <tr><td>१</td><td>क</td><td>२०८१/०५/१२</td><td>भ्रष्टाचार</td><td>०८२-CR-००१५</td>
+      <td>नेपाल सरकार</td><td>क</td><td></td><td>-</td><td>पेशी</td><td>-</td></tr>
+</table>"""
+
+_DETAIL = """<table width="100%" border="0" cellspacing="0" cellpadding="1">
+  <tr><td class="caption">मुद्दा</td><td>भ्रष्टाचार</td></tr>
+  <tr><td class="caption">मुद्दाको स्थिती</td><td>आदेश /फैसलाको किसिम</td></tr>
+</table>
+<table><tr><td>पेशी को विवरण</td></tr>
+<tr><td><table class="utivtbl"><tr><th>x</th><th>x</th><th>x</th><th>x</th></tr>
+  <tr><td>२०८२/०९/२८</td><td>राम</td><td>फैसला</td><td>सफाई</td></tr></table></td></tr></table>"""
+
+
+def _fake_fetch(url, data=None):
+    data = data or {}
+    if data.get("mode") == "showbench":
+        return _BENCH_SELECT
+    if "case_details" in url:
+        return _DETAIL
+    if data.get("mode") == "show":
+        return _BENCH_PAGE
+    return ""
+
+
+#: A special-court scrape sized to the fake fetch (one date, one case).
+_SPECIAL_PAYLOAD = {
+    "court": "special",
+    "enrich": True,
+    "lookback_days": 2,
+    "limit_dates": 1,
+    "today": "2025-04-20",
+}
+
+
+class _NgmTestCase(TestCase):
+    databases = "__all__"
+
+
+class KindRegistrationTests(_NgmTestCase):
+    def test_court_scrape_kind_is_registered(self):
+        spec = get_kind("court_scrape")
+        self.assertEqual(spec.kind, "court_scrape")
+        self.assertEqual(spec.lease_seconds, 1800)
+        self.assertEqual(spec.max_attempts, 3)
+
+
+class HandlerTests(_NgmTestCase):
+    def test_handler_writes_and_returns_stats(self):
+        from courts.job_handlers import handle_court_scrape
+
+        result = handle_court_scrape(_SPECIAL_PAYLOAD, fetch=_fake_fetch)
+
+        self.assertEqual(result["cases"], 1)
+        self.assertEqual(result["hearings"], 1)
+        self.assertEqual(result["enriched"], 1)
+        self.assertEqual(result["per_court"][0]["court"], "special")
+        self.assertEqual(
+            CourtCase.objects.using("ngm").filter(court_id="special").count(), 1
+        )
+
+    def test_handler_missing_court_raises(self):
+        from courts.job_handlers import handle_court_scrape
+
+        with self.assertRaises(ValueError):
+            handle_court_scrape({}, fetch=_fake_fetch)
+
+
+class EnqueueTests(_NgmTestCase):
+    def test_enqueue_all_posts_one_job_per_court_and_dedups(self):
+        from courts.scraper import registry
+
+        call_command("enqueue_scrape", "--court", "all")
+        n_courts = len(registry.REGISTRY)
+        self.assertEqual(Job.objects.filter(kind="court_scrape").count(), n_courts)
+
+        # Re-enqueuing while the jobs are still QUEUED is a no-op (dedup key).
+        call_command("enqueue_scrape", "--court", "all")
+        self.assertEqual(Job.objects.filter(kind="court_scrape").count(), n_courts)
+
+    def test_enqueue_unknown_court_errors(self):
+        from django.core.management.base import CommandError
+
+        with self.assertRaises(CommandError):
+            call_command("enqueue_scrape", "--court", "bogus")
+
+
+class ScrapeWorkerTests(_NgmTestCase):
+    def test_readonly_does_not_claim(self):
+        jobs_queue.enqueue(
+            kind="court_scrape", payload=_SPECIAL_PAYLOAD,
+            dedup_key="court_scrape:special",
+        )
+        call_command("scrape_worker")  # no --apply
+        self.assertEqual(
+            Job.objects.get(kind="court_scrape").status, Job.QUEUED
+        )
+
+    def test_apply_once_claims_runs_and_finalizes(self):
+        jobs_queue.enqueue(
+            kind="court_scrape", payload=_SPECIAL_PAYLOAD,
+            dedup_key="court_scrape:special",
+        )
+        with patch("courts.job_handlers.Fetcher", lambda: _fake_fetch):
+            call_command("scrape_worker", "--apply", "--once")
+
+        job = Job.objects.get(kind="court_scrape")
+        self.assertEqual(job.status, Job.DONE)
+        self.assertEqual(job.result["cases"], 1)
+        self.assertEqual(
+            CourtCase.objects.using("ngm").filter(court_id="special").count(), 1
+        )
+
+    def test_unknown_court_fails_terminally_not_retried(self):
+        # A KeyError (unknown court) is non-retryable: the worker finalizes it
+        # FAILED on the first attempt rather than re-queuing.
+        jobs_queue.enqueue(
+            kind="court_scrape", payload={"court": "bogus"},
+            dedup_key="court_scrape:bogus",
+        )
+        call_command("scrape_worker", "--apply", "--once")
+
+        job = Job.objects.get(kind="court_scrape")
+        self.assertEqual(job.status, Job.FAILED)
+        self.assertEqual(job.attempts, 1)

--- a/courts/tests/test_scraper_base.py
+++ b/courts/tests/test_scraper_base.py
@@ -85,6 +85,16 @@ class FrontierTests(_NgmTestCase):
         self.assertEqual(scraped_dates_for("special"), {"2082-01-05"})
         self.assertEqual(ScrapedDate.objects.using("ngm").count(), 1)
 
+    def test_mark_scraped_creates_court_for_empty_causelist(self):
+        # A crawled date with an EMPTY cause-list still gets marked scraped; the
+        # court FK must not fail just because no cases were written and the court
+        # is not yet in the DB. Regression: district courts with empty days threw
+        # IntegrityError (FOREIGN KEY constraint failed) on a fresh/unseeded DB.
+        self.assertFalse(Court.objects.using("ngm").filter(identifier="achhamdc").exists())
+        mark_scraped("achhamdc", "2082-01-06")
+        self.assertTrue(Court.objects.using("ngm").filter(identifier="achhamdc").exists())
+        self.assertEqual(scraped_dates_for("achhamdc"), {"2082-01-06"})
+
 
 class EnrichmentTests(_NgmTestCase):
     def _seed(self, cn="082-CR-0020"):

--- a/courts/tests/test_scraper_registry.py
+++ b/courts/tests/test_scraper_registry.py
@@ -48,17 +48,17 @@ class _FakeResp:
 
 def test_decode_forces_utf8_when_portal_omits_charset():
     # The real bug: portal serves UTF-8 Devanagari with no charset → requests
-    # defaults to ISO-8859-1 and mojibakes it. _decode must override to UTF-8.
-    from courts.management.commands.scrape_courtcases import _decode
+    # defaults to ISO-8859-1 and mojibakes it. decode must override to UTF-8.
+    from courts.scraper.fetch import decode
 
     resp = _FakeResp("text/html", {"utf-8-sig": "नेपाल सरकार", "ISO-8859-1": "à¤¨à¥‡à¤ª"})
-    assert _decode(resp) == "नेपाल सरकार"
+    assert decode(resp) == "नेपाल सरकार"
     assert resp.encoding == "utf-8-sig"
 
 
 def test_decode_honors_explicit_header_charset():
-    from courts.management.commands.scrape_courtcases import _decode
+    from courts.scraper.fetch import decode
 
     resp = _FakeResp("text/html; charset=utf-8", {"utf-8": "फैसला"}, encoding="utf-8")
-    assert _decode(resp) == "फैसला"
+    assert decode(resp) == "फैसला"
     assert resp.encoding == "utf-8"  # left untouched

--- a/jobs/consumers.py
+++ b/jobs/consumers.py
@@ -162,3 +162,22 @@ register(
         # Material is still served (metadata-searchable), and a re-upload re-runs.
     )
 )
+
+
+# --- court_scrape: crawl a court's recent cause-lists into the ngm lake -------
+#
+# Unlike the DB-free review/material kinds, court_scrape WRITES via the courts
+# ORM, so it is run by an in-process consumer with ngm DB access
+# (courts/management/commands/scrape_worker.py), not the external HTTP poller.
+# The queue still gives it lease/retry/backoff/dedup + the /api/jobs dashboard.
+# No build_payload (the payload is self-contained: court + lookback) and no
+# on_result (the crawl writes the lake itself; job.result just records stats).
+
+
+register(
+    KindSpec(
+        kind="court_scrape",
+        lease_seconds=1800,  # an incremental per-court crawl is minutes.
+        max_attempts=3,  # portal/network flakes retry with backoff, then dead-letter.
+    )
+)


### PR DESCRIPTION
### **User description**
## What

Runs the ported court-case scraper as a `court_scrape` **central-queue job kind** rather than a bare management command — the design the jobs-queue doc called for (the queue owns execution: leases / retry-backoff / dedup + the `/api/jobs` dashboard; a thin enqueuer triggers recurrence).

- `court_scrape` kind (`jobs/consumers.py`) — no migration (kind is free-form).
- `handle_court_scrape` (`courts/job_handlers.py`) — `run_crawl(write=True)` per court, heartbeats, returns per-court stats.
- **In-process** consumer `scrape_worker` — claims `jobs.queue` directly (the scraper writes the ngm lake via ORM, so it can't ride the DB-free HTTP poller). `--apply` / `--once`, classifies bad-payload errors non-retryable and network flakes retryable.
- Enqueuer `enqueue_scrape` — one job per court, `dedup_key=court_scrape:<court>`.
- Extracted `courts/scraper/fetch.py` (`Fetcher`/`decode`) so the command and handler share one fetch path.

## Bug fix

Dry-running **all four court types** surfaced a latent write-path bug: an **empty cause-list date** failed the `ScrapedDate → Court` FK because `_ensure_court` only ran when there were cases. `mark_scraped` now ensures the court. Prod mostly masked this via the 97 bulk-COPY'd courts; a fresh DB or a court not among the 97 broke. Includes a regression test that doesn't pre-seed the court.

## Test plan

- `courts/` + `jobs/` suites green (294 passed); `ruff check .` clean.
- Manual dry runs (live portal fetch → local sqlite, enrich on) for **special / supreme / high / district** — all write + enrich cleanly.

## Deploy

Infra CronJob `ngm-court-scrape` drafted in `services/infra` (**starts suspended** — unsuspend after this merges and the platform image carries `enqueue_scrape`/`scrape_worker`). Runs `enqueue_scrape --court all --lookback-days 30 --enrich` then `scrape_worker --apply --once`. `--lookback-days` is bounded on purpose: the `ScrapedDate` frontier is empty (the corpus came from bulk COPY, not scraping), so an unbounded run would re-crawl each court's full default lookback (district/high 10y, supreme 15y).

## Follow-ups (NOT in this PR — rest of the frozen NGM suite)

- [ ] `supreme_court_orders` — court-**order** acquisition scraper (captcha `/cp/` portal + PDF→R2). A separate feed; only the index→Material reshape exists today, so order coverage is frozen at the last backfill.
- [ ] `ppmo_blacklist` scraper (model + read API already ported).
- [ ] `ciaa_press_releases` / `ciaa_annual_reports`.
- [ ] Wire `materials/sourcing/nkp/` (kanun-patrika) to a scheduled job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add `court_scrape` queue execution

- Add enqueue, worker commands

- Share scraper HTTP fetcher

- Fix empty cause-list court FK


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["enqueue_scrape command"]
  B["jobs.queue court_scrape"]
  C["scrape_worker consumer"]
  D["handle_court_scrape"]
  E["court ORM lake writes"]
  A -- "dedup enqueue" --> B
  B -- "claim job" --> C
  C -- "dispatch" --> D
  D -- "crawl write" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>job_handlers.py</strong><dd><code>Add court scrape job handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-db3ad0ff02958fdfed1bf3509d74328315e43046b5dd01e71b5cd1ead01dd4ee">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enqueue_scrape.py</strong><dd><code>Add court scrape enqueuer command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-2b0165301f06b2191751768eee33748e1c7d5066f25e6c8b9c762c5742d37d30">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scrape_worker.py</strong><dd><code>Add in-process scrape job worker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-1ed72630ccc43efa2752bc2f63809195080313ea249a3a41a1dba5679c804c32">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>consumers.py</strong><dd><code>Register court scrape job kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-77cdedb6d0cd3c77a7c7df88e9c0141fc6fc2f4e2d578046ec6a3fce63ba036c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>scrape_courtcases.py</strong><dd><code>Use shared scraper fetcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-7ff9b2ff8f284ece2d75f153cc7512526f3b7654e1e1021afed0df64ae90229d">+2/-41</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fetch.py</strong><dd><code>Extract reusable portal fetcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-063fdb1caa6c671837b0b43513fdf6ebd7b37135220a7a14c8dcb70cca5536bd">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>base.py</strong><dd><code>Ensure court before marking scraped</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-ffb586961a49ecdc9cac23b5eeaedf6682373e6ccde407cf3e5f2b32213ccd47">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_job_scrape.py</strong><dd><code>Test queue scrape job wiring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-43e9fea1275224384432e79be612e3077854bec67a453030adadbdf05e256b9d">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_scraper_base.py</strong><dd><code>Test empty cause-list court creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-eb0e22d4d8a9aa00bb0a071a665a9a2d2e477caed79f55e7859ccac5e2acb3b3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_scraper_registry.py</strong><dd><code>Update decode tests import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/364/files#diff-d2942cb34431aa81019905d6e8d5026bddcaa08c1290cab03b72715882777f3a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added queued `court_scrape` jobs with support for enqueuing one tier at a time, selecting individual courts, or enqueuing all leaf courts.
  * Added a worker command to preview and apply `court_scrape` jobs (including retry/finalization behavior).
  * Added shared HTTP fetching/decoding and crawl progress support (e.g., per-court restriction and progress callbacks).
* **Bug Fixes**
  * Ensured court records are created when scraping empty cause lists.
  * Improved handling of missing charset and UTF-8 BOMs.
* **Refactor / Tests**
  * Added parsing field-length limits and expanded end-to-end job/worker test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->