### PR TITLE
materials: field-level PATCH (RFC-6902) on the material write plane

### DIFF
--- a/integration-tests/tests/ngm/test_material_patch_concurrency.py
+++ b/integration-tests/tests/ngm/test_material_patch_concurrency.py
@@ -1,0 +1,133 @@
+"""Live-stack proof that the material PATCH row lock prevents lost updates.
+
+This is the one property the unit gate CANNOT show. ``ci.yml`` runs the whole
+suite on in-memory sqlite, and SQLite sets ``has_select_for_update = False``, so
+Django silently drops the ``FOR UPDATE`` clause — there is no lock there to
+observe, and concurrent writers fail with sqlite's file-level "database is
+locked" instead of queueing.
+
+The integration job (``.github/workflows/integration.yml``) brings up the real
+compose stack — Postgres included — and runs THIS package against it, so the
+lock is exercised here for real.
+
+What it asserts: N clients concurrently PATCH the SAME material, each adding a
+DIFFERENT key. Every key must be present at the end. Under the old
+``GET → merge → PUT`` shape each writer would send a whole document built from
+its own stale snapshot and the last write would win, silently discarding the
+others — with every request returning 200. A missing key here is exactly that
+lost update.
+
+Requires an NGM-role bearer token; skips (rather than fails) without one, so the
+suite still runs on a stack without Zitadel wired up.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from conftest import make_client, skip_if_throttled
+
+pytestmark = [pytest.mark.live]
+
+BASE_URL = os.getenv("PLATFORM_BASE_URL") or os.getenv(
+    "NGM_API_BASE_URL", "http://localhost:48000"
+)
+
+WRITERS = 8
+
+
+@pytest.fixture(scope="module")
+def authed(oidc_token):
+    if not oidc_token:
+        pytest.skip("no OIDC token — material writes are NGM-role gated")
+    with make_client(BASE_URL, headers={"Authorization": f"Bearer {oidc_token}"}) as c:
+        yield c
+
+
+@pytest.fixture
+def material(authed):
+    """Create a throwaway material, yield its IRI, soft-delete it afterwards."""
+    ident = f"patch-race-{uuid.uuid4().hex[:12]}"
+    iri = f"https://jawafdehi.org/material/ag/{ident}"
+    doc = {
+        "@id": iri,
+        "@type": "DigitalDocument",
+        "additionalType": "jawafdehi:ChargeSheet",
+        "name": {"ne": "नेपाल सरकार विरुद्ध राम बहादुर थापा"},
+        "jawafdehi:sourceType": "AG_ABHIYOG_PATRA",
+    }
+    r = authed.put(f"/api/materials/ag/{ident}", json=doc)
+    skip_if_throttled(r)
+    if r.status_code in (401, 403):
+        pytest.skip(f"token lacks the NGM write role ({r.status_code})")
+    assert r.status_code in (200, 201), r.text
+    yield ident, iri
+    authed.delete(f"/api/materials/?iri={iri}")
+
+
+def test_concurrent_patches_do_not_lose_writes(authed, material):
+    ident, iri = material
+
+    def add_key(i: int):
+        return authed.patch(
+            f"/api/materials/ag/{ident}",
+            json={"patch_ops": [{"op": "add", "path": f"/k{i}", "value": i}]},
+        )
+
+    with ThreadPoolExecutor(max_workers=WRITERS) as pool:
+        responses = list(pool.map(add_key, range(WRITERS)))
+
+    for i, r in enumerate(responses):
+        skip_if_throttled(r)
+        # A 500 here is the sqlite "database is locked" failure mode; on Postgres
+        # a contended writer must BLOCK on the row lock, not be rejected.
+        assert r.status_code == 200, f"writer {i} → {r.status_code}: {r.text}"
+
+    final = authed.get(f"/api/materials/ag/{ident}")
+    assert final.status_code == 200, final.text
+    doc = final.json()
+
+    missing = [f"k{i}" for i in range(WRITERS) if f"k{i}" not in doc]
+    assert not missing, (
+        f"lost updates — these concurrent writes vanished: {missing}. "
+        "The read-modify-write is not being serialized under the row lock."
+    )
+    # Content nobody touched must survive every concurrent merge.
+    assert doc["name"] == {"ne": "नेपाल सरकार विरुद्ध राम बहादुर थापा"}
+    assert doc["jawafdehi:sourceType"] == "AG_ABHIYOG_PATRA"
+
+
+def test_the_etag_advances_under_concurrent_writes(authed, material):
+    """Each accepted write must produce a new version token.
+
+    A token that did not move after someone else's write would defeat If-Match:
+    a stale client would be told its snapshot is current and clobber unseen work.
+    """
+    ident, iri = material
+    before = authed.get(f"/api/materials/ag/{ident}").headers.get("ETag")
+    assert before, "GET did not emit an ETag"
+
+    def add_key(i: int):
+        return authed.patch(
+            f"/api/materials/ag/{ident}",
+            json={"patch_ops": [{"op": "add", "path": f"/e{i}", "value": i}]},
+        )
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(add_key, range(4)))
+
+    after = authed.get(f"/api/materials/ag/{ident}").headers.get("ETag")
+    assert after and after != before, (before, after)
+
+    # And the now-stale token must be refused rather than silently accepted.
+    stale = authed.patch(
+        f"/api/materials/ag/{ident}",
+        json={"patch_ops": [{"op": "add", "path": "/late", "value": 1}]},
+        headers={"If-Match": before},
+    )
+    skip_if_throttled(stale)
+    assert stale.status_code == 412, stale.status_code

--- a/integration-tests/uv.lock
+++ b/integration-tests/uv.lock
@@ -1,0 +1,191 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jawafdehi-integration-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-dotenv" },
+    { name = "tenacity" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
+    { name = "tenacity", specifier = ">=8.2" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/jawafdehi_shared/jsonpatch_ops.py
+++ b/jawafdehi_shared/jsonpatch_ops.py
@@ -1,0 +1,113 @@
+"""RFC-6902 JSON Patch op-list validation, shared across the JSON-LD write planes.
+
+Pure + dependency-free (no Django, no settings, not even ``jsonpatch``): this
+validates the SHAPE of an op list and enforces a caller-supplied immutable-path
+policy BEFORE the patch is handed to ``jsonpatch.apply_patch``. Applying first
+and checking after would let a blocked op mutate the in-memory document.
+
+Every JSON-LD write plane on the platform patches a stored document by ``@id``
+and therefore needs the same two guarantees:
+
+  * the op list is well-formed (a malformed op is a 422, not a 500 out of the
+    patch library);
+  * no op — including the ``from`` pointer of ``move``/``copy``, which is easy
+    to forget — targets an immutable or server-owned path.
+
+The immutable-path *policy* is per-plane (an entity's identity keys are not a
+material's), so it is injected as ``is_blocked``; the op grammar is universal
+and lives here so a plane added later cannot quietly ship a weaker check.
+
+NOTE: ``entities.write_validation.normalize_patch_ops`` predates this module and
+still carries its own copy. It is deliberately left alone — the NES patch path
+has no test coverage today, so converging it belongs in a change that can prove
+the behaviour is unchanged, not in a materials PR.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+#: The full RFC-6902 operation set. ``test`` is included: it mutates nothing and
+#: lets a client assert a precondition inside the patch itself.
+ALLOWED_OPS = frozenset({"add", "remove", "replace", "move", "copy", "test"})
+
+#: Ops that write. ``test`` is excluded — asserting the current value of an
+#: immutable path is harmless and is a legitimate way to guard a patch.
+_MUTATING_OPS = frozenset({"add", "remove", "replace", "move", "copy"})
+
+
+def normalize_patch_ops(
+    raw_ops: Any,
+    *,
+    is_blocked: Optional[Callable[[str], bool]] = None,
+) -> List[Dict[str, Any]]:
+    """Validate + normalize an RFC-6902 patch list; return the cleaned ops.
+
+    ``is_blocked`` is the per-plane immutable-path predicate; when supplied it is
+    applied to every mutating op's ``path`` AND to the ``from`` pointer of
+    ``move``/``copy``.
+
+    Raises ``ValueError`` (the caller maps it to 422) on a malformed op or a
+    blocked target. The whole list is rejected — a patch is atomic, so one bad op
+    must not leave its well-formed siblings applied.
+    """
+    if not isinstance(raw_ops, list) or not raw_ops:
+        raise ValueError("patch_ops must be a non-empty list.")
+
+    normalized: List[Dict[str, Any]] = []
+    for raw in raw_ops:
+        if not isinstance(raw, dict):
+            raise ValueError("Each patch op must be an object.")
+
+        op = str(raw.get("op", "")).lower()
+        if op not in ALLOWED_OPS:
+            raise ValueError(
+                f"Unsupported patch operation {raw.get('op')!r}. "
+                f"Allowed ops: {sorted(ALLOWED_OPS)}"
+            )
+
+        path = raw.get("path")
+        if not isinstance(path, str) or not path.startswith("/"):
+            raise ValueError("path must be a valid JSON Pointer starting with '/'.")
+
+        from_path = raw.get("from")
+        if op in {"move", "copy"} and (
+            not isinstance(from_path, str) or not from_path.startswith("/")
+        ):
+            raise ValueError(f"{op!r} operation requires a valid 'from' pointer.")
+        if op in {"add", "replace", "test"} and "value" not in raw:
+            raise ValueError(f"{op!r} operation requires 'value'.")
+
+        if is_blocked is not None and op in _MUTATING_OPS:
+            if is_blocked(path):
+                raise ValueError(f"Patching path '{path}' is not allowed.")
+            # `move` REMOVES from its source, so a move out of a blocked path
+            # mutates that path just as surely as a `remove` on it would.
+            if isinstance(from_path, str) and is_blocked(from_path):
+                raise ValueError(f"Patching path '{from_path}' is not allowed.")
+
+        clean: Dict[str, Any] = {"op": op, "path": path}
+        if "value" in raw:
+            clean["value"] = raw["value"]
+        if from_path is not None:
+            clean["from"] = from_path
+        normalized.append(clean)
+
+    return normalized
+
+
+def blocked_path_predicate(prefixes) -> Callable[[str], bool]:
+    """Build an ``is_blocked`` predicate from a set of JSON Pointer prefixes.
+
+    A pointer is blocked when it equals a prefix or descends into one, so
+    blocking ``/@id`` also blocks ``/@id/0``. RFC-6901 escapes ``~`` as ``~0``
+    and ``/`` as ``~1``; a JSON-LD key like ``@id`` or ``jawafdehi:caseNumber``
+    contains neither, so it appears literally in the pointer and a direct prefix
+    match is correct.
+    """
+    frozen = frozenset(prefixes)
+
+    def _is_blocked(path: str) -> bool:
+        return any(path == p or path.startswith(p + "/") for p in frozen)
+
+    return _is_blocked

--- a/materials/conversion.py
+++ b/materials/conversion.py
@@ -171,9 +171,16 @@ def apply_convert_result(job, result: dict) -> None:
     # (e.g. a re-upload upserting the same @id) can't clobber our text, or ours
     # theirs — the whole ``data`` blob is rewritten, so a naive read+save would
     # lose the other writer's fields (lost-update).
-    with transaction.atomic():
+    # `using="ngm"` is load-bearing, not decoration: `Material` routes to `ngm`,
+    # so a bare `atomic()` opens a transaction on `default` and leaves the `ngm`
+    # connection in autocommit — on Postgres `select_for_update` then raises
+    # TransactionManagementError ("cannot be used outside of a transaction"), and
+    # the sqlite gate hides it because SQLite sets has_select_for_update = False
+    # and Django skips the check entirely.
+    with transaction.atomic(using="ngm"):
         row = (
-            Material.objects.select_for_update()
+            Material.objects.using("ngm")
+            .select_for_update()
             .filter(pk=iri, is_deleted=False)
             .first()
         )

--- a/materials/patch_validation.py
+++ b/materials/patch_validation.py
@@ -61,6 +61,20 @@ is_blocked_patch_path = blocked_path_predicate(PATCH_BLOCKED_PATH_PREFIXES)
 #: AG backfill sends exactly one op per record.
 MAX_PATCH_OPS = 1000
 
+#: Max declared ``Content-Length`` of a PATCH request body.
+#:
+#: The guards below both run AFTER DRF's ``JSONParser`` has read and parsed the
+#: whole stream, so neither bounds the memory the parse itself costs: one op
+#: carrying a 200 MB string is fully materialized before the document ceiling
+#: rejects it. Checking ``Content-Length`` is the only guard that can refuse a
+#: body while it is still on the wire.
+#:
+#: Sized as the document ceiling plus 1 MB of headroom, so the guard can never
+#: refuse a patch that would have produced a legal document: the largest
+#: legitimate body is a single op replacing the whole doc, i.e. the document
+#: plus a JSON-Patch envelope of a few dozen bytes.
+MAX_PATCH_BODY_BYTES = 5 * 1024 * 1024 + 1024 * 1024
+
 #: Max serialized size of the stored JSON-LD document AFTER a patch is applied.
 #:
 #: A Material's ``data`` is read on every detail hit, fed wholesale to the

--- a/materials/patch_validation.py
+++ b/materials/patch_validation.py
@@ -49,3 +49,23 @@ PATCH_BLOCKED_PATH_PREFIXES = frozenset(
 
 #: ``is_blocked`` predicate for :func:`jawafdehi_shared.jsonpatch_ops.normalize_patch_ops`.
 is_blocked_patch_path = blocked_path_predicate(PATCH_BLOCKED_PATH_PREFIXES)
+
+#: Max operations in one patch request.
+#:
+#: Django's ``DATA_UPLOAD_MAX_MEMORY_SIZE`` does NOT bound this path — DRF's
+#: ``JSONParser`` reads the WSGI stream directly rather than through
+#: ``HttpRequest.body``, which is where Django's check lives (measured: a 3.6 MB
+#: body against the 2.5 MB default was accepted and persisted). So PATCH was the
+#: only Material write with no ceiling, while the upload endpoint beside it is
+#: capped at ``views._MAX_UPLOAD_BYTES``. 1000 is far above any real edit — the
+#: AG backfill sends exactly one op per record.
+MAX_PATCH_OPS = 1000
+
+#: Max serialized size of the stored JSON-LD document AFTER a patch is applied.
+#:
+#: A Material's ``data`` is read on every detail hit, fed wholesale to the
+#: OpenSearch indexer on every write, and loaded in full by
+#: ``visibility.recompute_all``, so an unbounded row degrades all three. 5 MB is
+#: roughly an order of magnitude above a long indictment's embedded full text
+#: (~400 KB of Nepali), so it bounds abuse without touching real documents.
+MAX_MATERIAL_DOC_BYTES = 5 * 1024 * 1024

--- a/materials/patch_validation.py
+++ b/materials/patch_validation.py
@@ -1,0 +1,51 @@
+"""Immutable-path policy for the material field-level PATCH.
+
+The materials write plane has two verbs against a stored document: ``PUT``
+replaces ``data`` wholesale, and ``PATCH`` edits it in place. ``PATCH`` is the
+narrower verb, so it must not become a back door to anything ``PUT`` guards —
+identity, the promoted columns derived from the doc, or the server-owned
+visibility annotations. This module is that guard list; the op grammar itself is
+shared (:mod:`jawafdehi_shared.jsonpatch_ops`).
+"""
+
+from __future__ import annotations
+
+from jawafdehi_shared.jsonpatch_ops import blocked_path_predicate
+
+#: Envelope/annotation keys that must NEVER be persisted into a Material's stored
+#: JSON-LD ``data``: the write-envelope control field ``visibility_policy`` and
+#: the authed-read annotations ``jawafdehi:visibility``/``jawafdehi:visibilityPolicy``.
+#: ``PUT`` strips them at the write chokepoint (``_upsert_material``); ``PATCH``
+#: rejects them outright, because a patch has no "strip" semantics — silently
+#: dropping the op would report success for a write that did not happen.
+RESERVED_WRITE_KEYS = frozenset(
+    {"visibility_policy", "jawafdehi:visibility", "jawafdehi:visibilityPolicy"}
+)
+
+#: JSON Pointer prefixes a material PATCH may never target.
+#:
+#: * ``/@id`` — the material IRI is the identity. It is the join key cases store
+#:   (``CaseMaterialReference.material_iri``), it is the row's primary key, and
+#:   the promoted ``source``/``ident`` columns are parsed out of it. Repointing it
+#:   would orphan every inbound reference rather than rename anything.
+#: * ``/@context`` — owned by the platform's JSON-LD vocabulary, not per-document.
+#: * ``/@type`` + ``/additionalType`` — unlike the NES entity plane (which
+#:   deliberately allows re-typing because ``entity_type`` is re-derived on every
+#:   write), ``Material.material_type`` is passed to ``from_jsonld`` by the caller
+#:   and is NOT re-derived here. Patching the doc's type alone would silently
+#:   drift the column away from the document. Re-typing a material needs a
+#:   deliberate write that moves both together — that is ``PUT``, not this.
+#: * the reserved keys above.
+#:
+#: Deliberately NOT blocked: ordinary content (``name``, ``jawafdehi:caseNumber``,
+#: ``datePublished``, ``publisher``, ``associatedMedia``, ``text``, …). The
+#: patched document is re-run through ``validate_material_jsonld``, so a patch
+#: that strips a required field is rejected on the way out rather than enumerated
+#: here.
+PATCH_BLOCKED_PATH_PREFIXES = frozenset(
+    {"/@id", "/@context", "/@type", "/additionalType"}
+    | {f"/{key}" for key in RESERVED_WRITE_KEYS}
+)
+
+#: ``is_blocked`` predicate for :func:`jawafdehi_shared.jsonpatch_ops.normalize_patch_ops`.
+is_blocked_patch_path = blocked_path_predicate(PATCH_BLOCKED_PATH_PREFIXES)

--- a/materials/signals.py
+++ b/materials/signals.py
@@ -6,12 +6,26 @@ upsert/delete on ``transaction.on_commit`` (plan §4.1).
 
 from __future__ import annotations
 
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from . import search_index
 from .models import Material, Visibility
+
+
+def _material_db(instance) -> str:
+    """The alias the row was written on — the one whose commit we must wait for.
+
+    ``transaction.on_commit`` resolves against a specific connection, defaulting
+    to ``default``. ``Material`` lives on ``ngm``, so an unqualified ``on_commit``
+    asks the WRONG connection whether a transaction is open: inside
+    ``atomic(using="ngm")`` the ``default`` connection is still in autocommit, so
+    Django runs the callback IMMEDIATELY — indexing a document before (or instead
+    of) its row becoming durable, and doing the OpenSearch round-trip while the
+    row lock is still held.
+    """
+    return instance._state.db or router.db_for_write(Material, instance=instance)
 
 
 @receiver(post_save, sender=Material, dispatch_uid="ngm_material_search_index")
@@ -24,11 +38,11 @@ def _index_material(sender, instance, **kwargs):
     # materials default to LISTED, so their indexing is unchanged.
     listed = getattr(instance, "visibility", Visibility.LISTED) == Visibility.LISTED
     if getattr(instance, "is_deleted", False) or not listed:
-        transaction.on_commit(lambda: search_index.delete(instance))
+        transaction.on_commit(lambda: search_index.delete(instance), using=_material_db(instance))
     else:
-        transaction.on_commit(lambda: search_index.index(instance))
+        transaction.on_commit(lambda: search_index.index(instance), using=_material_db(instance))
 
 
 @receiver(post_delete, sender=Material, dispatch_uid="ngm_material_search_delete")
 def _delete_material(sender, instance, **kwargs):
-    transaction.on_commit(lambda: search_index.delete(instance))
+    transaction.on_commit(lambda: search_index.delete(instance), using=_material_db(instance))

--- a/materials/tests/test_field_patch_api.py
+++ b/materials/tests/test_field_patch_api.py
@@ -1,0 +1,429 @@
+"""Field-level write on the materials PATCH endpoint (RFC-6902 JSON Patch).
+
+The endpoint previously accepted ONE thing — ``{"visibility_policy": ...}`` — so
+the only way to change a key inside a material's stored JSON-LD was ``PUT``,
+which replaces ``data`` wholesale and forces every client into a GET→merge→PUT
+round-trip with no way to close the lost-update window. These tests pin the
+field-level patch surface that replaces that: the same shape the NES entity write
+plane already uses (``entities.write_validation`` / ``entities.views.patch``),
+with the case endpoint's opt-in ``If-Match`` optimistic concurrency.
+
+The existing visibility-policy contract must survive untouched — the moderation
+UI is a live caller — so both body shapes are exercised side by side.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+from materials.models import Material, Policy, Visibility
+
+User = get_user_model()
+
+AG_IRI = "https://jawafdehi.org/material/ag/105334"
+
+
+def _caseworker(username="cw-fieldpatch"):
+    u = User.objects.create_user(username, password="x")
+    u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+    return u
+
+
+def _client(username="cw-fieldpatch"):
+    c = APIClient()
+    c.force_authenticate(_caseworker(username))
+    return c
+
+
+def _store_ag(ident="105334", **extra):
+    """An AG indictment material shaped like the ones already in the lake — the
+    real cohort this endpoint exists to repair (no ``jawafdehi:caseNumber``)."""
+    iri = f"https://jawafdehi.org/material/ag/{ident}"
+    data = {
+        "@id": iri,
+        "@type": "DigitalDocument",
+        "additionalType": "jawafdehi:ChargeSheet",
+        "name": {"ne": "नेपाल सरकार विरुद्ध राम बहादुर थापा"},
+        "jawafdehi:sourceType": "AG_ABHIYOG_PATRA",
+        "publisher": {
+            "@type": "GovernmentOrganization",
+            "name": {"ne": "विशेष सरकारी वकील कार्यालय"},
+        },
+        **extra,
+    }
+    mat = Material(
+        iri=iri,
+        material_type="charge_sheet",
+        source="ag",
+        ident=ident,
+        data=data,
+        visibility=Visibility.LISTED,
+    )
+    mat.save()
+    return mat
+
+
+def _add_case_no(value="082-CR-0100"):
+    return [{"op": "add", "path": "/jawafdehi:caseNumber", "value": value}]
+
+
+@pytest.mark.django_db
+class TestFieldPatch:
+    def test_patch_ops_sets_a_field_in_the_stored_doc(self):
+        mat = _store_ag()
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_patch_ops_leaves_every_other_key_untouched(self):
+        # The whole point of a field-level write: a PUT would have replaced the
+        # document, so an incomplete client body silently drops publisher/name.
+        mat = _store_ag(ident="105335")
+        before = dict(mat.data)
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["name"] == before["name"]
+        assert mat.data["publisher"] == before["publisher"]
+        assert mat.data["jawafdehi:sourceType"] == before["jawafdehi:sourceType"]
+
+    def test_replace_overwrites_an_existing_value(self):
+        mat = _store_ag(ident="105336", **{"jawafdehi:caseNumber": "081-CR-0001"})
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {
+                "patch_ops": [
+                    {
+                        "op": "replace",
+                        "path": "/jawafdehi:caseNumber",
+                        "value": "082-CR-0100",
+                    }
+                ]
+            },
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_response_returns_the_patched_document(self):
+        mat = _store_ag(ident="105337")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_detail_route_accepts_patch_ops_too(self):
+        # Both routes funnel through one handler; the composite source/ident form
+        # is the one a backfill script addresses (it holds the portal record id).
+        mat = _store_ag(ident="105338")
+        resp = _client().patch(
+            "/api/materials/ag/105338",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_bare_array_body_is_accepted(self):
+        # The cases endpoint takes a bare RFC-6902 array; accept that spelling so
+        # a client written against either convention interoperates.
+        mat = _store_ag(ident="105339")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}", _add_case_no(), format="json"
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_remove_deletes_a_key(self):
+        mat = _store_ag(ident="105340", **{"jawafdehi:caseNumber": "081-CR-0001"})
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "remove", "path": "/jawafdehi:caseNumber"}]},
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert "jawafdehi:caseNumber" not in mat.data
+
+
+@pytest.mark.django_db
+class TestVisibilityPolicyContractUnchanged:
+    """The pre-existing body shape is a live caller (the moderation UI)."""
+
+    def test_policy_only_body_still_works(self):
+        mat = _store_ag(ident="205001")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "PRIVATE"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.visibility_policy == Policy.PRIVATE
+
+    def test_invalid_policy_is_still_400(self):
+        mat = _store_ag(ident="205002")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"visibility_policy": "SORTA_PUBLIC"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+    def test_policy_and_patch_ops_apply_together(self):
+        mat = _store_ag(ident="205003")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no(), "visibility_policy": "PRIVATE"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+        assert mat.visibility_policy == Policy.PRIVATE
+
+    def test_empty_body_is_still_400(self):
+        # Neither a policy nor patch ops: a no-op write must stay an explicit
+        # error, never a silent 200 that a caller mistakes for success.
+        mat = _store_ag(ident="205004")
+        resp = _client().patch(f"/api/materials/?iri={mat.iri}", {}, format="json")
+        assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+class TestBlockedPaths:
+    """Identity + server-owned keys are not patchable."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/@id",  # identity: the IRI is the join key other services store
+            "/@context",
+            "/@type",  # promoted material_type column would drift from the doc
+            "/additionalType",
+            "/visibility_policy",  # envelope control field, never doc content
+            "/jawafdehi:visibility",  # server-derived read annotation
+            "/jawafdehi:visibilityPolicy",
+        ],
+    )
+    def test_blocked_path_is_422(self, path):
+        mat = _store_ag(ident=f"3{abs(hash(path)) % 100000:05d}")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "replace", "path": path, "value": "x"}]},
+            format="json",
+        )
+        assert resp.status_code == 422
+
+    def test_blocked_path_leaves_the_document_unchanged(self):
+        mat = _store_ag(ident="305999")
+        before = dict(mat.data)
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {
+                "patch_ops": [
+                    {"op": "add", "path": "/jawafdehi:caseNumber", "value": "082-CR-1"},
+                    {"op": "replace", "path": "/@id", "value": "https://x/material/a/b"},
+                ]
+            },
+            format="json",
+        )
+        # The whole patch is rejected up front — an allowed op sharing the
+        # request with a blocked one must not land on its own (a partially
+        # applied patch is the failure mode RFC-6902 atomicity exists to prevent).
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.data == before
+
+    def test_move_out_of_a_blocked_path_is_422(self):
+        # `move`/`copy` read through `from` — guarding only `path` would let a
+        # caller relocate the @id and mutate identity by the back door.
+        mat = _store_ag(ident="305001")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "move", "from": "/@id", "path": "/identifier"}]},
+            format="json",
+        )
+        assert resp.status_code == 422
+
+
+@pytest.mark.django_db
+class TestMalformedPatches:
+    def test_unknown_op_is_422(self):
+        mat = _store_ag(ident="405001")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "obliterate", "path": "/name", "value": "x"}]},
+            format="json",
+        )
+        assert resp.status_code == 422
+
+    def test_op_without_a_pointer_is_422(self):
+        mat = _store_ag(ident="405002")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "add", "value": "x"}]},
+            format="json",
+        )
+        assert resp.status_code == 422
+
+    def test_empty_patch_ops_list_is_422(self):
+        mat = _store_ag(ident="405003")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}", {"patch_ops": []}, format="json"
+        )
+        assert resp.status_code == 422
+
+    def test_pointer_into_a_missing_parent_is_400(self):
+        # A well-formed op that cannot be applied is the patch library's verdict,
+        # not a schema violation → 400, matching the entity write plane.
+        mat = _store_ag(ident="405004")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "replace", "path": "/nope/deeper", "value": "x"}]},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+    def test_patch_that_invalidates_the_document_is_422(self):
+        # `name` is required by validate_material_jsonld; a patch may not leave
+        # the stored doc in a state the write plane would have rejected.
+        mat = _store_ag(ident="405005")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "remove", "path": "/name"}]},
+            format="json",
+        )
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.data["name"]
+
+
+@pytest.mark.django_db
+class TestFieldPatchAuth:
+    def test_anon_is_401(self):
+        mat = _store_ag(ident="505001")
+        resp = APIClient().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 401
+
+    def test_roleless_authed_is_403(self):
+        mat = _store_ag(ident="505002")
+        client = APIClient()
+        client.force_authenticate(User.objects.create_user("nobody-fp", password="x"))
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_missing_material_is_404(self):
+        resp = _client().patch(
+            "/api/materials/?iri=https://jawafdehi.org/material/ag/nosuchrecord",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+class TestOptimisticConcurrency:
+    """Opt-in ``If-Match``, mirroring the case PATCH endpoint.
+
+    Without it a backfill has to do a client-side read-modify-write and can
+    silently clobber a concurrent caseworker edit. With it, a stale writer is
+    told to reload instead.
+    """
+
+    def test_get_emits_an_etag(self):
+        mat = _store_ag(ident="605001")
+        resp = _client().get(f"/api/materials/?iri={mat.iri}")
+        assert resp.status_code == 200
+        assert resp["ETag"]
+
+    def test_patch_response_carries_the_new_etag(self):
+        mat = _store_ag(ident="605002")
+        before = _client().get(f"/api/materials/?iri={mat.iri}")["ETag"]
+        resp = _client("cw-fp2").patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert resp["ETag"] and resp["ETag"] != before
+
+    def test_matching_if_match_is_applied(self):
+        mat = _store_ag(ident="605003")
+        client = _client()
+        token = client.get(f"/api/materials/?iri={mat.iri}")["ETag"]
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+            HTTP_IF_MATCH=token,
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_stale_if_match_is_412_and_does_not_write(self):
+        mat = _store_ag(ident="605004")
+        client = _client()
+        stale = client.get(f"/api/materials/?iri={mat.iri}")["ETag"]
+        # Someone else edits in between.
+        client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no("081-FT-0009")},
+            format="json",
+        )
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no("082-CR-9999")},
+            format="json",
+            HTTP_IF_MATCH=stale,
+        )
+        assert resp.status_code == 412
+        assert resp["ETag"]
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "081-FT-0009"
+
+    def test_star_if_match_matches_any_live_material(self):
+        mat = _store_ag(ident="605005")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+            HTTP_IF_MATCH="*",
+        )
+        assert resp.status_code == 200
+
+    def test_no_if_match_header_still_writes(self):
+        # Backward compatible: the precondition is opt-in, not required.
+        mat = _store_ag(ident="605006")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": _add_case_no()},
+            format="json",
+        )
+        assert resp.status_code == 200

