### PR TITLE
casework(ag): recover + backfill AG abhiyog case numbers

### DIFF
--- a/casework/backfill_ag_caseno.py
+++ b/casework/backfill_ag_caseno.py
@@ -20,8 +20,17 @@ is added in memory, and the whole document goes back.
 
 Concurrency caveat: unlike the case endpoint, the materials endpoint exposes no
 ETag/If-Match, so this read-modify-write cannot be made conditional. A
-concurrent writer's change between our GET and PUT would be lost. Keep this a
-single serialized writer and do not run it alongside an AG re-ingest.
+concurrent writer's change between our GET and PUT would be lost. Two defences,
+one enforced and one not:
+
+  * against ITSELF -- enforced. An advisory single-instance lock (``--lock-file``,
+    see :func:`single_instance`) refuses to start while another run holds it.
+    This is not hypothetical: three stray concurrent processes from earlier
+    launches tripled the request rate during the recovery dry-run and produced a
+    persistent spray of 429s that read as lake errors until they were found.
+  * against an AG RE-INGEST -- not enforced. That writer is a different process
+    on a different schedule, so this remains an operational constraint: do not
+    run the two together.
 
 Dry-run is the DEFAULT (logs the exact PUT it WOULD send, writes nothing).
 ``--apply`` opts into writing, and writing to any non-loopback host
@@ -32,8 +41,10 @@ Usage:
     uv run python -m casework.backfill_ag_caseno --map ... --apply --allow-remote-writes
 """
 import argparse
+import contextlib
 import copy
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -42,7 +53,7 @@ from pathlib import Path
 from casework.common.api import CaseworkApi
 from casework.common.cli import (
     add_common_args, basic_auth_from_env, configure_run_logging, log_event,
-    print_summary,
+    nonneg_float, nonneg_int, print_summary,
 )
 from casework.common.materials import ag_ident, material_path
 
@@ -69,6 +80,13 @@ CHARGE_SHEET_ADDITIONAL_TYPE = "jawafdehi:ChargeSheet"
 _IDENTITY_KEYS = ("jawafdehi:recordId", "jawafdehi:officeLevel")
 
 MAX_BACKOFF_S = 30
+
+#: Default advisory lock. Lives beside the run logs so it shares their lifetime
+#: and is obvious to an operator looking for why a run refused to start.
+DEFAULT_LOCK_FILE = Path(
+    os.environ.get("CASEWORK_RUN_LOG_DIR")
+    or Path(__file__).resolve().parents[1] / "work" / "enricher-runs"
+) / f"{STAGE}.lock"
 
 #: HTTP codes that will never succeed on a retry: the request or the caller's
 #: credentials are wrong, not the server's mood. Retrying them burns the entire
@@ -100,6 +118,76 @@ _FAILURE_OUTCOMES = frozenset({GET_ERROR, GET_FATAL, APPLY_FAILED})
 
 #: Required on every map row; the writer refuses a map that lacks them.
 _REQUIRED_ROW_KEYS = ("id", "material_iri", "case_number", "source", "in_lake")
+
+
+@contextlib.contextmanager
+def single_instance(lock_path):
+    """Refuse to start while another backfill run holds ``lock_path``.
+
+    The GET->merge->PUT here cannot be made conditional (the materials endpoint
+    exposes no ETag/If-Match), so overlapping runs can lose each other's writes.
+    That constraint was documented but enforced only by convention -- and it has
+    already bitten once: three stray concurrent processes from earlier launches
+    tripled the request rate during the recovery dry-run and produced a
+    persistent spray of 429s that read as lake errors until the strays were
+    found and killed.
+
+    Deliberately advisory and dependency-free: an ``O_EXCL`` create carrying our
+    PID. A lock whose owner is gone is STALE and gets reclaimed (a killed run
+    must not wedge the next one), and the lock is always released, including on
+    an exception. This does not coordinate with the AG re-ingest -- that remains
+    a scheduling constraint -- it only stops this verb racing itself.
+    """
+    path = Path(lock_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    while True:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            break
+        except FileExistsError:
+            holder = _lock_holder(path)
+            if holder is not None and _pid_alive(holder):
+                raise SystemExit(
+                    f"another {STAGE} run (pid {holder}) holds {path}. This verb "
+                    "must not race itself: the materials endpoint has no "
+                    "If-Match, so concurrent read-modify-writes lose updates. "
+                    "Wait for it, or pass --lock-file to run against a different "
+                    "target.")
+            # Stale: the owner died without releasing. Reclaim it.
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass  # someone else reclaimed it first; retry the create
+    try:
+        os.write(fd, str(os.getpid()).encode())
+        os.close(fd)
+        yield path
+    finally:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _lock_holder(path):
+    """The PID recorded in a lock file, or None if it is unreadable/garbage."""
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_alive(pid):
+    """True if `pid` is a live process. Signal 0 performs the permission and
+    existence checks without delivering anything; EPERM means it exists but is
+    owned by someone else, which still counts as alive."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 def validate_map(rows, origin):
@@ -210,6 +298,17 @@ def alt_case_numbers(row):
     return [a for a in (row.get("alt_case_number") or "").split(";") if a.strip()]
 
 
+def _backoff_s(interval, attempt):
+    """Exponential backoff, capped and clamped to >= 0.
+
+    ``time.sleep()`` raises ``ValueError`` on a negative argument, so a negative
+    ``--read-interval`` would abort the walk with a traceback partway through
+    rather than degrade. The flag is also rejected at the boundary
+    (``cli.nonneg_float``); this covers a direct caller.
+    """
+    return min(max(interval, 0) * (2 ** attempt), MAX_BACKOFF_S)
+
+
 def fetch_doc(api, rid, *, retries=4, interval=1.0):
     """GET one material, retrying a throttled/transient read.
 
@@ -239,12 +338,12 @@ def fetch_doc(api, rid, *, retries=4, interval=1.0):
             if attempt < retries:
                 raw = (exc.headers or {}).get("Retry-After")
                 wait = (float(raw) if raw and str(raw).isdigit()
-                        else min(interval * (2 ** attempt), MAX_BACKOFF_S))
-                time.sleep(min(wait, MAX_BACKOFF_S))
+                        else _backoff_s(interval, attempt))
+                time.sleep(min(max(wait, 0), MAX_BACKOFF_S))
         except Exception as exc:  # noqa: BLE001 - transport errors are retryable
             last = exc
             if attempt < retries:
-                time.sleep(min(interval * (2 ** attempt), MAX_BACKOFF_S))
+                time.sleep(_backoff_s(interval, attempt))
     return None, GET_ERROR, f"GET failed after {max(retries, 0) + 1} attempts: {last}"
 
 
@@ -295,6 +394,13 @@ def plan_one(api, row, *, retries=4, interval=1.0):
 
 
 def run(args):
+    lock = (single_instance(args.lock_file) if getattr(args, "lock_file", "")
+            else contextlib.nullcontext())
+    with lock:
+        return _run(args)
+
+
+def _run(args):
     logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
     rows = validate_map(
         json.loads(Path(args.map).read_text(encoding="utf-8")), f"map {args.map}")
@@ -401,20 +507,25 @@ def build_parser():
     parser.add_argument("--put-bodies", default="",
                         help="Optional path; append the exact PUT body that "
                              "would be (or was) sent, one JSON per line.")
-    parser.add_argument("--write-interval", type=float, default=0.5,
+    parser.add_argument("--write-interval", type=nonneg_float, default=0.5,
                         help="Seconds to pause after each applied write; the "
                              "materials API rate-limits under bursts.")
-    parser.add_argument("--read-retries", type=int, default=4,
+    parser.add_argument("--read-retries", type=nonneg_int, default=4,
                         help="Retries for a throttled/transient material GET "
                              "(429s are common on a long run; a 404 is never "
                              "retried).")
-    parser.add_argument("--read-interval", type=float, default=1.0,
+    parser.add_argument("--read-interval", type=nonneg_float, default=1.0,
                         help="Base backoff seconds between GET retries "
                              "(exponential, Retry-After honoured).")
-    parser.add_argument("--max-consecutive-failures", type=int, default=10,
+    parser.add_argument("--max-consecutive-failures", type=nonneg_int, default=10,
                         help="Abort after this many consecutive failed rows -- "
                              "a streak means a systemic fault (bad token, wrong "
                              "host), not odd records. 0 disables the breaker.")
+    parser.add_argument("--lock-file", default=str(DEFAULT_LOCK_FILE),
+                        help="Advisory single-instance lock. This verb must not "
+                             "race itself -- the materials endpoint has no "
+                             "If-Match, so overlapping read-modify-writes lose "
+                             "updates. Empty string disables it.")
     return parser
 
 

--- a/casework/backfill_ag_caseno.py
+++ b/casework/backfill_ag_caseno.py
@@ -36,6 +36,7 @@ import copy
 import json
 import sys
 import time
+import urllib.error
 from pathlib import Path
 
 from casework.common.api import CaseworkApi
@@ -43,13 +44,15 @@ from casework.common.cli import (
     add_common_args, basic_auth_from_env, configure_run_logging, log_event,
     print_summary,
 )
-from casework.common.materials import ag_ident
+from casework.common.materials import ag_ident, material_path
 
 STAGE = "backfill_ag_caseno"
 AG_SOURCE = "ag"
 MATERIAL_TYPE = "charge_sheet"
 EXPECTED_SOURCE_TYPE = "AG_ABHIYOG_PATRA"
 SPECIAL_OFFICE_LEVEL = 1
+
+MAX_BACKOFF_S = 30
 
 CASE_NO_KEY = "jawafdehi:caseNumber"
 SOURCE_KEY = "jawafdehi:caseNumberSource"
@@ -118,7 +121,38 @@ def merge_case_no(doc, row):
     return merged, added
 
 
-def plan_one(api, row):
+def fetch_doc(api, rid, *, retries=4, interval=1.0):
+    """GET one material, retrying a throttled/transient read.
+
+    Returns ``(doc, outcome, detail)`` with ``doc=None`` on failure. The
+    production materials API rate-limits under bursts: a straight walk of the
+    map fires one GET per material back-to-back and a large share come back
+    429, which -- treated as a plain error -- would silently demote those
+    materials to GET_ERROR and drop them from the backfill. A definitive 404
+    is NOT retried: that material is genuinely gone.
+    """
+    path = material_path(AG_SOURCE, ag_ident(rid))
+    last = None
+    for attempt in range(retries + 1):
+        try:
+            return api.get(path), None, ""
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None, GONE, "material not found"
+            last = exc
+            if attempt < retries:
+                raw = (exc.headers or {}).get("Retry-After")
+                wait = (float(raw) if raw and str(raw).isdigit()
+                        else min(interval * (2 ** attempt), MAX_BACKOFF_S))
+                time.sleep(min(wait, MAX_BACKOFF_S))
+        except Exception as exc:  # noqa: BLE001 - transport errors are retryable
+            last = exc
+            if attempt < retries:
+                time.sleep(min(interval * (2 ** attempt), MAX_BACKOFF_S))
+    return None, GET_ERROR, f"GET failed after {retries + 1} attempts: {last}"
+
+
+def plan_one(api, row, *, retries=4, interval=1.0):
     """GET -> guard -> merge for one row. Read-only; performs no write."""
     rid = row["id"]
     plan = {"id": rid, "iri": row["material_iri"],
@@ -128,12 +162,9 @@ def plan_one(api, row):
             "outcome": None, "guards": {}, "current_case_number": None,
             "added_keys": [], "detail": "", "merged": None}
 
-    try:
-        doc = api.get(f"/materials/{AG_SOURCE}/{ag_ident(rid)}/")
-    except Exception as exc:  # noqa: BLE001 - transport/HTTP both mean "no plan"
-        code = getattr(exc, "code", None)
-        plan["outcome"] = GONE if code == 404 else GET_ERROR
-        plan["detail"] = f"GET failed: {exc}"
+    doc, outcome, detail = fetch_doc(api, rid, retries=retries, interval=interval)
+    if doc is None:
+        plan["outcome"], plan["detail"] = outcome, detail
         return plan
 
     ok, guards = check_guards(doc, rid)
@@ -175,15 +206,22 @@ def run(args):
                 skipped["not_in_lake"], skipped["unrecoverable"],
                 "APPLY" if not args.dry_run else "DRY-RUN")
 
+    stats = {"skipped_not_in_lake": skipped["not_in_lake"],
+             "skipped_unrecoverable": skipped["unrecoverable"]}
+    if not targets:
+        # Build no client and demand no credentials for a no-op run.
+        logger.info("no writable targets; nothing to do")
+        return stats
+
     api = _build_api(args)
-    stats = {}
     bodies_path = Path(args.put_bodies) if args.put_bodies else None
     if bodies_path:
         bodies_path.parent.mkdir(parents=True, exist_ok=True)
         bodies_path.write_text("", encoding="utf-8")
 
     for row in targets:
-        plan = plan_one(api, row)
+        plan = plan_one(api, row, retries=args.read_retries,
+                        interval=args.read_interval)
 
         if plan["outcome"] == WOULD_APPLY:
             body = {"material_type": MATERIAL_TYPE, "material": plan["merged"]}
@@ -208,8 +246,6 @@ def run(args):
                   slug=f"ag/{plan['id']}", step="backfill",
                   status=plan["outcome"], detail=plan["detail"])
 
-    stats["skipped_not_in_lake"] = skipped["not_in_lake"]
-    stats["skipped_unrecoverable"] = skipped["unrecoverable"]
     return stats
 
 
@@ -236,6 +272,13 @@ def build_parser():
     parser.add_argument("--write-interval", type=float, default=0.5,
                         help="Seconds to pause after each applied write; the "
                              "materials API rate-limits under bursts.")
+    parser.add_argument("--read-retries", type=int, default=4,
+                        help="Retries for a throttled/transient material GET "
+                             "(429s are common on a long run; a 404 is never "
+                             "retried).")
+    parser.add_argument("--read-interval", type=float, default=1.0,
+                        help="Base backoff seconds between GET retries "
+                             "(exponential, Retry-After honoured).")
     return parser
 
 

--- a/casework/backfill_ag_caseno.py
+++ b/casework/backfill_ag_caseno.py
@@ -52,7 +52,29 @@ MATERIAL_TYPE = "charge_sheet"
 EXPECTED_SOURCE_TYPE = "AG_ABHIYOG_PATRA"
 SPECIAL_OFFICE_LEVEL = 1
 
+#: The ``additionalType`` discriminator ``materials/jsonld.py`` maps to
+#: ``charge_sheet``. Checked (not assumed) because the PUT sends
+#: ``MATERIAL_TYPE`` explicitly: the server would otherwise infer the type from
+#: this very field, and a bare ``DigitalDocument`` infers to ``document``. So a
+#: doc whose discriminator CONTRADICTS charge_sheet must never be written --
+#: sending our constant would silently retype it.
+CHARGE_SHEET_ADDITIONAL_TYPE = "jawafdehi:ChargeSheet"
+
+#: Identity fields the guard needs. NOTE: `materials/sourcing/ag/shaper.py` does
+#: NOT emit either of these -- they were observed only on the production docs,
+#: which means the rows in the lake were written by an ingest path that has since
+#: diverged from the in-repo shaper. Their ABSENCE is therefore reported as
+#: GUARD_MISSING, distinct from GUARD_FAIL: an all-rows GUARD_MISSING run means
+#: the ingest path changed, NOT that the recovered map is wrong.
+_IDENTITY_KEYS = ("jawafdehi:recordId", "jawafdehi:officeLevel")
+
 MAX_BACKOFF_S = 30
+
+#: HTTP codes that will never succeed on a retry: the request or the caller's
+#: credentials are wrong, not the server's mood. Retrying them burns the entire
+#: backoff ladder on EVERY row (with the defaults, ~15s x N rows) before
+#: surfacing what the very first response already said.
+_FATAL_HTTP = (400, 401, 403, 405, 410, 501)
 
 CASE_NO_KEY = "jawafdehi:caseNumber"
 SOURCE_KEY = "jawafdehi:caseNumberSource"
@@ -66,17 +88,62 @@ APPLY_FAILED = "APPLY_FAILED"
 SKIP_IDEMPOTENT = "SKIP_IDEMPOTENT"
 CONFLICT_QUARANTINE = "CONFLICT_QUARANTINE"
 GUARD_FAIL = "GUARD_FAIL"
+GUARD_MISSING = "GUARD_MISSING"
 GONE = "GONE"
 GET_ERROR = "GET_ERROR"
+GET_FATAL = "GET_FATAL"
+
+#: Outcomes that mean the run itself is broken (bad credentials, wrong host, a
+#: dead API) rather than one odd record. A consecutive streak of these trips the
+#: circuit breaker -- see :func:`run`.
+_FAILURE_OUTCOMES = frozenset({GET_ERROR, GET_FATAL, APPLY_FAILED})
+
+#: Required on every map row; the writer refuses a map that lacks them.
+_REQUIRED_ROW_KEYS = ("id", "material_iri", "case_number", "source", "in_lake")
+
+
+def validate_map(rows, origin):
+    """The map must be a non-empty list of row objects carrying every key the
+    planner dereferences.
+
+    The read-only producer validates its input (``source_abhiyog``'s
+    ``validate_records``); the WRITER had no equivalent, which is backwards. An
+    unvalidated map fails late and unevenly: a JSON object iterates as bare keys
+    (``'str' object has no attribute 'get'``), and a hand-trimmed row raises
+    KeyError at row N -- under ``--apply`` that leaves rows 1..N-1 already
+    written with no resume marker.
+    """
+    if not isinstance(rows, list) or not rows:
+        raise SystemExit(
+            f"{origin}: expected a non-empty JSON list of map rows, got "
+            f"{type(rows).__name__} "
+            f"(len={len(rows) if hasattr(rows, '__len__') else '?'})")
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise SystemExit(f"{origin}: row {i} is {type(row).__name__}, not a JSON object")
+        missing = [k for k in _REQUIRED_ROW_KEYS if k not in row]
+        if missing:
+            raise SystemExit(f"{origin}: row {i} (id={row.get('id')!r}) is missing {missing}")
+    return rows
 
 
 def select_targets(rows):
     """Rows eligible for a write: present in the lake AND with a recovered
