### PR TITLE
feat(cases): add ?entity= reverse-lookup filter to the cases list

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -14,6 +14,7 @@ import jsonpatch
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection, transaction
+from django.db.models import Exists, OuterRef
 from django.http import Http404, HttpResponse, HttpResponsePermanentRedirect
 from django.urls import reverse
 from django.utils import timezone
@@ -240,6 +241,19 @@ def _if_match_matches(request, case) -> bool:
                 required=False,
             ),
             OpenApiParameter(
+                name="entity",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Reverse lookup: published cases citing this NES entity by "
+                    "its canonical @id IRI (e.g. "
+                    "https://jawafdehi.org/entity/person/some-slug). "
+                    "Accused/alleged citations are ordered first, then "
+                    "reverse-chronologically."
+                ),
+                required=False,
+            ),
+            OpenApiParameter(
                 name="search",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
@@ -426,13 +440,41 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 ]
                 queryset = queryset.filter(id__in=case_ids_with_tag)
 
-        return queryset.prefetch_related(
+        queryset = queryset.prefetch_related(
             "entity_relationships",
             "courtcase_references",
             # ``CaseSerializer.get_evidence`` iterates ``material_references``;
             # prefetch it so a list page doesn't fire one query per card (N+1).
             "material_references",
-        ).order_by("-created_at")
+        )
+
+        # Reverse lookup: cases citing a specific NES entity by its canonical
+        # ``@id`` IRI (``CaseEntityRelationship.nes_id``), powering the "Related
+        # cases" section on an entity's record page. List action only — retrieve
+        # addresses a single case by slug. Visibility scoping above still holds,
+        # so an anonymous caller only sees PUBLISHED citations. ``accused`` /
+        # ``alleged`` cases float to the top; reverse-chron (``-created_at``)
+        # within each tier.
+        entity_param = self.request.query_params.get("entity")
+        if self.action == "list" and entity_param:
+            accused_first = Exists(
+                CaseEntityRelationship.objects.filter(
+                    case=OuterRef("pk"),
+                    nes_id=entity_param,
+                    relationship_type__in=[
+                        RelationshipType.ACCUSED,
+                        RelationshipType.ALLEGED,
+                    ],
+                )
+            )
+            return (
+                queryset.filter(entity_relationships__nes_id=entity_param)
+                .distinct()
+                .annotate(_accused_first=accused_first)
+                .order_by("-_accused_first", "-created_at")
+            )
+
+        return queryset.order_by("-created_at")
 
     # This list is ROLE-SCOPED: an anonymous caller gets a PUBLISHED-only page,
     # but the SAME URL returns a wider DRAFT/IN_REVIEW-inclusive page to an

