### PR TITLE
fix(courts): transliterate district case numbers + cap high case_type

### DIFF
--- a/courts/scraper/district.py
+++ b/courts/scraper/district.py
@@ -117,7 +117,16 @@ def _parse_row(
     # Cell 1 carries the case number on line 1 and (when present) a parenthetical
     # secondary/original id on line 2 — split on the <br>-derived newlines.
     case_parts = cells[1].get_text(separator="\n").strip().split("\n")
-    case_number = normalize_whitespace(case_parts[0]) if case_parts else ""
+    # Transliterate Devanagari digits to ASCII up front (as serial_no/case_id below
+    # already do): a district number has a NUMERIC middle segment (082-02-0001),
+    # which best_effort_normalize cannot canonicalise (_CASE_RE wants a letter-led
+    # middle) and so returns unchanged — leaving Devanagari digits that then fail
+    # court-case IRI minting and dead-letter the whole scrape.
+    case_number = (
+        nepali_to_roman_numerals(normalize_whitespace(case_parts[0]))
+        if case_parts
+        else ""
+    )
     if not case_number:
         return None
     case_number = best_effort_normalize(case_number)

--- a/courts/scraper/high.py
+++ b/courts/scraper/high.py
@@ -180,7 +180,9 @@ def _parse_row(
         court_identifier=court_identifier,
         registration_date_bs=registration_date or None,
         registration_date_ad=bs_to_ad(registration_date),
-        case_type=normalize_whitespace(cells[3].get_text()) or None,
+        # Cap to the column width (as district/special/the enrich path do): a
+        # mis-parsed cell must truncate, not dead-letter the whole court's scrape.
+        case_type=normalize_whitespace(cells[3].get_text())[:200] or None,
         plaintiff=normalize_whitespace(plaintiff_raw) or None,
         defendant=normalize_whitespace(defendant_raw) or None,
         # ``division`` (फाँट) is not a v2 court_cases column → extra_data only.

--- a/courts/tests/test_scraper_district.py
+++ b/courts/tests/test_scraper_district.py
@@ -251,3 +251,50 @@ def test_empty_page_returns_no_rows():
         )
         == []
     )
+
+
+# A district number with a NUMERIC middle segment (082-02-0001): best_effort_normalize
+# cannot canonicalise it (_CASE_RE wants a LETTER-led middle like CR), so it returns the
+# value UNCHANGED — the parser itself must transliterate the Devanagari digits, or the
+# raw Devanagari reaches court-case IRI minting and dead-letters the whole court's scrape.
+_DAILY_LIST_NUMERIC_MIDDLE = """
+<html><body>
+  <div>
+    <table>
+      <tr><td class="judge">न्यायाधीश राम</td><td align="right">इजलास नं. १</td></tr>
+    </table>
+    <table border="1" class="record_display">
+      <tr><th>क्र.सं.</th><th>मुद्दा नं.</th><th>दर्ता मिति</th><th>मुद्दा</th><th>वादी</th>
+          <th>प्रतिवादी</th><th>दफा</th><th>प्राथमिकता</th><th>कैफियत</th><th>किसिम</th></tr>
+      <tr>
+        <td>१</td>
+        <td>०८२-०२-०००१</td>
+        <td>२०८२/०२/०१</td>
+        <td>अंश</td>
+        <td>वादी क</td>
+        <td>प्रतिवादी ख</td>
+        <td>-</td><td>-</td><td></td>
+        <td>पेशी</td>
+      </tr>
+    </table>
+  </div>
+</body></html>
+"""
+
+
+def test_parse_daily_list_numeric_middle_case_number_is_ascii():
+    """A numeric-middle district number (082-02-0001) transliterates to ASCII and mints
+    a valid court-case IRI. Regression: the raw Devanagari digits fell through
+    best_effort_normalize unchanged and dead-lettered every district court at IRI minting."""
+    from jawafdehi_shared.entities.ids import build_courtcase_iri
+
+    rows = parse_daily_list(
+        _DAILY_LIST_NUMERIC_MIDDLE, court_identifier="achham_dc", date_bs="2082-02-15"
+    )
+    assert len(rows) == 1
+    (case, _hearing) = rows[0]
+    assert case.case_number == "082-02-0001"  # ASCII, not the raw ०८२-०२-०००१
+    # the IRI minter (which rejected the Devanagari form) now accepts it
+    assert build_courtcase_iri("achham_dc", case.case_number).endswith(
+        "/courtcase/achham_dc/082-02-0001"
+    )