-    number. Everything else is reported, never written."""
-    targets, skipped = [], {"not_in_lake": 0, "unrecoverable": 0}
+    number. Everything else is reported, never written.
+
+    ``in_lake`` is tri-state, and "unknown" is NOT "absent": a map produced with
+    ``--no-probe`` leaves it blank and a throttled probe leaves it ``error``.
+    Collapsing those into ``not_in_lake`` would report a 100% no-op run as
+    "none of these materials exist", which is a different (and false) claim.
+    """
+    targets = []
+    skipped = {"not_in_lake": 0, "unrecoverable": 0, "lake_state_unknown": 0}
     for row in rows:
-        if row.get("in_lake") != "true":
+        in_lake = row.get("in_lake")
+        if in_lake == "false":
             skipped["not_in_lake"] += 1
+        elif in_lake != "true":
+            skipped["lake_state_unknown"] += 1
         elif not row.get("case_number"):
             skipped["unrecoverable"] += 1
         else:
@@ -85,20 +152,32 @@ def select_targets(rows):
 
 
 def check_guards(doc, record_id):
-    """(ok, guards) -- identity/type/level agreement between doc and map row.
+    """``(outcome_or_None, guards)`` -- identity/type agreement, doc vs map row.
 
-    Guards the blast radius of a wrong id: a mismatch means we are about to
-    stamp a case number onto some OTHER document, so it quarantines instead.
+    ``None`` means every guard passed. Otherwise GUARD_MISSING (the doc carries
+    no identity fields at all -- see ``_IDENTITY_KEYS``) or GUARD_FAIL (it
+    carries them and they disagree). Distinguishing the two matters: a mismatch
+    means we were about to stamp a case number onto some OTHER document, while
+    an absence means the shape of the stored docs changed underneath us.
+
+    ``additionalType`` is rejected only when it CONTRADICTS charge_sheet, not
+    when it is absent -- absence is what the explicit ``material_type`` on the
+    PUT exists to cover.
     """
     guards = {
-        "recordId": str(doc.get("jawafdehi:recordId") or ""),
+        "recordId": doc.get("jawafdehi:recordId"),
         "officeLevel": doc.get("jawafdehi:officeLevel"),
         "sourceType": doc.get("jawafdehi:sourceType"),
+        "additionalType": doc.get("additionalType"),
     }
-    ok = (guards["recordId"] == str(record_id)
+    if all(doc.get(k) is None for k in _IDENTITY_KEYS):
+        return GUARD_MISSING, guards
+    additional = guards["additionalType"]
+    ok = (str(guards["recordId"]) == str(record_id)
           and guards["officeLevel"] == SPECIAL_OFFICE_LEVEL
-          and guards["sourceType"] == EXPECTED_SOURCE_TYPE)
-    return ok, guards
+          and guards["sourceType"] == EXPECTED_SOURCE_TYPE
+          and (additional is None or additional == CHARGE_SHEET_ADDITIONAL_TYPE))
+    return (None if ok else GUARD_FAIL), guards
 
 
 def merge_case_no(doc, row):
@@ -113,12 +192,22 @@ def merge_case_no(doc, row):
     merged[SOURCE_KEY] = row["source"]
     added = [CASE_NO_KEY, SOURCE_KEY]
     if row.get("ambiguous") == "true":
-        # Sources disagreed. Record that, and keep the rejected candidate, so a
+        # Sources disagreed. Record that, and keep the rejected candidates, so a
         # later binding pass can try both rather than trusting one silently.
+        # A LIST, not the map's `;`-joined string: that delimiter exists only
+        # because CSV needs a scalar cell. Carrying it into the JSON-LD document
+        # would force every consumer to split on `;`, and any consumer reading
+        # the field as a single case number would match nothing.
         merged[AMBIGUOUS_KEY] = True
-        merged[ALT_KEY] = row.get("alt_case_number") or ""
+        merged[ALT_KEY] = alt_case_numbers(row)
         added += [AMBIGUOUS_KEY, ALT_KEY]
     return merged, added
+
+
+def alt_case_numbers(row):
+    """The rejected candidates for a row, as a list (the map joins them with
+    `;` for its CSV column -- see ``source_abhiyog.build_rows``)."""
+    return [a for a in (row.get("alt_case_number") or "").split(";") if a.strip()]
 
 
 def fetch_doc(api, rid, *, retries=4, interval=1.0):
@@ -128,17 +217,24 @@ def fetch_doc(api, rid, *, retries=4, interval=1.0):
     production materials API rate-limits under bursts: a straight walk of the
     map fires one GET per material back-to-back and a large share come back
     429, which -- treated as a plain error -- would silently demote those
-    materials to GET_ERROR and drop them from the backfill. A definitive 404
-    is NOT retried: that material is genuinely gone.
+    materials to GET_ERROR and drop them from the backfill.
+
+    Only a genuinely transient failure is retried. A 404 is definitive (the
+    material is gone) and ``_FATAL_HTTP`` -- a bad request or bad credentials --
+    cannot improve by waiting: retrying an expired token would sleep the full
+    ladder on every row, ~15s x 473 rows before reporting the 401 that the first
+    response already carried.
     """
     path = material_path(AG_SOURCE, ag_ident(rid))
     last = None
-    for attempt in range(retries + 1):
+    for attempt in range(max(retries, 0) + 1):
         try:
             return api.get(path), None, ""
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 return None, GONE, "material not found"
+            if exc.code in _FATAL_HTTP:
+                return None, GET_FATAL, f"HTTP {exc.code} is not retryable: {exc}"
             last = exc
             if attempt < retries:
                 raw = (exc.headers or {}).get("Retry-After")
@@ -149,7 +245,7 @@ def fetch_doc(api, rid, *, retries=4, interval=1.0):
             last = exc
             if attempt < retries:
                 time.sleep(min(interval * (2 ** attempt), MAX_BACKOFF_S))
-    return None, GET_ERROR, f"GET failed after {retries + 1} attempts: {last}"
+    return None, GET_ERROR, f"GET failed after {max(retries, 0) + 1} attempts: {last}"
 
 
 def plan_one(api, row, *, retries=4, interval=1.0):
@@ -167,11 +263,15 @@ def plan_one(api, row, *, retries=4, interval=1.0):
         plan["outcome"], plan["detail"] = outcome, detail
         return plan
 
-    ok, guards = check_guards(doc, rid)
+    guard_outcome, guards = check_guards(doc, rid)
     plan["guards"] = guards
-    if not ok:
-        plan["outcome"] = GUARD_FAIL
-        plan["detail"] = f"identity/type guard failed: {guards}"
+    if guard_outcome is not None:
+        plan["outcome"] = guard_outcome
+        plan["detail"] = (
+            f"doc carries none of {list(_IDENTITY_KEYS)} -- the stored shape "
+            f"changed; re-verify the ingest path before writing: {guards}"
+            if guard_outcome is GUARD_MISSING
+            else f"identity/type guard failed: {guards}")
         return plan
 
     current = doc.get(CASE_NO_KEY)
@@ -196,18 +296,29 @@ def plan_one(api, row, *, retries=4, interval=1.0):
 
 def run(args):
     logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
-    rows = json.loads(Path(args.map).read_text(encoding="utf-8"))
+    rows = validate_map(
+        json.loads(Path(args.map).read_text(encoding="utf-8")), f"map {args.map}")
     targets, skipped = select_targets(rows)
     if args.limit:
         targets = targets[: args.limit]
 
     logger.info("map=%d in_lake+recovered=%d skipped(not_in_lake=%d, "
-                "unrecoverable=%d) mode=%s", len(rows), len(targets),
-                skipped["not_in_lake"], skipped["unrecoverable"],
+                "unrecoverable=%d, lake_state_unknown=%d) mode=%s", len(rows),
+                len(targets), skipped["not_in_lake"], skipped["unrecoverable"],
+                skipped["lake_state_unknown"],
                 "APPLY" if not args.dry_run else "DRY-RUN")
+    if skipped["lake_state_unknown"]:
+        # Not the same claim as "absent" -- say so rather than let the summary
+        # imply the lake was checked and came back empty.
+        logger.warning(
+            "%d rows have NO lake verdict (blank => produced with --no-probe; "
+            "'error' => the probe was throttled). They are skipped, but that is "
+            "'unknown', not 'absent' -- re-run source_abhiyog with probing to "
+            "resolve them.", skipped["lake_state_unknown"])
 
     stats = {"skipped_not_in_lake": skipped["not_in_lake"],
-             "skipped_unrecoverable": skipped["unrecoverable"]}
+             "skipped_unrecoverable": skipped["unrecoverable"],
+             "skipped_lake_state_unknown": skipped["lake_state_unknown"]}
     if not targets:
         # Build no client and demand no credentials for a no-op run.
         logger.info("no writable targets; nothing to do")
@@ -219,6 +330,7 @@ def run(args):
         bodies_path.parent.mkdir(parents=True, exist_ok=True)
         bodies_path.write_text("", encoding="utf-8")
 
+    consecutive_failures = 0
     for row in targets:
         plan = plan_one(api, row, retries=args.read_retries,
                         interval=args.read_interval)
@@ -245,6 +357,26 @@ def run(args):
         log_event(logger, paths["events"], run_id=run_id, stage=STAGE,
                   slug=f"ag/{plan['id']}", step="backfill",
                   status=plan["outcome"], detail=plan["detail"])
+
+        # Circuit breaker. A systemic fault -- expired token, missing NGM role,
+        # wrong host, API down -- fails identically on every row. Without this
+        # the run marches through the whole map issuing doomed requests (one
+        # --write-interval pause each) and exits 0 with a full tally of
+        # failures, which a wrapper reads as success.
+        if plan["outcome"] in _FAILURE_OUTCOMES:
+            consecutive_failures += 1
+            if (args.max_consecutive_failures
+                    and consecutive_failures >= args.max_consecutive_failures):
+                stats["ABORTED_CONSECUTIVE_FAILURES"] = consecutive_failures
+                logger.error(
+                    "ABORT: %d consecutive failures (last: %s -- %s). This looks "
+                    "systemic, not per-record; fix it and re-run (the pass is "
+                    "idempotent -- already-correct rows come back "
+                    "SKIP_IDEMPOTENT).",
+                    consecutive_failures, plan["outcome"], plan["detail"])
+                break
+        else:
+            consecutive_failures = 0
 
     return stats
 
@@ -279,6 +411,10 @@ def build_parser():
     parser.add_argument("--read-interval", type=float, default=1.0,
                         help="Base backoff seconds between GET retries "
                              "(exponential, Retry-After honoured).")
+    parser.add_argument("--max-consecutive-failures", type=int, default=10,
+                        help="Abort after this many consecutive failed rows -- "
+                             "a streak means a systemic fault (bad token, wrong "
+                             "host), not odd records. 0 disables the breaker.")
     return parser
 
 
@@ -286,7 +422,10 @@ def main(argv=None):
     args = build_parser().parse_args(argv)
     stats = run(args)
     print_summary(stats, args.dry_run, "backfill ag caseNumber")
-    return 0
+    # Nonzero ONLY when the circuit breaker tripped. The sibling verbs always
+    # return 0, but a systemic abort is precisely the case a wrapper must not
+    # read as success -- per-record outcomes stay in the summary.
+    return 1 if stats.get("ABORTED_CONSECUTIVE_FAILURES") else 0
 
 
 if __name__ == "__main__":