--- a/tests/api/test_cases_entity_filter.py
+++ b/tests/api/test_cases_entity_filter.py
@@ -1,0 +1,161 @@
+"""
+Tests for the ``?entity=<iri>`` reverse-lookup filter on GET /api/cases/.
+
+Powers the "Related cases" section on an entity's record page: the published
+cases that cite a given NES entity, with accused/alleged citations floated to
+the top and reverse-chronological within each tier.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseState,
+    CaseType,
+    RelationshipType,
+)
+from tests.conftest import create_case_with_entities
+
+X = "https://jawafdehi.org/entity/person/test-x"
+Y = "https://jawafdehi.org/entity/person/test-y"
+
+
+def _get(entity):
+    resp = APIClient().get("/api/cases/", {"entity": entity})
+    assert resp.status_code == 200
+    return resp.data
+
+
+@pytest.mark.django_db
+class TestCaseEntityFilter:
+    def test_returns_only_citing_published_cases(self):
+        create_case_with_entities(
+            slug="ef-accused",
+            title="Accused case",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[X],
+        )
+        create_case_with_entities(
+            slug="ef-related",
+            title="Related case",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            related_entities=[X],
+        )
+        # Published but does NOT cite X -> excluded.
+        create_case_with_entities(
+            slug="ef-other",
+            title="Other entity",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[Y],
+        )
+        # Cites X but IN_REVIEW -> hidden from the anonymous reverse lookup.
+        create_case_with_entities(
+            slug="ef-inreview",
+            title="In review",
+            state=CaseState.IN_REVIEW,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[X],
+        )
+
+        data = _get(X)
+
+        assert data["count"] == 2
+        assert {c["slug"] for c in data["results"]} == {"ef-accused", "ef-related"}
+
+    def test_unknown_entity_returns_empty(self):
+        create_case_with_entities(
+            slug="ef-lonely",
+            title="Lonely",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[X],
+        )
+
+        data = _get("https://jawafdehi.org/entity/person/nobody")
+
+        assert data["count"] == 0
+        assert data["results"] == []
+
+    def test_same_entity_two_roles_on_one_case_deduped(self):
+        # A case may cite the same entity in more than one role (the unique key
+        # is (case, nes_id, relationship_type)). The filter must return the case
+        # ONCE (this is why .distinct() exists) and tier it as accused.
+        case = create_case_with_entities(
+            slug="ef-multirole",
+            title="Multi-role",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            related_entities=[X],
+        )
+        CaseEntityRelationship.objects.create(
+            case=case, nes_id=X, relationship_type=RelationshipType.ACCUSED
+        )
+
+        data = _get(X)
+
+        assert data["count"] == 1
+        assert [c["slug"] for c in data["results"]] == ["ef-multirole"]
+
+    def test_anon_state_param_cannot_widen_past_published(self):
+        create_case_with_entities(
+            slug="ef-scoped-inreview",
+            title="In review",
+            state=CaseState.IN_REVIEW,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[X],
+        )
+
+        # Even explicitly asking for IN_REVIEW, an anonymous caller stays scoped
+        # to PUBLISHED (scoping runs before the state filter).
+        resp = APIClient().get("/api/cases/", {"entity": X, "state": "IN_REVIEW"})
+
+        assert resp.status_code == 200
+        assert resp.data["count"] == 0
+
+    def test_accused_alleged_float_to_top(self):
+        now = timezone.now()
+
+        # Related case is the MOST recent; it must still sort below every
+        # accused/alleged citation.
+        rel = create_case_with_entities(
+            slug="ord-related",
+            title="Related (newest)",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            related_entities=[X],
+        )
+        acc = create_case_with_entities(
+            slug="ord-accused",
+            title="Accused (oldest)",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[X],
+        )
+        alleged = Case.objects.create(
+            slug="ord-alleged",
+            title="Alleged (middle)",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+        )
+        CaseEntityRelationship.objects.create(
+            case=alleged, nes_id=X, relationship_type=RelationshipType.ALLEGED
+        )
+
+        # auto_now_add ignores create-time created_at; set it explicitly.
+        Case.objects.filter(pk=rel.pk).update(created_at=now)
+        Case.objects.filter(pk=alleged.pk).update(created_at=now - timedelta(days=1))
+        Case.objects.filter(pk=acc.pk).update(created_at=now - timedelta(days=2))
+
+        order = [c["slug"] for c in _get(X)["results"]]
+
+        # accused/alleged tier first (reverse-chron within: alleged newer than
+        # accused), then the related case last despite being the newest overall.
+        assert order == ["ord-alleged", "ord-accused", "ord-related"]


### PR DESCRIPTION
## What

Adds a `?entity=<iri>` reverse-lookup filter to `GET /api/cases/`: the published cases that cite a given NES entity by its canonical `@id` IRI (`CaseEntityRelationship.nes_id`). Powers a new "Related cases" section on the entity record page (frontend PR: Jawafdehi/Jawafdehi#257).

## Behavior

- Filters `entity_relationships__nes_id == <iri>`, `.distinct()` (a case may cite the same entity in more than one role).
- **Accused/alleged citations float to the top** (an `Exists` annotation), then reverse-chronological (`-created_at`) within each tier.
- **List action only.** Visibility scoping is unchanged and runs first, so an anonymous caller only ever sees PUBLISHED citations — `?entity=X&state=IN_REVIEW` still returns nothing.
- Composes with the existing `case_type` / `search` filters and pagination; the join column `(nes_id, relationship_type)` is already indexed.

## Tests

`tests/api/test_cases_entity_filter.py`: filter returns only citing published cases; unknown entity → empty; multi-role dedup (`.distinct()`); anon `state=` cannot widen past PUBLISHED; accused/alleged-first ordering.

## Notes

- The `entity` param is declared in the OpenAPI schema alongside `case_type` / `state`.
- No schema or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
