### PR TITLE
fix(courts): stop storing internal bench-id as special-court bench_type

### DIFF
--- a/courts/scraper/special.py
+++ b/courts/scraper/special.py
@@ -64,8 +64,7 @@ def crawl_date(fetch, court_id, date_bs, nepali_date) -> list[tuple[ParsedCase, 
                   "bench_type": bench["value"], "yo": "1"},
         )
         rows.extend(
-            parse_bench_page(page, date_bs=date_bs, bench_type=bench["value"],
-                             bench_label=bench["label"])
+            parse_bench_page(page, date_bs=date_bs, bench_label=bench["label"])
         )
     return rows
 
@@ -99,7 +98,6 @@ def parse_bench_page(
     html: str,
     *,
     date_bs: str,
-    bench_type: str | None = None,
     bench_label: str | None = None,
 ) -> list[tuple[ParsedCase, ParsedHearing]]:
     """Parse one bench's case table (stage 2) into (case, hearing) rows."""
@@ -124,7 +122,6 @@ def parse_bench_page(
             tr.find_all("td"),
             date_bs=date_bs,
             hearing_date_ad=hearing_date_ad,
-            bench_type=bench_type,
             bench_label=bench_label,
             court_number=court_number,
             judge_names=judge_names,
@@ -157,7 +154,6 @@ def _parse_row(
     *,
     date_bs: str,
     hearing_date_ad: date | None,
-    bench_type: str | None,
     bench_label: str | None,
     court_number: str,
     judge_names: str | None,
@@ -191,7 +187,11 @@ def _parse_row(
         court_identifier=COURT_ID,
         hearing_date_bs=date_bs,
         hearing_date_ad=hearing_date_ad,
-        bench_type=bench_type,
+        # NB: bench_type is intentionally left unset. The bench <select> option
+        # VALUE is an internal per-sitting bench id (e.g. "8860"), NOT a bench TYPE
+        # (single/joint) — writing it here produced 36k numeric-junk bench_types
+        # across the special court. The bench's identity is its judges, carried in
+        # judge_names (+ the short form in extra_data.bench_label).
         serial_no=nepali_to_roman_numerals(normalize_whitespace(cells[0].get_text()))
         or None,
         judge_names=judge_names,

--- a/courts/tests/test_scraper_special.py
+++ b/courts/tests/test_scraper_special.py
@@ -38,7 +38,7 @@ def test_parse_bench_options_discovers_benches():
 
 
 def test_parse_bench_page_maps_rows_and_normalizes():
-    rows = parse_bench_page(_BENCH_PAGE, date_bs="2082-01-05", bench_type="1")
+    rows = parse_bench_page(_BENCH_PAGE, date_bs="2082-01-05", bench_label="इजलास १")
     assert len(rows) == 2
 
     (case0, hearing0) = rows[0]
@@ -61,12 +61,16 @@ def test_parse_bench_page_maps_rows_and_normalizes():
     assert hearing0.decision_type == "सफाई"
     assert hearing0.judge_names and "राम" in hearing0.judge_names
     assert hearing0.extra_data["court_number"] == "इजलास नं. १"
+    # bench_type is NOT the internal bench dropdown id; the bench label (judges)
+    # is kept in extra_data instead.
+    assert hearing0.bench_type is None
+    assert hearing0.extra_data["bench_label"] == "इजलास १"
 
 
 def test_ported_normalization_composes_with_parse():
     # The whole point of the port: parsed hearings feed the case_status
     # normalization to derive a verdict the cause-list never states directly.
-    rows = parse_bench_page(_BENCH_PAGE, date_bs="2082-01-05", bench_type="1")
+    rows = parse_bench_page(_BENCH_PAGE, date_bs="2082-01-05", bench_label="इजलास १")
     decided_hearing = rows[0][1]
     pending_hearing = rows[1][1]
 


### PR DESCRIPTION
Forward-looking scraper fix from the NGM v2 round-2 DQ profile. The two one-time data cleanups are **run out-of-band, not committed as management commands** (use-and-throw scripts — see below).

## What's in this PR (permanent code)
The Special-court cause-list scraper stored the bench `<select>` option **value** — an internal per-sitting bench id like `8860` — in the hearing's `bench_type`, which is meant for a bench *type* (single/joint). Result: **36,433 hearings (100% Special)** with a bare-integer `bench_type` that is not a type at all. The bench's identity is its judges, already captured in `judge_names` (+ the short form in `extra_data.bench_label`), so the scraper now leaves `bench_type` unset. (`courts/scraper/special.py` + test.)

## Out-of-band one-time backfills (not in this PR)
Both are use-and-throw scripts run in the platform pod via `manage.py shell`, dry-run by default (`APPLY=1` to write). **Smoke-tested locally end-to-end** against a seeded sqlite `ngm` DB (dry-run / apply / idempotency + a 9-assertion state check, all pass).

1. **bench_type cleanup** — numeric `bench_type` → NULL, raw archived to `extra_data._dq.bench_type_raw` (reversible). Not indexed → no reindex.
2. **verdict_judge recovery** — ~468k DECIDED cases (`verdict_date_ad` present) have an empty `verdict_judge`; the deciding bench sits on the `court_case_hearings` row for the verdict date (`judge_names` ~98% present). The script fills only decided-but-empty rows from the verdict-date hearing (preferring a final-verdict sitting), marks `extra_data._dq.verdict_judge_derived`, and leaves the rest NULL. `verdict_judge` **is** indexed → run `reindex_courtcases --since <start>` after an APPLY pass.

### Validation (real ngm_v2, via the read-only judicial proxy)
On districts that *do* fill `verdict_judge` (baglungdc, gorkhadc): **100%** of decided-with-judge cases have `judge_names` on the verdict-date hearing, and it's the **same judge** — just a fuller honorific form (`माननीय जिल्ला न्यायाधीश श्री X` vs enrichment's `श्री X`). Special (never fills it): all 11,880 gap cases recoverable.

### Rollout (after merge)
1. `backfill_bench_type` script: dry-run → `APPLY=1` (~36k rows; no reindex).
2. `backfill_verdict_judge` script: dry-run → `APPLY=1`, then `reindex_courtcases --since <start>`.

Full round-2 profile + the scripts: `jawafdehi-meta docs/2026-07-24-ngm-v2-data-quality-round2/` and `work/2026-07-24-ngm-dq-fixes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)