--- a/casework/backfill_ag_caseno.py
+++ b/casework/backfill_ag_caseno.py
@@ -1,0 +1,250 @@
+"""Backfill ``jawafdehi:caseNumber`` onto AG अभियोगपत्र materials in the lake.
+
+Consumes the map produced by ``casework.source_abhiyog`` and restores the one
+field the bulk scrape lost, so the indictments can be joined to their cases:
+
+    GET /materials/ag/<id>/          (the CURRENT full document)
+      -> GUARD identity + type       (recordId == id, officeLevel == 1,
+                                      sourceType == AG_ABHIYOG_PATRA)
+      -> GUARD existing value        (same -> SKIP idempotent;
+                                      DIFFERENT -> QUARANTINE, never overwrite)
+      -> MERGE onto the full doc     (add caseNumber + provenance only)
+      -> PUT the COMPLETE document   (api.put_material)
+
+Why a read-modify-write rather than a patch: the materials endpoint has NO
+partial-update verb. ``PATCH`` there sets only ``visibility_policy``, and
+``PUT`` funnels into ``upsert_single_source_material``, which replaces the
+``data`` column WHOLESALE. Sending only the new field would therefore destroy
+``text`` and ``associatedMedia``. So the current document is fetched, the field
+is added in memory, and the whole document goes back.
+
+Concurrency caveat: unlike the case endpoint, the materials endpoint exposes no
+ETag/If-Match, so this read-modify-write cannot be made conditional. A
+concurrent writer's change between our GET and PUT would be lost. Keep this a
+single serialized writer and do not run it alongside an AG re-ingest.
+
+Dry-run is the DEFAULT (logs the exact PUT it WOULD send, writes nothing).
+``--apply`` opts into writing, and writing to any non-loopback host
+additionally requires ``--allow-remote-writes`` (enforced in CaseworkApi).
+
+Usage:
+    uv run python -m casework.backfill_ag_caseno --map work/ag-caseno-map.json
+    uv run python -m casework.backfill_ag_caseno --map ... --apply --allow-remote-writes
+"""
+import argparse
+import copy
+import json
+import sys
+import time
+from pathlib import Path
+
+from casework.common.api import CaseworkApi
+from casework.common.cli import (
+    add_common_args, basic_auth_from_env, configure_run_logging, log_event,
+    print_summary,
+)
+from casework.common.materials import ag_ident
+
+STAGE = "backfill_ag_caseno"
+AG_SOURCE = "ag"
+MATERIAL_TYPE = "charge_sheet"
+EXPECTED_SOURCE_TYPE = "AG_ABHIYOG_PATRA"
+SPECIAL_OFFICE_LEVEL = 1
+
+CASE_NO_KEY = "jawafdehi:caseNumber"
+SOURCE_KEY = "jawafdehi:caseNumberSource"
+AMBIGUOUS_KEY = "jawafdehi:caseNumberAmbiguous"
+ALT_KEY = "jawafdehi:caseNumberAlt"
+
+#: Outcomes. Only WOULD_APPLY/APPLIED mutate anything.
+WOULD_APPLY = "WOULD_APPLY"
+APPLIED = "APPLIED"
+APPLY_FAILED = "APPLY_FAILED"
+SKIP_IDEMPOTENT = "SKIP_IDEMPOTENT"
+CONFLICT_QUARANTINE = "CONFLICT_QUARANTINE"
+GUARD_FAIL = "GUARD_FAIL"
+GONE = "GONE"
+GET_ERROR = "GET_ERROR"
+
+
+def select_targets(rows):
+    """Rows eligible for a write: present in the lake AND with a recovered
+    number. Everything else is reported, never written."""
+    targets, skipped = [], {"not_in_lake": 0, "unrecoverable": 0}
+    for row in rows:
+        if row.get("in_lake") != "true":
+            skipped["not_in_lake"] += 1
+        elif not row.get("case_number"):
+            skipped["unrecoverable"] += 1
+        else:
+            targets.append(row)
+    return targets, skipped
+
+
+def check_guards(doc, record_id):
+    """(ok, guards) -- identity/type/level agreement between doc and map row.
+
+    Guards the blast radius of a wrong id: a mismatch means we are about to
+    stamp a case number onto some OTHER document, so it quarantines instead.
+    """
+    guards = {
+        "recordId": str(doc.get("jawafdehi:recordId") or ""),
+        "officeLevel": doc.get("jawafdehi:officeLevel"),
+        "sourceType": doc.get("jawafdehi:sourceType"),
+    }
+    ok = (guards["recordId"] == str(record_id)
+          and guards["officeLevel"] == SPECIAL_OFFICE_LEVEL
+          and guards["sourceType"] == EXPECTED_SOURCE_TYPE)
+    return ok, guards
+
+
+def merge_case_no(doc, row):
+    """The CURRENT doc plus the recovered case number. Pure: returns a copy.
+
+    Only ever ADDS keys -- every existing key (notably ``text`` and
+    ``associatedMedia``) is carried through untouched, which is what makes the
+    wholesale PUT safe.
+    """
+    merged = copy.deepcopy(doc)
+    merged[CASE_NO_KEY] = row["case_number"]
+    merged[SOURCE_KEY] = row["source"]
+    added = [CASE_NO_KEY, SOURCE_KEY]
+    if row.get("ambiguous") == "true":
+        # Sources disagreed. Record that, and keep the rejected candidate, so a
+        # later binding pass can try both rather than trusting one silently.
+        merged[AMBIGUOUS_KEY] = True
+        merged[ALT_KEY] = row.get("alt_case_number") or ""
+        added += [AMBIGUOUS_KEY, ALT_KEY]
+    return merged, added
+
+
+def plan_one(api, row):
+    """GET -> guard -> merge for one row. Read-only; performs no write."""
+    rid = row["id"]
+    plan = {"id": rid, "iri": row["material_iri"],
+            "target_case_number": row["case_number"], "source": row["source"],
+            "ambiguous": row.get("ambiguous") == "true",
+            "alt_case_number": row.get("alt_case_number") or "",
+            "outcome": None, "guards": {}, "current_case_number": None,
+            "added_keys": [], "detail": "", "merged": None}
+
+    try:
+        doc = api.get(f"/materials/{AG_SOURCE}/{ag_ident(rid)}/")
+    except Exception as exc:  # noqa: BLE001 - transport/HTTP both mean "no plan"
+        code = getattr(exc, "code", None)
+        plan["outcome"] = GONE if code == 404 else GET_ERROR
+        plan["detail"] = f"GET failed: {exc}"
+        return plan
+
+    ok, guards = check_guards(doc, rid)
+    plan["guards"] = guards
+    if not ok:
+        plan["outcome"] = GUARD_FAIL
+        plan["detail"] = f"identity/type guard failed: {guards}"
+        return plan
+
+    current = doc.get(CASE_NO_KEY)
+    plan["current_case_number"] = current
+    if current:
+        if str(current).strip() == row["case_number"]:
+            plan["outcome"] = SKIP_IDEMPOTENT
+            plan["detail"] = "already set to the same value"
+        else:
+            plan["outcome"] = CONFLICT_QUARANTINE
+            plan["detail"] = (f"lake has {current!r} != recovered "
+                              f"{row['case_number']!r}; never overwritten")
+        return plan
+
+    merged, added = merge_case_no(doc, row)
+    plan["merged"] = merged
+    plan["added_keys"] = added
+    plan["outcome"] = WOULD_APPLY
+    plan["detail"] = f"add {CASE_NO_KEY}={row['case_number']} [{row['source']}]"
+    return plan
+
+
+def run(args):
+    logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
+    rows = json.loads(Path(args.map).read_text(encoding="utf-8"))
+    targets, skipped = select_targets(rows)
+    if args.limit:
+        targets = targets[: args.limit]
+
+    logger.info("map=%d in_lake+recovered=%d skipped(not_in_lake=%d, "
+                "unrecoverable=%d) mode=%s", len(rows), len(targets),
+                skipped["not_in_lake"], skipped["unrecoverable"],
+                "APPLY" if not args.dry_run else "DRY-RUN")
+
+    api = _build_api(args)
+    stats = {}
+    bodies_path = Path(args.put_bodies) if args.put_bodies else None
+    if bodies_path:
+        bodies_path.parent.mkdir(parents=True, exist_ok=True)
+        bodies_path.write_text("", encoding="utf-8")
+
+    for row in targets:
+        plan = plan_one(api, row)
+
+        if plan["outcome"] == WOULD_APPLY:
+            body = {"material_type": MATERIAL_TYPE, "material": plan["merged"]}
+            if bodies_path:
+                with bodies_path.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps(
+                        {"id": plan["id"], "method": "PUT",
+                         "path": f"/materials/{AG_SOURCE}/{ag_ident(plan['id'])}/",
+                         "body": body}, ensure_ascii=False) + "\n")
+            if not args.dry_run:
+                try:
+                    api.put_material(AG_SOURCE, ag_ident(plan["id"]),
+                                     plan["merged"], material_type=MATERIAL_TYPE)
+                    plan["outcome"] = APPLIED
+                except Exception as exc:  # noqa: BLE001
+                    plan["outcome"] = APPLY_FAILED
+                    plan["detail"] = f"PUT failed: {exc}"
+                time.sleep(args.write_interval)
+
+        stats[plan["outcome"]] = stats.get(plan["outcome"], 0) + 1
+        log_event(logger, paths["events"], run_id=run_id, stage=STAGE,
+                  slug=f"ag/{plan['id']}", step="backfill",
+                  status=plan["outcome"], detail=plan["detail"])
+
+    stats["skipped_not_in_lake"] = skipped["not_in_lake"]
+    stats["skipped_unrecoverable"] = skipped["unrecoverable"]
+    return stats
+
+
+def _build_api(args):
+    """Bearer for production, Basic for a loopback DEV_AUTH server (a local
+    server routes any Bearer to OIDC and rejects it, so token-only would fail
+    every local run)."""
+    if args.api_token:
+        return CaseworkApi(base_url=args.api_base_url, token=args.api_token,
+                           allow_remote_writes=args.allow_remote_writes)
+    return CaseworkApi(base_url=args.api_base_url, basic=basic_auth_from_env(),
+                       allow_remote_writes=args.allow_remote_writes)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Backfill jawafdehi:caseNumber onto AG materials.")
+    add_common_args(parser)
+    parser.add_argument("--map", required=True,
+                        help="JSON map from casework.source_abhiyog.")
+    parser.add_argument("--put-bodies", default="",
+                        help="Optional path; append the exact PUT body that "
+                             "would be (or was) sent, one JSON per line.")
+    parser.add_argument("--write-interval", type=float, default=0.5,
+                        help="Seconds to pause after each applied write; the "
+                             "materials API rate-limits under bursts.")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    stats = run(args)
+    print_summary(stats, args.dry_run, "backfill ag caseNumber")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from casework.common.api import CaseworkApi
 from casework.common.cli import (
     _utc_iso_now, add_common_args, basic_auth_from_env, configure_run_logging,
-    log_run_footer, log_run_header, print_summary,
+    log_run_footer, log_run_header, nonneg_float, nonneg_int, print_summary,
 )
 from casework.common.materials import material_iri, probe_material
 
@@ -454,12 +454,12 @@ def build_parser():
                         help="CSV with a `slug` column and material-IRI columns.")
     parser.add_argument("--report", default="",
                         help="Optional path to write a JSON run report.")
-    parser.add_argument("--probe-retries", type=int, default=4,
+    parser.add_argument("--probe-retries", type=nonneg_int, default=4,
                         help="Retries for a throttled/uncertain material probe "
                              "(the API 429s under a sustained walk, and an "
                              "uncertain probe ABORTS the whole case). 0 for a "
                              "single shot, the pre-2026-07 behaviour.")
-    parser.add_argument("--probe-interval", type=float, default=1.0,
+    parser.add_argument("--probe-interval", type=nonneg_float, default=1.0,
                         help="Base backoff seconds between probe retries "
                              "(exponential, Retry-After honoured).")
     return parser

--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -160,13 +160,23 @@ def missing_candidates(case, candidates):
     return [(s, i) for (s, i) in candidates if material_iri(s, i) not in have]
 
 
-def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE):
+def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE,
+              *, probe_retries=0, probe_interval=1.0):
     """Build a BindPlan for one case. Probes each candidate via ``material_exists``.
 
     Guarantees: never plans a write for a non-DRAFT case; never includes an
     absent or uncertain material; aborts the whole case if ANY candidate is
     uncertain (a partial list would destroy data); emits NOOP when the merge
     changes nothing so a re-run is idempotent.
+
+    ``probe_retries`` matters because "uncertain" is a HARD STOP here: the
+    production materials API answers 429 under a sustained walk, and a throttled
+    read is indistinguishable from a dead server once it collapses to the
+    uncertain verdict. Without retry a rate-limit burst mid-run aborts cases
+    whose materials are perfectly present -- a false negative that reads exactly
+    like a data problem. Retrying converts "slow down" back into a real answer.
+    The default is 0 (single shot, the historical behaviour) so a direct caller
+    is unchanged; the CLI turns it on.
     """
     slug = case.get("slug")
     state = case.get("state")
@@ -181,7 +191,8 @@ def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE):
         iri = material_iri(source, ident)
         if iri in have:
             continue  # already bound -> contributes nothing
-        pr = probe_material(api, source, ident)
+        pr = probe_material(api, source, ident, retries=probe_retries,
+                            interval=probe_interval)
         probes.append(pr)
         if pr.verdict is True:
             if iri not in add:
@@ -334,7 +345,9 @@ def run(args, api=None, rows=None):
             continue
 
         try:
-            plan = plan_case(api, case, etag, candidates_from_row(row))
+            plan = plan_case(api, case, etag, candidates_from_row(row),
+                             probe_retries=args.probe_retries,
+                             probe_interval=args.probe_interval)
         except Exception as exc:  # noqa: BLE001 -- one bad case must not sink the batch
             ms = int((time.monotonic() - t0) * 1000)
             stats["PLAN_FAILED"] = stats.get("PLAN_FAILED", 0) + 1
@@ -441,6 +454,14 @@ def build_parser():
                         help="CSV with a `slug` column and material-IRI columns.")
     parser.add_argument("--report", default="",
                         help="Optional path to write a JSON run report.")
+    parser.add_argument("--probe-retries", type=int, default=4,
+                        help="Retries for a throttled/uncertain material probe "
+                             "(the API 429s under a sustained walk, and an "
+                             "uncertain probe ABORTS the whole case). 0 for a "
+                             "single shot, the pre-2026-07 behaviour.")
+    parser.add_argument("--probe-interval", type=float, default=1.0,
+                        help="Base backoff seconds between probe retries "
+                             "(exponential, Retry-After honoured).")
     return parser
 
 

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -217,6 +217,35 @@ class CaseworkApi:
             raw = r.read().decode()
             return json.loads(raw) if raw.strip() else {}
 
+    def put_material(self, source, ident, doc, material_type=None, timeout=60):
+        """``PUT /materials/<source>/<ident>/`` -- replace a material's JSON-LD.
+
+        The materials endpoint has NO partial-update verb: ``PATCH`` there sets
+        ONLY ``visibility_policy`` (``materials/views.py::_patch_visibility_policy``),
+        and this ``PUT`` funnels into ``upsert_single_source_material``, which
+        writes the ``data`` column WHOLESALE. So ``doc`` MUST be the COMPLETE
+        document -- a partial doc silently destroys ``text``/``associatedMedia``.
+        Callers therefore do a read-modify-write (GET, merge, PUT).
+
+        ``visibility_policy`` is deliberately NOT sent: the server applies an
+        explicit policy on update but leaves it untouched when omitted, so
+        omitting preserves a caseworker's manual policy across re-upsert.
+
+        ``material_type`` may be omitted -- the server infers it from the doc's
+        ``additionalType``/``@type``. Writes go through ``_request``, so the
+        non-loopback write-guard applies exactly as it does for case PATCHes.
+        """
+        url = self.base_url + f"/materials/{source}/{urllib.parse.quote(ident, safe='')}/"
+        body_doc = {"material": doc}
+        if material_type:
+            body_doc["material_type"] = material_type
+        body = json.dumps(body_doc, ensure_ascii=False).encode("utf-8")
+        with self._request("PUT", url, data=body,
+                           headers=self._headers("application/json"),
+                           timeout=timeout) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw.strip() else {}
+
     def patch_field(self, slug, field, value, timeout=60, if_match=None):
         return self._patch(slug, build_replace_patch(field, value), timeout, if_match=if_match)
 

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -1,5 +1,6 @@
 """Shared argparse, logging and reporting for casework enricher CLIs."""
 
+import argparse
 import json
 import logging
 import os
@@ -29,6 +30,33 @@ def basic_auth_from_env():
             "JAWAFDEHI_API_TOKEN) for Bearer auth, or set CASEWORK_API_USER + "
             "CASEWORK_API_PASSWORD for local DEV_AUTH Basic auth.")
     return user, password
