### PR TITLE
casework(ag): recover the abhiyog patra case-number map (sourcing only)

### DIFF
--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from casework.common.api import CaseworkApi
 from casework.common.cli import (
     _utc_iso_now, add_common_args, basic_auth_from_env, configure_run_logging,
-    log_run_footer, log_run_header, print_summary,
+    log_run_footer, log_run_header, nonneg_float, nonneg_int, print_summary,
 )
 from casework.common.materials import material_iri, probe_material
 
@@ -160,13 +160,23 @@ def missing_candidates(case, candidates):
     return [(s, i) for (s, i) in candidates if material_iri(s, i) not in have]
 
 
-def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE):
+def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE,
+              *, probe_retries=0, probe_interval=1.0):
     """Build a BindPlan for one case. Probes each candidate via ``material_exists``.
 
     Guarantees: never plans a write for a non-DRAFT case; never includes an
     absent or uncertain material; aborts the whole case if ANY candidate is
     uncertain (a partial list would destroy data); emits NOOP when the merge
     changes nothing so a re-run is idempotent.
+
+    ``probe_retries`` matters because "uncertain" is a HARD STOP here: the
+    production materials API answers 429 under a sustained walk, and a throttled
+    read is indistinguishable from a dead server once it collapses to the
+    uncertain verdict. Without retry a rate-limit burst mid-run aborts cases
+    whose materials are perfectly present -- a false negative that reads exactly
+    like a data problem. Retrying converts "slow down" back into a real answer.
+    The default is 0 (single shot, the historical behaviour) so a direct caller
+    is unchanged; the CLI turns it on.
     """
     slug = case.get("slug")
     state = case.get("state")
@@ -181,7 +191,8 @@ def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE):
         iri = material_iri(source, ident)
         if iri in have:
             continue  # already bound -> contributes nothing
-        pr = probe_material(api, source, ident)
+        pr = probe_material(api, source, ident, retries=probe_retries,
+                            interval=probe_interval)
         probes.append(pr)
         if pr.verdict is True:
             if iri not in add:
@@ -334,7 +345,9 @@ def run(args, api=None, rows=None):
             continue
 
         try:
-            plan = plan_case(api, case, etag, candidates_from_row(row))
+            plan = plan_case(api, case, etag, candidates_from_row(row),
+                             probe_retries=args.probe_retries,
+                             probe_interval=args.probe_interval)
         except Exception as exc:  # noqa: BLE001 -- one bad case must not sink the batch
             ms = int((time.monotonic() - t0) * 1000)
             stats["PLAN_FAILED"] = stats.get("PLAN_FAILED", 0) + 1
@@ -441,6 +454,14 @@ def build_parser():
                         help="CSV with a `slug` column and material-IRI columns.")
     parser.add_argument("--report", default="",
                         help="Optional path to write a JSON run report.")
+    parser.add_argument("--probe-retries", type=nonneg_int, default=4,
+                        help="Retries for a throttled/uncertain material probe "
+                             "(the API 429s under a sustained walk, and an "
+                             "uncertain probe ABORTS the whole case). 0 for a "
+                             "single shot, the pre-2026-07 behaviour.")
+    parser.add_argument("--probe-interval", type=nonneg_float, default=1.0,
+                        help="Base backoff seconds between probe retries "
+                             "(exponential, Retry-After honoured).")
     return parser
 
 

--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -162,7 +162,12 @@ def missing_candidates(case, candidates):
 
 def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE,
               *, probe_retries=0, probe_interval=1.0):
-    """Build a BindPlan for one case. Probes each candidate via ``material_exists``.
+    """Build a BindPlan for one case. Probes each candidate via ``probe_material``.
+
+    It calls ``probe_material`` rather than the thinner ``material_exists``
+    wrapper for two reasons: the wrapper takes no retry controls (see below),
+    and the full ``ProbeResult`` carries the HTTP status and probed path that
+    the plan's per-material audit line reports.
 
     Guarantees: never plans a write for a non-DRAFT case; never includes an
     absent or uncertain material; aborts the whole case if ANY candidate is

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import logging
+import math
 import os
 import sys
 import time
@@ -47,15 +48,23 @@ def nonneg_int(raw):
 
 
 def nonneg_float(raw):
-    """argparse type for a duration that cannot be negative.
+    """argparse type for a finite duration that cannot be negative.
 
     ``time.sleep()`` raises ``ValueError`` on a negative argument, so a negative
     ``--probe-interval`` / ``--read-interval`` / ``--write-interval`` does not
     "sleep less" -- it aborts the walk partway through with a traceback.
+
+    ``float()`` also accepts ``nan`` and ``inf``, and a bare ``value < 0`` lets
+    both through: every comparison against NaN is False. NaN then reaches
+    ``time.sleep(nan)`` and raises the same ValueError the check above exists to
+    prevent, and it does so on the RETRY path -- i.e. only once the run is
+    already in trouble. ``inf`` is the slow version: ``materials._backoff_s``
+    caps it, but the read/write intervals sleep on it directly and would park
+    the walk forever.
     """
     value = float(raw)
-    if value < 0:
-        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    if not math.isfinite(value) or value < 0:
+        raise argparse.ArgumentTypeError(f"must be a finite number >= 0, got {raw!r}")
     return value
 
 

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -1,5 +1,6 @@
 """Shared argparse, logging and reporting for casework enricher CLIs."""
 
+import argparse
 import json
 import logging
 import os
@@ -29,6 +30,33 @@ def basic_auth_from_env():
             "JAWAFDEHI_API_TOKEN) for Bearer auth, or set CASEWORK_API_USER + "
             "CASEWORK_API_PASSWORD for local DEV_AUTH Basic auth.")
     return user, password
+
+
+def nonneg_int(raw):
+    """argparse type for a count that cannot be negative.
+
+    A bare ``type=int`` accepts ``--probe-retries -1``, and a negative count
+    silently means something different from what the flag says: it empties the
+    ``range(retries + 1)`` that drives every retry loop, so nothing is attempted
+    at all. Reject it at the boundary rather than let each call site guess.
+    """
+    value = int(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    return value
+
+
+def nonneg_float(raw):
+    """argparse type for a duration that cannot be negative.
+
+    ``time.sleep()`` raises ``ValueError`` on a negative argument, so a negative
+    ``--probe-interval`` / ``--read-interval`` / ``--write-interval`` does not
+    "sleep less" -- it aborts the walk partway through with a traceback.
+    """
+    value = float(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {value}")
+    return value
 
 
 def add_common_args(parser):

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -11,6 +11,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 from casework.common.api import BROWSER_UA
 
@@ -107,10 +109,13 @@ def probe_material(api, source, ident, timeout=45, *, retries=0, interval=1.0):
     ``retries`` defaults to 0 -- a single shot, i.e. exactly the historical
     behaviour -- so enabling backoff never silently changes the timing of an
     existing caller. Any caller that walks a large cohort against production
-    SHOULD opt in. NOTE: ``bind_materials`` does not yet, and it escalates an
-    uncertain probe to "abort the whole case", so a rate-limit burst there
-    aborts cases whose materials are actually present; wiring it up is a
-    deliberate behaviour change and is left to its owner.
+    SHOULD opt in, and both current ones do: ``bind_materials.plan_case`` and
+    ``source_abhiyog.build_rows`` each forward their own ``--probe-retries`` /
+    ``--probe-interval`` (CLI default 4 retries at a 1.0s base). That matters
+    most in the binder, where an uncertain probe escalates to "abort the whole
+    case" -- without retry a rate-limit burst aborts cases whose materials are
+    perfectly present. Note ``material_exists`` deliberately keeps the default:
+    it is the thin tri-state wrapper and takes no retry controls.
     """
     path = material_path(source, ident)
     result = None