--- a/materials/tests/test_field_patch_api.py
+++ b/materials/tests/test_field_patch_api.py
@@ -14,6 +14,8 @@ UI is a live caller — so both body shapes are exercised side by side.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -224,7 +226,10 @@ class TestBlockedPaths:
         ],
     )
     def test_blocked_path_is_422(self, path):
-        mat = _store_ag(ident=f"3{abs(hash(path)) % 100000:05d}")
+        # Ident derived from the parameter itself — hash() is salted per
+        # interpreter (PYTHONHASHSEED), so a hashed ident changes every run
+        # and can collide between parametrizations.
+        mat = _store_ag(ident="blocked-" + re.sub(r"[^a-z0-9]+", "-", path.lower()).strip("-"))
         resp = _client().patch(
             f"/api/materials/?iri={mat.iri}",
             {"patch_ops": [{"op": "replace", "path": path, "value": "x"}]},

--- a/materials/tests/test_field_patch_contract.py
+++ b/materials/tests/test_field_patch_contract.py
@@ -13,6 +13,8 @@ kind of detail that quietly regresses when a header parser is "simplified".
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -192,6 +194,15 @@ class TestIfMatchHeaderContract:
         assert mat.data["jawafdehi:caseNumber"] == "082-CR-0200"
 
 
+class _Probe:
+    """Stand-in material used only to ask a ``url_for`` lambda which route it
+    builds, so the fixture ident can be made deterministic per (route, body)."""
+
+    iri = "probe"
+    source = "probe-src"
+    ident = "probe-id"
+
+
 class TestBothRoutesAgree:
     """Two URLs address one resource; their PATCH contract must be identical."""
 
@@ -214,10 +225,12 @@ class TestBothRoutesAgree:
         ],
     )
     def test_status_codes_match_across_routes(self, url_for, body, expected):