+
+
+def nonneg_int(raw):
+    """argparse type for a count that cannot be negative.
+
+    A bare ``type=int`` accepts ``--probe-retries -1``, and a negative count
+    silently means something different from what the flag says: it empties the
+    ``range(retries + 1)`` that drives every retry loop, so nothing is attempted
+    at all. Reject it at the boundary rather than let each call site guess.
+    """
+    value = int(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    return value
+
+
+def nonneg_float(raw):
+    """argparse type for a duration that cannot be negative.
+
+    ``time.sleep()`` raises ``ValueError`` on a negative argument, so a negative
+    ``--probe-interval`` / ``--read-interval`` / ``--write-interval`` does not
+    "sleep less" -- it aborts the walk partway through with a traceback.
+    """
+    value = float(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    return value
 
 
 def add_common_args(parser):

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -143,10 +143,18 @@ def _probe_once(api, source, ident, path, timeout):
 
 
 def _backoff_s(retry_after, attempt, interval):
-    """Server-advertised Retry-After wins; else exponential, capped."""
+    """Server-advertised Retry-After wins; else exponential, capped.
+
+    Clamped to >= 0 for the same reason ``retries`` is clamped in
+    :func:`probe_material`: ``time.sleep()`` raises ``ValueError`` on a negative
+    argument, so a negative ``interval`` reaching here would abort the walk with
+    a traceback partway through rather than degrade. The CLIs also reject it at
+    the flag boundary (``cli.nonneg_float``); this is the library-level guard for
+    a direct caller.
+    """
     if retry_after is not None:
-        return min(retry_after, _MAX_BACKOFF_S)
-    return min(interval * (2 ** attempt), _MAX_BACKOFF_S)
+        return min(max(retry_after, 0), _MAX_BACKOFF_S)
+    return min(max(interval, 0) * (2 ** attempt), _MAX_BACKOFF_S)
 
 
 def material_exists(api, source, ident, timeout=45):

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -6,6 +6,7 @@ source_content. The current payload is
 {material_iri, additional_details, material: {material_type, urls:[{link, role}]}}
 and `material` resolves ONLY on the case DETAIL endpoint.
 """
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -61,15 +62,32 @@ class ProbeResult:
     ``verdict``: True (exists) / False (absent) / None (uncertain).
     ``status``: the HTTP code (200/400/404/5xx) or None on a transport error.
     ``path``: the exact request path probed, for the log.
+    ``retry_after``: seconds the server asked us to wait (429 only), else None.
     """
     source: str
     ident: str
     path: str
     status: int | None
     verdict: bool | None
+    retry_after: float | None = None
 
 
-def probe_material(api, source, ident, timeout=45):
+def material_path(source, ident):
+    """The control-plane path for one material. Single definition so a read and
+    the subsequent write can never disagree about how an ident is escaped."""
+    return f"/materials/{source}/{urllib.parse.quote(ident, safe='')}/"
+
+
+#: HTTP 429. The production materials API rate-limits under bursts, and a
+#: throttled read is INDISTINGUISHABLE from a 5xx once it collapses to the
+#: "uncertain" verdict -- which callers treat as a hard stop (bind_materials
+#: aborts the whole case). So it is retried here, in the shared primitive,
+#: rather than in any one caller.
+_RATE_LIMITED = 429
+_MAX_BACKOFF_S = 30
+
+
+def probe_material(api, source, ident, timeout=45, *, retries=0, interval=1.0):
     """Probe GET /materials/<source>/<ident>/ and return a ProbeResult.
 
     verdict is True (200), False (400/404 -- definitively absent), or None
@@ -79,16 +97,52 @@ def probe_material(api, source, ident, timeout=45):
     inheriting its auth and browser UA. The server validates IRI *grammar*
     only and never checks material existence on write, so this client-side
     probe is the only thing between a typo'd ident and a bound stub.
+
+    An uncertain outcome is RETRIED with exponential backoff (``retries``
+    extra attempts, honouring ``Retry-After`` on a 429) before it is reported.
+    Without this a burst of probes against production returns a spray of
+    "uncertain" that is really just throttling, which callers then act on as
+    if the lake were unreachable.
+
+    ``retries`` defaults to 0 -- a single shot, i.e. exactly the historical
+    behaviour -- so enabling backoff never silently changes the timing of an
+    existing caller. Any caller that walks a large cohort against production
+    SHOULD opt in. NOTE: ``bind_materials`` does not yet, and it escalates an
+    uncertain probe to "abort the whole case", so a rate-limit burst there
+    aborts cases whose materials are actually present; wiring it up is a
+    deliberate behaviour change and is left to its owner.
     """
-    path = f"/materials/{source}/{urllib.parse.quote(ident, safe='')}/"
+    path = material_path(source, ident)
+    result = None
+    for attempt in range(retries + 1):
+        result = _probe_once(api, source, ident, path, timeout)
+        if result.verdict is not None:
+            return result
+        if attempt < retries:
+            time.sleep(_backoff_s(result.retry_after, attempt, interval))
+    return result
+
+
+def _probe_once(api, source, ident, path, timeout):
     try:
         api.get(path, timeout=timeout)
         return ProbeResult(source, ident, path, 200, True)
     except urllib.error.HTTPError as exc:
         verdict = False if exc.code in (400, 404) else None
-        return ProbeResult(source, ident, path, exc.code, verdict)
+        retry_after = None
+        if exc.code == _RATE_LIMITED:
+            raw = (exc.headers or {}).get("Retry-After")
+            retry_after = float(raw) if raw and str(raw).isdigit() else None
+        return ProbeResult(source, ident, path, exc.code, verdict, retry_after)
     except Exception:
         return ProbeResult(source, ident, path, None, None)
+
+
+def _backoff_s(retry_after, attempt, interval):
+    """Server-advertised Retry-After wins; else exponential, capped."""
+    if retry_after is not None:
+        return min(retry_after, _MAX_BACKOFF_S)
+    return min(interval * (2 ** attempt), _MAX_BACKOFF_S)
 
 
 def material_exists(api, source, ident, timeout=45):

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -114,7 +114,11 @@ def probe_material(api, source, ident, timeout=45, *, retries=0, interval=1.0):
     """
     path = material_path(source, ident)
     result = None
-    for attempt in range(retries + 1):
+    # `max(retries, 0)`: a negative count (argparse accepts `--probe-retries -1`)
+    # would make the range EMPTY, so nothing was ever probed and this returned
+    # the `None` initializer -- breaking the documented tri-state for every
+    # caller (`material_exists` and `build_rows` both do `.verdict` on it).
+    for attempt in range(max(retries, 0) + 1):
         result = _probe_once(api, source, ident, path, timeout)
         if result.verdict is not None:
             return result

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -41,6 +41,19 @@ def court_order_ident(court, case_no):
     return f"{court}.{case_no.strip().lower()}"
 
 
+def ag_ident(record_id):
+    """AG अभियोगपत्र (indictment): the ident IS the AG portal record id.
+
+    `materials/sourcing/ag/shaper.py` deliberately keys the IRI on `record_id`
+    and NOT on the case number: ~969 case numbers repeat across AG offices, so
+    keying on the case number would collide distinct indictments onto one `@id`
+    and silently overwrite them on upsert. That choice is what makes case-number
+    recovery a DIRECT id join -- `/material/ag/<record_id>` round-trips straight
+    back to the portal record it was scraped from (no sha256 content-join).
+    """
+    return str(record_id).strip()
+
+
 @dataclass
 class ProbeResult:
     """Outcome of one existence probe, with enough detail to log an audit line.

--- a/casework/source_abhiyog.py
+++ b/casework/source_abhiyog.py
@@ -1,0 +1,296 @@
+"""Recover the {material/ag/<id> -> case number} map for AG अभियोगपत्र (the
+sourcing-side candidate producer; READ-ONLY, never writes).
+
+The bulk AG scrape landed ~99.7k charge sheets in the lake but lost the case
+number, so the indictments cannot be joined to their cases. This CLI rebuilds
+that map for the विशेष सरकारी वकील कार्यालय (Special Government Attorney
+Office) cohort:
+
+    GET ag.gov.np search API (office_type=1, office_id=2)   -> the full cohort
+      -> EXTRACT case number   (court_case_no > file > description, canonicalised)
+      -> CROSS-VALIDATE        (>=2 sources disagreeing -> flagged, both kept)
+      -> PROBE the lake        (materials.probe_material: in-lake / absent)
+      -> EMIT csv + json map   (consumed by casework.backfill_ag_caseno)
+
+Why the ident join is direct: the material IRI ident IS the AG portal record id
+(see :func:`casework.common.materials.ag_ident`), so a portal record and a lake
+material share a key with no content hashing.
+
+Why three extraction sources: the portal's own ``court_case_no`` column is null
+for most rows (it was never backfilled upstream). The case number survives in
+the FILENAME (``081-CR-0094_<ts>.pdf``) and, in Devanagari, inside the
+``description`` (``(०८१-CR-००९४)``). Rows where none of the three carries a
+number are genuinely un-recoverable from metadata: they are banking-offence /
+foreign-employment prosecutions that never get a ``-CR-`` number, and the PDF
+body does not carry one either (the header reads ``२०८२ सालको मु.द.नं.......``).
+
+This tool NEVER writes -- it has no --apply. It only produces the map that
+``casework.backfill_ag_caseno`` later consumes.
+
+Usage:
+    uv run python -m casework.source_abhiyog --out work/ag-caseno-map
+    uv run python -m casework.source_abhiyog --snapshot cached.json --no-probe
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from casework.common.api import BROWSER_UA, CaseworkApi
+from casework.common.cli import (
+    add_common_args, basic_auth_from_env, configure_run_logging, log_event,
+    print_summary,
+)
+from casework.common.materials import ag_ident, material_iri, probe_material
+
+STAGE = "source_abhiyog"
+AG_SOURCE = "ag"
+
+#: Special Government Attorney Office. ``/offices/level/1`` on the portal lists
+#: exactly ONE office (id=2, alias `sgao`) -- levels 2/3 are the उच्च (High) and
+#: जिल्ला (District) offices, whose names do not contain विशेष. Omitting
+#: year_id/month_id returns the whole cohort in a single unpaginated response.
+AG_SEARCH_URL = (
+    "https://ag.gov.np/search-abhiyogpatra"
+    "?office_type=1&office_id=2&district_office_id=&year_id=&month_id="
+)
+SPECIAL_OFFICE_LEVEL = 1
+
+#: Devanagari digit -> ASCII. Without this a case number like ०८१-CR-००९४ keeps
+#: its Devanagari digits and never matches an ASCII case number.
+_DEVA_DIGITS = str.maketrans("०१२३४५६७८९", "0123456789")
+#: Case number inside a filename, before the `_<unix-ts>.<ext>` upload suffix.
+_FILE_RE = re.compile(r"^\s*([0-9]{3}-[A-Za-z]+-[0-9]+)_[0-9]+\.[A-Za-z0-9]+\s*$")
+#: Case number embedded in a Nepali description, e.g. `(०८१-CR-००९४)`.
+_DESC_RE = re.compile(r"([०-९]{3}-[A-Za-z]+-[०-९]+)")
+#: A bare court_case_no cell, tolerant of either digit script.
+_CCN_RE = re.compile(r"([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)")
+#: Canonical shape after normalisation.
+_CANON_RE = re.compile(r"^([0-9]{3})-([A-Za-z]+)-([0-9]+)$")
+
+#: Highest-trust first. `court_case_no` is the portal's own structured column;
+#: the filename is machine-stapled at upload; the description is hand-typed and
+#: therefore the most typo-prone, so it loses every tie.
+SOURCE_PRIORITY = ("court_case_no", "file", "description")
+
+
+def canonical_case_no(raw):
+    """Normalise a raw case number to `NNN-TYPE-NNNN`, or None if it isn't one.
+
+    Devanagari digits are transliterated and the type token upper-cased, so the
+    same case reached via three different fields collapses to one string that
+    can be compared for agreement. Leading zeros are preserved -- they are
+    significant in a case number.
+    """
+    if not raw:
+        return None
+    m = _CANON_RE.match(str(raw).strip().translate(_DEVA_DIGITS))
+    if not m:
+        return None
+    return f"{m.group(1)}-{m.group(2).upper()}-{m.group(3)}"
+
+
+def extract_case_no(record):
+    """All case-number candidates for one portal record, keyed by source.
+
+    Returns ``(case_number, source, candidates, agree)``. ``agree`` is None when
+    fewer than two sources produced a value, else True/False. A disagreement is
+    NOT resolved here beyond the priority order -- both values are reported so
+    the caller can flag the row rather than silently pick one.
+    """
+    candidates = {}
+
+    ccn = record.get("court_case_no")
+    if ccn:
+        m = _CCN_RE.search(str(ccn))
+        if m and (c := canonical_case_no(m.group(1))):
+            candidates["court_case_no"] = c
+
+    fm = _FILE_RE.match(str(record.get("file") or ""))
+    if fm and (c := canonical_case_no(fm.group(1))):
+        candidates["file"] = c
+
+    dm = _DESC_RE.search(str(record.get("description") or ""))
+    if dm and (c := canonical_case_no(dm.group(1))):
+        candidates["description"] = c
+
+    case_no = source = None
+    for key in SOURCE_PRIORITY:
+        if key in candidates:
+            case_no, source = candidates[key], key
+            break
+
+    agree = None if len(candidates) < 2 else len(set(candidates.values())) == 1
+    return case_no, source, candidates, agree
+
+
+def fiscal_year(record):
+    return str(((record.get("month") or {}).get("year") or {}).get("name") or "")
+
+
+def fetch_snapshot(url=AG_SEARCH_URL, timeout=120):
+    """GET the Special-office cohort from ag.gov.np. External source, not the
+    control plane, so it does NOT go through CaseworkApi -- but it reuses the
+    same browser UA (the portal serves JSON only to browser-like agents)."""
+    req = urllib.request.Request(
+        url, headers={"User-Agent": BROWSER_UA, "Accept": "application/json",
+                      "X-Requested-With": "XMLHttpRequest"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        data = json.load(r)
+    if not isinstance(data, list) or not data:
+        raise SystemExit(f"unexpected AG search response: {type(data).__name__}")
+    return data
+
+
+def probe_lake(api, record_id, *, retries=5, interval=1.0):
+    """in-lake verdict for one record, throttled and 429-aware.
+
+    The production materials API rate-limits under bursts, and a 429 reaches
+    :func:`probe_material` as an "uncertain" (None) verdict -- indistinguishable
+    from a real 5xx. Retrying on None with a growing pause turns a throttled
+    read back into a definite answer instead of a false "unknown".
+    """
+    ident = ag_ident(record_id)
+    for attempt in range(retries):
+        result = probe_material(api, AG_SOURCE, ident)
+        if result.verdict is not None:
+            return result.verdict
+        time.sleep(min(interval * (2 ** attempt), 30))
+    return None
+
+
+def build_rows(records, api=None, *, probe=True, interval=1.0, logger=None,
+               events_path=None, run_id=""):
+    """One output row per portal record (extraction + optional lake probe)."""
+    rows = []
+    for record in records:
+        rid = record.get("id")
+        case_no, source, candidates, agree = extract_case_no(record)
+        ambiguous = agree is False
+        alts = sorted(v for v in set(candidates.values()) if v != case_no)
+        in_lake = ""
+        if probe and api is not None:
+            verdict = probe_lake(api, rid, interval=interval)
+            in_lake = {True: "true", False: "false", None: "error"}[verdict]
+        rows.append({
+            "id": rid,
+            "material_iri": material_iri(AG_SOURCE, ag_ident(rid)),
+            "case_number": case_no or "",
+            "source": source or "",
+            "ambiguous": "true" if ambiguous else "",
+            "alt_case_number": ";".join(alts),
+            "in_lake": in_lake,
+            "name": (record.get("name") or "").strip(),
+            "fy": fiscal_year(record),
+            "filing_date_bs": record.get("created_date_np") or "",
+            "file": record.get("file") or "",
+        })
+        if logger and events_path:
+            log_event(
+                logger, events_path, run_id=run_id, stage=STAGE,
+                slug=f"ag/{rid}", step="extract",
+                status="recovered" if case_no else "unrecoverable",
+                detail=f"case_no={case_no or '-'} source={source or '-'} "
+                       f"in_lake={in_lake or '-'}"
+                       + (" AMBIGUOUS" if ambiguous else ""))
+    return rows
+
+
+COLUMNS = ("id", "material_iri", "case_number", "source", "ambiguous",
+           "alt_case_number", "in_lake", "name", "fy", "filing_date_bs", "file")
+
+
+def write_outputs(rows, out_prefix):
+    """Write `<prefix>.csv` and `<prefix>.json`; returns the two paths."""
+    prefix = Path(out_prefix)
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    csv_path, json_path = prefix.with_suffix(".csv"), prefix.with_suffix(".json")
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(COLUMNS), extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(
+        json.dumps([{k: r[k] for k in COLUMNS} for r in rows],
+                   ensure_ascii=False, indent=1), encoding="utf-8")
+    return csv_path, json_path
+
+
+def summarise(rows):
+    recovered = [r for r in rows if r["case_number"]]
+    return {
+        "records": len(rows),
+        "recovered": len(recovered),
+        "unrecoverable": len(rows) - len(recovered),
+        "ambiguous": sum(1 for r in rows if r["ambiguous"]),
+        "in_lake": sum(1 for r in rows if r["in_lake"] == "true"),
+        "not_in_lake": sum(1 for r in rows if r["in_lake"] == "false"),
+        "probe_error": sum(1 for r in rows if r["in_lake"] == "error"),
+    }
+
+
+def _build_api(args):
+    if args.api_token:
+        return CaseworkApi(base_url=args.api_base_url, token=args.api_token)
+    return CaseworkApi(base_url=args.api_base_url, basic=basic_auth_from_env())
+
+
+def run(args):
+    logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
+
+    if args.snapshot and Path(args.snapshot).exists():
+        records = json.loads(Path(args.snapshot).read_text(encoding="utf-8"))
+        logger.info("snapshot: %d records from %s", len(records), args.snapshot)
+    else:
+        records = fetch_snapshot()
+        logger.info("fetched %d records from ag.gov.np", len(records))
+        if args.snapshot:
+            Path(args.snapshot).write_text(
+                json.dumps(records, ensure_ascii=False, indent=1), encoding="utf-8")
+
+    if args.limit:
+        records = records[: args.limit]
+
+    api = None if args.no_probe else _build_api(args)
+    rows = build_rows(records, api, probe=not args.no_probe,
+                      interval=args.probe_interval, logger=logger,
+                      events_path=paths["events"], run_id=run_id)
+    csv_path, json_path = write_outputs(rows, args.out)
+    stats = summarise(rows)
+    logger.info("wrote %s and %s", csv_path, json_path)
+    return stats, rows
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Recover the ag/<id> -> case number map (read-only).")
+    add_common_args(parser)
+    parser.add_argument("--out", default="work/ag-caseno-map",
+                        help="Output path prefix; writes <prefix>.csv/.json.")
+    parser.add_argument("--snapshot", default="",
+                        help="Cache path for the raw AG response; reused if it "
+                             "exists (re-runs then need no network).")
+    parser.add_argument("--no-probe", action="store_true",
+                        help="Skip the lake existence probe (offline; leaves "
+                             "in_lake blank).")
+    parser.add_argument("--probe-interval", type=float, default=1.0,
+                        help="Base seconds between lake probes; backs off "
+                             "exponentially on a throttled/uncertain read.")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    stats, _ = run(args)
+    # Always read-only: dry_run=True regardless of --apply, which this verb
+    # does not honour (it has no write path at all).
+    print_summary(stats, True, "source abhiyog")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/casework/source_abhiyog.py
+++ b/casework/source_abhiyog.py
@@ -61,10 +61,17 @@ AG_SEARCH_URL = (
 #: Devanagari digit -> ASCII. Without this a case number like ०८१-CR-००९४ keeps
 #: its Devanagari digits and never matches an ASCII case number.
 _DEVA_DIGITS = str.maketrans("०१२३४५६७८९", "0123456789")
-#: Case number inside a filename, before the `_<unix-ts>.<ext>` upload suffix.
-_FILE_RE = re.compile(r"^\s*([0-9]{3}-[A-Za-z]+-[0-9]+)_[0-9]+\.[A-Za-z0-9]+\s*$")
-#: Case number embedded in a Nepali description, e.g. `(०८१-CR-००९४)`.
-_DESC_RE = re.compile(r"([०-९]{3}-[A-Za-z]+-[०-९]+)")
+#: Case number inside a filename, before the OPTIONAL `_<unix-ts>` upload
+#: suffix. The timestamp is stapled on by the portal's uploader, so it is the
+#: common shape -- but making it mandatory silently dropped any filename that
+#: carries the case number without one (`081-CR-0094.pdf`).
+_FILE_RE = re.compile(
+    r"^\s*([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)(?:_[0-9]+)?\.[A-Za-z0-9]+\s*$")
+#: Case number embedded in a Nepali description, e.g. `(०८१-CR-००९४)`. Tolerant
+#: of EITHER digit script (and a mix of the two): the description is hand-typed,
+#: so a typist using ASCII digits is common, and a Devanagari-only class scored
+#: those records "unrecoverable" when the number was sitting right there.
+_DESC_RE = re.compile(r"([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)")
 #: A bare court_case_no cell, tolerant of either digit script.
 _CCN_RE = re.compile(r"([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)")
 #: Canonical shape after normalisation.

--- a/casework/source_abhiyog.py
+++ b/casework/source_abhiyog.py
@@ -36,8 +36,6 @@ import csv
 import json
 import re
 import sys
-import time
-import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -59,7 +57,6 @@ AG_SEARCH_URL = (
     "https://ag.gov.np/search-abhiyogpatra"
     "?office_type=1&office_id=2&district_office_id=&year_id=&month_id="
 )
-SPECIAL_OFFICE_LEVEL = 1
 
 #: Devanagari digit -> ASCII. Without this a case number like ०८१-CR-००९४ keeps
 #: its Devanagari digits and never matches an ASCII case number.
@@ -133,6 +130,23 @@ def fiscal_year(record):
     return str(((record.get("month") or {}).get("year") or {}).get("name") or "")
 
 
+def validate_records(data, origin):
+    """The cohort must be a non-empty list of record objects.
+
+    Applied to a CACHED snapshot as well as a freshly fetched one: a truncated
+    or hand-edited cache is otherwise trusted blindly, and a JSON object slips
+    through to iterate as bare KEYS (``'str' object has no attribute 'get'``)
+    or silently yields an empty map.
+    """
+    if not isinstance(data, list) or not data:
+        raise SystemExit(
+            f"{origin}: expected a non-empty JSON list of AG records, got "
+            f"{type(data).__name__} (len={len(data) if hasattr(data, '__len__') else '?'})")
+    if not all(isinstance(r, dict) for r in data):
+        raise SystemExit(f"{origin}: every AG record must be a JSON object")
+    return data
+
+
 def fetch_snapshot(url=AG_SEARCH_URL, timeout=120):
     """GET the Special-office cohort from ag.gov.np. External source, not the
     control plane, so it does NOT go through CaseworkApi -- but it reuses the
@@ -142,41 +156,47 @@ def fetch_snapshot(url=AG_SEARCH_URL, timeout=120):
                       "X-Requested-With": "XMLHttpRequest"})
     with urllib.request.urlopen(req, timeout=timeout) as r:
         data = json.load(r)