@@ -127,6 +132,45 @@ def probe_material(api, source, ident, timeout=45, *, retries=0, interval=1.0):
     return result
 
 
+def _retry_after_s(raw, *, now=None):
+    """Seconds to wait per a ``Retry-After`` header, or None if unusable.
+
+    RFC 9110 10.2.3 gives the header TWO forms -- ``delta-seconds`` (an integer)
+    and an ``HTTP-date`` -- and a server may send either. Reading only digits
+    silently discards the date form, so the probe throws away the one number the
+    server actually gave it and retries on its local schedule instead. Our own
+    control plane sends the integer form (DRF's throttling), but the 429s that
+    matter can also come from an intermediary (WAF/CDN), which is exactly where
+    the date form shows up.
+
+    A date already in the past clamps to 0 rather than going negative: clock
+    skew between us and the server is normal, and ``time.sleep()`` raises on a
+    negative argument. Anything unparseable returns None -- fall back to the
+    exponential schedule; a malformed header must not become a traceback on the
+    retry path. The caller still runs the result through :func:`_backoff_s`, so
+    a server asking for an hour is capped like any other wait.
+    """
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        return float(int(text))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:  # RFC 9110 says GMT; an omitted zone means the same
+        when = when.replace(tzinfo=timezone.utc)
+    reference = now or datetime.now(timezone.utc)
+    return max((when - reference).total_seconds(), 0.0)
+
+
 def _probe_once(api, source, ident, path, timeout):
     try:
         api.get(path, timeout=timeout)
@@ -135,8 +179,7 @@ def _probe_once(api, source, ident, path, timeout):
         verdict = False if exc.code in (400, 404) else None
         retry_after = None
         if exc.code == _RATE_LIMITED:
-            raw = (exc.headers or {}).get("Retry-After")
-            retry_after = float(raw) if raw and str(raw).isdigit() else None
+            retry_after = _retry_after_s((exc.headers or {}).get("Retry-After"))
         return ProbeResult(source, ident, path, exc.code, verdict, retry_after)
     except Exception:
         return ProbeResult(source, ident, path, None, None)

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -6,6 +6,7 @@ source_content. The current payload is
 {material_iri, additional_details, material: {material_type, urls:[{link, role}]}}
 and `material` resolves ONLY on the case DETAIL endpoint.
 """
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -41,6 +42,19 @@ def court_order_ident(court, case_no):
     return f"{court}.{case_no.strip().lower()}"
 
 
+def ag_ident(record_id):
+    """AG अभियोगपत्र (indictment): the ident IS the AG portal record id.
+
+    `materials/sourcing/ag/shaper.py` deliberately keys the IRI on `record_id`
+    and NOT on the case number: ~969 case numbers repeat across AG offices, so
+    keying on the case number would collide distinct indictments onto one `@id`
+    and silently overwrite them on upsert. That choice is what makes case-number
+    recovery a DIRECT id join -- `/material/ag/<record_id>` round-trips straight
+    back to the portal record it was scraped from (no sha256 content-join).
+    """
+    return str(record_id).strip()
+
+
 @dataclass
 class ProbeResult:
     """Outcome of one existence probe, with enough detail to log an audit line.
@@ -48,15 +62,32 @@ class ProbeResult:
     ``verdict``: True (exists) / False (absent) / None (uncertain).
     ``status``: the HTTP code (200/400/404/5xx) or None on a transport error.
     ``path``: the exact request path probed, for the log.
+    ``retry_after``: seconds the server asked us to wait (429 only), else None.
     """
     source: str
     ident: str
     path: str
     status: int | None
     verdict: bool | None
+    retry_after: float | None = None
 
 
-def probe_material(api, source, ident, timeout=45):
+def material_path(source, ident):
+    """The control-plane path for one material. Single definition so a read and
+    the subsequent write can never disagree about how an ident is escaped."""
+    return f"/materials/{source}/{urllib.parse.quote(ident, safe='')}/"
+
+
+#: HTTP 429. The production materials API rate-limits under bursts, and a
+#: throttled read is INDISTINGUISHABLE from a 5xx once it collapses to the
+#: "uncertain" verdict -- which callers treat as a hard stop (bind_materials
+#: aborts the whole case). So it is retried here, in the shared primitive,
+#: rather than in any one caller.
+_RATE_LIMITED = 429
+_MAX_BACKOFF_S = 30
+
+
+def probe_material(api, source, ident, timeout=45, *, retries=0, interval=1.0):
     """Probe GET /materials/<source>/<ident>/ and return a ProbeResult.
 
     verdict is True (200), False (400/404 -- definitively absent), or None
@@ -66,16 +97,64 @@ def probe_material(api, source, ident, timeout=45):
     inheriting its auth and browser UA. The server validates IRI *grammar*
     only and never checks material existence on write, so this client-side
     probe is the only thing between a typo'd ident and a bound stub.