--- a/courts/tests/test_scraper_high.py
+++ b/courts/tests/test_scraper_high.py
@@ -208,3 +208,36 @@ def test_parse_high_detail_drops_status_artifact_and_uses_hearings():
     assert "case_status" not in enr.core_fields
     # verdict recovered from the final decisive hearing (फैसला / सफाई → acquittal)
     assert enr.core_fields["verdict_type"] == ACQUITTED
+
+
+def test_parse_bench_page_caps_overlong_case_type():
+    """An overlong/mis-parsed मुद्दा cell truncates to the column width (200) instead of
+    dead-lettering the court on a varchar(200) overflow. Regression: the High cause-list
+    left case_type uncapped while district/special/the enrich path all cap it."""
+    long_type = "क" * 250  # over CourtCase.case_type's varchar(200)
+    page = f"""
+    <html><body>
+      <h4>इजलास नं. १</h4>
+      <table class="table table-bordered table-hover">
+        <tbody>
+          <tr class="data_row">
+            <td>१</td><td>फौजदारी</td><td>२०८१/०५/१२</td><td>{long_type}</td>
+            <td>०८१-CR-०१२३</td>
+            <td>वादी क</td><td>-</td><td>-</td><td>पेशी</td>
+          </tr>
+        </tbody>
+      </table>
+    </body></html>
+    """
+    rows = parse_bench_page(
+        page,
+        court_identifier="high_patan",
+        date_bs="2081-05-12",
+        bench_id="101",
+        bench_no="१",
+        judge_name="न्या. गोपाल राई",
+    )
+    assert len(rows) == 1
+    (case, _hearing) = rows[0]
+    assert len(case.case_type) == 200
+    assert case.case_number == "081-CR-0123"  # unaffected


### PR DESCRIPTION
## Problem

Turning the court-case scraper on (`ngm-court-scrape`, #364) surfaced that **district-court scraping was fully broken**. On the first scheduled runs, **66 `court_scrape` jobs dead-lettered** — almost all district courts — with:

```
Invalid court/case_number for court-case IRI: 'achhamdc'/'०८२-०२-०००१'
```

District cause-list case numbers have a **numeric** middle segment (`082-02-0001`). `normalize_case_number` / `best_effort_normalize` only canonicalise a **letter-led** middle (`_CASE_RE = ^(\d+)-([A-Z][A-Z0-9]*)-(\d+)$`), so for a numeric-middle number they raise `ValueError` and pass the value through **unchanged** — leaving the raw **Devanagari** (`०८२-०२-०००१`), which the court-case IRI minter rejects (non-ASCII). Every district court that actually had cases failed all 3 retries and died. (Supreme/High were fine — their numbers are letter-middle and canonicalise to ASCII.)

A separate High court job also died on a `varchar(200)` overflow from an over-long / mis-parsed `मुद्दा` (case_type) cell — the High cause-list left `case_type` uncapped while district/special and High's own enrich path all cap it.

## Fix

- **`district.py`** — transliterate the primary case number's digits up front (`nepali_to_roman_numerals`), exactly as the file already does for `serial_no` / `case_id` / `secondary_case_number`. `082-02-0001` now reaches the IRI minter as ASCII.
- **`high.py`** — cap cause-list `case_type` to `[:200]`, matching its siblings.

## Verification

- `courts/` suite + ruff green; **2 regression tests** added (numeric-middle → ASCII + valid IRI; over-long case_type → truncated to 200).
- **Live fetch+parse** of a real previously-dead district (**Sunsari**) most-recent date: all case numbers ASCII + IRI-valid, including numeric-middle `083-02-0001`.

## Follow-ups (not in this PR)

- The per-parser `[:200]` caps are fragile — this is the *second* parser to miss one. A central truncation at the persistence boundary (`base.upsert_causelist` / enrich apply, by column `max_length`) would prevent the whole class. Left out to keep this change tightly scoped.
- After deploy: requeue the dead district/high `court_scrape` jobs (the `ScrapedDate` frontier keeps already-done courts cheap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of district case numbers containing Nepali numerals, ensuring consistent case numbers and valid case links.
  * Prevented unusually long case-type entries from disrupting high-court cause-list processing.

* **Tests**
  * Added coverage for Nepali numeral conversion in district case numbers.
  * Added coverage for truncating overlong case-type values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->