-    if not isinstance(data, list) or not data:
-        raise SystemExit(f"unexpected AG search response: {type(data).__name__}")
-    return data
+    return validate_records(data, "ag.gov.np search response")
 
 
-def probe_lake(api, record_id, *, retries=5, interval=1.0):
-    """in-lake verdict for one record, throttled and 429-aware.
+_VERDICT_LABEL = {True: "true", False: "false", None: "error"}
 
-    The production materials API rate-limits under bursts, and a 429 reaches
-    :func:`probe_material` as an "uncertain" (None) verdict -- indistinguishable
-    from a real 5xx. Retrying on None with a growing pause turns a throttled
-    read back into a definite answer instead of a false "unknown".
+
+def build_rows(records, api=None, *, probe=True, interval=1.0, retries=4,
+               logger=None, events_path=None, run_id="", probe_cache=None):
+    """One output row per portal record (extraction + optional lake probe).
+
+    ``probe_cache`` (id -> verdict label) is read AND written, so a re-run over
+    the same cohort re-probes only what it has no answer for -- the probe is a
+    ~1s-apart sequential walk of the whole cohort, so an uncached re-run costs
+    minutes and needlessly re-pressures the rate limiter.
     """
-    ident = ag_ident(record_id)
-    for attempt in range(retries):
-        result = probe_material(api, AG_SOURCE, ident)
-        if result.verdict is not None:
-            return result.verdict
-        time.sleep(min(interval * (2 ** attempt), 30))
-    return None
-
-
-def build_rows(records, api=None, *, probe=True, interval=1.0, logger=None,
-               events_path=None, run_id=""):
-    """One output row per portal record (extraction + optional lake probe)."""
     rows = []
+    cache = probe_cache if probe_cache is not None else {}
     for record in records:
         rid = record.get("id")
+        if rid is None or not str(rid).strip():
+            # No id means no ident, and ag_ident(None) would cheerfully build
+            # `/material/ag/None`. Drop the record rather than emit a row that
+            # looks bindable.
+            if logger:
+                logger.warning("skipping AG record with no id: %r",
+                               {k: record.get(k) for k in ("file", "name")})
+            continue
         case_no, source, candidates, agree = extract_case_no(record)
         ambiguous = agree is False
         alts = sorted(v for v in set(candidates.values()) if v != case_no)
         in_lake = ""
         if probe and api is not None:
-            verdict = probe_lake(api, rid, interval=interval)
-            in_lake = {True: "true", False: "false", None: "error"}[verdict]
+            key = str(rid)
+            if key not in cache or cache[key] == "error":
+                # Opt in to backoff: this walks the whole cohort against
+                # production, which is exactly the burst that gets throttled.
+                verdict = probe_material(api, AG_SOURCE, ag_ident(rid),
+                                         retries=retries,
+                                         interval=interval).verdict
+                cache[key] = _VERDICT_LABEL[verdict]
+            in_lake = cache[key]
         rows.append({
             "id": rid,
             "material_iri": material_iri(AG_SOURCE, ag_ident(rid)),
@@ -206,10 +226,16 @@ COLUMNS = ("id", "material_iri", "case_number", "source", "ambiguous",
 
 
 def write_outputs(rows, out_prefix):
-    """Write `<prefix>.csv` and `<prefix>.json`; returns the two paths."""
+    """Write `<prefix>.csv` and `<prefix>.json`; returns the two paths.
+
+    The extension is APPENDED, not substituted: `Path.with_suffix` would turn
+    `--out map.v2` into `map.csv`, silently collapsing `map.v1` and `map.v2`
+    onto the same pair of files.
+    """
     prefix = Path(out_prefix)
     prefix.parent.mkdir(parents=True, exist_ok=True)
-    csv_path, json_path = prefix.with_suffix(".csv"), prefix.with_suffix(".json")
+    csv_path = prefix.with_name(prefix.name + ".csv")
+    json_path = prefix.with_name(prefix.name + ".json")
     with csv_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=list(COLUMNS), extrasaction="ignore")
         writer.writeheader()
@@ -243,7 +269,9 @@ def run(args):
     logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
 
     if args.snapshot and Path(args.snapshot).exists():
-        records = json.loads(Path(args.snapshot).read_text(encoding="utf-8"))
+        records = validate_records(
+            json.loads(Path(args.snapshot).read_text(encoding="utf-8")),
+            f"cached snapshot {args.snapshot}")
         logger.info("snapshot: %d records from %s", len(records), args.snapshot)
     else:
         records = fetch_snapshot()
@@ -255,10 +283,28 @@ def run(args):
     if args.limit:
         records = records[: args.limit]
 
+    cache_path = Path(args.probe_cache) if args.probe_cache else None
+    probe_cache = {}
+    if cache_path and cache_path.exists() and not args.refresh_probes:
+        probe_cache = json.loads(cache_path.read_text(encoding="utf-8"))
+        logger.info("probe cache: %d cached verdicts from %s",
+                    len(probe_cache), cache_path)
+
     api = None if args.no_probe else _build_api(args)
-    rows = build_rows(records, api, probe=not args.no_probe,
-                      interval=args.probe_interval, logger=logger,
-                      events_path=paths["events"], run_id=run_id)
+    try:
+        rows = build_rows(records, api, probe=not args.no_probe,
+                          interval=args.probe_interval,
+                          retries=args.probe_retries, logger=logger,
+                          events_path=paths["events"], run_id=run_id,
+                          probe_cache=probe_cache)
+    finally:
+        # Persist whatever was learned even if the walk died part-way, so an
+        # interrupted probe run does not have to start from zero.
+        if cache_path and probe_cache:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(json.dumps(probe_cache, indent=1),
+                                  encoding="utf-8")
+
     csv_path, json_path = write_outputs(rows, args.out)
     stats = summarise(rows)
     logger.info("wrote %s and %s", csv_path, json_path)
@@ -278,16 +324,29 @@ def build_parser():
                         help="Skip the lake existence probe (offline; leaves "
                              "in_lake blank).")
     parser.add_argument("--probe-interval", type=float, default=1.0,
-                        help="Base seconds between lake probes; backs off "
-                             "exponentially on a throttled/uncertain read.")
+                        help="Base backoff seconds for a throttled/uncertain "
+                             "lake probe (exponential, Retry-After honoured).")
+    parser.add_argument("--probe-retries", type=int, default=4,
+                        help="Retries for a throttled/uncertain lake probe; "
+                             "0 for a single shot.")
+    parser.add_argument("--probe-cache", default="",
+                        help="JSON path caching id -> in-lake verdict, so a "
+                             "re-run only probes what it lacks an answer for.")
+    parser.add_argument("--refresh-probes", action="store_true",
+                        help="Ignore an existing --probe-cache and re-probe.")
     return parser
 
 
 def main(argv=None):
     args = build_parser().parse_args(argv)
+    if not args.dry_run:
+        # add_common_args gives every verb --apply; this one has no write path,
+        # so say so rather than print a misleading "DRY RUN" and move on.
+        print("note: --apply has no effect on source_abhiyog; it is read-only "
+              "and only produces the map that casework.backfill_ag_caseno "
+              "consumes.", file=sys.stderr)
     stats, _ = run(args)
-    # Always read-only: dry_run=True regardless of --apply, which this verb
-    # does not honour (it has no write path at all).
+    # Always read-only: dry_run=True regardless of --apply.
     print_summary(stats, True, "source abhiyog")
     return 0
 

--- a/casework/source_abhiyog.py
+++ b/casework/source_abhiyog.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from casework.common.api import BROWSER_UA, CaseworkApi
 from casework.common.cli import (
     add_common_args, basic_auth_from_env, configure_run_logging, log_event,
-    print_summary,
+    nonneg_float, nonneg_int, print_summary,
 )
 from casework.common.materials import ag_ident, material_iri, probe_material
 
@@ -151,6 +151,27 @@ def validate_records(data, origin):
             f"{type(data).__name__} (len={len(data) if hasattr(data, '__len__') else '?'})")
     if not all(isinstance(r, dict) for r in data):
         raise SystemExit(f"{origin}: every AG record must be a JSON object")
+    return data
+
+
+def validate_probe_cache(data, origin):
+    """The probe cache must be a JSON object of ``id -> verdict label``.
+
+    Same reasoning as :func:`validate_records`, applied to the other file this
+    CLI reads back. ``build_rows`` ASSIGNS into the cache (``cache[key] = ...``),
+    so a cache corrupted into a JSON list raises ``TypeError: list indices must
+    be integers`` partway through the cohort walk -- after the probes already
+    spent, and with nothing written.
+    """
+    if not isinstance(data, dict):
+        raise SystemExit(
+            f"probe cache {origin}: expected a JSON object of "
+            f"id -> verdict, got {type(data).__name__}")
+    bad = [k for k, v in data.items() if v not in _VERDICT_LABEL.values()]
+    if bad:
+        raise SystemExit(
+            f"probe cache {origin}: {len(bad)} entries have a verdict outside "
+            f"{sorted(_VERDICT_LABEL.values())} (e.g. {bad[:3]})")
     return data
 
 
@@ -293,7 +314,8 @@ def run(args):
     cache_path = Path(args.probe_cache) if args.probe_cache else None
     probe_cache = {}
     if cache_path and cache_path.exists() and not args.refresh_probes:
-        probe_cache = json.loads(cache_path.read_text(encoding="utf-8"))
+        probe_cache = validate_probe_cache(
+            json.loads(cache_path.read_text(encoding="utf-8")), cache_path)
         logger.info("probe cache: %d cached verdicts from %s",
                     len(probe_cache), cache_path)
 
@@ -330,10 +352,10 @@ def build_parser():
     parser.add_argument("--no-probe", action="store_true",
                         help="Skip the lake existence probe (offline; leaves "
                              "in_lake blank).")
-    parser.add_argument("--probe-interval", type=float, default=1.0,
+    parser.add_argument("--probe-interval", type=nonneg_float, default=1.0,
                         help="Base backoff seconds for a throttled/uncertain "
                              "lake probe (exponential, Retry-After honoured).")
-    parser.add_argument("--probe-retries", type=int, default=4,
+    parser.add_argument("--probe-retries", type=nonneg_int, default=4,
                         help="Retries for a throttled/uncertain lake probe; "
                              "0 for a single shot.")
     parser.add_argument("--probe-cache", default="",

--- a/tests/casework/test_backfill_ag_caseno.py
+++ b/tests/casework/test_backfill_ag_caseno.py
@@ -1,0 +1,206 @@
+# tests/casework/test_backfill_ag_caseno.py
+import json
+import types
+import urllib.error
+
+from casework.backfill_ag_caseno import (
+    APPLIED, CONFLICT_QUARANTINE, GET_ERROR, GONE, GUARD_FAIL,
+    SKIP_IDEMPOTENT, WOULD_APPLY, check_guards, merge_case_no, plan_one, run,
+    select_targets,
+)
+
+CASE_NO = "jawafdehi:caseNumber"
+
+
+def doc(**over):
+    """A stored AG material as the detail endpoint returns it."""
+    base = {
+        "@id": "https://jawafdehi.org/material/ag/83475",
+        "name": {"ne": "जिल्ला कालिकोट"},
+        "text": {"ne": "आरोप पत्र"},
+        "associatedMedia": [{"@type": "MediaObject", "contentUrl": "x.pdf"}],
+        "jawafdehi:recordId": "83475",
+        "jawafdehi:officeLevel": 1,
+        "jawafdehi:sourceType": "AG_ABHIYOG_PATRA",
+    }
+    base.update(over)
+    return base
+
+
+def row(**over):
+    base = {"id": 83475, "material_iri": "https://jawafdehi.org/material/ag/83475",
+            "case_number": "081-CR-0094", "source": "file", "ambiguous": "",
+            "alt_case_number": "", "in_lake": "true"}
+    base.update(over)
+    return base
+
+
+class FakeApi:
+    def __init__(self, docs=None, error=None):
+        self.docs = docs or {}
+        self.error = error
+        self.puts = []
+
+    def get(self, path, timeout=60):
+        if self.error:
+            raise self.error
+        ident = path.removeprefix("/materials/ag/").rstrip("/")
+        if ident not in self.docs:
+            raise urllib.error.HTTPError(path, 404, "nf", {}, None)
+        return self.docs[ident]
+
+    def put_material(self, source, ident, doc, material_type=None, timeout=60):
+        self.puts.append((source, ident, doc, material_type))
+        return {}
+
+
+# --------------------------------------------------------------------------
+# selection
+# --------------------------------------------------------------------------
+
+def test_select_targets_excludes_absent_and_unrecoverable():
+    rows = [row(), row(id=2, in_lake="false"), row(id=3, case_number="")]
+    targets, skipped = select_targets(rows)
+    assert [t["id"] for t in targets] == [83475]
+    assert skipped == {"not_in_lake": 1, "unrecoverable": 1}
+
+
+# --------------------------------------------------------------------------
+# guards
+# --------------------------------------------------------------------------
+
+def test_guards_pass_on_matching_special_office_doc():
+    ok, guards = check_guards(doc(), 83475)
+    assert ok is True
+    assert guards["officeLevel"] == 1
+
+
+def test_guards_reject_record_id_mismatch():
+    # Would otherwise stamp a case number onto a DIFFERENT document.
+    ok, _ = check_guards(doc(**{"jawafdehi:recordId": "999"}), 83475)
+    assert ok is False
+
+
+def test_guards_reject_non_special_office_and_wrong_source_type():
+    assert check_guards(doc(**{"jawafdehi:officeLevel": 3}), 83475)[0] is False
+    assert check_guards(doc(**{"jawafdehi:sourceType": "OTHER"}), 83475)[0] is False
+
+
+# --------------------------------------------------------------------------
+# merge -- the safety-critical part (PUT replaces `data` wholesale)
+# --------------------------------------------------------------------------
+
+def test_merge_preserves_every_existing_key():
+    original = doc()
+    merged, added = merge_case_no(original, row())
+    for key in original:
+        assert merged[key] == original[key], f"{key} was mutated or dropped"
+    assert merged[CASE_NO] == "081-CR-0094"
+    assert added == [CASE_NO, "jawafdehi:caseNumberSource"]
+
+
+def test_merge_does_not_mutate_the_input_doc():
+    original = doc()
+    merge_case_no(original, row())
+    assert CASE_NO not in original
+
+
+def test_merge_flags_ambiguous_and_keeps_alternate():
+    merged, added = merge_case_no(
+        doc(), row(ambiguous="true", alt_case_number="081-CR-0009"))
+    assert merged["jawafdehi:caseNumberAmbiguous"] is True
+    assert merged["jawafdehi:caseNumberAlt"] == "081-CR-0009"
+    assert len(added) == 4
+
+
+# --------------------------------------------------------------------------
+# planning
+# --------------------------------------------------------------------------
+
+def test_plan_would_apply_when_field_absent():
+    plan = plan_one(FakeApi({"83475": doc()}), row())
+    assert plan["outcome"] == WOULD_APPLY
+    assert plan["merged"][CASE_NO] == "081-CR-0094"
+
+
+def test_plan_is_idempotent_when_value_already_correct():
+    api = FakeApi({"83475": doc(**{CASE_NO: "081-CR-0094"})})
+    assert plan_one(api, row())["outcome"] == SKIP_IDEMPOTENT
+
+
+def test_plan_quarantines_a_different_existing_value():
+    api = FakeApi({"83475": doc(**{CASE_NO: "079-CR-0001"})})
+    plan = plan_one(api, row())
+    assert plan["outcome"] == CONFLICT_QUARANTINE
+    assert plan["merged"] is None  # nothing to write
+
+
+def test_plan_guard_fail_produces_no_merge():
+    api = FakeApi({"83475": doc(**{"jawafdehi:officeLevel": 3})})
+    plan = plan_one(api, row())
+    assert plan["outcome"] == GUARD_FAIL
+    assert plan["merged"] is None
+
+
+def test_plan_reports_gone_and_transport_error_distinctly():
+    assert plan_one(FakeApi({}), row())["outcome"] == GONE
+    api = FakeApi({"83475": doc()}, error=urllib.error.URLError("boom"))
+    assert plan_one(api, row())["outcome"] == GET_ERROR
+
+
+# --------------------------------------------------------------------------
+# run() -- dry-run must never write
+# --------------------------------------------------------------------------
+
+def _args(map_path, **over):
+    base = dict(map=str(map_path), dry_run=True, limit=0, verbose=False,
+                put_bodies="", write_interval=0, api_token="tok",
+                api_base_url="http://127.0.0.1:48010", allow_remote_writes=False)
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def _write_map(tmp_path, rows):
+    p = tmp_path / "map.json"
+    p.write_text(json.dumps(rows, ensure_ascii=False), encoding="utf-8")
+    return p
+
+
+def test_dry_run_plans_but_sends_no_put(tmp_path, monkeypatch):
+    api = FakeApi({"83475": doc()})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    stats = run(_args(_write_map(tmp_path, [row()])))
+    assert stats[WOULD_APPLY] == 1
+    assert api.puts == []          # the whole point
+
+
+def test_apply_sends_the_complete_merged_document(tmp_path, monkeypatch):
+    api = FakeApi({"83475": doc()})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    stats = run(_args(_write_map(tmp_path, [row()]), dry_run=False))
+    assert stats[APPLIED] == 1
+    _, ident, sent, mtype = api.puts[0]
+    assert (ident, mtype) == ("83475", "charge_sheet")
+    # a partial PUT would destroy these -- assert the whole doc went back
+    assert sent["text"] == {"ne": "आरोप पत्र"}
+    assert sent["associatedMedia"]
+    assert sent[CASE_NO] == "081-CR-0094"
+
+
+def test_put_bodies_are_recorded_for_inspection(tmp_path, monkeypatch):
+    api = FakeApi({"83475": doc()})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    bodies = tmp_path / "bodies.jsonl"
+    run(_args(_write_map(tmp_path, [row()]), put_bodies=str(bodies)))
+    written = json.loads(bodies.read_text(encoding="utf-8").strip())
+    assert written["method"] == "PUT"
+    assert written["body"]["material"][CASE_NO] == "081-CR-0094"
+
+
+def test_run_counts_skipped_rows_without_fetching_them(tmp_path, monkeypatch):
+    api = FakeApi({"83475": doc()})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    rows = [row(), row(id=2, in_lake="false"), row(id=3, case_number="")]
+    stats = run(_args(_write_map(tmp_path, rows)))
+    assert stats["skipped_not_in_lake"] == 1
+    assert stats["skipped_unrecoverable"] == 1

--- a/tests/casework/test_backfill_ag_caseno.py
+++ b/tests/casework/test_backfill_ag_caseno.py
@@ -3,10 +3,12 @@ import json
 import types
 import urllib.error
 
+import pytest
+
 from casework.backfill_ag_caseno import (
-    APPLIED, CONFLICT_QUARANTINE, GET_ERROR, GONE, GUARD_FAIL,
-    SKIP_IDEMPOTENT, WOULD_APPLY, check_guards, merge_case_no, plan_one, run,
-    select_targets,
+    APPLIED, APPLY_FAILED, CONFLICT_QUARANTINE, GET_ERROR, GET_FATAL, GONE,
+    GUARD_FAIL, GUARD_MISSING, SKIP_IDEMPOTENT, WOULD_APPLY, check_guards,
+    merge_case_no, plan_one, run, select_targets, validate_map,
 )
 
 CASE_NO = "jawafdehi:caseNumber"
@@ -19,6 +21,7 @@ def doc(**over):
         "name": {"ne": "जिल्ला कालिकोट"},
         "text": {"ne": "आरोप पत्र"},
         "associatedMedia": [{"@type": "MediaObject", "contentUrl": "x.pdf"}],
+        "additionalType": "jawafdehi:ChargeSheet",
         "jawafdehi:recordId": "83475",
         "jawafdehi:officeLevel": 1,
         "jawafdehi:sourceType": "AG_ABHIYOG_PATRA",
@@ -79,7 +82,37 @@ def test_select_targets_excludes_absent_and_unrecoverable():
     rows = [row(), row(id=2, in_lake="false"), row(id=3, case_number="")]
     targets, skipped = select_targets(rows)
     assert [t["id"] for t in targets] == [83475]
-    assert skipped == {"not_in_lake": 1, "unrecoverable": 1}
+    assert skipped == {"not_in_lake": 1, "unrecoverable": 1, "lake_state_unknown": 0}
+
+
+def test_unknown_lake_state_is_not_reported_as_absent():
+    # A --no-probe map leaves in_lake blank and a throttled probe leaves
+    # "error". Counting either as not_in_lake would claim the lake was checked.
+    _, skipped = select_targets([row(in_lake=""), row(id=2, in_lake="error")])
+    assert skipped["lake_state_unknown"] == 2
+    assert skipped["not_in_lake"] == 0
+
+
+# --------------------------------------------------------------------------
+# map validation -- the writer must not trust its input
+# --------------------------------------------------------------------------
+
+def test_validate_map_rejects_a_non_list_or_empty_map():
+    for bad in ({}, [], {"a": row()}, [1], None):
+        with pytest.raises(SystemExit):
+            validate_map(bad, "map")
+
+
+def test_validate_map_rejects_a_row_missing_a_dereferenced_key():
+    # plan_one does row["material_iri"]; a KeyError mid-apply would leave the
+    # backfill half-written with no resume marker.
+    incomplete = {k: v for k, v in row().items() if k != "material_iri"}
+    with pytest.raises(SystemExit, match="material_iri"):
+        validate_map([incomplete], "map")
+
+
+def test_validate_map_accepts_a_real_map():
+    assert validate_map([row()], "map") == [row()]
 
 
 # --------------------------------------------------------------------------
@@ -87,20 +120,45 @@ def test_select_targets_excludes_absent_and_unrecoverable():
 # --------------------------------------------------------------------------
 
 def test_guards_pass_on_matching_special_office_doc():
-    ok, guards = check_guards(doc(), 83475)
-    assert ok is True
+    outcome, guards = check_guards(doc(), 83475)
+    assert outcome is None
     assert guards["officeLevel"] == 1
 
 
 def test_guards_reject_record_id_mismatch():
     # Would otherwise stamp a case number onto a DIFFERENT document.
-    ok, _ = check_guards(doc(**{"jawafdehi:recordId": "999"}), 83475)
-    assert ok is False
+    outcome, _ = check_guards(doc(**{"jawafdehi:recordId": "999"}), 83475)
+    assert outcome == GUARD_FAIL
 
 
 def test_guards_reject_non_special_office_and_wrong_source_type():
-    assert check_guards(doc(**{"jawafdehi:officeLevel": 3}), 83475)[0] is False
-    assert check_guards(doc(**{"jawafdehi:sourceType": "OTHER"}), 83475)[0] is False
+    assert check_guards(doc(**{"jawafdehi:officeLevel": 3}), 83475)[0] == GUARD_FAIL
+    assert check_guards(doc(**{"jawafdehi:sourceType": "OTHER"}), 83475)[0] == GUARD_FAIL
+
+
+def test_absent_identity_fields_are_distinguished_from_a_mismatch():
+    # `materials/sourcing/ag/shaper.py` emits NEITHER jawafdehi:recordId nor
+    # jawafdehi:officeLevel, so a doc written by the in-repo shaper carries no
+    # identity at all. That is "the stored shape changed", not "wrong record" --
+    # conflating them would report an ingest-path change as 473 bad matches.
+    shaped_by_the_repo = {k: v for k, v in doc().items()
+                          if not k.startswith("jawafdehi:record")
+                          and k != "jawafdehi:officeLevel"}
+    assert check_guards(shaped_by_the_repo, 83475)[0] == GUARD_MISSING
+
+
+def test_guards_reject_a_contradicting_additional_type():
+    # The PUT sends material_type=charge_sheet explicitly; writing it onto a doc
+    # whose own discriminator says otherwise would silently RETYPE the material.
+    outcome, _ = check_guards(doc(additionalType="jawafdehi:PressRelease"), 83475)
+    assert outcome == GUARD_FAIL
+
+
+def test_a_missing_additional_type_is_tolerated():
+    # Absence is exactly what the explicit material_type on the PUT covers --
+    # and omitting it would let the server infer `document` from DigitalDocument.
+    bare = {k: v for k, v in doc().items() if k != "additionalType"}
+    assert check_guards(bare, 83475)[0] is None
 
 
 # --------------------------------------------------------------------------
@@ -126,8 +184,15 @@ def test_merge_flags_ambiguous_and_keeps_alternate():
     merged, added = merge_case_no(
         doc(), row(ambiguous="true", alt_case_number="081-CR-0009"))
     assert merged["jawafdehi:caseNumberAmbiguous"] is True
-    assert merged["jawafdehi:caseNumberAlt"] == "081-CR-0009"
+    # A LIST -- the map's `;` join is a CSV artefact, not a JSON-LD value.
+    assert merged["jawafdehi:caseNumberAlt"] == ["081-CR-0009"]
     assert len(added) == 4
+
+
+def test_multiple_alternates_are_a_list_not_a_delimited_string():
+    merged, _ = merge_case_no(
+        doc(), row(ambiguous="true", alt_case_number="081-CR-0009;082-CR-0011"))
+    assert merged["jawafdehi:caseNumberAlt"] == ["081-CR-0009", "082-CR-0011"]
 
 
 # --------------------------------------------------------------------------
@@ -181,6 +246,23 @@ def test_404_is_not_retried():
     assert api.attempts == 1  # definitive: one shot only
 
 
+@pytest.mark.parametrize("code", [400, 401, 403, 410])
+def test_client_errors_are_not_retried(code):
+    # An expired token (401) or a missing NGM role (403) cannot improve by
+    # waiting. Retrying would sleep the whole ladder on EVERY row -- ~15s x 473
+    # rows -- before reporting what the first response already said.
+    api = FlakyApi(doc(), fail_times=99, code=code)
+    outcome = plan_one(api, row(), retries=4, interval=0)["outcome"]
+    assert outcome in (GET_FATAL, GONE)
+    assert api.attempts == 1
+
+
+def test_5xx_is_still_retried():
+    api = FlakyApi(doc(), fail_times=2, code=503)
+    assert plan_one(api, row(), retries=3, interval=0)["outcome"] == WOULD_APPLY
+    assert api.attempts == 3
+
+
 # --------------------------------------------------------------------------
 # run() -- dry-run must never write
 # --------------------------------------------------------------------------
@@ -190,7 +272,7 @@ def _args(map_path, **over):
                 put_bodies="", write_interval=0, api_token="tok",
                 api_base_url="http://127.0.0.1:48010", allow_remote_writes=False,
                 # no real backoff in tests
-                read_retries=0, read_interval=0)
+                read_retries=0, read_interval=0, max_consecutive_failures=10)
     base.update(over)
     return types.SimpleNamespace(**base)
 
@@ -239,3 +321,60 @@ def test_run_counts_skipped_rows_without_fetching_them(tmp_path, monkeypatch):
     stats = run(_args(_write_map(tmp_path, rows)))
     assert stats["skipped_not_in_lake"] == 1
     assert stats["skipped_unrecoverable"] == 1
+
+
+# --------------------------------------------------------------------------
+# circuit breaker -- a systemic fault must not walk the whole map
+# --------------------------------------------------------------------------
+
+class DeadApi:
+    """Every GET 500s -- an API that is down, or the wrong host entirely."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get(self, path, timeout=60):
+        self.calls += 1
+        raise urllib.error.HTTPError(path, 500, "boom", {}, None)
+
+
+def test_a_streak_of_failures_aborts_instead_of_walking_the_whole_map(
+        tmp_path, monkeypatch):
+    api = DeadApi()
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    rows = [row(id=i) for i in range(1, 51)]
+    stats = run(_args(_write_map(tmp_path, rows), read_retries=0,
+                      max_consecutive_failures=3))
+    assert stats["ABORTED_CONSECUTIVE_FAILURES"] == 3
+    assert api.calls == 3            # stopped at 3, not 50
+    assert stats[GET_ERROR] == 3
+
+
+def test_the_breaker_resets_on_a_success_so_isolated_failures_pass_through(
+        tmp_path, monkeypatch):
+    # 404, ok, 404 -- three rows, never 2 failures in a row.
+    api = FakeApi({"2": doc(**{"@id": "https://jawafdehi.org/material/ag/2",
+                               "jawafdehi:recordId": "2"})})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    rows = [row(id=1), row(id=2, material_iri="https://jawafdehi.org/material/ag/2"),
+            row(id=3)]
+    stats = run(_args(_write_map(tmp_path, rows), max_consecutive_failures=2))
+    assert "ABORTED_CONSECUTIVE_FAILURES" not in stats
+    assert stats[GONE] == 2 and stats[WOULD_APPLY] == 1
+
+
+def test_a_systemic_apply_failure_aborts_the_write_pass(tmp_path, monkeypatch):
+    class RefusingApi(FakeApi):
+        def put_material(self, *a, **kw):
+            raise urllib.error.HTTPError("/m", 403, "no ngm role", {}, None)
+
+    api = RefusingApi({str(i): doc(**{
+        "@id": f"https://jawafdehi.org/material/ag/{i}",
+        "jawafdehi:recordId": str(i)}) for i in range(1, 21)})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    rows = [row(id=i, material_iri=f"https://jawafdehi.org/material/ag/{i}")
+            for i in range(1, 21)]
+    stats = run(_args(_write_map(tmp_path, rows), dry_run=False,
+                      max_consecutive_failures=3))
+    assert stats["ABORTED_CONSECUTIVE_FAILURES"] == 3
+    assert stats[APPLY_FAILED] == 3  # not 20 doomed writes