+
+    An uncertain outcome is RETRIED with exponential backoff (``retries``
+    extra attempts, honouring ``Retry-After`` on a 429) before it is reported.
+    Without this a burst of probes against production returns a spray of
+    "uncertain" that is really just throttling, which callers then act on as
+    if the lake were unreachable.
+
+    ``retries`` defaults to 0 -- a single shot, i.e. exactly the historical
+    behaviour -- so enabling backoff never silently changes the timing of an
+    existing caller. Any caller that walks a large cohort against production
+    SHOULD opt in. NOTE: ``bind_materials`` does not yet, and it escalates an
+    uncertain probe to "abort the whole case", so a rate-limit burst there
+    aborts cases whose materials are actually present; wiring it up is a
+    deliberate behaviour change and is left to its owner.
     """
-    path = f"/materials/{source}/{urllib.parse.quote(ident, safe='')}/"
+    path = material_path(source, ident)
+    result = None
+    # `max(retries, 0)`: a negative count (argparse accepts `--probe-retries -1`)
+    # would make the range EMPTY, so nothing was ever probed and this returned
+    # the `None` initializer -- breaking the documented tri-state for every
+    # caller (`material_exists` and `build_rows` both do `.verdict` on it).
+    for attempt in range(max(retries, 0) + 1):
+        result = _probe_once(api, source, ident, path, timeout)
+        if result.verdict is not None:
+            return result
+        if attempt < retries:
+            time.sleep(_backoff_s(result.retry_after, attempt, interval))
+    return result
+
+
+def _probe_once(api, source, ident, path, timeout):
     try:
         api.get(path, timeout=timeout)
         return ProbeResult(source, ident, path, 200, True)
     except urllib.error.HTTPError as exc:
         verdict = False if exc.code in (400, 404) else None
-        return ProbeResult(source, ident, path, exc.code, verdict)
+        retry_after = None
+        if exc.code == _RATE_LIMITED:
+            raw = (exc.headers or {}).get("Retry-After")
+            retry_after = float(raw) if raw and str(raw).isdigit() else None
+        return ProbeResult(source, ident, path, exc.code, verdict, retry_after)
     except Exception:
         return ProbeResult(source, ident, path, None, None)
+
+
+def _backoff_s(retry_after, attempt, interval):
+    """Server-advertised Retry-After wins; else exponential, capped.
+
+    Clamped to >= 0 for the same reason ``retries`` is clamped in
+    :func:`probe_material`: ``time.sleep()`` raises ``ValueError`` on a negative
+    argument, so a negative ``interval`` reaching here would abort the walk with
+    a traceback partway through rather than degrade. The CLIs also reject it at
+    the flag boundary (``cli.nonneg_float``); this is the library-level guard for
+    a direct caller.
+    """
+    if retry_after is not None:
+        return min(max(retry_after, 0), _MAX_BACKOFF_S)
+    return min(max(interval, 0) * (2 ** attempt), _MAX_BACKOFF_S)
 
 
 def material_exists(api, source, ident, timeout=45):

--- a/casework/source_abhiyog.py
+++ b/casework/source_abhiyog.py
@@ -1,0 +1,387 @@
+"""Recover the {material/ag/<id> -> case number} map for AG अभियोगपत्र (the
+sourcing-side candidate producer; READ-ONLY, never writes).
+
+The bulk AG scrape landed ~99.7k charge sheets in the lake but lost the case
+number, so the indictments cannot be joined to their cases. This CLI rebuilds
+that map for the विशेष सरकारी वकील कार्यालय (Special Government Attorney
+Office) cohort:
+
+    GET ag.gov.np search API (office_type=1, office_id=2)   -> the full cohort
+      -> EXTRACT case number   (court_case_no > file > description, canonicalised)
+      -> CROSS-VALIDATE        (>=2 sources disagreeing -> flagged, both kept)
+      -> PROBE the lake        (materials.probe_material: in-lake / absent)
+      -> EMIT csv + json map   (the input a later backfill verb consumes)
+
+Why the ident join is direct: the material IRI ident IS the AG portal record id
+(see :func:`casework.common.materials.ag_ident`), so a portal record and a lake
+material share a key with no content hashing.
+
+Why three extraction sources: the portal's own ``court_case_no`` column is null
+for most rows (it was never backfilled upstream). The case number survives in
+the FILENAME (``081-CR-0094_<ts>.pdf``) and, in Devanagari, inside the
+``description`` (``(०८१-CR-००९४)``). Rows where none of the three carries a
+number are genuinely un-recoverable from metadata: they are banking-offence /
+foreign-employment prosecutions that never get a ``-CR-`` number, and the PDF
+body does not carry one either (the header reads ``२०८२ सालको मु.द.नं.......``).
+
+This tool NEVER writes -- it has no --apply. It only produces the map. The
+verb that applies it to the lake is deliberately NOT in this change: it is a
+field-level ``PATCH`` against the materials write plane, which lands
+separately. Recovering the map and writing it are independent steps, and the
+map is worth having on its own -- it is what makes the write reviewable.
+
+Usage:
+    uv run python -m casework.source_abhiyog --out work/ag-caseno-map
+    uv run python -m casework.source_abhiyog --snapshot cached.json --no-probe
+"""
+import argparse
+import csv
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+from casework.common.api import BROWSER_UA, CaseworkApi
+from casework.common.cli import (
+    add_common_args, basic_auth_from_env, configure_run_logging, log_event,
+    nonneg_float, nonneg_int, print_summary,
+)
+from casework.common.materials import ag_ident, material_iri, probe_material
+
+STAGE = "source_abhiyog"
+AG_SOURCE = "ag"
+
+#: Special Government Attorney Office. ``/offices/level/1`` on the portal lists
+#: exactly ONE office (id=2, alias `sgao`) -- levels 2/3 are the उच्च (High) and
+#: जिल्ला (District) offices, whose names do not contain विशेष. Omitting
+#: year_id/month_id returns the whole cohort in a single unpaginated response.
+AG_SEARCH_URL = (
+    "https://ag.gov.np/search-abhiyogpatra"
+    "?office_type=1&office_id=2&district_office_id=&year_id=&month_id="
+)
+
+#: Devanagari digit -> ASCII. Without this a case number like ०८१-CR-००९४ keeps
+#: its Devanagari digits and never matches an ASCII case number.
+_DEVA_DIGITS = str.maketrans("०१२३४५६७८९", "0123456789")
+#: Case number inside a filename, before the OPTIONAL `_<unix-ts>` upload
+#: suffix. The timestamp is stapled on by the portal's uploader, so it is the
+#: common shape -- but making it mandatory silently dropped any filename that
+#: carries the case number without one (`081-CR-0094.pdf`).
+_FILE_RE = re.compile(
+    r"^\s*([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)(?:_[0-9]+)?\.[A-Za-z0-9]+\s*$")
+#: Case number embedded in a Nepali description, e.g. `(०८१-CR-००९४)`. Tolerant
+#: of EITHER digit script (and a mix of the two): the description is hand-typed,
+#: so a typist using ASCII digits is common, and a Devanagari-only class scored
+#: those records "unrecoverable" when the number was sitting right there.
+_DESC_RE = re.compile(r"([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)")
+#: A bare court_case_no cell, tolerant of either digit script.
+_CCN_RE = re.compile(r"([0-9०-९]{3}-[A-Za-z]+-[0-9०-९]+)")
+#: Canonical shape after normalisation.
+_CANON_RE = re.compile(r"^([0-9]{3})-([A-Za-z]+)-([0-9]+)$")
+
+#: Highest-trust first. `court_case_no` is the portal's own structured column;
+#: the filename is machine-stapled at upload; the description is hand-typed and
+#: therefore the most typo-prone, so it loses every tie.
+SOURCE_PRIORITY = ("court_case_no", "file", "description")
+
+
+def canonical_case_no(raw):
+    """Normalise a raw case number to `NNN-TYPE-NNNN`, or None if it isn't one.
+
+    Devanagari digits are transliterated and the type token upper-cased, so the
+    same case reached via three different fields collapses to one string that
+    can be compared for agreement. Leading zeros are preserved -- they are
+    significant in a case number.
+    """
+    if not raw:
+        return None
+    m = _CANON_RE.match(str(raw).strip().translate(_DEVA_DIGITS))
+    if not m:
+        return None
+    return f"{m.group(1)}-{m.group(2).upper()}-{m.group(3)}"
+
+
+def extract_case_no(record):
+    """All case-number candidates for one portal record, keyed by source.
+
+    Returns ``(case_number, source, candidates, agree)``. ``agree`` is None when
+    fewer than two sources produced a value, else True/False. A disagreement is
+    NOT resolved here beyond the priority order -- both values are reported so
+    the caller can flag the row rather than silently pick one.
+    """
+    candidates = {}
+
+    ccn = record.get("court_case_no")
+    if ccn:
+        m = _CCN_RE.search(str(ccn))
+        if m and (c := canonical_case_no(m.group(1))):
+            candidates["court_case_no"] = c
+
+    fm = _FILE_RE.match(str(record.get("file") or ""))
+    if fm and (c := canonical_case_no(fm.group(1))):
+        candidates["file"] = c
+
+    dm = _DESC_RE.search(str(record.get("description") or ""))
+    if dm and (c := canonical_case_no(dm.group(1))):
+        candidates["description"] = c
+
+    case_no = source = None
+    for key in SOURCE_PRIORITY:
+        if key in candidates:
+            case_no, source = candidates[key], key
+            break
+
+    agree = None if len(candidates) < 2 else len(set(candidates.values())) == 1
+    return case_no, source, candidates, agree
+
+
+def fiscal_year(record):
+    return str(((record.get("month") or {}).get("year") or {}).get("name") or "")
+
+
+def validate_records(data, origin):
+    """The cohort must be a non-empty list of record objects.
+
+    Applied to a CACHED snapshot as well as a freshly fetched one: a truncated
+    or hand-edited cache is otherwise trusted blindly, and a JSON object slips
+    through to iterate as bare KEYS (``'str' object has no attribute 'get'``)
+    or silently yields an empty map.
+    """
+    if not isinstance(data, list) or not data:
+        raise SystemExit(
+            f"{origin}: expected a non-empty JSON list of AG records, got "
+            f"{type(data).__name__} (len={len(data) if hasattr(data, '__len__') else '?'})")
+    if not all(isinstance(r, dict) for r in data):
+        raise SystemExit(f"{origin}: every AG record must be a JSON object")
+    return data
+
+
+def validate_probe_cache(data, origin):
+    """The probe cache must be a JSON object of ``id -> verdict label``.
+
+    Same reasoning as :func:`validate_records`, applied to the other file this
+    CLI reads back. ``build_rows`` ASSIGNS into the cache (``cache[key] = ...``),
+    so a cache corrupted into a JSON list raises ``TypeError: list indices must
+    be integers`` partway through the cohort walk -- after the probes already
+    spent, and with nothing written.
+    """
+    if not isinstance(data, dict):
+        raise SystemExit(
+            f"probe cache {origin}: expected a JSON object of "
+            f"id -> verdict, got {type(data).__name__}")
+    bad = [k for k, v in data.items() if v not in _VERDICT_LABEL.values()]
+    if bad:
+        raise SystemExit(
+            f"probe cache {origin}: {len(bad)} entries have a verdict outside "
+            f"{sorted(_VERDICT_LABEL.values())} (e.g. {bad[:3]})")
+    return data
+
+
+def fetch_snapshot(url=AG_SEARCH_URL, timeout=120):
+    """GET the Special-office cohort from ag.gov.np. External source, not the
+    control plane, so it does NOT go through CaseworkApi -- but it reuses the
+    same browser UA (the portal serves JSON only to browser-like agents)."""
+    req = urllib.request.Request(
+        url, headers={"User-Agent": BROWSER_UA, "Accept": "application/json",
+                      "X-Requested-With": "XMLHttpRequest"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        data = json.load(r)
+    return validate_records(data, "ag.gov.np search response")
+
+
+_VERDICT_LABEL = {True: "true", False: "false", None: "error"}
+
+
+def build_rows(records, api=None, *, probe=True, interval=1.0, retries=4,
+               logger=None, events_path=None, run_id="", probe_cache=None):
+    """One output row per portal record (extraction + optional lake probe).
+
+    ``probe_cache`` (id -> verdict label) is read AND written, so a re-run over
+    the same cohort re-probes only what it has no answer for -- the probe is a
+    ~1s-apart sequential walk of the whole cohort, so an uncached re-run costs
+    minutes and needlessly re-pressures the rate limiter.
+    """
+    rows = []
+    cache = probe_cache if probe_cache is not None else {}
+    for record in records:
+        rid = record.get("id")
+        if rid is None or not str(rid).strip():
+            # No id means no ident, and ag_ident(None) would cheerfully build
+            # `/material/ag/None`. Drop the record rather than emit a row that
+            # looks bindable.
+            if logger:
+                logger.warning("skipping AG record with no id: %r",
+                               {k: record.get(k) for k in ("file", "name")})
+            continue
+        case_no, source, candidates, agree = extract_case_no(record)
+        ambiguous = agree is False
+        alts = sorted(v for v in set(candidates.values()) if v != case_no)
+        in_lake = ""
+        if probe and api is not None:
+            key = str(rid)
+            if key not in cache or cache[key] == "error":
+                # Opt in to backoff: this walks the whole cohort against
+                # production, which is exactly the burst that gets throttled.
+                verdict = probe_material(api, AG_SOURCE, ag_ident(rid),
+                                         retries=retries,
+                                         interval=interval).verdict
+                cache[key] = _VERDICT_LABEL[verdict]
+            in_lake = cache[key]
+        rows.append({
+            "id": rid,
+            "material_iri": material_iri(AG_SOURCE, ag_ident(rid)),
+            "case_number": case_no or "",
+            "source": source or "",
+            "ambiguous": "true" if ambiguous else "",
+            "alt_case_number": ";".join(alts),
+            "in_lake": in_lake,
+            "name": (record.get("name") or "").strip(),
+            "fy": fiscal_year(record),
+            "filing_date_bs": record.get("created_date_np") or "",
+            "file": record.get("file") or "",
+        })
+        if logger and events_path:
+            log_event(
+                logger, events_path, run_id=run_id, stage=STAGE,
+                slug=f"ag/{rid}", step="extract",
+                status="recovered" if case_no else "unrecoverable",
+                detail=f"case_no={case_no or '-'} source={source or '-'} "
+                       f"in_lake={in_lake or '-'}"
+                       + (" AMBIGUOUS" if ambiguous else ""))
+    return rows
+
+
+COLUMNS = ("id", "material_iri", "case_number", "source", "ambiguous",
+           "alt_case_number", "in_lake", "name", "fy", "filing_date_bs", "file")
+
+
+def write_outputs(rows, out_prefix):
+    """Write `<prefix>.csv` and `<prefix>.json`; returns the two paths.
+
+    The extension is APPENDED, not substituted: `Path.with_suffix` would turn
+    `--out map.v2` into `map.csv`, silently collapsing `map.v1` and `map.v2`
+    onto the same pair of files.
+    """
+    prefix = Path(out_prefix)
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    csv_path = prefix.with_name(prefix.name + ".csv")
+    json_path = prefix.with_name(prefix.name + ".json")
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(COLUMNS), extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(
+        json.dumps([{k: r[k] for k in COLUMNS} for r in rows],
+                   ensure_ascii=False, indent=1), encoding="utf-8")
+    return csv_path, json_path
+
+
+def summarise(rows):
+    recovered = [r for r in rows if r["case_number"]]
+    return {
+        "records": len(rows),
+        "recovered": len(recovered),
+        "unrecoverable": len(rows) - len(recovered),
+        "ambiguous": sum(1 for r in rows if r["ambiguous"]),
+        "in_lake": sum(1 for r in rows if r["in_lake"] == "true"),
+        "not_in_lake": sum(1 for r in rows if r["in_lake"] == "false"),
+        "probe_error": sum(1 for r in rows if r["in_lake"] == "error"),
+    }
+
+
+def _build_api(args):
+    if args.api_token:
+        return CaseworkApi(base_url=args.api_base_url, token=args.api_token)
+    return CaseworkApi(base_url=args.api_base_url, basic=basic_auth_from_env())
+
+
+def run(args):
+    logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
+
+    if args.snapshot and Path(args.snapshot).exists():
+        records = validate_records(
+            json.loads(Path(args.snapshot).read_text(encoding="utf-8")),
+            f"cached snapshot {args.snapshot}")
+        logger.info("snapshot: %d records from %s", len(records), args.snapshot)
+    else:
+        records = fetch_snapshot()
+        logger.info("fetched %d records from ag.gov.np", len(records))
+        if args.snapshot:
+            Path(args.snapshot).write_text(
+                json.dumps(records, ensure_ascii=False, indent=1), encoding="utf-8")
+
+    if args.limit:
+        records = records[: args.limit]
+
+    cache_path = Path(args.probe_cache) if args.probe_cache else None
+    probe_cache = {}
+    if cache_path and cache_path.exists() and not args.refresh_probes:
+        probe_cache = validate_probe_cache(
+            json.loads(cache_path.read_text(encoding="utf-8")), cache_path)
+        logger.info("probe cache: %d cached verdicts from %s",
+                    len(probe_cache), cache_path)
+
+    api = None if args.no_probe else _build_api(args)
+    try:
+        rows = build_rows(records, api, probe=not args.no_probe,
+                          interval=args.probe_interval,
+                          retries=args.probe_retries, logger=logger,
+                          events_path=paths["events"], run_id=run_id,
+                          probe_cache=probe_cache)
+    finally:
+        # Persist whatever was learned even if the walk died part-way, so an
+        # interrupted probe run does not have to start from zero.
+        if cache_path and probe_cache:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(json.dumps(probe_cache, indent=1),
+                                  encoding="utf-8")
+
+    csv_path, json_path = write_outputs(rows, args.out)
+    stats = summarise(rows)
+    logger.info("wrote %s and %s", csv_path, json_path)
+    return stats, rows
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Recover the ag/<id> -> case number map (read-only).")
+    add_common_args(parser)
+    parser.add_argument("--out", default="work/ag-caseno-map",
+                        help="Output path prefix; writes <prefix>.csv/.json.")
+    parser.add_argument("--snapshot", default="",
+                        help="Cache path for the raw AG response; reused if it "
+                             "exists (re-runs then need no network).")
+    parser.add_argument("--no-probe", action="store_true",
+                        help="Skip the lake existence probe (offline; leaves "
+                             "in_lake blank).")
+    parser.add_argument("--probe-interval", type=nonneg_float, default=1.0,
+                        help="Base backoff seconds for a throttled/uncertain "
+                             "lake probe (exponential, Retry-After honoured).")
+    parser.add_argument("--probe-retries", type=nonneg_int, default=4,
+                        help="Retries for a throttled/uncertain lake probe; "
+                             "0 for a single shot.")
+    parser.add_argument("--probe-cache", default="",
+                        help="JSON path caching id -> in-lake verdict, so a "
+                             "re-run only probes what it lacks an answer for.")
+    parser.add_argument("--refresh-probes", action="store_true",
+                        help="Ignore an existing --probe-cache and re-probe.")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if not args.dry_run:
+        # add_common_args gives every verb --apply; this one has no write path,
+        # so say so rather than print a misleading "DRY RUN" and move on.
+        print("note: --apply has no effect on source_abhiyog; it is read-only "
+              "and only produces the map a later backfill verb consumes.",
+              file=sys.stderr)
+    stats, _ = run(args)
+    # Always read-only: dry_run=True regardless of --apply.
+    print_summary(stats, True, "source abhiyog")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/casework/source_abhiyog.py
+++ b/casework/source_abhiyog.py
@@ -308,7 +308,14 @@ def run(args):
         records = fetch_snapshot()
         logger.info("fetched %d records from ag.gov.np", len(records))
         if args.snapshot:
-            Path(args.snapshot).write_text(
+            # mkdir for the same reason write_outputs and the probe-cache write
+            # do: the conventional target is `work/`, which is gitignored and so
+            # absent in a fresh clone. Without this a first run raises
+            # FileNotFoundError HERE -- after the full-cohort fetch has already
+            # been spent, discarding the one response worth caching.
+            snapshot_path = Path(args.snapshot)
+            snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_path.write_text(
                 json.dumps(records, ensure_ascii=False, indent=1), encoding="utf-8")
 
     if args.limit:

--- a/tests/casework/test_bind_materials.py
+++ b/tests/casework/test_bind_materials.py
@@ -194,6 +194,46 @@ def test_plan_case_aborts_on_uncertain_never_partial():
     assert plan.uncertain == [CO]
 
 
+class ThrottledThenOkApi(FakeApi):
+    """429s the first `fail_times` probes, then answers normally.
+
+    Models the production materials API under a sustained bind walk.
+    """
+
+    def __init__(self, fail_times, **kw):
+        super().__init__(**kw)
+        self._left = fail_times
+        self.attempts = 0
+
+    def get(self, path, timeout=60):
+        self.attempts += 1
+        if self._left > 0:
+            self._left -= 1
+            raise urllib.error.HTTPError(path, 429, "slow down", {}, None)
+        return super().get(path, timeout=timeout)
+
+
+def test_throttled_probe_no_longer_falsely_aborts_the_case():
+    # Before the retry, a 429 collapsed to "uncertain" and killed the whole
+    # case even though the material is present.
+    api = ThrottledThenOkApi(2, exists={"ciaa_press_release/2037"})
+    case = {"slug": "c", "state": "DRAFT", "evidence": []}
+    plan = plan_case(api, case, "e", [("ciaa_press_release", "2037")],
+                     probe_retries=3, probe_interval=0)
+    assert plan.action == "WOULD_PATCH"
+    assert plan.uncertain == []
+    assert [i["material_iri"] for i in plan.patch_items] == [PR]
+    assert api.attempts == 3
+
+
+def test_single_shot_still_aborts_so_the_old_behaviour_is_available():
+    api = ThrottledThenOkApi(2, exists={"ciaa_press_release/2037"})
+    case = {"slug": "c", "state": "DRAFT", "evidence": []}
+    plan = plan_case(api, case, "e", [("ciaa_press_release", "2037")],
+                     probe_retries=0)
+    assert plan.action == "ABORT_UNCERTAIN"
+
+
 # ---------------------------------------------------------------------------
 # apply_plan -- guarded, conditional on If-Match.
 # ---------------------------------------------------------------------------
@@ -234,6 +274,8 @@ def _args(dry_run, tmp_path):
     return types.SimpleNamespace(
         dry_run=dry_run, verbose=False, api_base_url="http://127.0.0.1:48010",
         api_token="", allow_remote_writes=False, report="", batch_csv="",
+        # no real backoff in tests
+        probe_retries=0, probe_interval=0,
     )
 
 

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -423,3 +423,57 @@ def test_log_run_footer_is_one_info_record_with_counts_and_duration(caplog):
     assert "error=0" in message
     assert "12.3" in message
     assert "tokens: 4200 in / 900 out" in message
+
+
+# ---------------------------------------------------------------------------
+# nonneg_int / nonneg_float -- reject at the flag boundary.
+#
+# A bare `type=int`/`type=float` accepts a negative value, and every consumer
+# then means something different by it: a negative retry count EMPTIES the
+# `range(retries + 1)` that drives the retry loops (so nothing is attempted at
+# all), and a negative interval makes `time.sleep()` raise ValueError mid-walk.
+# ---------------------------------------------------------------------------
+
+
+def test_nonneg_int_accepts_zero_and_positive():
+    from casework.common.cli import nonneg_int
+    assert nonneg_int("0") == 0
+    assert nonneg_int("4") == 4
+
+
+def test_nonneg_int_rejects_a_negative_count():
+    from casework.common.cli import nonneg_int
+    with pytest.raises(argparse.ArgumentTypeError):
+        nonneg_int("-1")
+
+
+def test_nonneg_float_accepts_zero_and_positive():
+    from casework.common.cli import nonneg_float
+    assert nonneg_float("0") == 0.0
+    assert nonneg_float("1.5") == 1.5
+
+
+def test_nonneg_float_rejects_a_negative_duration():
+    from casework.common.cli import nonneg_float
+    with pytest.raises(argparse.ArgumentTypeError):
+        nonneg_float("-0.5")
+
+
+def test_the_probe_flags_reject_negatives_end_to_end():
+    # SystemExit(2) is argparse's own "bad argument" exit.
+    from casework.bind_materials import build_parser as bind_parser
+    from casework.source_abhiyog import build_parser as source_parser
+    for parser, required, flag in (
+        (source_parser(), [], "--probe-interval"),
+        (source_parser(), [], "--probe-retries"),
+        (bind_parser(), ["--batch-csv", "b.csv"], "--probe-interval"),
+        (bind_parser(), ["--batch-csv", "b.csv"], "--probe-retries"),
+    ):
+        # Parse the SAME command line with a valid value first. Without this the
+        # SystemExit below proves nothing: argparse exits 2 for an unrecognised
+        # flag too, so a typo'd flag name would make the assertion pass while
+        # testing nothing. (It did — the version this replaces fed `--map` to a
+        # parser that has no such option.)
+        assert parser.parse_args(required + [flag, "0"]) is not None
+        with pytest.raises(SystemExit):
+            parser.parse_args(required + [flag, "-1"])

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -459,6 +459,20 @@ def test_nonneg_float_rejects_a_negative_duration():
         nonneg_float("-0.5")
 
 
+@pytest.mark.parametrize("raw", ["nan", "NaN", "inf", "-inf", "infinity"])
+def test_nonneg_float_rejects_non_finite_durations(raw):
+    """`float("nan") < 0` is False, so a bare >= 0 check lets NaN straight in.
+
+    It then reaches `time.sleep(nan)` -- ValueError, mid-walk, exactly the
+    failure the negative check exists to prevent. `inf` is a slower version of
+    the same bug: `_backoff_s` caps it at _MAX_BACKOFF_S, but the read/write
+    intervals sleep on it directly and would hang the run forever.
+    """
+    from casework.common.cli import nonneg_float
+    with pytest.raises(argparse.ArgumentTypeError):
+        nonneg_float(raw)
+
+
 def test_the_probe_flags_reject_negatives_end_to_end():
     # SystemExit(2) is argparse's own "bad argument" exit.
     from casework.bind_materials import build_parser as bind_parser

--- a/tests/casework/test_materials.py
+++ b/tests/casework/test_materials.py
@@ -214,3 +214,30 @@ def test_probe_material_reports_none_status_on_transport_error():
     from casework.common.materials import probe_material
     pr = probe_material(_StubApi(urllib.error.URLError("x")), "ag", "1")
     assert pr.status is None and pr.verdict is None
+
+
+def test_probe_material_still_probes_once_with_a_negative_retry_count():
+    # argparse accepts `--probe-retries -1`; range(-1 + 1) is EMPTY, so this
+    # used to return the None initializer and every caller's `.verdict`
+    # raised AttributeError.
+    from casework.common.materials import material_exists, probe_material
+    pr = probe_material(_StubApi({"@id": "x"}), "ag", "1", retries=-1)
+    assert pr is not None and pr.verdict is True
+    assert material_exists(_StubApi({"@id": "x"}), "ag", "1") is True
+
+
+def test_backoff_never_returns_a_negative_sleep():
+    # time.sleep() raises ValueError on a negative argument, so a negative
+    # interval would abort the walk with a traceback rather than degrade.
+    from casework.common.materials import _backoff_s
+    assert _backoff_s(None, 0, -5) == 0
+    assert _backoff_s(-3, 0, 1.0) == 0
+    assert _backoff_s(None, 3, 1.0) == 8
+
+
+def test_probe_material_survives_a_negative_interval():
+    # The uncertain path is the one that sleeps; it must not raise.
+    from casework.common.materials import probe_material
+    err = urllib.error.HTTPError("u", 503, "boom", {}, None)
+    pr = probe_material(_StubApi(err), "ag", "1", retries=2, interval=-1)
+    assert pr.status == 503 and pr.verdict is None

--- a/tests/casework/test_materials.py
+++ b/tests/casework/test_materials.py
@@ -1,6 +1,9 @@
 # tests/casework/test_materials.py
 import urllib.error
 import urllib.request
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from casework.common.api import BROWSER_UA
 from casework.common.materials import (
@@ -241,3 +244,61 @@ def test_probe_material_survives_a_negative_interval():
     err = urllib.error.HTTPError("u", 503, "boom", {}, None)
     pr = probe_material(_StubApi(err), "ag", "1", retries=2, interval=-1)
     assert pr.status == 503 and pr.verdict is None
+
+
+# ---------------------------------------------------------------------------
+# Retry-After has TWO wire forms (RFC 9110 10.2.3): delta-seconds and an
+# HTTP-date. Accepting only digits means a date-form 429 is silently discarded
+# and the probe falls back to its local schedule -- ignoring the one number the
+# server actually told us.
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_retry_after_reads_delta_seconds():
+    from casework.common.materials import _retry_after_s
+    assert _retry_after_s("120", now=_NOW) == 120.0
+
+
+def test_retry_after_reads_an_http_date_as_remaining_seconds():
+    from casework.common.materials import _retry_after_s
+    assert _retry_after_s("Thu, 23 Jul 2026 12:00:45 GMT", now=_NOW) == 45.0
+
+
+def test_retry_after_in_the_past_is_zero_not_a_negative_sleep():
+    """A clock skew or a slow hop can put the date behind us; sleep() would raise."""
+    from casework.common.materials import _retry_after_s
+    assert _retry_after_s("Thu, 23 Jul 2026 11:59:00 GMT", now=_NOW) == 0.0
+
+
+@pytest.mark.parametrize("raw", [None, "", "later", "Thu, 99 Xxx 2026"])
+def test_retry_after_ignores_what_it_cannot_parse(raw):
+    """Unparseable -> None, i.e. fall back to the exponential schedule. A
+    malformed header must not become an exception on the retry path."""
+    from casework.common.materials import _retry_after_s
+    assert _retry_after_s(raw, now=_NOW) is None
+
+
+def test_probe_material_honours_an_http_date_retry_after(monkeypatch):
+    """End-to-end: the date must reach the sleep, still under the backoff cap."""
+    from casework.common import materials as mod
+
+    when = (datetime.now(timezone.utc) + timedelta(seconds=12)).strftime(
+        "%a, %d %b %Y %H:%M:%S GMT")
+    err = urllib.error.HTTPError("u", 429, "slow down", {"Retry-After": when}, None)
+    slept = []
+    monkeypatch.setattr(mod.time, "sleep", slept.append)
+
+    pr = mod.probe_material(_StubApi(err), "ag", "1", retries=1, interval=1.0)
+
+    assert pr.status == 429 and pr.verdict is None
+    # ~12s from the server, NOT the 1.0s local schedule it would have used
+    # had the date been discarded.
+    assert len(slept) == 1 and 10 <= slept[0] <= 13, slept
+
+
+def test_retry_after_stays_under_the_backoff_cap():
+    """A server asking for an hour must not park the walk for an hour."""
+    from casework.common.materials import _MAX_BACKOFF_S, _backoff_s
+    assert _backoff_s(3600.0, 0, 1.0) == _MAX_BACKOFF_S

--- a/tests/casework/test_materials.py
+++ b/tests/casework/test_materials.py
@@ -280,22 +280,36 @@ def test_retry_after_ignores_what_it_cannot_parse(raw):
     assert _retry_after_s(raw, now=_NOW) is None
 
 
+class _FixedDatetime(datetime):
+    """`datetime` whose `now()` is _NOW, so a date-form header is exact.
+
+    Reading the live clock here would make the assertion a tolerance band: the
+    header's `strftime` truncates sub-seconds, and any pause between building it
+    and parsing it eats into the remaining delay. A band is also a weaker
+    assertion -- it would still pass if the date were parsed slightly wrong.
+    """
+
+    @classmethod
+    def now(cls, tz=None):
+        return _NOW.astimezone(tz) if tz else _NOW
+
+
 def test_probe_material_honours_an_http_date_retry_after(monkeypatch):
     """End-to-end: the date must reach the sleep, still under the backoff cap."""
     from casework.common import materials as mod
 
-    when = (datetime.now(timezone.utc) + timedelta(seconds=12)).strftime(
-        "%a, %d %b %Y %H:%M:%S GMT")
+    when = (_NOW + timedelta(seconds=12)).strftime("%a, %d %b %Y %H:%M:%S GMT")
     err = urllib.error.HTTPError("u", 429, "slow down", {"Retry-After": when}, None)
     slept = []
+    monkeypatch.setattr(mod, "datetime", _FixedDatetime)
     monkeypatch.setattr(mod.time, "sleep", slept.append)
 
     pr = mod.probe_material(_StubApi(err), "ag", "1", retries=1, interval=1.0)
 
     assert pr.status == 429 and pr.verdict is None
-    # ~12s from the server, NOT the 1.0s local schedule it would have used
+    # Exactly the server's 12s, NOT the 1.0s local schedule it would have used
     # had the date been discarded.
-    assert len(slept) == 1 and 10 <= slept[0] <= 13, slept
+    assert slept == [12.0]
 
 
 def test_retry_after_stays_under_the_backoff_cap():

--- a/tests/casework/test_source_abhiyog.py
+++ b/tests/casework/test_source_abhiyog.py
@@ -1,0 +1,249 @@
+# tests/casework/test_source_abhiyog.py
+import json
+import urllib.error
+
+import pytest
+
+from casework.source_abhiyog import (
+    build_rows, canonical_case_no, extract_case_no, fiscal_year, summarise,
+    validate_records, write_outputs,
+)
+
+
+def record(**over):
+    """A portal record shaped like the ag.gov.np search response."""
+    base = {
+        "id": 83475,
+        "name": "जिल्ला कालिकोट",
+        "description": "भ्रष्ट्राचार गरेको सम्बन्धमा (०८१-CR-००९४)",
+        "file": "081-CR-0094_1750232440.pdf",
+        "court_case_no": None,
+        "created_date_np": "2082-3-4",
+        "month": {"year": {"name": "2082"}},
+    }
+    base.update(over)
+    return base
+
+
+class FakeApi:
+    """Scripts material existence the way the real probe sees it."""
+
+    def __init__(self, exists=(), absent=(), uncertain=()):
+        self.exists, self.absent = set(exists), set(absent)
+        self.uncertain = set(uncertain)
+        self.calls = []
+
+    def get(self, path, timeout=60):
+        self.calls.append(path)
+        ident = path.removeprefix("/materials/ag/").rstrip("/")
+        if ident in self.uncertain:
+            raise urllib.error.URLError("boom")
+        if ident in self.exists:
+            return {"@id": ident}
+        raise urllib.error.HTTPError(path, 404, "nf", {}, None)
+
+
+# --------------------------------------------------------------------------
+# canonicalisation
+# --------------------------------------------------------------------------
+
+def test_canonical_transliterates_devanagari_and_upcases_type():
+    assert canonical_case_no("०८१-cr-००९४") == "081-CR-0094"
+
+
+def test_canonical_preserves_leading_zeros():
+    # 0094 must not collapse to 94 -- leading zeros are significant.
+    assert canonical_case_no("081-CR-0094") == "081-CR-0094"
+
+
+def test_canonical_rejects_non_case_numbers():
+    for junk in ("", None, "not-a-case", "81-CR-94x", "बैंकिङ्ग कसूर"):
+        assert canonical_case_no(junk) is None
+
+
+# --------------------------------------------------------------------------
+# extraction + cross-validation
+# --------------------------------------------------------------------------
+
+def test_court_case_no_wins_over_file_and_description():
+    case_no, source, cands, agree = extract_case_no(
+        record(court_case_no="082-FT-0442"))
+    assert (case_no, source) == ("082-FT-0442", "court_case_no")
+    # all three still reported, so a disagreement is visible
+    assert set(cands) == {"court_case_no", "file", "description"}
+    assert agree is False
+
+
+def test_file_wins_over_description_when_court_case_no_missing():
+    case_no, source, _, agree = extract_case_no(record())
+    assert (case_no, source, agree) == ("081-CR-0094", "file", True)
+
+
+def test_description_used_when_filename_has_no_case_number():
+    case_no, source, _, _ = extract_case_no(
+        record(file="प्रतिवादी सरस्वती खड्का_1719399807.pdf"))
+    assert (case_no, source) == ("081-CR-0094", "description")
+
+
+def test_disagreement_is_flagged_not_silently_resolved():
+    case_no, _, cands, agree = extract_case_no(
+        record(file="080-CR-0009_1.pdf",
+               description="घुस लिई (०८१-CR-०००९)"))
+    assert agree is False
+    assert case_no == "080-CR-0009"          # priority pick
+    assert cands["description"] == "081-CR-0009"  # rejected value retained
+
+
+def test_description_with_ascii_digits_is_recovered():
+    # The description is hand-typed, so a typist using ASCII digits is common.
+    # A Devanagari-only class scored these "unrecoverable" with the number
+    # sitting right there in the field.
+    case_no, source, _, _ = extract_case_no(
+        {"file": "प्रतिवादी_1.pdf", "description": "भ्रष्टाचार गरेको (081-CR-0094)"})
+    assert (case_no, source) == ("081-CR-0094", "description")
+
+
+def test_description_with_mixed_digit_scripts_is_recovered():
+    case_no, _, _, _ = extract_case_no(
+        {"file": "x.pdf", "description": "(०८१-CR-0094)"})
+    assert case_no == "081-CR-0094"
+
+
+def test_filename_without_the_upload_timestamp_is_recovered():
+    # `_<unix-ts>` is stapled on by the portal uploader, so it is the common
+    # shape -- but requiring it dropped every filename that lacks one.
+    case_no, source, _, _ = extract_case_no({"file": "081-CR-0094.pdf"})
+    assert (case_no, source) == ("081-CR-0094", "file")
+
+
+def test_filename_with_the_timestamp_still_wins_the_same_number():
+    case_no, source, _, _ = extract_case_no({"file": "081-CR-0094_1750232440.pdf"})
+    assert (case_no, source) == ("081-CR-0094", "file")
+
+
+def test_unrecoverable_record_yields_no_case_number():
+    case_no, source, cands, agree = extract_case_no(record(
+        file="लक्ष्मण चालिसे_1642407863.pdf", description="बैंकिङ्ग कसुर"))
+    assert (case_no, source, cands, agree) == (None, None, {}, None)
+
+
+def test_fiscal_year_reads_nested_month_year():
+    assert fiscal_year(record()) == "2082"
+    assert fiscal_year({"month": None}) == ""
+
+
+# --------------------------------------------------------------------------
+# rows + lake probe
+# --------------------------------------------------------------------------
+
+def test_build_rows_marks_in_lake_and_absent():
+    rows = build_rows([record(id=1), record(id=2)],
+                      FakeApi(exists=["1"]), interval=0)
+    assert [r["in_lake"] for r in rows] == ["true", "false"]
+    assert rows[0]["material_iri"] == "https://jawafdehi.org/material/ag/1"
+
+
+def test_build_rows_can_skip_probe_entirely():
+    rows = build_rows([record()], api=None, probe=False)
+    assert rows[0]["in_lake"] == ""
+
+
+def test_uncertain_probe_reports_error_not_a_false_absent():
+    # A throttled/5xx read must never be recorded as "definitely not in lake".
+    rows = build_rows([record(id=7)], FakeApi(uncertain=["7"]), interval=0)
+    assert rows[0]["in_lake"] == "error"
+
+
+def test_record_without_id_is_dropped_not_emitted_as_ag_none():
+    # ag_ident(None) would build `/material/ag/None`; such a row must not exist.
+    rows = build_rows([record(id=None), record(id=5)], api=None, probe=False)
+    assert [r["id"] for r in rows] == [5]
+
+
+def test_probe_cache_is_reused_and_not_reprobed():
+    api = FakeApi(exists=["1"])
+    cache = {}
+    build_rows([record(id=1)], api, interval=0, probe_cache=cache)
+    assert cache == {"1": "true"} and len(api.calls) == 1
+    build_rows([record(id=1)], api, interval=0, probe_cache=cache)
+    assert len(api.calls) == 1  # second run served from cache
+
+
+def test_probe_cache_retries_a_previously_errored_verdict():
+    # An "error" is not an answer -- a re-run must try it again.
+    api = FakeApi(exists=["1"])
+    cache = {"1": "error"}
+    build_rows([record(id=1)], api, interval=0, probe_cache=cache)
+    assert cache["1"] == "true"
+
+
+def test_ambiguous_row_carries_the_alternate():
+    rows = build_rows([record(file="080-CR-0009_1.pdf",
+                              description="(०८१-CR-०००९)")],
+                      api=None, probe=False)
+    assert rows[0]["ambiguous"] == "true"
+    assert rows[0]["alt_case_number"] == "081-CR-0009"
+
+
+# --------------------------------------------------------------------------
+# outputs
+# --------------------------------------------------------------------------
+
+def test_validate_records_rejects_a_corrupt_cache():
+    # A truncated/hand-edited snapshot must fail loudly, not iterate as keys.
+    for bad in ({}, [], {"a": {"id": 1}}, [1, 2], None):
+        with pytest.raises(SystemExit):
+            validate_records(bad, "cache")
+
+
+def test_validate_records_accepts_a_real_cohort():
+    assert validate_records([record()], "cache") == [record()]
+
+
+def test_write_outputs_appends_rather_than_replacing_a_dotted_suffix(tmp_path):
+    # `Path.with_suffix` would collapse map.v2 -> map.csv, clobbering map.v1.
+    csv_path, json_path = write_outputs([], tmp_path / "map.v2")
+    assert csv_path.name == "map.v2.csv"
+    assert json_path.name == "map.v2.json"
+
+
+def test_write_outputs_round_trips_devanagari(tmp_path):
+    rows = build_rows([record()], api=None, probe=False)
+    csv_path, json_path = write_outputs(rows, tmp_path / "map")
+    assert csv_path.exists() and json_path.exists()
+    loaded = json.loads(json_path.read_text(encoding="utf-8"))
+    assert loaded[0]["name"] == "जिल्ला कालिकोट"
+    assert "जिल्ला" in csv_path.read_text(encoding="utf-8")
+
+
+def test_summarise_counts_each_bucket():
+    rows = build_rows(
+        [record(id=1), record(id=2, file="x_1.pdf", description="बैंकिङ्ग")],
+        FakeApi(exists=["1"]), interval=0)
+    stats = summarise(rows)
+    assert stats["records"] == 2
+    assert stats["recovered"] == 1
+    assert stats["unrecoverable"] == 1
+    assert stats["in_lake"] == 1
+    assert stats["not_in_lake"] == 1
+
+
+def test_validate_probe_cache_rejects_a_corrupt_cache():
+    # build_rows ASSIGNS into the cache, so a list raises `list indices must be
+    # integers` partway through the walk -- after the probes are already spent.
+    from casework.source_abhiyog import validate_probe_cache
+    for bad in ([], ["1"], "true", 3):
+        with pytest.raises(SystemExit):
+            validate_probe_cache(bad, "cache.json")
+
+
+def test_validate_probe_cache_rejects_an_unknown_verdict_label():
+    from casework.source_abhiyog import validate_probe_cache
+    with pytest.raises(SystemExit, match="verdict"):
+        validate_probe_cache({"1": "maybe"}, "cache.json")
+
+
+def test_validate_probe_cache_accepts_every_real_verdict():
+    from casework.source_abhiyog import validate_probe_cache
+    cache = {"1": "true", "2": "false", "3": "error"}
+    assert validate_probe_cache(cache, "cache.json") == cache

--- a/tests/casework/test_source_abhiyog.py
+++ b/tests/casework/test_source_abhiyog.py
@@ -247,3 +247,34 @@ def test_validate_probe_cache_accepts_every_real_verdict():
     from casework.source_abhiyog import validate_probe_cache
     cache = {"1": "true", "2": "false", "3": "error"}
     assert validate_probe_cache(cache, "cache.json") == cache
+
+
+# --------------------------------------------------------------------------
+# run() -- the snapshot cache is written straight after the full-cohort fetch,
+# which is the single most expensive (and rate-limited) call in the tool. It
+# must not be the thing that throws.
+# --------------------------------------------------------------------------
+
+def test_run_creates_the_snapshot_parent_directory(tmp_path, monkeypatch):
+    """`--snapshot work/ag-raw.json` on a first run must not FileNotFoundError.
+
+    `work/` is gitignored, so it does not exist in a fresh clone -- and the
+    write lands AFTER the cohort has already been fetched, so the crash
+    discards the one response we most want to keep. `write_outputs` and the
+    probe-cache write both mkdir their parent; this path was the outlier.
+    """
+    from casework import source_abhiyog as mod
+
+    monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setattr(mod, "fetch_snapshot", lambda: [record()])
+
+    snapshot = tmp_path / "work" / "nested" / "ag-raw.json"
+    assert not snapshot.parent.exists()
+    args = mod.build_parser().parse_args(
+        ["--no-probe", "--out", str(tmp_path / "out" / "map"),
+         "--snapshot", str(snapshot)])
+
+    stats, rows = mod.run(args)
+
+    assert stats["records"] == 1
+    assert json.loads(snapshot.read_text(encoding="utf-8"))[0]["id"] == 83475


### PR DESCRIPTION
Replaces #369, cut down to the half that stands on its own. #369 bundled two
separable things — *recovering* the case-number map and *writing* it to the lake
— and the write half is obsoleted by the field-level PATCH in #370. This is the
recovery half only. #369 is closed rather than force-pushed so its review thread
stays readable.

## Why

The bulk AG scrape landed ~99.7k charge sheets in the lake but dropped the case
number, so the indictments cannot be joined to their cases. This rebuilds that
map for the विशेष सरकारी वकील कार्यालय cohort.

## What it does

`source_abhiyog` is **read-only**. It has no write path at all, and `--apply`
says so explicitly rather than printing a misleading `DRY RUN`.

```
GET ag.gov.np search API (office_type=1, office_id=2)   -> the full cohort
  -> EXTRACT case number   (court_case_no > file > description, canonicalised)
  -> CROSS-VALIDATE        (>=2 sources disagreeing -> flagged, both kept)
  -> PROBE the lake        (in-lake / absent)
  -> EMIT csv + json map
```

**Three extraction sources**, because the portal's own `court_case_no` column is
null for most rows — it was never backfilled upstream. The number survives in the
PDF filename (`081-CR-0094_<ts>.pdf`) and, in Devanagari, inside the description
(`(०८१-CR-००९४)`).

**Rows where none of the three carries a number are reported, not guessed at.**
They are genuinely un-recoverable from metadata: banking-offence and
foreign-employment prosecutions never get a `-CR-` number, and the PDF body does
not carry one either (the header reads `२०८२ सालको मु.द.नं.......`).

**The join is direct**, not content-hashed: a material IRI's ident *is* the AG
portal record id.

## Also in here

`probe_material` grew retry/backoff and `bind_materials` now uses it. Same root
cause: the production materials API 429s under a sustained walk, and an
uncertain probe is a **hard stop** that aborts the case. So a rate-limit burst
was aborting cases whose materials were perfectly present — a false negative
that reads exactly like a data problem. Default is 0 retries, so a direct caller
is unchanged; the CLI turns it on.

## Not in here

The verb that **writes** the map to the lake. That is a field-level `PATCH`
against the materials write plane (#370) and lands separately, once #370 is
merged and deployed. Recovering the map and applying it are independent steps,
and the map is worth having on its own — it is what makes the write reviewable.

Dropping it also drops ~980 lines that #370 obsoletes outright: a `GET → merge →
PUT whole document` loop, its guards (which were TOCTOU by construction — checked
after a GET, acted on later), and a 70-line advisory lock that existed *only*
because that shape is racy. Under #370 the guards become `test` ops evaluated
inside the row lock, and the 553 GETs disappear entirely.

## Verification

- `tests/casework/` — 627 passed
- full suite, CI-exact (`--ignore=integration-tests`) — 2323 passed
- `ruff check` clean; pre-commit clean

**No production writes.** This verb has no `--apply` path to exercise.

## One thing worth knowing

While porting, the negative-duration CLI test turned out to be passing for the
wrong reason: it fed `--map` to a parser that has no such option, so argparse
exited 2 on the *unrecognised flag* and `pytest.raises(SystemExit)` held
regardless of the value under test. It now parses the same command line with a
valid value first, so the exit can only come from the flag being tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only tool to map portal materials to case numbers, with CSV and JSON exports.
  * Added case-number normalization, ambiguity detection, fiscal-year extraction, lake availability status, and probe caching for incremental runs.
  * Added configurable material-probing retries and intervals, including rate-limit-aware backoff via new CLI flags.
* **Bug Fixes**
  * Transient throttling/uncertain probe outcomes can now recover through retries instead of triggering premature aborts.
  * Negative values for retry/interval options are now rejected at parse time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->