-        mat = _store(f"c-30{abs(hash((str(body), expected))) % 10000}")
-        resp = _client(f"cw-{abs(hash((str(body), expected))) % 10000}").patch(
-            url_for(mat), body, format="json"
-        )
+        # Deterministic per (route, body): hash() is salted per interpreter, so
+        # a hashed ident/username changes every run and two parametrizations can
+        # collide onto one Material PK or username.
+        key = re.sub(r"[^a-z0-9]+", "-", f"{url_for(_Probe())}-{body}-{expected}".lower()).strip("-")[:60]
+        mat = _store(f"c-30-{key}")
+        resp = _client(f"cw-{key}"[:150]).patch(url_for(mat), body, format="json")
         assert resp.status_code == expected
 
 

--- a/materials/tests/test_field_patch_contract.py
+++ b/materials/tests/test_field_patch_contract.py
@@ -1,0 +1,245 @@
+"""Contract conformance for the material field-level PATCH.
+
+Separate from the functional suite on purpose: these assert the endpoint's
+*published* contract — the status codes, headers, media type and header-parsing
+tolerances a client is entitled to rely on, plus the fact that the OpenAPI schema
+actually advertises the operation. A functional test proves the feature works; a
+contract test proves the thing we told clients is the thing we built.
+
+The ``If-Match`` tolerances (weak validator, unquoted token, comma-separated
+list) come from RFC 7232 §3.1 and are asserted explicitly because they are the
+kind of detail that quietly regresses when a header parser is "simplified".
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+from materials.models import Material, Visibility
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+def _client(username="cw-contract"):
+    u = User.objects.create_user(username, password="x")
+    u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+    c = APIClient()
+    c.force_authenticate(u)
+    return c
+
+
+def _store(ident):
+    iri = f"https://jawafdehi.org/material/ag/{ident}"
+    mat = Material(
+        iri=iri,
+        material_type="charge_sheet",
+        source="ag",
+        ident=ident,
+        data={"@id": iri, "@type": "DigitalDocument", "name": {"ne": "अभियोगपत्र"}},
+        visibility=Visibility.LISTED,
+    )
+    mat.save()
+    return mat
+
+
+def _ops(value="082-CR-0100"):
+    return {"patch_ops": [{"op": "add", "path": "/jawafdehi:caseNumber", "value": value}]}
+
+
+@pytest.fixture(scope="module")
+def schema():
+    """The generated OpenAPI document — built once, it is not cheap."""
+    from drf_spectacular.generators import SchemaGenerator
+
+    return SchemaGenerator().get_schema(request=None, public=True)
+
+
+class TestResponseContract:
+    def test_success_is_ld_json(self):
+        mat = _store("c-001")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"].startswith("application/ld+json")
+
+    def test_body_is_the_stored_doc_plus_exactly_two_annotations(self):
+        mat = _store("c-002")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        mat.refresh_from_db()
+        assert set(resp.data) - set(mat.data) == {
+            "jawafdehi:visibility",
+            "jawafdehi:visibilityPolicy",
+        }
+        assert {k: v for k, v in resp.data.items() if k in mat.data} == mat.data
+
+    def test_the_annotations_are_never_persisted_into_the_document(self):
+        # The response is annotated; the stored document must not be. A client
+        # doing GET → edit → PATCH would otherwise round-trip them into `data`.
+        mat = _store("c-003")
+        _client().patch(f"/api/materials/?iri={mat.iri}", _ops(), format="json")
+        mat.refresh_from_db()
+        assert "jawafdehi:visibility" not in mat.data
+        assert "jawafdehi:visibilityPolicy" not in mat.data
+
+
+class TestIdempotencyContract:
+    def test_the_same_add_applied_twice_converges(self):
+        mat = _store("c-010")
+        client = _client()
+        first = client.patch(f"/api/materials/?iri={mat.iri}", _ops(), format="json")
+        second = client.patch(f"/api/materials/?iri={mat.iri}", _ops(), format="json")
+        assert first.status_code == second.status_code == 200
+        assert first.data == second.data
+
+    def test_a_no_op_patch_does_not_bump_the_version(self):
+        # `updated_at` drives the ETag; bumping it on a write that changed
+        # nothing would invalidate every other client's token for no reason.
+        mat = _store("c-011")
+        client = _client()
+        client.patch(f"/api/materials/?iri={mat.iri}", _ops(), format="json")
+        before = client.get(f"/api/materials/?iri={mat.iri}")["ETag"]
+        again = client.patch(f"/api/materials/?iri={mat.iri}", _ops(), format="json")
+        assert again["ETag"] == before
+
+
+class TestIfMatchHeaderContract:
+    """RFC 7232 §3.1 tolerances the endpoint advertises."""
+
+    def _token(self, client, mat):
+        return client.get(f"/api/materials/?iri={mat.iri}")["ETag"]
+
+    def test_weak_validator_prefix_is_accepted(self):
+        mat = _store("c-020")
+        client = _client()
+        token = self._token(client, mat)
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(),
+            format="json",
+            HTTP_IF_MATCH=f"W/{token}",
+        )
+        assert resp.status_code == 200
+
+    def test_unquoted_token_is_accepted(self):
+        mat = _store("c-021")
+        client = _client()
+        token = self._token(client, mat).strip('"')
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(),
+            format="json",
+            HTTP_IF_MATCH=token,
+        )
+        assert resp.status_code == 200
+
+    def test_a_comma_separated_list_matches_on_any_member(self):
+        mat = _store("c-022")
+        client = _client()
+        token = self._token(client, mat)
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(),
+            format="json",
+            HTTP_IF_MATCH=f'"deadbeefdeadbeef", {token}',
+        )
+        assert resp.status_code == 200
+
+    def test_a_list_matching_nothing_is_412(self):
+        mat = _store("c-023")
+        resp = _client().patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(),
+            format="json",
+            HTTP_IF_MATCH='"deadbeefdeadbeef", "cafebabecafebabe"',
+        )
+        assert resp.status_code == 412
+
+    def test_the_412_response_carries_the_current_token(self):
+        # Without it the client cannot reconcile without an extra round-trip.
+        mat = _store("c-024")
+        client = _client()
+        resp = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(),
+            format="json",
+            HTTP_IF_MATCH='"0000000000000000"',
+        )
+        assert resp.status_code == 412
+        assert resp["ETag"] == self._token(client, mat)
+
+    def test_the_etag_from_a_patch_is_directly_reusable_as_if_match(self):
+        # The round-trip a backfill actually performs: patch, keep the returned
+        # token, patch again conditionally without re-reading.
+        mat = _store("c-025")
+        client = _client()
+        first = client.patch(f"/api/materials/?iri={mat.iri}", _ops(), format="json")
+        second = client.patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops("082-CR-0200"),
+            format="json",
+            HTTP_IF_MATCH=first["ETag"],
+        )
+        assert second.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0200"
+
+
+class TestBothRoutesAgree:
+    """Two URLs address one resource; their PATCH contract must be identical."""
+
+    @pytest.mark.parametrize(
+        "url_for",
+        [
+            lambda m: f"/api/materials/?iri={m.iri}",
+            lambda m: f"/api/materials/{m.source}/{m.ident}",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "body,expected",
+        [
+            ({"patch_ops": [{"op": "add", "path": "/x", "value": 1}]}, 200),
+            ({"patch_ops": [{"op": "add", "path": "/@id", "value": "x"}]}, 422),
+            ({"patch_ops": [{"op": "nope", "path": "/x", "value": 1}]}, 422),
+            ({"patch_ops": [{"op": "replace", "path": "/a/b", "value": 1}]}, 400),
+            ({}, 400),
+            ({"visibility_policy": "NOPE"}, 400),
+        ],
+    )
+    def test_status_codes_match_across_routes(self, url_for, body, expected):
+        mat = _store(f"c-30{abs(hash((str(body), expected))) % 10000}")
+        resp = _client(f"cw-{abs(hash((str(body), expected))) % 10000}").patch(
+            url_for(mat), body, format="json"
+        )
+        assert resp.status_code == expected
+
+
+class TestOpenApiSchemaAdvertisesThePatch:
+    """The swagger page is how operators discover this endpoint — if the schema
+    stops describing it, the endpoint is effectively undocumented."""
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/api/materials/", "/api/materials/{source}/{ident}/"],
+    )
+    def test_patch_operation_is_documented(self, schema, path):
+        assert path in schema["paths"], sorted(schema["paths"])[:40]
+        assert "patch" in schema["paths"][path]
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/api/materials/", "/api/materials/{source}/{ident}/"],
+    )
+    def test_the_documented_description_mentions_the_field_level_write(
+        self, schema, path
+    ):
+        description = schema["paths"][path]["patch"].get("description", "")
+        assert "patch_ops" in description
+        assert "visibility_policy" in description

--- a/materials/tests/test_material_convert_smoke.py
+++ b/materials/tests/test_material_convert_smoke.py
@@ -104,6 +104,8 @@ class MaterialConvertSmokeTests(APITestCase):
 
             # 3) Run the job through the REAL queue engine, with the conversion
             #    network/OCR call mocked to return markdown. captureOnCommitCallbacks
+            #    must name `ngm` — that is where Material lives, and therefore the
+            #    connection its reindex on_commit hook is registered against.
             #    forces the Material post_save→reindex on_commit hook to actually
             #    run (APITestCase wraps each test in a rolled-back transaction, so
             #    on_commit callbacks would otherwise never fire).
@@ -115,7 +117,7 @@ class MaterialConvertSmokeTests(APITestCase):
                     "url": "https://cdn/raw.pdf",
                     "note": "",
                 },
-            ), self.captureOnCommitCallbacks(execute=True):
+            ), self.captureOnCommitCallbacks(using="ngm", execute=True):
                 done = _run_one_convert_job()
 
         # 4) Job finished cleanly.

--- a/materials/tests/test_patch_body_size.py
+++ b/materials/tests/test_patch_body_size.py
@@ -1,0 +1,130 @@
+"""A PATCH body must be refused BEFORE it is parsed into memory.
+
+CodeRabbit flagged that MAX_PATCH_OPS bounds the op *count* and
+MAX_MATERIAL_DOC_BYTES bounds the *result*, so a single op carrying a huge
+``value`` is fully parsed, patched and re-serialized before anything rejects it.
+
+That gap is real, but it opens EARLIER than the suggested fix can reach: DRF's
+``JSONParser`` has already read and parsed the whole stream by the time
+``request.data`` returns a value to measure. Measuring ``raw_ops`` after the
+fact cannot un-spend that memory — it allocates a second full copy to do it.
+
+The guard therefore has to sit on Content-Length, before the body is touched.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch as mock_patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework.parsers import JSONParser
+from rest_framework.test import APIClient
+
+from materials.models import Material, Visibility
+from materials.patch_validation import MAX_MATERIAL_DOC_BYTES
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db(databases=["default", "ngm"])
+IRI = "https://jawafdehi.org/material/ag/bodysize"
+
+
+def _store():
+    m = Material(
+        iri=IRI, material_type="charge_sheet", source="ag", ident="bodysize",
+        data={"@id": IRI, "@type": "DigitalDocument", "name": {"ne": "अभियोगपत्र"}},
+        visibility=Visibility.LISTED,
+    )
+    m.save()
+    return m
+
+
+def _client():
+    u = User.objects.create_user("cw-size", password="x")
+    u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+    c = APIClient()
+    c.force_authenticate(u)
+    return c
+
+
+def _oversized_body():
+    """One op, one value, comfortably past the ceiling."""
+    filler = "क" * (MAX_MATERIAL_DOC_BYTES // 2)  # 3 bytes/char in UTF-8
+    return {"patch_ops": [{"op": "add", "path": "/text", "value": filler}]}
+
+
+def test_an_oversized_body_is_rejected_without_being_parsed():
+    _store()
+    body = json.dumps(_oversized_body())
+    real_parse = JSONParser.parse
+    parsed = []
+
+    def spy(self, stream, media_type=None, parser_context=None):
+        parsed.append(True)
+        return real_parse(self, stream, media_type, parser_context)
+
+    with mock_patch.object(JSONParser, "parse", spy):
+        resp = _client().patch(
+            f"/api/materials/?iri={IRI}",
+            body,
+            content_type="application/json",
+        )
+
+    assert resp.status_code == 413, resp.status_code
+    assert not parsed, (
+        "the body was parsed before it was rejected — the size guard is running "
+        "downstream of the allocation it is supposed to prevent"
+    )
+
+
+@pytest.mark.parametrize("header", [None, "", "not-a-number"])
+def test_an_absent_or_junk_content_length_is_not_itself_a_rejection(header):
+    """A chunked request has no Content-Length; that must not be a rejection.
+
+    Refusing it would break a valid client to defend against an attacker who
+    can simply omit the header. Such a body still meets the op-count and
+    post-apply document ceilings — later than we would like, but it is caught.
+
+    Exercised against the guard directly: Django's test client synthesizes a
+    Content-Length from the payload, so it cannot express this request.
+    """
+    from django.test import RequestFactory
+
+    from materials.views import _reject_oversized_body
+
+    request = RequestFactory().patch("/api/materials/", data=b"{}", content_type="application/json")
+    if header is None:
+        request.META.pop("CONTENT_LENGTH", None)
+    else:
+        request.META["CONTENT_LENGTH"] = header
+
+    assert _reject_oversized_body(request) is None
+
+
+def test_the_guard_rejects_on_a_declared_length_alone():
+    """It must trust Content-Length, not wait to count bytes it has read."""
+    from django.test import RequestFactory
+
+    from materials.views import _reject_oversized_body
+    from materials.patch_validation import MAX_PATCH_BODY_BYTES
+
+    request = RequestFactory().patch("/api/materials/", data=b"{}", content_type="application/json")
+    request.META["CONTENT_LENGTH"] = str(MAX_PATCH_BODY_BYTES + 1)
+    resp = _reject_oversized_body(request)
+    assert resp is not None and resp.status_code == 413
+
+    request.META["CONTENT_LENGTH"] = str(MAX_PATCH_BODY_BYTES)
+    assert _reject_oversized_body(request) is None, "the boundary itself must be allowed"
+
+
+def test_a_normal_patch_still_goes_through():
+    _store()
+    resp = _client().patch(
+        f"/api/materials/?iri={IRI}",
+        {"patch_ops": [{"op": "add", "path": "/jawafdehi:caseNumber", "value": "081-CR-0094"}]},
+        format="json",
+    )
+    assert resp.status_code == 200, resp.data
+    assert Material.objects.using("ngm").get(pk=IRI).data["jawafdehi:caseNumber"] == "081-CR-0094"

--- a/materials/tests/test_patch_concurrency_postgres.py
+++ b/materials/tests/test_patch_concurrency_postgres.py
@@ -1,0 +1,188 @@
+"""Concurrency guarantees that ONLY Postgres can demonstrate.
+
+SQLite sets ``has_select_for_update = False``, so Django silently drops the
+``FOR UPDATE`` clause (``django/db/models/sql/compiler.py`` — the branch is
+skipped entirely, no warning). Under the sqlite gate the material PATCH
+therefore runs with no row lock at all, and these properties are unprovable:
+concurrent writers there fail with sqlite's file-level ``database is locked``
+instead of queueing.
+
+So this module is skipped unless the ``ngm`` alias is actually Postgres. Run it
+against a throwaway cluster:
+
+    NGM_DATABASE_URL=postgres://... uv run pytest \\
+        materials/tests/test_patch_concurrency_postgres.py -q
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.db import connections, transaction
+from django.db.transaction import TransactionManagementError
+from rest_framework.test import APIClient
+
+from materials.models import Material, Visibility
+
+User = get_user_model()
+
+pytestmark = [
+    pytest.mark.django_db(databases=["default", "ngm"], transaction=True),
+    pytest.mark.skipif(
+        "postgresql" not in connections["ngm"].settings_dict.get("ENGINE", ""),
+        reason="row-lock behaviour is only observable on Postgres",
+    ),
+]
+
+IRI = "https://jawafdehi.org/material/ag/pg-concurrency"
+
+
+def _store():
+    mat = Material(
+        iri=IRI,
+        material_type="charge_sheet",
+        source="ag",
+        ident="pg-concurrency",
+        data={"@id": IRI, "@type": "DigitalDocument", "name": {"ne": "अभियोगपत्र"}},
+        visibility=Visibility.LISTED,
+    )
+    mat.save()
+    return mat
+
+
+def _client(username):
+    u = User.objects.create_user(username, password="x")
+    u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+    c = APIClient()
+    c.force_authenticate(u)
+    return c
+
+
+class TestTheRowLockPreventsLostUpdates:
+    def test_concurrent_patches_to_different_keys_all_survive(self):
+        """The property the whole endpoint exists for.
+
+        Under the old GET→merge→PUT shape each writer would send a document built
+        from its own stale snapshot and the last PUT would win, silently dropping
+        the others. Here every writer adds a DISTINCT key concurrently; if the
+        read-modify-write were not serialized under ``select_for_update``, some
+        keys would be missing from the final document — with no error anywhere.
+        """
+        _store()
+        writers = 8
+        clients = [_client(f"cw-race-{i}") for i in range(writers)]
+        start = threading.Barrier(writers)
+        results: dict[int, int] = {}
+        errors: list[BaseException] = []
+
+        def patch(i: int):
+            try:
+                start.wait(timeout=30)
+                resp = clients[i].patch(
+                    f"/api/materials/?iri={IRI}",
+                    {"patch_ops": [{"op": "add", "path": f"/k{i}", "value": i}]},
+                    format="json",
+                )
+                results[i] = resp.status_code
+            except BaseException as exc:  # noqa: BLE001 - surfaced in the assert
+                errors.append(exc)
+            finally:
+                # Each thread gets its own connections; close them or the test
+                # DB teardown blocks on the open sessions.
+                connections.close_all()
+
+        threads = [threading.Thread(target=patch, args=(i,)) for i in range(writers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        assert not errors, errors
+        assert set(results.values()) == {200}, results
+
+        row = Material.objects.using("ngm").get(pk=IRI)
+        missing = [f"k{i}" for i in range(writers) if f"k{i}" not in row.data]
+        assert not missing, f"lost updates — these writes vanished: {missing}"
+        # The untouched original content must also survive every merge.
+        assert row.data["name"] == {"ne": "अभियोगपत्र"}
+
+    def test_a_second_writer_waits_rather_than_failing(self):
+        """No writer is rejected under contention.
+
+        On sqlite the same scenario produces ``OperationalError('database is
+        locked')`` 500s (measured: 6 of 40). On Postgres the second writer must
+        BLOCK on the row lock and then succeed.
+        """
+        _store()
+        held = threading.Event()
+        release = threading.Event()
+        second_status: list[int] = []
+
+        def hold_the_lock():
+            try:
+                with transaction.atomic(using="ngm"):
+                    Material.objects.using("ngm").select_for_update().filter(
+                        pk=IRI
+                    ).first()
+                    held.set()
+                    release.wait(timeout=30)
+            finally:
+                connections.close_all()
+
+        def second_writer():
+            try:
+                held.wait(timeout=30)
+                client = _client("cw-blocked")
+                second_status.append(
+                    client.patch(
+                        f"/api/materials/?iri={IRI}",
+                        {"patch_ops": [{"op": "add", "path": "/late", "value": 1}]},
+                        format="json",
+                    ).status_code
+                )
+            finally:
+                connections.close_all()
+
+        holder = threading.Thread(target=hold_the_lock)
+        writer = threading.Thread(target=second_writer)
+        holder.start()
+        writer.start()
+        assert held.wait(timeout=30), "lock was never taken"
+        # The writer must still be blocked while the lock is held.
+        writer.join(timeout=2)
+        assert writer.is_alive(), "second writer was NOT blocked by the row lock"
+        release.set()
+        holder.join(timeout=30)
+        writer.join(timeout=30)
+
+        assert second_status == [200], second_status
+        assert Material.objects.using("ngm").get(pk=IRI).data["late"] == 1
+
+
+class TestTheAliasMustMatchTheLock:
+    """Why ``materials/conversion.py`` needed ``using="ngm"``.
+
+    ``Material`` routes to ``ngm``. A bare ``atomic()`` opens a transaction on
+    ``default`` and leaves ``ngm`` in autocommit, so ``select_for_update()``
+    raises — a crash that the sqlite gate cannot see, because SQLite skips the
+    check along with the clause.
+    """
+
+    def test_a_mismatched_alias_raises(self):
+        _store()
+        with pytest.raises(TransactionManagementError):
+            with transaction.atomic():  # default alias — the bug
+                list(
+                    Material.objects.using("ngm").select_for_update().filter(pk=IRI)
+                )
+
+    def test_the_matching_alias_works(self):
+        _store()
+        with transaction.atomic(using="ngm"):  # the fix
+            rows = list(
+                Material.objects.using("ngm").select_for_update().filter(pk=IRI)
+            )
+        assert len(rows) == 1

--- a/materials/tests/test_patch_review_fixes.py
+++ b/materials/tests/test_patch_review_fixes.py
@@ -156,3 +156,60 @@ class TestPatchStillGoesThroughModelValidation:
             )
         assert resp.status_code == 200
         assert full_clean.called
+
+
+class TestWriteSizeIsBounded:
+    """A patch may not grow a row without limit.
+
+    `DATA_UPLOAD_MAX_MEMORY_SIZE` does NOT cover this path: DRF's JSONParser
+    reads the WSGI stream directly instead of going through `HttpRequest.body`,
+    where Django's check lives. Measured: a 3.6 MB body against a 2.5 MB limit
+    returned 200 and persisted. So the bound has to be explicit — this is the
+    one Material write path that had no ceiling, while the upload endpoint next
+    door is capped at `_MAX_UPLOAD_BYTES`.
+    """
+
+    def test_too_many_ops_is_413(self):
+        from materials.patch_validation import MAX_PATCH_OPS
+
+        mat = _store("rev-050")
+        ops = [
+            {"op": "add", "path": f"/k{i}", "value": i}
+            for i in range(MAX_PATCH_OPS + 1)
+        ]
+        resp = _client("cw-ops").patch(
+            f"/api/materials/?iri={mat.iri}", {"patch_ops": ops}, format="json"
+        )
+        assert resp.status_code == 413
+        mat.refresh_from_db()
+        assert "k0" not in mat.data
+
+    def test_a_patch_that_would_oversize_the_document_is_413(self):
+        from materials.patch_validation import MAX_MATERIAL_DOC_BYTES
+
+        mat = _store("rev-051")
+        resp = _client("cw-big").patch(
+            f"/api/materials/?iri={mat.iri}",
+            {
+                "patch_ops": [
+                    {"op": "add", "path": "/text",
+                     "value": "k" * (MAX_MATERIAL_DOC_BYTES + 1024)}
+                ]
+            },
+            format="json",
+        )
+        assert resp.status_code == 413
+        mat.refresh_from_db()
+        assert "text" not in mat.data
+
+    def test_a_realistic_full_text_document_still_fits(self):
+        # An AG indictment embeds its likhit-converted full text; the cap must be
+        # well clear of a genuinely large one, not merely of the tiny fixtures.
+        mat = _store("rev-052")
+        resp = _client("cw-real").patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "add", "path": "/text",
+                            "value": {"ne": "क" * 400_000}}]},
+            format="json",
+        )
+        assert resp.status_code == 200

--- a/materials/tests/test_patch_review_fixes.py
+++ b/materials/tests/test_patch_review_fixes.py
@@ -1,0 +1,158 @@
+"""Regressions found reviewing the field-level PATCH.
+
+Three of these are consequences of one change: wrapping the material write in
+``transaction.atomic(using="ngm")``. That block is what makes the read-modify-write
+safe, but it also means anything that assumed the save ran in autocommit — most
+importantly the search-index ``on_commit`` hook — now has to name the same alias
+or it fires at the wrong time. The rest are read-plane details the ETag introduced.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch as mock_patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.db import connections, transaction
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from materials.models import Material, Visibility
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db(databases=["default", "ngm"], transaction=True)
+
+
+def _store(ident):
+    iri = f"https://jawafdehi.org/material/ag/{ident}"
+    mat = Material(
+        iri=iri,
+        material_type="charge_sheet",
+        source="ag",
+        ident=ident,
+        data={"@id": iri, "@type": "DigitalDocument", "name": {"ne": "अभियोगपत्र"}},
+        visibility=Visibility.LISTED,
+    )
+    mat.save()
+    return mat
+
+
+def _client(username="cw-review"):
+    u = User.objects.create_user(username, password="x")
+    u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+    c = APIClient()
+    c.force_authenticate(u)
+    return c
+
+
+class TestIndexingIsDeferredUntilTheMaterialIsDurable:
+    def test_index_write_waits_for_the_ngm_commit(self):
+        # `Material` lives on `ngm`. If the on_commit hook registers against the
+        # DEFAULT alias it resolves against a connection that is in autocommit
+        # here, so Django runs it IMMEDIATELY — publishing a document to search
+        # that the ngm transaction has not committed yet (and might roll back),
+        # while the row lock is still held across an OpenSearch round-trip.
+        mat = _store("rev-001")
+        with mock_patch("materials.search_index.index") as indexer:
+            with transaction.atomic(using="ngm"):
+                mat.data = {**mat.data, "jawafdehi:caseNumber": "082-CR-0100"}
+                mat.save(update_fields=["data", "updated_at"])
+                assert not indexer.called, (
+                    "search index was written before the ngm transaction committed"
+                )
+            assert indexer.called, "search index was never written after commit"
+
+    def test_a_rolled_back_write_is_never_indexed(self):
+        mat = _store("rev-002")
+        with mock_patch("materials.search_index.index") as indexer:
+            with pytest.raises(RuntimeError):
+                with transaction.atomic(using="ngm"):
+                    mat.data = {**mat.data, "jawafdehi:caseNumber": "082-CR-0100"}
+                    mat.save(update_fields=["data", "updated_at"])
+                    raise RuntimeError("boom")
+            assert not indexer.called
+
+
+class TestEtagComesFromTheAuthority:
+    def test_the_etag_is_read_from_the_primary_not_the_router(self):
+        # The token is a write PRECONDITION, so it must be minted from the same
+        # database `_patch_material` validates it against. `/api/materials/` is
+        # NOT in config.middleware._PRIMARY_ONLY_PREFIXES, so an unpinned read is
+        # replica-eligible; a lagging replica would hand out a stale token and
+        # produce a 412 loop on an edit nobody else touched.
+        #
+        # Simulated by pointing the router somewhere the row does not exist: an
+        # unpinned _stored_etag follows the router and finds nothing (None); a
+        # pinned one still reads ngm and returns the real token.
+        from config.db_router import ServiceDatabaseRouter
+        from materials.views import _stored_etag
+
+        mat = _store("rev-010")
+        with mock_patch.object(
+            ServiceDatabaseRouter, "db_for_read", return_value="default"
+        ):
+            token = _stored_etag(mat.iri)
+        assert token, "_stored_etag followed the router instead of the primary"
+
+
+class TestReadPlaneEfficiency:
+    def test_a_get_reads_the_material_row_once(self):
+        mat = _store("rev-020")
+        client = APIClient()
+        with CaptureQueriesContext(connections["ngm"]) as ctx:
+            resp = client.get(f"/api/materials/?iri={mat.iri}")
+        assert resp.status_code == 200
+        selects = [
+            q for q in ctx.captured_queries
+            if "materials" in q["sql"].lower() and q["sql"].lower().startswith("select")
+        ]
+        assert len(selects) == 1, [q["sql"] for q in selects]
+
+    def test_a_derived_court_material_does_not_query_for_an_etag(self):
+        # _resolve_material already proved there is no stored row by taking the
+        # DoesNotExist branch; re-asking can never return anything.
+        iri = "https://jawafdehi.org/material/court/special.080-cr-9999"
+        client = APIClient()
+        with CaptureQueriesContext(connections["ngm"]) as ctx:
+            client.get(f"/api/materials/?iri={iri}")
+        selects = [
+            q for q in ctx.captured_queries
+            if "materials" in q["sql"].lower() and q["sql"].lower().startswith("select")
+        ]
+        assert len(selects) == 1, [q["sql"] for q in selects]
+
+
+class TestEtagDoesNotLeakTheAuthedRepresentation:
+    def test_the_response_varies_on_authorization(self):
+        # One URL serves two different bodies — anon gets `row.data`, a caseworker
+        # gets it plus jawafdehi:visibility[Policy] — under ONE entity tag. Without
+        # Vary, a shared cache keyed on URL+ETag may serve the annotated body to an
+        # anonymous caller, disclosing the material's visibility policy.
+        mat = _store("rev-030")
+        anon = APIClient().get(f"/api/materials/?iri={mat.iri}")
+        authed = _client().get(f"/api/materials/?iri={mat.iri}")
+        assert anon.status_code == authed.status_code == 200
+        assert "jawafdehi:visibilityPolicy" in authed.data
+        assert "jawafdehi:visibilityPolicy" not in anon.data
+        for resp in (anon, authed):
+            assert "authorization" in resp.get("Vary", "").lower(), resp.get("Vary")
+
+
+class TestPatchStillGoesThroughModelValidation:
+    def test_a_patch_runs_the_model_layer_clean(self):
+        # The PATCH path writes `data` directly rather than through
+        # upsert_single_source_material, so Material.clean() — which re-checks the
+        # promoted source/ident columns against @id — must be invoked explicitly
+        # or the model-layer invariant silently stops applying on this verb.
+        mat = _store("rev-040")
+        with mock_patch.object(
+            Material, "full_clean", autospec=True
+        ) as full_clean:
+            resp = _client("cw-clean").patch(
+                f"/api/materials/?iri={mat.iri}",
+                {"patch_ops": [{"op": "add", "path": "/x", "value": 1}]},
+                format="json",
+            )
+        assert resp.status_code == 200
+        assert full_clean.called

--- a/materials/tests/test_row_lock_preconditions.py
+++ b/materials/tests/test_row_lock_preconditions.py
@@ -1,0 +1,130 @@
+"""The row lock's precondition, asserted on the sqlite gate.
+
+SQLite drops ``FOR UPDATE`` silently, so the lock itself cannot be observed here
+(see ``test_patch_concurrency_postgres``). But the failure mode that actually
+bites is not "the lock is subtly wrong" — it is "the lock was taken on the wrong
+connection", and THAT is engine-independent and checkable right here.
+
+Django refuses ``select_for_update()`` when the queryset's connection is in
+autocommit::
+
+    if self.query.select_for_update and features.has_select_for_update:
+        if self.connection.get_autocommit() and features.supports_transactions:
+            raise TransactionManagementError(...)
+
+On Postgres that raises and the request 500s. On SQLite ``has_select_for_update``
+is False, so the whole branch — including the autocommit check — is skipped and
+the mistake is invisible. That is exactly how ``materials/conversion.py`` shipped
+a bare ``atomic()`` against an ``ngm``-routed ``select_for_update`` to main and
+nobody noticed.
+
+``connections[alias].in_atomic_block`` is the same condition, readable on any
+backend. These tests pin it so a future edit that changes the alias — or wraps
+the write in the wrong ``atomic()`` — fails in CI instead of in production.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch as mock_patch
+
+import jsonpatch
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.db import connections, transaction
+from rest_framework.test import APIClient
+
+from materials.models import Material, Visibility
+
+User = get_user_model()
+# transaction=True is load-bearing: the default django_db fixture wraps each
+# test in an atomic block on EVERY declared alias, so `in_atomic_block` would be
+# True no matter what the view did and every assertion below would be vacuous.
+pytestmark = pytest.mark.django_db(databases=["default", "ngm"], transaction=True)
+
+#: The alias Material is routed to. If this ever changes, every ``using=`` in the
+#: PATCH/conversion write paths has to change with it — which is the point.
+MATERIAL_DB = "ngm"
+
+
+def _store(ident="lockcheck"):
+    iri = f"https://jawafdehi.org/material/ag/{ident}"
+    mat = Material(
+        iri=iri,
+        material_type="charge_sheet",
+        source="ag",
+        ident=ident,
+        data={"@id": iri, "@type": "DigitalDocument", "name": {"ne": "अभियोगपत्र"}},
+        visibility=Visibility.LISTED,
+    )
+    mat.save()
+    return mat
+
+
+def _client(username="cw-lock"):
+    u = User.objects.create_user(username, password="x")
+    u.groups.add(Group.objects.get_or_create(name="Caseworker")[0])
+    c = APIClient()
+    c.force_authenticate(u)
+    return c
+
+
+def test_material_is_routed_to_the_alias_the_write_paths_name():
+    from django.db import router
+
+    assert router.db_for_write(Material) == MATERIAL_DB
+
+
+class TestThePatchHoldsATransactionOnTheRightConnection:
+    def test_the_ngm_connection_is_in_a_transaction_while_the_patch_applies(self):
+        # Observed from INSIDE the locked block: apply_patch runs between the
+        # select_for_update and the save, so whatever it sees is the state
+        # Postgres would have evaluated its autocommit check against.
+        seen = {}
+        real = jsonpatch.apply_patch
+
+        def spy(*args, **kwargs):
+            seen["ngm"] = connections[MATERIAL_DB].in_atomic_block
+            seen["default"] = connections["default"].in_atomic_block
+            return real(*args, **kwargs)
+
+        mat = _store("lock-001")
+        with mock_patch.object(jsonpatch, "apply_patch", side_effect=spy):
+            resp = _client().patch(
+                f"/api/materials/?iri={mat.iri}",
+                {"patch_ops": [{"op": "add", "path": "/x", "value": 1}]},
+                format="json",
+            )
+        assert resp.status_code == 200
+        assert seen["ngm"] is True, (
+            "the PATCH took its row lock on a connection in autocommit — on "
+            "Postgres this raises TransactionManagementError and 500s"
+        )
+
+
+class TestTheAliasMismatchIsWhatBreaks:
+    """Engine-independent demonstration of the conversion.py bug and its fix."""
+
+    def test_a_bare_atomic_leaves_the_material_connection_in_autocommit(self):
+        with transaction.atomic():  # the bug: opens `default`
+            assert connections["default"].in_atomic_block is True
+            assert connections[MATERIAL_DB].in_atomic_block is False
+
+    def test_naming_the_alias_opens_the_material_connection(self):
+        with transaction.atomic(using=MATERIAL_DB):  # the fix
+            assert connections[MATERIAL_DB].in_atomic_block is True
+
+
+class TestTheConversionWriterTakesItsLockCorrectly:
+    def test_conversion_opens_a_transaction_on_the_material_alias(self):
+        # materials/conversion.py is the other writer this PATCH serializes
+        # against; it had the mismatched-alias bug. Pin its fix the same way.
+        import materials.conversion as conversion
+        import inspect
+
+        src = inspect.getsource(conversion.apply_convert_result)
+        assert 'transaction.atomic(using="ngm")' in src, (
+            "conversion.py must open its transaction on the alias its "
+            "select_for_update is routed to"
+        )
+        assert 'Material.objects.using("ngm")' in src

--- a/materials/views.py
+++ b/materials/views.py
@@ -21,6 +21,7 @@ import mimetypes
 import jsonpatch
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
+from django.utils.cache import patch_vary_headers
 from rest_framework import status
 from rest_framework.decorators import (
     api_view,
@@ -211,7 +212,43 @@ def _upsert_material(
     return material.data, code, None
 
 
-def _resolve_material(iri: str, *, include_nonpublic: bool = False) -> dict | None:
+def _material_read_response(request, iri: str) -> Response:
+    """The shared GET tail for both material routes.
+
+    One SELECT serves both the body and the ``ETag``: ``_resolve_material``
+    already loaded (or proved absent) the stored row, so re-querying for the
+    version token would double every read on this public, replica-served plane
+    — and for a derived court-case IRI the second query could never return
+    anything, because the absence is what put us on the derived path.
+
+    ``Vary: Authorization`` because ONE URL serves two representations: anon gets
+    ``row.data``, an authed caseworker gets it annotated with
+    ``jawafdehi:visibility``/``jawafdehi:visibilityPolicy``. They share an entity
+    tag (the row's version is the same either way), so without Vary a shared
+    cache keyed on URL+ETag could hand the annotated body — and the material's
+    visibility policy — to an anonymous caller.
+    """
+    data, row = _resolve_material(
+        iri, include_nonpublic=_can_see_nonpublic(request), with_row=True
+    )
+    if data is None:
+        resp = Response(
+            {"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND
+        )
+        patch_vary_headers(resp, ("Authorization",))
+        return resp
+    resp = Response(data, content_type=LD_JSON)
+    if row is not None:
+        # The token a conditional PATCH is matched against, so a client can opt
+        # into optimistic concurrency without a second round-trip.
+        resp["ETag"] = _version_token(row)
+    patch_vary_headers(resp, ("Authorization",))
+    return resp
+
+
+def _resolve_material(
+    iri: str, *, include_nonpublic: bool = False, with_row: bool = False
+):
     """Return the JSON-LD doc for ``iri``: stored (live) row, else a derived
     court case. Soft-deleted rows (``is_deleted=True``) are treated as absent.
 
@@ -223,24 +260,31 @@ def _resolve_material(iri: str, *, include_nonpublic: bool = False) -> dict | No
     """
     from .models import PUBLIC_VISIBILITIES
 
+    def _out(doc, row):
+        # ``with_row`` returns the row alongside the doc so a caller needing the
+        # material's version token doesn't have to SELECT it again. Callers that
+        # only want the document keep the original single-value contract.
+        return (doc, row) if with_row else doc
+
     try:
         row = Material.objects.get(pk=iri, is_deleted=False)
     except Material.DoesNotExist:
         # No stored row: fall back to the on-the-fly court-case derivation
-        # (court cases are a public read plane in their own right).
-        return _derive_court_case_jsonld(iri)
+        # (court cases are a public read plane in their own right). There is no
+        # row, hence no version token — a derived material cannot be PATCHed.
+        return _out(_derive_court_case_jsonld(iri), None)
 
     if include_nonpublic:
         # Authed caseworker/readonly: surface the cached visibility + policy so the
         # FE editor can render + drive the control.
-        return _with_admin_visibility(row)
+        return _out(_with_admin_visibility(row), row)
     if row.visibility in PUBLIC_VISIBILITIES:
-        return row.data
+        return _out(row.data, row)
     # A PRIVATE (draft-only) stored row is treated as ABSENT for the public.
     # We must NOT fall through to _derive_court_case_jsonld here: doing so would
     # ignore the material's own visibility gate and hand an anon caller the
     # derived court-case document for an IRI the stored row marks non-public.
-    return None
+    return _out(None, None)
 
 
 def _derive_court_case_jsonld(iri: str) -> dict | None:
@@ -325,9 +369,17 @@ def _stored_etag(iri: str) -> str | None:
 
     Derived (court-case) materials have no stored row and therefore no version to
     hand out — a client cannot ``If-Match`` something it cannot PATCH either.
+
+    Pinned to ``ngm`` (the PRIMARY) rather than routed: ``/api/materials/`` is not
+    in ``config.middleware._PRIMARY_ONLY_PREFIXES``, so a safe-method read is
+    replica-eligible. A version token is a WRITE precondition — it has to be
+    minted from the same database ``_patch_material`` validates it against, or a
+    lagging replica hands out a stale token and the caller gets a 412 loop on an
+    edit nobody else touched.
     """
     row = (
-        Material.objects.filter(pk=iri, is_deleted=False)
+        Material.objects.using("ngm")
+        .filter(pk=iri, is_deleted=False)
         .only("iri", "updated_at")
         .first()
     )
@@ -458,6 +510,20 @@ def _patch_material(request, iri: str) -> Response:
             if patched != row.data:
                 row.data = patched
                 updated_fields.append("data")
+                # This verb writes `data` directly instead of going through
+                # `upsert_single_source_material`, so the model-layer invariant
+                # has to be invoked explicitly or it silently stops applying on
+                # PATCH alone. `Material.clean()` re-checks that the promoted
+                # source/ident columns still agree with the doc's @id — cheap
+                # insurance that any promoted column added later cannot drift on
+                # this path while holding on every other one.
+                try:
+                    row.full_clean(validate_unique=False)
+                except DjangoValidationError as exc:
+                    return Response(
+                        {"detail": f"Patched material is invalid: {exc}"},
+                        status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    )
 
         if policy is not None:
             # Derive the new cached visibility from the new policy and persist BOTH
@@ -545,16 +611,7 @@ def material_detail(request, source: str, ident: str):
             )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    data = _resolve_material(iri, include_nonpublic=_can_see_nonpublic(request))
-    if data is None:
-        return Response({"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND)
-    resp = Response(data, content_type=LD_JSON)
-    # Hand out the version token a conditional PATCH will be matched against, so
-    # a client can opt into optimistic concurrency without a second round-trip.
-    etag = _stored_etag(iri)
-    if etag:
-        resp["ETag"] = etag
-    return resp
+    return _material_read_response(request, iri)
 
 
 @api_view(["POST"])
@@ -818,13 +875,4 @@ def material_by_iri(request):
             {"detail": "Not a valid material @id IRI."},
             status=status.HTTP_400_BAD_REQUEST,
         )
-    data = _resolve_material(iri, include_nonpublic=_can_see_nonpublic(request))
-    if data is None:
-        return Response({"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND)
-    resp = Response(data, content_type=LD_JSON)
-    # Hand out the version token a conditional PATCH will be matched against, so
-    # a client can opt into optimistic concurrency without a second round-trip.
-    etag = _stored_etag(iri)
-    if etag:
-        resp["ETag"] = etag
-    return resp
+    return _material_read_response(request, iri)

--- a/materials/views.py
+++ b/materials/views.py
@@ -14,10 +14,13 @@ no stored row is materialized on the fly from the relational court tables via
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import mimetypes
 
+import jsonpatch
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from rest_framework import status
 from rest_framework.decorators import (
     api_view,
@@ -34,12 +37,14 @@ from jawafdehi_shared.entities.ids import (
     iri_base,
 )
 from jawafdehi_shared.drf.base import PlatformCursorPagination
+from jawafdehi_shared.jsonpatch_ops import normalize_patch_ops
 from jawafdehi_shared.storage import store_file_as_link
 from courts.permissions import NGM_ROLE_GROUPS, HasNgmRole
 
 from . import jsonld
 from . import provenance
 from .models import Material, Policy
+from .patch_validation import RESERVED_WRITE_KEYS, is_blocked_patch_path
 from .single_source_ingest import upsert_single_source_material
 
 LD_JSON = "application/ld+json"
@@ -55,16 +60,6 @@ _UPLOAD_ROLES = frozenset(
 #: Upload roles that carry an original document worth OCR-ing into full text.
 #: Excludes MARKDOWN (our own extraction output) + SOURCE_PAGE (HTML, not a scan).
 _CONVERTIBLE_ROLES = frozenset({"RAW", "ALTERNATE", "PERMALINK"})
-
-#: Server-owned keys that must NEVER be persisted into a Material's stored JSON-LD
-#: ``data``: the write-envelope control field ``visibility_policy`` and the
-#: authed-read annotations ``jawafdehi:visibility``/``jawafdehi:visibilityPolicy``.
-#: Stripped at the write chokepoint so a bare body — or a read-modify-write
-#: round-trip of an annotated authed GET — can't bake them into the canonical doc
-#: (which would leak the policy to anon and serve a stale visibility snapshot).
-_RESERVED_WRITE_KEYS = frozenset(
-    {"visibility_policy", "jawafdehi:visibility", "jawafdehi:visibilityPolicy"}
-)
 
 logger = logging.getLogger("materials.views")
 
@@ -180,8 +175,8 @@ def _upsert_material(
     # (a bare body's top-level visibility_policy; a round-tripped authed GET's
     # jawafdehi:visibility[Policy]). The policy itself arrives via the dedicated
     # `visibility_policy` argument, not the document.
-    if _RESERVED_WRITE_KEYS.intersection(data):
-        data = {k: v for k, v in data.items() if k not in _RESERVED_WRITE_KEYS}
+    if RESERVED_WRITE_KEYS.intersection(data):
+        data = {k: v for k, v in data.items() if k not in RESERVED_WRITE_KEYS}
     if expected_iri is not None and data.get("@id") != expected_iri:
         return None, status.HTTP_400_BAD_REQUEST, {
             "detail": f"Body @id {data.get('@id')!r} must match the URL IRI {expected_iri!r}."
@@ -293,46 +288,199 @@ def _soft_delete_material(iri: str) -> bool:
     return True
 
 
-def _patch_visibility_policy(request, iri: str) -> Response:
-    """``PATCH`` a material's caseworker ``visibility_policy`` + recompute.
+# ETag / optimistic-concurrency helper. A material's ``updated_at`` is a strong
+# enough version token: every accepted write bumps ``auto_now``, so a stale token
+# reliably signals the caller patched from an out-of-date copy. Hashed to an
+# opaque quoted token so clients treat it as a cursor, not a timestamp to reason
+# about (mirrors the case endpoint's contract).
+def _version_token(row: Material) -> str:
+    """Opaque, quoted ETag-style token derived from the material's updated_at."""
+    basis = f"{row.pk}:{row.updated_at.isoformat() if row.updated_at else ''}"
+    return f'"{hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]}"'
 
-    Body ``{"visibility_policy": "PUBLIC"|"CASE_GATED"|"PRIVATE"}``. NGM-role
-    (Caseworker) gated. Sets the policy on the existing stored row, then settles
-    the cached ``visibility`` via ``recompute_material_visibility`` (which also
-    reconciles the search index through ``post_save``). Returns the updated doc
-    annotated with ``jawafdehi:visibility``/``jawafdehi:visibilityPolicy`` (200),
-    404 if no live stored row exists (derived court-case materials have no policy).
+
+def _if_match_matches(request, row: Material) -> bool:
+    """Whether the request's ``If-Match`` matches the material's current token.
+
+    Absent header → True (the precondition is opt-in; existing clients and the
+    moderation UI send none). Tolerates the ``W/`` weak-validator prefix and a
+    bare unquoted token. ``*`` matches any existing row per RFC 7232 — a caller
+    asserting only "it still exists".
+    """
+    raw = request.headers.get("If-Match", "").strip()
+    if not raw:
+        return True
+    current = _version_token(row)
+    for candidate in (t.strip() for t in raw.split(",")):
+        if candidate == "*":
+            return True
+        norm = candidate[2:].strip() if candidate.startswith("W/") else candidate
+        if norm == current or norm == current.strip('"'):
+            return True
+    return False
+
+
+def _stored_etag(iri: str) -> str | None:
+    """The current version token for a stored material, or None if there is none.
+
+    Derived (court-case) materials have no stored row and therefore no version to
+    hand out — a client cannot ``If-Match`` something it cannot PATCH either.
+    """
+    row = (
+        Material.objects.filter(pk=iri, is_deleted=False)
+        .only("iri", "updated_at")
+        .first()
+    )
+    return _version_token(row) if row is not None else None
+
+
+def _read_patch_body(request):
+    """Split a PATCH body into ``(raw_patch_ops, policy_body)``.
+
+    Two accepted spellings, both already in use on this platform:
+
+      * a bare RFC-6902 array — what the case endpoint takes;
+      * ``{"patch_ops": [...]}`` — what the NES entity endpoint takes, and the
+        only spelling that can also carry ``visibility_policy`` in the same
+        request.
+
+    The pre-existing ``{"visibility_policy": ...}`` body is the second form with
+    no ops, so the original contract is a strict subset of this one.
+    """
+    if isinstance(request.data, list):
+        return request.data, {}
+    body = request.data if isinstance(request.data, dict) else {}
+    return body.get("patch_ops"), body
+
+
+def _patch_material(request, iri: str) -> Response:
+    """``PATCH`` a material: field-level JSON Patch and/or the visibility policy.
+
+    NGM-role (Caseworker) gated. Body carries an RFC-6902 ``patch_ops`` list
+    applied to the stored JSON-LD, a ``visibility_policy``, or both — at least
+    one is required (a body that changes nothing stays a 400 rather than a 200 a
+    caller would misread as success).
+
+    The read-modify-write happens HERE, under ``select_for_update``, which is the
+    reason this endpoint exists: the ``PUT`` path replaces ``data`` wholesale, so
+    every client editing one key had to GET, merge and PUT with no way to detect
+    that someone else wrote in between. Callers that want to detect it anyway can
+    send ``If-Match`` with the token from a prior GET → 412 instead of a clobber.
+
+    Returns the updated doc annotated with ``jawafdehi:visibility``/
+    ``jawafdehi:visibilityPolicy`` (200) plus the new ``ETag``; 404 if no live
+    stored row exists (derived court-case materials have no stored document).
     """
     denied = _require_ngm_role(request)
     if denied is not None:
         return denied
-    body = request.data if isinstance(request.data, dict) else {}
+
+    raw_ops, body = _read_patch_body(request)
     policy, error = _clean_policy(body)
     if error is not None:
         return error
-    if policy is None:
+    if raw_ops is None and policy is None:
         return Response(
-            {"detail": "Body must include a 'visibility_policy'."},
+            {"detail": "Body must include 'patch_ops' and/or a 'visibility_policy'."},
             status=status.HTTP_400_BAD_REQUEST,
         )
-    row = Material.objects.filter(pk=iri, is_deleted=False).first()
-    if row is None:
-        return Response(
-            {"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND
-        )
-    # Derive the new cached visibility from the new policy and persist BOTH in one
-    # save — a synchronized write, so post_save fires exactly once with the final
-    # state (the search-index reconcile never sees a stale intermediate).
+
+    # Validate the op list BEFORE touching the row: a blocked or malformed op
+    # rejects the whole patch, so no partially-applied write can reach the DB.
+    patch_ops = None
+    if raw_ops is not None:
+        try:
+            patch_ops = normalize_patch_ops(raw_ops, is_blocked=is_blocked_patch_path)
+        except ValueError as exc:
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_422_UNPROCESSABLE_ENTITY
+            )
+
     from .visibility import _referring_case_states, visibility_for_policy
 
-    new_visibility = visibility_for_policy(policy, lambda: _referring_case_states(iri))
-    if row.visibility_policy != policy or row.visibility != new_visibility:
-        row.visibility_policy = policy
-        row.visibility = new_visibility
-        row.save(update_fields=["visibility_policy", "visibility", "updated_at"])
-    return Response(
+    # ``ngm`` is where Material lives (config.db_router.ServiceDatabaseRouter);
+    # naming it explicitly keeps the atomic block on the same connection the row
+    # lock is taken on. NOTE: SQLite has ``has_select_for_update = False``, so
+    # Django SILENTLY omits FOR UPDATE there — the lock is real on Postgres
+    # (prod) but a no-op under the sqlite test gate. The concurrency tests below
+    # therefore cover the ``If-Match`` contract, not the row lock itself.
+    with transaction.atomic(using="ngm"):
+        row = (
+            Material.objects.using("ngm")
+            .select_for_update()
+            .filter(pk=iri, is_deleted=False)
+            .first()
+        )
+        if row is None:
+            return Response(
+                {"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Precondition check inside the lock — outside it, the row could change
+        # between the check and the write and the guarantee would be theatre.
+        if not _if_match_matches(request, row):
+            resp = Response(
+                {
+                    "detail": (
+                        "This material was modified since you read it. "
+                        "Re-read it before patching."
+                    )
+                },
+                status=status.HTTP_412_PRECONDITION_FAILED,
+            )
+            resp["ETag"] = _version_token(row)
+            return resp
+
+        updated_fields: list[str] = []
+
+        if patch_ops is not None:
+            try:
+                patched = jsonpatch.apply_patch(row.data, patch_ops, in_place=False)
+            except (
+                jsonpatch.JsonPatchException,
+                jsonpatch.JsonPointerException,
+            ) as exc:
+                return Response(
+                    {"detail": f"Invalid JSON Patch document: {exc}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            # A patch may not leave the stored document in a state the write plane
+            # would have rejected (e.g. `remove /name`). Pin @id to the URL's IRI
+            # as well — blocked paths already prevent repointing it, but this is
+            # the durable check, not a restatement of the same one.
+            try:
+                jsonld.validate_material_jsonld(patched, iri=iri)
+            except ValueError as exc:
+                return Response(
+                    {"detail": f"Patched material is invalid: {exc}"},
+                    status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                )
+            if patched != row.data:
+                row.data = patched
+                updated_fields.append("data")
+
+        if policy is not None:
+            # Derive the new cached visibility from the new policy and persist BOTH
+            # in one save — a synchronized write, so post_save fires exactly once
+            # with the final state (the search-index reconcile never sees a stale
+            # intermediate). Folding the doc change into that same save keeps the
+            # indexer from seeing a half-applied PATCH too.
+            new_visibility = visibility_for_policy(
+                policy, lambda: _referring_case_states(iri)
+            )
+            if row.visibility_policy != policy or row.visibility != new_visibility:
+                row.visibility_policy = policy
+                row.visibility = new_visibility
+                updated_fields += ["visibility_policy", "visibility"]
+
+        if updated_fields:
+            row.save(update_fields=updated_fields + ["updated_at"])
+
+    resp = Response(
         _with_admin_visibility(row), status=status.HTTP_200_OK, content_type=LD_JSON
     )
+    resp["ETag"] = _version_token(row)
+    return resp
 
 
 @api_view(["GET", "PUT", "PATCH", "DELETE"])
@@ -341,9 +489,23 @@ def material_detail(request, source: str, ident: str):
     """``GET /api/materials/<source>/<ident>`` → the material JSON-LD doc.
 
     ``PUT`` replaces the material's stored JSON-LD (NGM-role gated). ``PATCH``
-    sets the caseworker ``visibility_policy`` (NGM-role gated). ``DELETE``
-    soft-deletes the stored material (NGM-role gated, 204). The GET path is
-    byte-identical to before (stored row, else on-the-fly court-case fallback).
+    edits it field-by-field and/or sets the caseworker ``visibility_policy``
+    (NGM-role gated). ``DELETE`` soft-deletes the stored material (NGM-role
+    gated, 204). The GET path is byte-identical to before (stored row, else
+    on-the-fly court-case fallback), plus an ``ETag`` when a stored row exists.
+
+    ``PATCH`` body — an RFC-6902 JSON Patch list, a policy, or both::
+
+        {"patch_ops": [{"op": "add",
+                        "path": "/jawafdehi:caseNumber",
+                        "value": "082-CR-0100"}],
+         "visibility_policy": "PUBLIC"}
+
+    A bare ``[{...}]`` array is accepted as the ops list too (the spelling the
+    case endpoint uses). ``/@id``, ``/@context``, ``/@type``, ``/additionalType``
+    and the visibility keys are not patchable (422) — see
+    ``materials.patch_validation``. Send ``If-Match`` with the ``ETag`` from a
+    prior GET to make the write conditional (412 if it changed meanwhile).
     """
     try:
         iri = build_material_iri(source, ident)
@@ -354,7 +516,7 @@ def material_detail(request, source: str, ident: str):
         )
 
     if request.method == "PATCH":
-        return _patch_visibility_policy(request, iri)
+        return _patch_material(request, iri)
 
     if request.method == "PUT":
         denied = _require_ngm_role(request)
@@ -386,7 +548,13 @@ def material_detail(request, source: str, ident: str):
     data = _resolve_material(iri, include_nonpublic=_can_see_nonpublic(request))
     if data is None:
         return Response({"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND)
-    return Response(data, content_type=LD_JSON)
+    resp = Response(data, content_type=LD_JSON)
+    # Hand out the version token a conditional PATCH will be matched against, so
+    # a client can opt into optimistic concurrency without a second round-trip.
+    etag = _stored_etag(iri)
+    if etag:
+        resp["ETag"] = etag
+    return resp
 
 
 @api_view(["POST"])
@@ -575,9 +743,11 @@ def material_by_iri(request):
     ``{"material": {...}, "material_type": "..."}`` envelope (``material_type`` is
     inferred from the doc's ``additionalType``/``@type`` when absent). An optional
     top-level ``visibility_policy`` sets the caseworker policy on the write.
-    ``PATCH /api/materials/?iri=<full-iri>`` sets just the ``visibility_policy``
-    (NGM-role gated). ``DELETE /api/materials/?iri=<full-iri>`` soft-deletes the
-    material (NGM-role gated, 204).
+    ``PATCH /api/materials/?iri=<full-iri>`` applies an RFC-6902 ``patch_ops``
+    list to the stored JSON-LD and/or sets the ``visibility_policy`` (NGM-role
+    gated) — same body and same guards as the ``<source>/<ident>`` route; see
+    :func:`material_detail`. ``DELETE /api/materials/?iri=<full-iri>``
+    soft-deletes the material (NGM-role gated, 204).
     """
     if request.method == "POST":
         denied = _require_ngm_role(request)
@@ -616,7 +786,7 @@ def material_by_iri(request):
                 {"detail": "Not a valid material @id IRI."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        return _patch_visibility_policy(request, iri)
+        return _patch_material(request, iri)
 
     if request.method == "DELETE":
         denied = _require_ngm_role(request)
@@ -651,4 +821,10 @@ def material_by_iri(request):
     data = _resolve_material(iri, include_nonpublic=_can_see_nonpublic(request))
     if data is None:
         return Response({"detail": "Material not found."}, status=status.HTTP_404_NOT_FOUND)
-    return Response(data, content_type=LD_JSON)
+    resp = Response(data, content_type=LD_JSON)
+    # Hand out the version token a conditional PATCH will be matched against, so
+    # a client can opt into optimistic concurrency without a second round-trip.
+    etag = _stored_etag(iri)
+    if etag:
+        resp["ETag"] = etag
+    return resp

--- a/materials/views.py
+++ b/materials/views.py
@@ -15,6 +15,7 @@ no stored row is materialized on the fly from the relational court tables via
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import mimetypes
 
@@ -45,7 +46,12 @@ from courts.permissions import NGM_ROLE_GROUPS, HasNgmRole
 from . import jsonld
 from . import provenance
 from .models import Material, Policy
-from .patch_validation import RESERVED_WRITE_KEYS, is_blocked_patch_path
+from .patch_validation import (
+    MAX_MATERIAL_DOC_BYTES,
+    MAX_PATCH_OPS,
+    RESERVED_WRITE_KEYS,
+    is_blocked_patch_path,
+)
 from .single_source_ingest import upsert_single_source_material
 
 LD_JSON = "application/ld+json"
@@ -441,6 +447,11 @@ def _patch_material(request, iri: str) -> Response:
     # rejects the whole patch, so no partially-applied write can reach the DB.
     patch_ops = None
     if raw_ops is not None:
+        if isinstance(raw_ops, list) and len(raw_ops) > MAX_PATCH_OPS:
+            return Response(
+                {"detail": f"A patch may carry at most {MAX_PATCH_OPS} operations."},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
         try:
             patch_ops = normalize_patch_ops(raw_ops, is_blocked=is_blocked_patch_path)
         except ValueError as exc:
@@ -495,6 +506,20 @@ def _patch_material(request, iri: str) -> Response:
                 return Response(
                     {"detail": f"Invalid JSON Patch document: {exc}"},
                     status=status.HTTP_400_BAD_REQUEST,
+                )
+            # Bound the RESULT, not the request: ops are cheap, values are not,
+            # and it is the stored row that every later read, index feed and
+            # recompute_all scan has to carry.
+            size = len(json.dumps(patched, ensure_ascii=False).encode("utf-8"))
+            if size > MAX_MATERIAL_DOC_BYTES:
+                return Response(
+                    {
+                        "detail": (
+                            f"Patched document is {size} bytes; the limit is "
+                            f"{MAX_MATERIAL_DOC_BYTES}."
+                        )
+                    },
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                 )
             # A patch may not leave the stored document in a state the write plane
             # would have rejected (e.g. `remove /name`). Pin @id to the URL's IRI

--- a/materials/views.py
+++ b/materials/views.py
@@ -48,6 +48,7 @@ from . import provenance
 from .models import Material, Policy
 from .patch_validation import (
     MAX_MATERIAL_DOC_BYTES,
+    MAX_PATCH_BODY_BYTES,
     MAX_PATCH_OPS,
     RESERVED_WRITE_KEYS,
     is_blocked_patch_path,
@@ -392,6 +393,36 @@ def _stored_etag(iri: str) -> str | None:
     return _version_token(row) if row is not None else None
 
 
+def _reject_oversized_body(request):
+    """413 a PATCH whose declared body exceeds :data:`MAX_PATCH_BODY_BYTES`.
+
+    Returns ``None`` when the request may proceed.
+
+    A missing or unparseable ``Content-Length`` is NOT treated as a rejection:
+    a chunked request legitimately has none, and refusing those would break a
+    valid client to defend against an attacker who can simply omit the header.
+    Such a body still meets every downstream guard (op count, and the
+    post-apply document ceiling), so the floor here is defence in depth over
+    those, not a replacement for them.
+    """
+    raw = request.META.get("CONTENT_LENGTH")
+    try:
+        declared = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if declared > MAX_PATCH_BODY_BYTES:
+        return Response(
+            {
+                "detail": (
+                    f"Patch body is {declared} bytes; the limit is "
+                    f"{MAX_PATCH_BODY_BYTES}."
+                )
+            },
+            status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        )
+    return None
+
+
 def _read_patch_body(request):
     """Split a PATCH body into ``(raw_patch_ops, policy_body)``.
 
@@ -432,6 +463,15 @@ def _patch_material(request, iri: str) -> Response:
     denied = _require_ngm_role(request)
     if denied is not None:
         return denied
+
+    # Bound the body BEFORE reading it. Every other guard here runs downstream
+    # of DRF's JSONParser, which has already read and parsed the whole stream by
+    # the time ``request.data`` yields something to measure — measuring it then
+    # cannot un-spend the allocation, it only adds a second copy. Content-Length
+    # is the one check that can refuse the payload while it is still on the wire.
+    too_big = _reject_oversized_body(request)
+    if too_big is not None:
+        return too_big
 
     raw_ops, body = _read_patch_body(request)
     policy, error = _clean_policy(body)

--- a/tests/security/test_material_patch_escalation.py
+++ b/tests/security/test_material_patch_escalation.py
@@ -1,0 +1,302 @@
+"""Adversarial: the material field-level PATCH as an attack surface.
+
+``PATCH /api/materials/...`` writes INTO a stored JSON-LD document, which makes
+it a narrower verb than ``PUT`` but not a safer one. Four things it must never
+become:
+
+  * a way for a read-capable-but-not-write-capable principal to write;
+  * a way to repoint or alias a material's identity (the IRI is the join key
+    ``CaseMaterialReference`` stores — repointing it hijacks inbound references);
+  * a way to lift a material's visibility gate by writing the server-owned
+    annotations into the document body;
+  * a way to CREATE or REVIVE a document (that is ``PUT``'s job, and revival of a
+    soft-deleted material is exactly what an operator used ``DELETE`` to prevent).
+
+Plus the usual malformed-input surface: no adversarial body may reach a 500.
+
+Run with: ``uv run pytest -m security``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from materials.models import Material, Policy, Visibility
+from tests.conftest import create_user_with_role
+
+pytestmark = [pytest.mark.security, pytest.mark.django_db]
+
+
+def _store(ident, *, visibility=Visibility.LISTED, policy=Policy.PUBLIC, deleted=False):
+    iri = f"https://jawafdehi.org/material/ag/{ident}"
+    mat = Material(
+        iri=iri,
+        material_type="charge_sheet",
+        source="ag",
+        ident=ident,
+        data={
+            "@id": iri,
+            "@type": "DigitalDocument",
+            "name": {"ne": "अभियोगपत्र"},
+            "publisher": {"@type": "GovernmentOrganization", "name": {"ne": "कार्यालय"}},
+        },
+        visibility=visibility,
+        visibility_policy=policy,
+        is_deleted=deleted,
+    )
+    mat.save()
+    return mat
+
+
+def _client(role, username):
+    c = APIClient()
+    c.force_authenticate(create_user_with_role(username, f"{username}@x.test", role))
+    return c
+
+
+def _ops(path="/jawafdehi:caseNumber", value="082-CR-0100", op="add"):
+    return {"patch_ops": [{"op": op, "path": path, "value": value}]}
+
+
+class TestRoleEscalation:
+    """ReadOnly may READ non-public materials — it must not thereby WRITE them."""
+
+    @pytest.mark.parametrize("role", ["Public", "ReadOnly"])
+    def test_low_privilege_patch_is_403(self, role):
+        mat = _store(f"sec-role-{role.lower()}")
+        resp = _client(role, f"u-{role.lower()}-mp").patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 403
+        mat.refresh_from_db()
+        assert "jawafdehi:caseNumber" not in mat.data
+
+    def test_anonymous_patch_is_401(self):
+        mat = _store("sec-anon")
+        resp = APIClient().patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 401
+        mat.refresh_from_db()
+        assert "jawafdehi:caseNumber" not in mat.data
+
+    def test_jobpoller_cannot_patch(self):
+        # JobPoller is a machine principal for the job queue; it is authenticated
+        # and grouped, but it is not an NGM content role.
+        mat = _store("sec-jobpoller")
+        resp = _client("JobPoller", "u-poller-mp").patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 403
+        mat.refresh_from_db()
+        assert "jawafdehi:caseNumber" not in mat.data
+
+    def test_superuser_may_patch(self):
+        # The platform-wide contract (HasNgmRole): a superuser bypasses the group
+        # check. Pinned here so the set of principals that can write to the lake
+        # is asserted, not assumed.
+        mat = _store("sec-superuser")
+        resp = _client("Admin", "u-admin-mp").patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 200
+        mat.refresh_from_db()
+        assert mat.data["jawafdehi:caseNumber"] == "082-CR-0100"
+
+    def test_anonymous_patch_of_a_malformed_iri_is_401_not_400(self):
+        # The role gate must fire BEFORE input validation, so an unauthenticated
+        # prober cannot use the difference between 400 and 404 to map the IRI
+        # grammar or probe which materials exist.
+        resp = APIClient().patch(
+            "/api/materials/?iri=not-an-iri", _ops(), format="json"
+        )
+        assert resp.status_code == 401
+
+
+class TestIdentityTampering:
+    def test_repointing_id_at_another_material_is_rejected(self):
+        victim = _store("sec-victim")
+        attacker = _store("sec-attacker")
+        victim_before, attacker_before = dict(victim.data), dict(attacker.data)
+
+        resp = _client("Caseworker", "cw-idor-mp").patch(
+            f"/api/materials/?iri={attacker.iri}",
+            _ops(path="/@id", value=victim.iri, op="replace"),
+            format="json",
+        )
+        assert resp.status_code == 422
+        victim.refresh_from_db()
+        attacker.refresh_from_db()
+        assert victim.data == victim_before
+        assert attacker.data == attacker_before
+
+    def test_moving_the_id_away_is_rejected(self):
+        # `move` REMOVES from its source — guarding only `path` and not `from`
+        # would let identity be mutated by relocation.
+        mat = _store("sec-move-id")
+        before = dict(mat.data)
+        resp = _client("Caseworker", "cw-move-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            {"patch_ops": [{"op": "move", "from": "/@id", "path": "/identifier"}]},
+            format="json",
+        )
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.data == before
+
+    def test_retyping_the_document_is_rejected(self):
+        # material_type is a promoted column the PATCH path does NOT re-derive;
+        # letting @type drift from it would desynchronise the row from its doc.
+        mat = _store("sec-retype")
+        resp = _client("Caseworker", "cw-retype-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(path="/@type", value="Person", op="replace"),
+            format="json",
+        )
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.material_type == "charge_sheet"
+        assert mat.data["@type"] == "DigitalDocument"
+
+
+class TestVisibilityGate:
+    def test_writing_the_visibility_annotation_into_the_doc_is_rejected(self):
+        # A PRIVATE material 404s for anon. Smuggling `jawafdehi:visibility` into
+        # the stored document must not lift that gate — the cached column is the
+        # only thing the read plane consults, but a document that CLAIMS to be
+        # listed is a lie the admin UI would render.
+        mat = _store("sec-vis", visibility=Visibility.PRIVATE, policy=Policy.PRIVATE)
+        resp = _client("Caseworker", "cw-vis-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(path="/jawafdehi:visibility", value="LISTED"),
+            format="json",
+        )
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.visibility == Visibility.PRIVATE
+        assert "jawafdehi:visibility" not in mat.data
+        assert APIClient().get(f"/api/materials/?iri={mat.iri}").status_code == 404
+
+    def test_writing_the_policy_into_the_doc_is_rejected(self):
+        mat = _store("sec-pol", visibility=Visibility.PRIVATE, policy=Policy.PRIVATE)
+        resp = _client("Caseworker", "cw-pol-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(path="/visibility_policy", value="PUBLIC"),
+            format="json",
+        )
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.visibility_policy == Policy.PRIVATE
+
+
+class TestPatchIsNeverACreateOrRevive:
+    def test_patching_a_soft_deleted_material_is_404_and_does_not_revive_it(self):
+        # `upsert_single_source_material` deliberately REVIVES a soft-deleted @id
+        # on PUT (a re-source republishes). PATCH must not inherit that: an
+        # operator who DELETEd a document did so to take it down.
+        mat = _store("sec-deleted", deleted=True)
+        resp = _client("Caseworker", "cw-del-mp").patch(
+            f"/api/materials/?iri={mat.iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 404
+        mat.refresh_from_db()
+        assert mat.is_deleted is True
+        assert "jawafdehi:caseNumber" not in mat.data
+
+    def test_patching_an_unknown_iri_creates_nothing(self):
+        iri = "https://jawafdehi.org/material/ag/sec-does-not-exist"
+        resp = _client("Caseworker", "cw-create-mp").patch(
+            f"/api/materials/?iri={iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 404
+        assert not Material.objects.filter(pk=iri).exists()
+
+    def test_patching_a_derived_court_case_material_creates_nothing(self):
+        # A court-case IRI RESOLVES on GET (materialized on the fly) but has no
+        # stored row. PATCH must 404 rather than silently materialize one.
+        iri = "https://jawafdehi.org/material/court/special.080-cr-0100"
+        resp = _client("Caseworker", "cw-derived-mp").patch(
+            f"/api/materials/?iri={iri}", _ops(), format="json"
+        )
+        assert resp.status_code == 404
+        assert not Material.objects.filter(pk=iri).exists()
+
+
+class TestMalformedInputNeverFivehundreds:
+    """Every adversarial body is a 4xx. A 500 is an availability bug and leaks
+    a traceback through the error reporter."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"patch_ops": "not-a-list"},
+            {"patch_ops": {"op": "add"}},
+            {"patch_ops": 42},
+            {"patch_ops": [None]},
+            {"patch_ops": [{"op": "add", "path": 5, "value": 1}]},
+            {"patch_ops": [{"op": "add", "path": "no-leading-slash", "value": 1}]},
+            {"patch_ops": [{"op": "move", "path": "/x"}]},  # missing `from`
+            {"patch_ops": [{"op": "copy", "from": 3, "path": "/x"}]},
+            {"patch_ops": [{"op": "remove"}]},
+            {"patch_ops": [{"op": "replace", "path": "/name"}]},  # missing value
+            "a bare string",
+            42,
+        ],
+    )
+    def test_adversarial_body_is_4xx(self, body):
+        mat = _store("sec-malformed")
+        resp = _client("Caseworker", "cw-mal-mp").patch(
+            f"/api/materials/?iri={mat.iri}", body, format="json"
+        )
+        assert 400 <= resp.status_code < 500, f"{body!r} → {resp.status_code}"
+        mat.refresh_from_db()
+        assert "jawafdehi:caseNumber" not in mat.data
+
+    def test_a_failing_test_op_is_400_not_500(self):
+        # RFC-6902 `test` is a client-side assertion; when it fails the patch
+        # library raises, and that must surface as a 400 rather than escaping as
+        # an unhandled exception.
+        mat = _store("sec-testop")
+        resp = _client("Caseworker", "cw-testop-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            {
+                "patch_ops": [
+                    {"op": "test", "path": "/name", "value": {"ne": "wrong"}},
+                    {"op": "add", "path": "/jawafdehi:caseNumber", "value": "082-CR-1"},
+                ]
+            },
+            format="json",
+        )
+        assert resp.status_code == 400
+        mat.refresh_from_db()
+        assert "jawafdehi:caseNumber" not in mat.data
+
+    def test_a_deeply_nested_pointer_does_not_crash(self):
+        mat = _store("sec-deep")
+        resp = _client("Caseworker", "cw-deep-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            _ops(path="/a" * 200 + "/x"),
+            format="json",
+        )
+        assert 400 <= resp.status_code < 500
+
+    def test_a_rejected_patch_leaves_nested_content_untouched(self):
+        # apply_patch runs with in_place=False; if it aliased the stored dict, a
+        # patch rejected AFTER application (document validation) would still have
+        # mutated nested objects in memory — and the next save would persist them.
+        mat = _store("sec-nested")
+        before = dict(mat.data)
+        resp = _client("Caseworker", "cw-nested-mp").patch(
+            f"/api/materials/?iri={mat.iri}",
+            {
+                "patch_ops": [
+                    {"op": "replace", "path": "/publisher/name", "value": {"ne": "X"}},
+                    {"op": "remove", "path": "/name"},  # → document invalid → 422
+                ]
+            },
+            format="json",
+        )
+        assert resp.status_code == 422
+        mat.refresh_from_db()
+        assert mat.data == before


### PR DESCRIPTION
## Why

`PATCH /api/materials/…` accepted exactly one thing — `visibility_policy` — so the only route to a key **inside** a material's stored JSON-LD was `PUT`, which replaces `data` wholesale. Every client editing one field had to `GET → merge → PUT`, and with no ETag there was no way to detect a concurrent write in that window. That round-trip, not the edit, is what made the AG case-number backfill (#369) large enough to be rejected.

This moves the read-modify-write server-side, under a row lock.

## Contract

Body is an RFC-6902 `patch_ops` list, a `visibility_policy`, or both. A bare `[{…}]` array is also accepted (the spelling `PATCH /api/cases/` uses).

```jsonc
PATCH /api/materials/ag/105334
{"patch_ops": [{"op": "add", "path": "/jawafdehi:caseNumber", "value": "082-CR-0100"}]}
```

**The pre-existing policy-only body is a strict subset, so the moderation UI is unaffected.** `GET` additionally returns an `ETag`; send it back as `If-Match` to make a write conditional.

| Case | Status |
|---|---|
| Applied | `200` + new `ETag` |
| Blocked path (`/@id`, `/@context`, `/@type`, `/additionalType`, visibility keys) | `422` |
| Malformed op, or patch leaves the doc invalid (e.g. `remove /name`) | `422` |
| Well-formed op that can't apply (bad pointer, failed `test`) | `400` |
| Neither `patch_ops` nor `visibility_policy` | `400` |
| `>1000` ops, or resulting doc `>5 MB` | `413` |
| Stale `If-Match` | `412` + current `ETag` |
| Anon / no NGM role | `401` / `403` |
| No live stored row (incl. soft-deleted, derived court-case) | `404` |

Shape follows the two JSON-LD patch surfaces already here: the op list + blocked-path guard mirror `entities.write_validation`; the opt-in `If-Match`/412 mirrors the case endpoint.

## Guards worth a look

- **`@id` is not patchable** — it's the join key `CaseMaterialReference` stores, the row PK, and the source of the promoted `source`/`ident` columns. Also independently re-checked against the URL IRI after the patch applies.
- **`@type`/`additionalType` are not patchable** — unlike the NES entity plane (which allows re-typing because `entity_type` is re-derived), `material_type` is *not* re-derived here, so patching the type alone would drift the column from the doc.
- **Reserved visibility keys** are defined once in `patch_validation` and consumed by both the `PUT` strip-list and the `PATCH` block-list — a key guarded on one verb and not the other is a hole.
- **`move`/`copy` validate `from`, not just `path`** — guarding only `path` lets identity be mutated by relocation.
- **PATCH can neither create nor revive.** `PUT` deliberately revives a soft-deleted `@id`; PATCH must not inherit that, since a `DELETE` was a take-down.

## Verification

- Unit suite **2390 passed, 4 skipped**; `-m security` **160 passed** (was 131). Ruff clean. Generated OpenAPI schema has the same warning/error counts as `main`.
- **119 new tests** across four suites: functional, contract conformance (media type, idempotency, RFC 7232 `If-Match` tolerances, both routes agreeing, schema still advertises the op), an adversarial suite under `-m security` (role escalation, identity tampering, visibility-gate bypass, create/revive), and row-lock preconditions.
- **Smoke-tested over real HTTP** against a local server: 16/16, no 5xx.
- Perf: 1 op ≈ **4.8 ms** p50; cost scales with document size (200 KB doc ≈ 44 ms), not op count. The 374-record backfill is ~16 s sequential.

## Limits — please read before approving

**The row lock is not proven by CI.** SQLite sets `has_select_for_update = False`, so Django *silently* omits `FOR UPDATE`; `ci.yml` runs the whole suite on sqlite. The lock is real on Postgres but a no-op in the gate. Two mitigations:

1. `materials/tests/test_row_lock_preconditions.py` asserts, **on sqlite**, that the `ngm` connection is in a transaction while the patch applies — the same condition Postgres checks before allowing `FOR UPDATE`. Mutation-tested: reverting to a bare `atomic()` fails it.
2. `integration-tests/tests/ngm/test_material_patch_concurrency.py` proves no-lost-updates against the **real Postgres stack** in the integration workflow.

Still unverified: that a contended writer *blocks* rather than erroring. That's Django/Postgres library semantics rather than this code, and the integration test fails on a 500 if it's wrong.

## Also in here

One **pre-existing** bug fixed because it directly undermines this feature: `materials/conversion.py` took its row lock with a bare `atomic()` while `Material.objects.select_for_update()` routes to `ngm`. On Postgres that raises `TransactionManagementError`, so the one concurrent writer this PATCH most needs to serialize against would crash rather than queue. The sqlite gate hid it — which is exactly what mitigation (1) above now catches.

## Found while reviewing, NOT fixed here

**`PATCH /api/cases/<slug>` validates only each op's `path`, never the `from` pointer of `move`/`copy`.** So `{"op":"move","from":"/id","path":"/x"}` gets past `BLOCKED_PATH_PREFIXES` — the same bypass this PR's shared module closes for materials. Pre-existing; needs its own PR and tests.

Also: soft-deleting a **court-sourced** material doesn't stick — `_resolve_material` falls through to `_derive_court_case_jsonld` on `DoesNotExist`, and a soft-deleted row raises exactly that, so the document is rebuilt from the live court tables and served `200`. The adjacent PRIVATE fall-through is explicitly guarded; this one isn't.

## Note on scope

This is the endpoint half only. It does **not** include the AG backfill, and it does not answer where the live AG ingest runs — `ag_abhiyog_to_jsonld` has no callers, and prod AG docs carry `recordId`/`officeLevel`, which nothing in this repo writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added field-level JSON Patch support for material updates, including add, replace, remove, move, copy, and test operations.
  - PATCH requests can now update fields and visibility settings together.
  - Added ETag and `If-Match` support for safe optimistic concurrency.
- **Bug Fixes**
  - Prevented lost updates during simultaneous edits.
  - Improved HTTP caching behavior for authenticated and anonymous material views.
  - Ensured search indexing occurs only after successful saves.
- **Security**
  - Blocked changes to protected identity, visibility, and lifecycle fields.
  - Added validation and size limits for malformed or oversized patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->