--- a/tests/casework/test_backfill_ag_caseno.py
+++ b/tests/casework/test_backfill_ag_caseno.py
@@ -1,5 +1,6 @@
 # tests/casework/test_backfill_ag_caseno.py
 import json
+import os
 import types
 import urllib.error
 
@@ -272,7 +273,8 @@ def _args(map_path, **over):
                 put_bodies="", write_interval=0, api_token="tok",
                 api_base_url="http://127.0.0.1:48010", allow_remote_writes=False,
                 # no real backoff in tests
-                read_retries=0, read_interval=0, max_consecutive_failures=10)
+                read_retries=0, read_interval=0, max_consecutive_failures=10,
+                lock_file="")
     base.update(over)
     return types.SimpleNamespace(**base)
 
@@ -378,3 +380,60 @@ def test_a_systemic_apply_failure_aborts_the_write_pass(tmp_path, monkeypatch):
                       max_consecutive_failures=3))
     assert stats["ABORTED_CONSECUTIVE_FAILURES"] == 3
     assert stats[APPLY_FAILED] == 3  # not 20 doomed writes
+
+
+# --------------------------------------------------------------------------
+# single-instance lock -- this verb must not race itself
+#
+# The materials endpoint has no ETag/If-Match, so two overlapping
+# GET->merge->PUT passes silently lose each other's writes. This already bit
+# once: three stray concurrent processes tripled the request rate during the
+# recovery dry-run and produced a spray of 429s that read as lake errors.
+# --------------------------------------------------------------------------
+
+def test_a_second_instance_refuses_to_start(tmp_path):
+    from casework.backfill_ag_caseno import single_instance
+    lock = tmp_path / "backfill.lock"
+    with single_instance(lock):
+        assert lock.exists()
+        with pytest.raises(SystemExit, match="holds"):
+            with single_instance(lock):
+                raise AssertionError("the second instance must not get in")
+
+
+def test_the_lock_is_released_even_when_the_run_raises(tmp_path):
+    from casework.backfill_ag_caseno import single_instance
+    lock = tmp_path / "backfill.lock"
+    with pytest.raises(ValueError):
+        with single_instance(lock):
+            raise ValueError("boom")
+    assert not lock.exists()          # a crashed run must not wedge the next one
+    with single_instance(lock):       # and the next one starts cleanly
+        assert lock.exists()
+
+
+def test_a_stale_lock_from_a_dead_process_is_reclaimed(tmp_path):
+    from casework.backfill_ag_caseno import single_instance
+    lock = tmp_path / "backfill.lock"
+    # PID 2^22 is above Linux's default pid_max: nothing owns it.
+    lock.write_text("4194304", encoding="utf-8")
+    with single_instance(lock):
+        assert lock.read_text(encoding="utf-8") == str(os.getpid())
+
+
+def test_an_unparseable_lock_is_treated_as_stale(tmp_path):
+    # A truncated/garbage lock file must not wedge the verb forever.
+    from casework.backfill_ag_caseno import single_instance
+    lock = tmp_path / "backfill.lock"
+    lock.write_text("not-a-pid", encoding="utf-8")
+    with single_instance(lock):
+        assert lock.read_text(encoding="utf-8") == str(os.getpid())
+
+
+def test_run_takes_the_lock_and_releases_it(tmp_path, monkeypatch):
+    api = FakeApi({"83475": doc()})
+    monkeypatch.setattr("casework.backfill_ag_caseno._build_api", lambda a: api)
+    lock = tmp_path / "run.lock"
+    stats = run(_args(_write_map(tmp_path, [row()]), lock_file=str(lock)))
+    assert stats[WOULD_APPLY] == 1
+    assert not lock.exists()

--- a/tests/casework/test_backfill_ag_caseno.py
+++ b/tests/casework/test_backfill_ag_caseno.py
@@ -54,6 +54,23 @@ class FakeApi:
         return {}
 
 
+class FlakyApi:
+    """Fails the first `fail_times` GETs with `code`, then serves `doc`.
+
+    Models the production materials API, which 429s under a sustained walk.
+    """
+
+    def __init__(self, doc, fail_times, code):
+        self._doc, self._fail_times, self._code = doc, fail_times, code
+        self.attempts = 0
+
+    def get(self, path, timeout=60):
+        self.attempts += 1
+        if self.attempts <= self._fail_times:
+            raise urllib.error.HTTPError(path, self._code, "boom", {}, None)
+        return self._doc
+
+
 # --------------------------------------------------------------------------
 # selection
 # --------------------------------------------------------------------------
@@ -143,9 +160,25 @@ def test_plan_guard_fail_produces_no_merge():
 
 
 def test_plan_reports_gone_and_transport_error_distinctly():
-    assert plan_one(FakeApi({}), row())["outcome"] == GONE
+    # A 404 is definitive and must NOT be retried; a transport error is
+    # retryable and only becomes GET_ERROR once the retries are spent.
+    assert plan_one(FakeApi({}), row(), retries=0)["outcome"] == GONE
     api = FakeApi({"83475": doc()}, error=urllib.error.URLError("boom"))
-    assert plan_one(api, row())["outcome"] == GET_ERROR
+    assert plan_one(api, row(), retries=0, interval=0)["outcome"] == GET_ERROR
+
+
+def test_throttled_get_is_retried_then_succeeds():
+    # 429 twice, then the real document -- must end in a plan, not GET_ERROR.
+    api = FlakyApi(doc(), fail_times=2, code=429)
+    plan = plan_one(api, row(), retries=3, interval=0)
+    assert plan["outcome"] == WOULD_APPLY
+    assert api.attempts == 3
+
+
+def test_404_is_not_retried():
+    api = FlakyApi(doc(), fail_times=99, code=404)
+    assert plan_one(api, row(), retries=3, interval=0)["outcome"] == GONE
+    assert api.attempts == 1  # definitive: one shot only
 
 
 # --------------------------------------------------------------------------
@@ -155,7 +188,9 @@ def test_plan_reports_gone_and_transport_error_distinctly():
 def _args(map_path, **over):
     base = dict(map=str(map_path), dry_run=True, limit=0, verbose=False,
                 put_bodies="", write_interval=0, api_token="tok",
-                api_base_url="http://127.0.0.1:48010", allow_remote_writes=False)
+                api_base_url="http://127.0.0.1:48010", allow_remote_writes=False,
+                # no real backoff in tests
+                read_retries=0, read_interval=0)
     base.update(over)
     return types.SimpleNamespace(**base)
 

--- a/tests/casework/test_bind_materials.py
+++ b/tests/casework/test_bind_materials.py
@@ -194,6 +194,46 @@ def test_plan_case_aborts_on_uncertain_never_partial():
     assert plan.uncertain == [CO]
 
 
+class ThrottledThenOkApi(FakeApi):
+    """429s the first `fail_times` probes, then answers normally.
+
+    Models the production materials API under a sustained bind walk.
+    """
+
+    def __init__(self, fail_times, **kw):
+        super().__init__(**kw)
+        self._left = fail_times
+        self.attempts = 0
+
+    def get(self, path, timeout=60):
+        self.attempts += 1
+        if self._left > 0:
+            self._left -= 1
+            raise urllib.error.HTTPError(path, 429, "slow down", {}, None)
+        return super().get(path, timeout=timeout)
+
+
+def test_throttled_probe_no_longer_falsely_aborts_the_case():
+    # Before the retry, a 429 collapsed to "uncertain" and killed the whole
+    # case even though the material is present.
+    api = ThrottledThenOkApi(2, exists={"ciaa_press_release/2037"})
+    case = {"slug": "c", "state": "DRAFT", "evidence": []}
+    plan = plan_case(api, case, "e", [("ciaa_press_release", "2037")],
+                     probe_retries=3, probe_interval=0)
+    assert plan.action == "WOULD_PATCH"
+    assert plan.uncertain == []
+    assert [i["material_iri"] for i in plan.patch_items] == [PR]
+    assert api.attempts == 3
+
+
+def test_single_shot_still_aborts_so_the_old_behaviour_is_available():
+    api = ThrottledThenOkApi(2, exists={"ciaa_press_release/2037"})
+    case = {"slug": "c", "state": "DRAFT", "evidence": []}
+    plan = plan_case(api, case, "e", [("ciaa_press_release", "2037")],
+                     probe_retries=0)
+    assert plan.action == "ABORT_UNCERTAIN"
+
+
 # ---------------------------------------------------------------------------
 # apply_plan -- guarded, conditional on If-Match.
 # ---------------------------------------------------------------------------
@@ -234,6 +274,8 @@ def _args(dry_run, tmp_path):
     return types.SimpleNamespace(
         dry_run=dry_run, verbose=False, api_base_url="http://127.0.0.1:48010",
         api_token="", allow_remote_writes=False, report="", batch_csv="",
+        # no real backoff in tests
+        probe_retries=0, probe_interval=0,
     )
 
 

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -423,3 +423,53 @@ def test_log_run_footer_is_one_info_record_with_counts_and_duration(caplog):
     assert "error=0" in message
     assert "12.3" in message
     assert "tokens: 4200 in / 900 out" in message
+
+
+# ---------------------------------------------------------------------------
+# nonneg_int / nonneg_float -- reject at the flag boundary.
+#
+# A bare `type=int`/`type=float` accepts a negative value, and every consumer
+# then means something different by it: a negative retry count EMPTIES the
+# `range(retries + 1)` that drives the retry loops (so nothing is attempted at
+# all), and a negative interval makes `time.sleep()` raise ValueError mid-walk.
+# ---------------------------------------------------------------------------
+
+
+def test_nonneg_int_accepts_zero_and_positive():
+    from casework.common.cli import nonneg_int
+    assert nonneg_int("0") == 0
+    assert nonneg_int("4") == 4
+
+
+def test_nonneg_int_rejects_a_negative_count():
+    from casework.common.cli import nonneg_int
+    with pytest.raises(argparse.ArgumentTypeError):
+        nonneg_int("-1")
+
+
+def test_nonneg_float_accepts_zero_and_positive():
+    from casework.common.cli import nonneg_float
+    assert nonneg_float("0") == 0.0
+    assert nonneg_float("1.5") == 1.5
+
+
+def test_nonneg_float_rejects_a_negative_duration():
+    from casework.common.cli import nonneg_float
+    with pytest.raises(argparse.ArgumentTypeError):
+        nonneg_float("-0.5")
+
+
+def test_the_probe_and_write_flags_reject_negatives_end_to_end():
+    # SystemExit(2) is argparse's own "bad argument" exit.
+    from casework.backfill_ag_caseno import build_parser as backfill_parser
+    from casework.source_abhiyog import build_parser as source_parser
+    for parser, flag in (
+        (source_parser(), "--probe-interval"),
+        (source_parser(), "--probe-retries"),
+        (backfill_parser(), "--read-interval"),
+        (backfill_parser(), "--read-retries"),
+        (backfill_parser(), "--write-interval"),
+        (backfill_parser(), "--max-consecutive-failures"),
+    ):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--map", "m.json", flag, "-1"])

--- a/tests/casework/test_materials.py
+++ b/tests/casework/test_materials.py
@@ -214,3 +214,13 @@ def test_probe_material_reports_none_status_on_transport_error():
     from casework.common.materials import probe_material
     pr = probe_material(_StubApi(urllib.error.URLError("x")), "ag", "1")
     assert pr.status is None and pr.verdict is None
+
+
+def test_probe_material_still_probes_once_with_a_negative_retry_count():
+    # argparse accepts `--probe-retries -1`; range(-1 + 1) is EMPTY, so this
+    # used to return the None initializer and every caller's `.verdict`
+    # raised AttributeError.
+    from casework.common.materials import material_exists, probe_material
+    pr = probe_material(_StubApi({"@id": "x"}), "ag", "1", retries=-1)
+    assert pr is not None and pr.verdict is True
+    assert material_exists(_StubApi({"@id": "x"}), "ag", "1") is True

--- a/tests/casework/test_materials.py
+++ b/tests/casework/test_materials.py
@@ -224,3 +224,20 @@ def test_probe_material_still_probes_once_with_a_negative_retry_count():
     pr = probe_material(_StubApi({"@id": "x"}), "ag", "1", retries=-1)
     assert pr is not None and pr.verdict is True
     assert material_exists(_StubApi({"@id": "x"}), "ag", "1") is True
+
+
+def test_backoff_never_returns_a_negative_sleep():
+    # time.sleep() raises ValueError on a negative argument, so a negative
+    # interval would abort the walk with a traceback rather than degrade.
+    from casework.common.materials import _backoff_s
+    assert _backoff_s(None, 0, -5) == 0
+    assert _backoff_s(-3, 0, 1.0) == 0
+    assert _backoff_s(None, 3, 1.0) == 8
+
+
+def test_probe_material_survives_a_negative_interval():
+    # The uncertain path is the one that sleeps; it must not raise.
+    from casework.common.materials import probe_material
+    err = urllib.error.HTTPError("u", 503, "boom", {}, None)
+    pr = probe_material(_StubApi(err), "ag", "1", retries=2, interval=-1)
+    assert pr.status == 503 and pr.verdict is None

--- a/tests/casework/test_source_abhiyog.py
+++ b/tests/casework/test_source_abhiyog.py
@@ -226,3 +226,24 @@ def test_summarise_counts_each_bucket():
     assert stats["unrecoverable"] == 1
     assert stats["in_lake"] == 1
     assert stats["not_in_lake"] == 1
+
+
+def test_validate_probe_cache_rejects_a_corrupt_cache():
+    # build_rows ASSIGNS into the cache, so a list raises `list indices must be
+    # integers` partway through the walk -- after the probes are already spent.
+    from casework.source_abhiyog import validate_probe_cache
+    for bad in ([], ["1"], "true", 3):
+        with pytest.raises(SystemExit):
+            validate_probe_cache(bad, "cache.json")
+
+
+def test_validate_probe_cache_rejects_an_unknown_verdict_label():
+    from casework.source_abhiyog import validate_probe_cache
+    with pytest.raises(SystemExit, match="verdict"):
+        validate_probe_cache({"1": "maybe"}, "cache.json")
+
+
+def test_validate_probe_cache_accepts_every_real_verdict():
+    from casework.source_abhiyog import validate_probe_cache
+    cache = {"1": "true", "2": "false", "3": "error"}
+    assert validate_probe_cache(cache, "cache.json") == cache

--- a/tests/casework/test_source_abhiyog.py
+++ b/tests/casework/test_source_abhiyog.py
@@ -1,0 +1,158 @@
+# tests/casework/test_source_abhiyog.py
+import json
+import urllib.error
+
+from casework.source_abhiyog import (
+    build_rows, canonical_case_no, extract_case_no, fiscal_year, summarise,
+    write_outputs,
+)
+
+
+def record(**over):
+    """A portal record shaped like the ag.gov.np search response."""
+    base = {
+        "id": 83475,
+        "name": "जिल्ला कालिकोट",
+        "description": "भ्रष्ट्राचार गरेको सम्बन्धमा (०८१-CR-००९४)",
+        "file": "081-CR-0094_1750232440.pdf",
+        "court_case_no": None,
+        "created_date_np": "2082-3-4",
+        "month": {"year": {"name": "2082"}},
+    }
+    base.update(over)
+    return base
+
+
+class FakeApi:
+    """Scripts material existence the way the real probe sees it."""
+
+    def __init__(self, exists=(), absent=(), uncertain=()):
+        self.exists, self.absent = set(exists), set(absent)
+        self.uncertain = set(uncertain)
+        self.calls = []
+
+    def get(self, path, timeout=60):
+        self.calls.append(path)
+        ident = path.removeprefix("/materials/ag/").rstrip("/")
+        if ident in self.uncertain:
+            raise urllib.error.URLError("boom")
+        if ident in self.exists:
+            return {"@id": ident}
+        raise urllib.error.HTTPError(path, 404, "nf", {}, None)
+
+
+# --------------------------------------------------------------------------
+# canonicalisation
+# --------------------------------------------------------------------------
+
+def test_canonical_transliterates_devanagari_and_upcases_type():
+    assert canonical_case_no("०८१-cr-००९४") == "081-CR-0094"
+
+
+def test_canonical_preserves_leading_zeros():
+    # 0094 must not collapse to 94 -- leading zeros are significant.
+    assert canonical_case_no("081-CR-0094") == "081-CR-0094"
+
+
+def test_canonical_rejects_non_case_numbers():
+    for junk in ("", None, "not-a-case", "81-CR-94x", "बैंकिङ्ग कसूर"):
+        assert canonical_case_no(junk) is None
+
+
+# --------------------------------------------------------------------------
+# extraction + cross-validation
+# --------------------------------------------------------------------------
+
+def test_court_case_no_wins_over_file_and_description():
+    case_no, source, cands, agree = extract_case_no(
+        record(court_case_no="082-FT-0442"))
+    assert (case_no, source) == ("082-FT-0442", "court_case_no")
+    # all three still reported, so a disagreement is visible
+    assert set(cands) == {"court_case_no", "file", "description"}
+    assert agree is False
+
+
+def test_file_wins_over_description_when_court_case_no_missing():
+    case_no, source, _, agree = extract_case_no(record())
+    assert (case_no, source, agree) == ("081-CR-0094", "file", True)
+
+
+def test_description_used_when_filename_has_no_case_number():
+    case_no, source, _, _ = extract_case_no(
+        record(file="प्रतिवादी सरस्वती खड्का_1719399807.pdf"))
+    assert (case_no, source) == ("081-CR-0094", "description")
+
+
+def test_disagreement_is_flagged_not_silently_resolved():
+    case_no, _, cands, agree = extract_case_no(
+        record(file="080-CR-0009_1.pdf",
+               description="घुस लिई (०८१-CR-०००९)"))
+    assert agree is False
+    assert case_no == "080-CR-0009"          # priority pick
+    assert cands["description"] == "081-CR-0009"  # rejected value retained
+
+
+def test_unrecoverable_record_yields_no_case_number():
+    case_no, source, cands, agree = extract_case_no(record(
+        file="लक्ष्मण चालिसे_1642407863.pdf", description="बैंकिङ्ग कसुर"))
+    assert (case_no, source, cands, agree) == (None, None, {}, None)
+
+
+def test_fiscal_year_reads_nested_month_year():
+    assert fiscal_year(record()) == "2082"
+    assert fiscal_year({"month": None}) == ""
+
+
+# --------------------------------------------------------------------------
+# rows + lake probe
+# --------------------------------------------------------------------------
+
+def test_build_rows_marks_in_lake_and_absent():
+    rows = build_rows([record(id=1), record(id=2)],
+                      FakeApi(exists=["1"]), interval=0)
+    assert [r["in_lake"] for r in rows] == ["true", "false"]
+    assert rows[0]["material_iri"] == "https://jawafdehi.org/material/ag/1"
+
+
+def test_build_rows_can_skip_probe_entirely():
+    rows = build_rows([record()], api=None, probe=False)
+    assert rows[0]["in_lake"] == ""
+
+
+def test_uncertain_probe_reports_error_not_a_false_absent():
+    # A throttled/5xx read must never be recorded as "definitely not in lake".
+    rows = build_rows([record(id=7)], FakeApi(uncertain=["7"]), interval=0)
+    assert rows[0]["in_lake"] == "error"
+
+
+def test_ambiguous_row_carries_the_alternate():
+    rows = build_rows([record(file="080-CR-0009_1.pdf",
+                              description="(०८१-CR-०००९)")],
+                      api=None, probe=False)
+    assert rows[0]["ambiguous"] == "true"
+    assert rows[0]["alt_case_number"] == "081-CR-0009"
+
+
+# --------------------------------------------------------------------------
+# outputs
+# --------------------------------------------------------------------------
+
+def test_write_outputs_round_trips_devanagari(tmp_path):
+    rows = build_rows([record()], api=None, probe=False)
+    csv_path, json_path = write_outputs(rows, tmp_path / "map")
+    assert csv_path.exists() and json_path.exists()
+    loaded = json.loads(json_path.read_text(encoding="utf-8"))
+    assert loaded[0]["name"] == "जिल्ला कालिकोट"
+    assert "जिल्ला" in csv_path.read_text(encoding="utf-8")
+
+
+def test_summarise_counts_each_bucket():
+    rows = build_rows(
+        [record(id=1), record(id=2, file="x_1.pdf", description="बैंकिङ्ग")],
+        FakeApi(exists=["1"]), interval=0)
+    stats = summarise(rows)
+    assert stats["records"] == 2
+    assert stats["recovered"] == 1
+    assert stats["unrecoverable"] == 1
+    assert stats["in_lake"] == 1
+    assert stats["not_in_lake"] == 1

--- a/tests/casework/test_source_abhiyog.py
+++ b/tests/casework/test_source_abhiyog.py
@@ -2,9 +2,11 @@
 import json
 import urllib.error
 
+import pytest
+
 from casework.source_abhiyog import (
     build_rows, canonical_case_no, extract_case_no, fiscal_year, summarise,
-    write_outputs,
+    validate_records, write_outputs,
 )
 
 
@@ -125,6 +127,29 @@ def test_uncertain_probe_reports_error_not_a_false_absent():
     assert rows[0]["in_lake"] == "error"
 
 
+def test_record_without_id_is_dropped_not_emitted_as_ag_none():
+    # ag_ident(None) would build `/material/ag/None`; such a row must not exist.
+    rows = build_rows([record(id=None), record(id=5)], api=None, probe=False)
+    assert [r["id"] for r in rows] == [5]
+
+
+def test_probe_cache_is_reused_and_not_reprobed():
+    api = FakeApi(exists=["1"])
+    cache = {}
+    build_rows([record(id=1)], api, interval=0, probe_cache=cache)
+    assert cache == {"1": "true"} and len(api.calls) == 1
+    build_rows([record(id=1)], api, interval=0, probe_cache=cache)
+    assert len(api.calls) == 1  # second run served from cache
+
+
+def test_probe_cache_retries_a_previously_errored_verdict():
+    # An "error" is not an answer -- a re-run must try it again.
+    api = FakeApi(exists=["1"])
+    cache = {"1": "error"}
+    build_rows([record(id=1)], api, interval=0, probe_cache=cache)
+    assert cache["1"] == "true"
+
+
 def test_ambiguous_row_carries_the_alternate():
     rows = build_rows([record(file="080-CR-0009_1.pdf",
                               description="(०८१-CR-०००९)")],
@@ -136,6 +161,24 @@ def test_ambiguous_row_carries_the_alternate():
 # --------------------------------------------------------------------------
 # outputs
 # --------------------------------------------------------------------------
+
+def test_validate_records_rejects_a_corrupt_cache():
+    # A truncated/hand-edited snapshot must fail loudly, not iterate as keys.
+    for bad in ({}, [], {"a": {"id": 1}}, [1, 2], None):
+        with pytest.raises(SystemExit):
+            validate_records(bad, "cache")
+
+
+def test_validate_records_accepts_a_real_cohort():
+    assert validate_records([record()], "cache") == [record()]
+
+
+def test_write_outputs_appends_rather_than_replacing_a_dotted_suffix(tmp_path):
+    # `Path.with_suffix` would collapse map.v2 -> map.csv, clobbering map.v1.
+    csv_path, json_path = write_outputs([], tmp_path / "map.v2")
+    assert csv_path.name == "map.v2.csv"
+    assert json_path.name == "map.v2.json"
+
 
 def test_write_outputs_round_trips_devanagari(tmp_path):
     rows = build_rows([record()], api=None, probe=False)

--- a/tests/casework/test_source_abhiyog.py
+++ b/tests/casework/test_source_abhiyog.py
@@ -94,6 +94,33 @@ def test_disagreement_is_flagged_not_silently_resolved():
     assert cands["description"] == "081-CR-0009"  # rejected value retained
 
 
+def test_description_with_ascii_digits_is_recovered():
+    # The description is hand-typed, so a typist using ASCII digits is common.
+    # A Devanagari-only class scored these "unrecoverable" with the number
+    # sitting right there in the field.
+    case_no, source, _, _ = extract_case_no(
+        {"file": "प्रतिवादी_1.pdf", "description": "भ्रष्टाचार गरेको (081-CR-0094)"})
+    assert (case_no, source) == ("081-CR-0094", "description")
+
+
+def test_description_with_mixed_digit_scripts_is_recovered():
+    case_no, _, _, _ = extract_case_no(
+        {"file": "x.pdf", "description": "(०८१-CR-0094)"})
+    assert case_no == "081-CR-0094"
+
+
+def test_filename_without_the_upload_timestamp_is_recovered():
+    # `_<unix-ts>` is stapled on by the portal uploader, so it is the common
+    # shape -- but requiring it dropped every filename that lacks one.
+    case_no, source, _, _ = extract_case_no({"file": "081-CR-0094.pdf"})
+    assert (case_no, source) == ("081-CR-0094", "file")
+
+
+def test_filename_with_the_timestamp_still_wins_the_same_number():
+    case_no, source, _, _ = extract_case_no({"file": "081-CR-0094_1750232440.pdf"})
+    assert (case_no, source) == ("081-CR-0094", "file")
+
+
 def test_unrecoverable_record_yields_no_case_number():
     case_no, source, cands, agree = extract_case_no(record(
         file="लक्ष्मण चालिसे_1642407863.pdf", description="बैंकिङ्ग कसुर"))


### PR DESCRIPTION
### **User description**
## What

Two new operator verbs under `casework/` that rebuild the `{material/ag/<id> → case number}` map the bulk AG scrape lost, so अभियोगपत्र (indictments) can be joined to their cases. Scoped to the **विशेष सरकारी वकील कार्यालय** (Special Government Attorney Office) cohort.

| File | Role |
|---|---|
| `casework/source_abhiyog.py` | **Read-only candidate producer.** Reads ag.gov.np, extracts the case number, probes the lake, emits `<prefix>.csv` + `.json`. Has no `--apply` and no write path at all. |
| `casework/backfill_ag_caseno.py` | **The writer.** Consumes that map, does GET → guard → merge → PUT. Dry-run by default. |

The split follows the existing `casework/` shape — read-only verbs feeding a single writer, one verb per file — and the map file in between is the human checkpoint where 473 planned writes were reviewed before any of them happened.

Supporting changes: `CaseworkApi.put_material()`, and `ag_ident()` / `material_path()` / rate-limit retry in `casework/common/materials.py`.

## Why a read-modify-write, not a patch

The materials endpoint has no partial-update verb. `PATCH` there sets only `visibility_policy`, and `PUT` funnels into `upsert_single_source_material`, which replaces the `data` column **wholesale** — so a partial PUT would destroy `text` and `associatedMedia`. The tool therefore fetches the current document, adds the field in memory, and sends the whole thing back. `merge_case_no` only ever *adds* keys, and a test asserts every original key survives.

There is no ETag/If-Match on this endpoint, so the read-modify-write can't be made conditional. Documented in the module docstring: keep it a single serialized writer, don't run it alongside an AG re-ingest.

## Results (read-only, no writes performed)

- **553** records in the Special-office cohort (one unpaginated GET; `/offices/level/1` has exactly one office).
- **493 / 553 (89%)** case numbers recovered — `court_case_no` 119, filename 279, description 95.
- **60** genuinely unrecoverable: banking-offence / foreign-employment prosecutions that never get a `-CR-` number, absent from every metadata field *and* the PDF body (the header reads `२०८२ सालको मु.द.नं.......`, blank because the indictment is filed before court registration).
- **7** flagged ambiguous rather than silently resolved — both values kept.
- Dry-run over the cohort: **473 WOULD_APPLY, 0 conflicts, 0 guard failures.**

## Safety posture

`--apply` **has never been run.** This branch performs no production writes.

- Dry-run is the default; `--apply` opts in, and a non-loopback host additionally requires `--allow-remote-writes` (enforced in `CaseworkApi._request`).
- An existing *different* `caseNumber` is quarantined, never overwritten. An identical one is `SKIP_IDEMPOTENT`.
- Identity guards (`recordId`, `officeLevel`, `sourceType`, `additionalType`) bound the blast radius of a wrong id.
- Circuit breaker aborts on a streak of failures so a bad token can't walk the whole map.

## Review

Ran `/code-review` at high effort (8 angles); it produced 10 findings and **all 10 are fixed** in `c9ade2e` — input validation on the writer, non-retryable 4xx, `GUARD_MISSING` vs `GUARD_FAIL`, `additionalType` verification, unknown-vs-absent lake state, circuit breaker, alt-as-list, negative-retry crash, and both extraction regexes.

## Known follow-up — needs a decision, not blocking this PR

`check_guards` reads `jawafdehi:recordId` and `jawafdehi:officeLevel`. **Nothing in this repo produces them** — `materials/sourcing/ag/shaper.py` emits neither. Production docs evidently carry them (the dry-run guard-passed 473 rows), which means the rows in the lake were written by an ingest path that has since diverged from the in-repo shaper. Worth confirming what wrote them before any real `--apply`. Handled defensively here: absence reports as `GUARD_MISSING`, distinct from a mismatch.

Separately, the **root cause** of the data loss is still live: the shaper reads the case number from `court_case_no` only, which the portal leaves null on most records, so every future AG ingest keeps dropping ~2/3 of what's recoverable. That fix touches server-side ingest and is pending sign-off — deliberately **not** in this PR.

## Testing

- **651** casework tests pass (+21 new).
- `ruff` clean, pre-commit clean, no `--no-verify`.
- Full suite: 2399 passed, 3 failed — all 3 pre-existing and environmental (live cross-service search 503, unconfigured OIDC), **verified identical on a clean tree**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWPHgVHfJB57cynbWY6tXt


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add AG case-number recovery CLI

- Add guarded backfill writer

- Retry throttled material probes

- Cover recovery, backfill, retries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AG portal cohort"] -- "extract case numbers" --> B["CSV JSON map"]
  B -- "validate plan" --> C["Material GET guard merge"]
  C -- "dry-run or PUT" --> D["AG material caseNumber"]
  E["Material probes"] -- "retry throttling" --> B
  E -- "retry throttling" --> F["Case evidence binder"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>source_abhiyog.py</strong><dd><code>Read-only AG case-number map producer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-9c5a4099f214906d4a14238fe0e68138d039c5916a2cd6c9c9d8978517cb2a23">+362/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>backfill_ag_caseno.py</strong><dd><code>Guarded AG case-number backfill writer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-634b304b6420e59e90979690cd27447eba8f2eb96da5805d737145eb2104fec9">+432/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>api.py</strong><dd><code>Add complete material PUT client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-543d520a75c6ab7cb169dc2e1d945691ed725d6ba3e177c282f2c9cbcd83b341">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>materials.py</strong><dd><code>Add AG identifiers and probe retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-20b825889b9cb5ba33e60c094787cbce4d1355c292eb96a5fdd8dee848afe7aa">+74/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bind_materials.py</strong><dd><code>Retry material probes during binding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-b1f31c7ffcaa826affeaf82726dd7b71879345983cbf16f1aba9941410a98f44">+24/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_source_abhiyog.py</strong><dd><code>Test AG extraction and output mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-32332229ebfbee4bbbd7350276544b008fa2a39a9f1862959525bacb270a79ed">+228/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_backfill_ag_caseno.py</strong><dd><code>Test guarded backfill planning and writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-c5384546bf627693da8d6eac7a4e63608476509fce01018af898db7e8ac45f74">+380/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_bind_materials.py</strong><dd><code>Test throttled bind probe retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-3b8c104b9aaa426245fcb1376cdf2a2b07d2d77e703e3f7bdd9bde8559cc9841">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_materials.py</strong><dd><code>Test negative retry probe behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/369/files#diff-ae00aa8ee830e42dc2527cf3eebcfd7764700c11e5748aa19a4337aebea0d946">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
model: openai/cx/gpt-5.5
fallback_models: ['openai/cx/gpt-5.4-mini']
output_relevant_configurations: True
ENABLE_AUTO_APPROVAL: True
git_provider: github
custom_reasoning_model: False
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to recover canonical case numbers from portal records and export them as CSV/JSON.
  * Added a safe workflow for backfilling case numbers into existing materials, including dry-run previews and ambiguity reporting.
  * Added optional inspection of planned or completed update payloads.

* **Bug Fixes**
  * Improved resilience to rate limiting and temporary service errors with configurable retries and backoff.
  * Prevented overwriting conflicting existing case numbers and stopped processing after repeated systemic failures.

* **Tests**
  * Added comprehensive coverage for recovery, validation, retries, safety checks, and update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->