### PR TITLE
feat(courts): capture Supreme/Special court orders (scrape_court_orders)

### DIFF
--- a/courts/management/commands/scrape_court_orders.py
+++ b/courts/management/commands/scrape_court_orders.py
@@ -1,0 +1,428 @@
+"""Capture Supreme/Special court-order documents into the platform.
+
+The recurring replacement for the retired ``supreme_court_orders`` Scrapy spider
+(archived ``Jawafdehi/ngm``). Order documents live behind a CAPTCHA-gated search
+form on ``supremecourt.gov.np/cp/`` — separate from the cause-list/detail pages
+``scrape_courtcases`` walks. For each decided Supreme/Special case still missing
+its order, this GETs the homepage (to seed the CAPTCHA session cookie), POSTs the
+search form, parses the result page, downloads each order file to the durable
+store, mints a ``court_order`` Material (``isPartOf`` the ngm case), and records a
+canonical DocumentSource on the case's ``document_sources`` column.
+
+Dry-run by default (GET→CAPTCHA→POST→parse, read-only, reports the outcome).
+``--write`` persists (downloads, stores, materializes, updates the case).
+
+    manage.py scrape_court_orders --limit 5                     # dry-run recon
+    manage.py scrape_court_orders --case supreme:082-WO-0123    # one case, dry-run
+    manage.py scrape_court_orders --court special --write       # persist backlog
+    manage.py scrape_court_orders --write --limit 3000          # the CronJob run
+
+The pure parse/shape/select halves live in ``courts.scraper.orders`` (unit-tested);
+this command adds the live HTTP, the download→store→materialize plumbing, and the
+``extra_data`` order-state writes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+import time
+from datetime import date
+from urllib.parse import urlparse
+
+from django.core.files.base import ContentFile
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Max
+from django.utils import timezone
+
+from courts.models import CourtCase, CourtCaseHearing
+from courts.scraper import orders as O
+from jawafdehi_shared.storage import store_file_as_link
+from materials.jsonld import MaterialType, court_order_to_jsonld
+from materials.provenance import attach_media_object, build_provenance
+from materials.single_source_ingest import upsert_single_source_material
+
+_UA = "Mozilla/5.0 (X11; Linux x86_64) Jawafdehi-courts-crawler"
+
+#: File-extension → encodingFormat for the order documents the portal serves.
+_ENCODING = {
+    ".pdf": "application/pdf",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument"
+    ".wordprocessingml.document",
+}
+
+#: Homepage GETs tolerated when the CAPTCHA cookie fails to appear.
+MAX_HOMEPAGE_RETRIES = 3
+#: Fresh-session retries after the server rejects the CAPTCHA answer.
+MAX_CAPTCHA_RETRIES = 5
+
+#: Opt-in gate (mirrors the retired spider's ``ENABLE_CAPTCHA_COOKIE_EXTRACT``):
+#: this command drives a CAPTCHA-gated search against a live government portal,
+#: so it refuses to run — even a read-only dry-run — unless this env is truthy.
+#: The recurring CronJob sets it; an accidental/unattended invocation stays inert.
+CAPTURE_ENABLED_ENV = "ENABLE_COURT_ORDER_CAPTURE"
+
+
+class OrdersHttpClient:
+    """The live ``/cp`` transport: a fresh cookie jar per case (a returning
+    ``court_session`` cookie suppresses the Set-Cookie the CAPTCHA answer rides
+    on), read-only GET/POST/download. Never raises — a transport failure returns
+    ``status=None`` so the caller can treat it as a transient, re-crawlable error.
+    """
+
+    def __init__(self, timeout: int = 60):
+        import requests
+
+        self._requests = requests
+        self._timeout = timeout
+        self._session = None
+
+    def new_session(self) -> None:
+        self._session = self._requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": _UA,
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+        )
+
+    def homepage(self) -> tuple[int | None, str | None, str | None]:
+        """GET the homepage → ``(status, court_session_cookie_value, retry_after)``."""
+        try:
+            resp = self._session.get(O.HOMEPAGE_URL, timeout=self._timeout)
+        except Exception:
+            return None, None, None
+        return (
+            resp.status_code,
+            self._session.cookies.get("court_session"),
+            resp.headers.get("Retry-After"),
+        )
+
+    def search(self, form: dict) -> tuple[int | None, str, str | None]:
+        """POST the search form → ``(status, html, retry_after)``."""
+        headers = {"Origin": O.ORIGIN, "Referer": O.HOMEPAGE_URL}
+        try:
+            resp = self._session.post(
+                O.HOMEPAGE_URL, data=form, headers=headers, timeout=self._timeout
+            )
+        except Exception:
+            return None, "", None
+        return resp.status_code, resp.text, resp.headers.get("Retry-After")
+
+    def download(self, url: str) -> tuple[int | None, bytes]:
+        """GET one order file → ``(status, content)`` (uses the CAPTCHA session)."""
+        try:
+            resp = self._session.get(url, timeout=self._timeout)
+        except Exception:
+            return None, b""
+        return resp.status_code, resp.content
+
+
+def build_http_client(timeout: int) -> OrdersHttpClient:
+    """Factory (a seam for tests to inject a fake transport)."""
+    return OrdersHttpClient(timeout=timeout)
+
+
+class _Backoff:
+    """A polite server-error backoff — exponential, honoring ``Retry-After``.
+
+    The June rate experiment found no per-IP wall at ~1,200 cases/hr off-peak but
+    could not test Nepal midday peak; this self-regulates that untested window
+    (REPORT.md rec #2). ``sleep`` is injected so tests don't wait.
+    """
+
+    LADDER = (30, 60, 120, 300, 600)
+
+    def __init__(self, sleep):
+        self._sleep = sleep
+        self._idx = -1
+
+    def ok(self) -> None:
+        self._idx = -1
+
+    def server_error(self, retry_after: str | None = None) -> None:
+        self._idx = min(self._idx + 1, len(self.LADDER) - 1)
+        secs = self.LADDER[self._idx]
+        try:
+            secs = max(secs, int(float(retry_after))) if retry_after else secs
+        except (TypeError, ValueError):
+            pass
+        self._sleep(secs)
+
+
+class Command(BaseCommand):
+    help = "Capture Supreme/Special court-order documents into the platform."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--court", default="all", help="supreme | special | all (default all)"
+        )
+        parser.add_argument(
+            "--limit", type=int, default=3000, help="max cases per run (default 3000)"
+        )
+        parser.add_argument(
+            "--delay", type=float, default=3.0,
+            help="seconds between cases (default 3.0; the proven-polite prod rate)",
+        )
+        parser.add_argument(
+            "--case", default=None,
+            help="a single 'court:case_number' (smoke test; ignores backlog filters)",
+        )
+        parser.add_argument(
+            "--today", default=None, help="AD anchor date YYYY-MM-DD (default: today)"
+        )
+        parser.add_argument("--timeout", type=int, default=60, help="HTTP timeout (s)")
+        parser.add_argument(
+            "--write", action="store_true",
+            help="download + persist (default: dry-run — GET/POST/parse only)",
+        )
+
+    def handle(self, *args, **o):
+        if os.environ.get(CAPTURE_ENABLED_ENV, "").strip().lower() not in ("1", "true", "yes"):
+            raise CommandError(
+                "court-order capture is DISABLED. This command drives a "
+                "CAPTCHA-gated search against supremecourt.gov.np; set "
+                f"{CAPTURE_ENABLED_ENV}=1 to run it (the recurring CronJob sets this)."
+            )
+        courts = self._resolve_courts(o["court"])
+        today = self._anchor(o["today"])
+        write = o["write"]
+        delay = max(0.0, o["delay"])
+        cases = self._select_cases(o["case"], courts, o["limit"], today)
+        client = build_http_client(o["timeout"])
+        backoff = _Backoff(time.sleep)
+
+        mode = "WRITE" if write else "DRY-RUN"
+        self.stdout.write(
+            f"scrape_court_orders [{mode}] courts={list(courts)} "
+            f"cases={len(cases)} today={today}"
+        )
+
+        tally = {k: 0 for k in ("docs", "no_record", "too_recent", "failed", "transient")}
+        for i, case in enumerate(cases, 1):
+            outcome, detail = self._process(case, client, today, write, backoff)
+            tally[outcome] = tally.get(outcome, 0) + 1
+            self.stdout.write(
+                f"  [{i}/{len(cases)}] {case.court_id}:{case.case_number} "
+                f"-> {outcome}{f' ({detail})' if detail else ''}"
+            )
+            if delay and i < len(cases):
+                time.sleep(delay)
+
+        self.stdout.write(
+            "done: "
+            + " ".join(f"{k}={v}" for k, v in tally.items())
+        )
+
+    # ── case selection ───────────────────────────────────────────────────────
+
+    def _select_cases(self, one, courts, limit, today):
+        if one:
+            court, _, case_number = one.partition(":")
+            if not case_number:
+                raise CommandError("--case must be 'court:case_number'")
+            case = (
+                CourtCase.objects.using("ngm")
+                .filter(court_id=court, case_number=case_number, is_deleted=False)
+                .first()
+            )
+            if case is None:
+                raise CommandError(f"case not found: {court}:{case_number}")
+            return [case]
+        return list(O.orders_backlog_queryset(courts=courts, today=today)[:limit])
+
+    @staticmethod
+    def _resolve_courts(value):
+        value = (value or "all").lower()
+        if value == "all":
+            return O.ORDER_COURTS
+        if value in O.ORDER_COURTS:
+            return (value,)
+        raise CommandError(f"--court must be one of {('all', *O.ORDER_COURTS)}, got {value!r}")
+
+    # ── per-case capture cycle ───────────────────────────────────────────────
+
+    def _process(self, case, client, today, write, backoff):
+        """Run the GET→CAPTCHA→POST→parse cycle and apply the outcome.
+
+        Returns ``(outcome, detail)`` where outcome is one of docs/no_record/
+        too_recent/failed/transient.
+        """
+        result = self._search_with_retries(case, client, backoff)
+        if result is None:
+            return self._apply_transient(case, "captcha_unresolved", write)
+
+        if result.status == O.SERVER_ERROR:
+            return self._apply_transient(case, f"server_error: {result.detail}"[:200], write)
+        if result.status == O.NOT_RESULTS_PAGE:
+            return self._apply_transient(case, "not_results_page", write)
+        if result.status == O.NO_RECORD:
+            return self._apply_no_record(case, today, write)
+        # result.status == DOCS
+        return self._capture_docs(case, result.doc_urls, client, write, backoff)
+
+    def _search_with_retries(self, case, client, backoff):
+        """GET→CAPTCHA→POST, retrying a fresh session on a missing/invalid CAPTCHA.
+
+        Returns an ``OrderResult`` (docs/no_record/server_error/not_results_page),
+        or ``None`` when the CAPTCHA could never be resolved this run.
+        """
+        for _ in range(MAX_CAPTCHA_RETRIES):
+            captcha = None
+            for _ in range(MAX_HOMEPAGE_RETRIES):
+                client.new_session()
+                status, cookie, retry_after = client.homepage()
+                if status is None or status >= 500:
+                    backoff.server_error(retry_after)
+                    continue
+                captcha = O.extract_captcha(cookie)
+                if captcha:
+                    break
+            if not captcha:
+                continue
+
+            form = O.order_form_data(
+                case.court_id, case.case_number, case.registration_date_bs, captcha
+            )
+            status, html, retry_after = client.search(form)
+            if status is None or status >= 500:
+                backoff.server_error(retry_after)
+                continue
+            backoff.ok()
+            result = O.parse_order_results(html)
+            if result.status == O.INVALID_CAPTCHA:
+                continue  # fresh session, new CAPTCHA
+            return result
+        return None
+
+    def _capture_docs(self, case, doc_urls, client, write, backoff):
+        """Download each order file, store durably, and materialize."""
+        if not write:  # dry-run: report the found documents without downloading
+            return "docs", f"{len(doc_urls)} file(s) [dry-run]"
+
+        files = []
+        for url in doc_urls:
+            status, content = client.download(url)
+            if status is None or status >= 500:
+                backoff.server_error()
+                return self._apply_transient(case, f"download {status} {url}"[:200], write)
+            if status != 200 or not content:
+                return self._apply_transient(case, f"download {status} {url}"[:200], write)
+            ext = (posixpath.splitext(urlparse(url).path)[1] or ".doc").lower()
+            files.append(
+                {
+                    "source_url": url,
+                    "content": content,
+                    "is_pdf": ext == ".pdf",
+                    "ext": ext,
+                    "sha": hashlib.sha256(content).hexdigest(),
+                    "len": len(content),
+                }
+            )
+        backoff.ok()
+
+        stored = []
+        safe_case = case.case_number.replace("/", "-")
+        for n, f in enumerate(files, 1):
+            # A unique per-file name: the durable store hashes the NAME (not the
+            # bytes), so two same-extension files on one case would otherwise
+            # collide. Mirrors the retired pipeline's ``{case}.{n}{ext}``.
+            name = f"{case.court_id}-{safe_case}.{n}{f['ext']}"
+            link = store_file_as_link(ContentFile(f["content"], name=name))["link"]
+            stored.append({**f, "link": link})
+
+        src = O.build_order_document_source(case.court_id, case.case_number, stored)
+        self._materialize(case, src, stored)
+
+        case.document_sources = [src]
+        case.extra_data = O.mark_success(
+            case.extra_data,
+            links=[link["link"] for link in src["url"]],
+            now_iso=self._now_iso(),
+        )
+        case.save(
+            using="ngm",
+            update_fields=["document_sources", "extra_data", "updated_at"],
+        )
+        return "docs", f"{len(stored)} file(s)"
+
+    def _materialize(self, case, src, stored):
+        """Mint/refresh the standalone ``court_order`` Material for the case.
+
+        Built from the DocumentSource, then the ``associatedMedia`` is rebuilt so
+        each file carries capture provenance (sha256). Feeding the durable link in
+        via ``court_order_to_jsonld`` AND ``attach_media_object`` would emit a
+        no-sha duplicate MediaObject, so the roled media are (re)attached here.
+        """
+        doc = court_order_to_jsonld(
+            src, court_identifier=case.court_id, case_number=case.case_number, n=None
+        )
+        doc["associatedMedia"] = []
+        by_link = {f["link"]: f for f in stored}
+        for link in src["url"]:
+            f = by_link[link["link"]]
+            attach_media_object(
+                doc,
+                content_url=link["link"],
+                role=link["role"],
+                encoding_format=_ENCODING.get(f["ext"]),
+                provenance=build_provenance(
+                    sha256=f["sha"],
+                    fetch_method="scrape",
+                    source_url=f["source_url"],
+                    content_length=f["len"],
+                ),
+            )
+        upsert_single_source_material(doc, material_type=MaterialType.COURT_ORDER)
+
+    # ── outcome application ──────────────────────────────────────────────────
+
+    def _apply_no_record(self, case, today, write):
+        """No document on the portal: a permanent failure for an old decided case,
+        else a soft ``too_recent`` re-check."""
+        expected = O.is_document_expected(self._last_hearing(case), today=today)
+        outcome = "failed" if expected else "too_recent"
+        if not write:
+            return outcome, "no document [dry-run]"
+        if expected:
+            case.extra_data = O.mark_failed(
+                case.extra_data, error="no_document_old_case", now_iso=self._now_iso()
+            )
+        else:
+            case.extra_data = O.mark_too_recent(case.extra_data, now_iso=self._now_iso())
+        case.save(using="ngm", update_fields=["extra_data", "updated_at"])
+        return outcome, "no document"
+
+    def _apply_transient(self, case, error, write):
+        if not write:
+            return "transient", f"{error} [dry-run]"
+        case.extra_data = O.mark_transient(
+            case.extra_data, error=error, now_iso=self._now_iso()
+        )
+        case.save(using="ngm", update_fields=["extra_data", "updated_at"])
+        return "transient", error
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _last_hearing(self, case) -> date | None:
+        return (
+            CourtCaseHearing.objects.using("ngm")
+            .filter(court_id=case.court_id, case_number=case.case_number)
+            .aggregate(m=Max("hearing_date_ad"))["m"]
+        )
+
+    @staticmethod
+    def _now_iso() -> str:
+        return timezone.now().isoformat()
+
+    @staticmethod
+    def _anchor(value) -> date:
+        if not value:
+            return timezone.localdate()
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise CommandError(f"--today must be YYYY-MM-DD, got {value!r}") from exc

--- a/courts/management/commands/scrape_court_orders.py
+++ b/courts/management/commands/scrape_court_orders.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import hashlib
 import os
 import posixpath
+import random
 import time
 from datetime import date
 from urllib.parse import urlparse
@@ -43,7 +44,20 @@ from materials.jsonld import MaterialType, court_order_to_jsonld
 from materials.provenance import attach_media_object, build_provenance
 from materials.single_source_ingest import upsert_single_source_material
 
-_UA = "Mozilla/5.0 (X11; Linux x86_64) Jawafdehi-courts-crawler"
+# Browser User-Agents rotated per case — mirrors the retired spider + the June
+# rate-experiment probe (proven 0.009% 5xx over 43k cycles against this portal).
+# The /cp CAPTCHA portal is a distinct host from the cause-list crawler, so the
+# monolith's identifying UA is untested here; the browser UAs are the known-good.
+_USER_AGENTS = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+)
 
 #: File-extension → encodingFormat for the order documents the portal serves.
 _ENCODING = {
@@ -83,7 +97,7 @@ class OrdersHttpClient:
         self._session = self._requests.Session()
         self._session.headers.update(
             {
-                "User-Agent": _UA,
+                "User-Agent": random.choice(_USER_AGENTS),  # noqa: S311 (not crypto)
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                 "Accept-Language": "en-US,en;q=0.9",
             }
@@ -93,13 +107,17 @@ class OrdersHttpClient:
         """GET the homepage → ``(status, court_session_cookie_value, retry_after)``."""
         try:
             resp = self._session.get(O.HOMEPAGE_URL, timeout=self._timeout)
+            return resp.status_code, self._court_session(), resp.headers.get("Retry-After")
         except Exception:
             return None, None, None
-        return (
-            resp.status_code,
-            self._session.cookies.get("court_session"),
-            resp.headers.get("Retry-After"),
-        )
+
+    def _court_session(self) -> str | None:
+        """The raw ``court_session`` cookie value, defensively (``.get`` raises
+        ``CookieConflictError`` if the jar ever holds two same-named cookies)."""
+        try:
+            return self._session.cookies.get("court_session")
+        except Exception:
+            return None
 
     def search(self, form: dict) -> tuple[int | None, str, str | None]:
         """POST the search form → ``(status, html, retry_after)``."""
@@ -201,7 +219,9 @@ class Command(BaseCommand):
             f"cases={len(cases)} today={today}"
         )
 
-        tally = {k: 0 for k in ("docs", "no_record", "too_recent", "failed", "transient")}
+        # The no-record branch resolves to failed | too_recent, so those — plus
+        # docs and transient — are the outcomes _process actually returns.
+        tally = {k: 0 for k in ("docs", "too_recent", "failed", "transient")}
         for i, case in enumerate(cases, 1):
             outcome, detail = self._process(case, client, today, write, backoff)
             tally[outcome] = tally.get(outcome, 0) + 1
@@ -303,6 +323,10 @@ class Command(BaseCommand):
         if not write:  # dry-run: report the found documents without downloading
             return "docs", f"{len(doc_urls)} file(s) [dry-run]"
 
+        # All-or-nothing: any file failing leaves the WHOLE case transient (nothing
+        # stored, re-crawlable) rather than the retired pipeline's partial capture.
+        # Keeps a case's order Material + document_sources internally consistent —
+        # a captured case always has every one of its files, never a subset.
         files = []
         for url in doc_urls:
             status, content = client.download(url)

--- a/courts/scraper/orders.py
+++ b/courts/scraper/orders.py
@@ -1,0 +1,377 @@
+"""Court-order capture (Supreme + Special) — the pure parse/shape/select core.
+
+Ports the retired ``supreme_court_orders`` Scrapy spider (archived ``Jawafdehi/ngm``)
+into the monolith. Order documents live behind a CAPTCHA-gated search form on
+``supremecourt.gov.np/cp/`` that is SEPARATE from the cause-list / case-detail
+pages the rest of ``courts.scraper`` walks — those detail pages carry no order
+links (empirically confirmed). Only the Supreme and Special courts publish order
+documents on this portal (district/high probed 0/400), so capture is scoped to
+``ORDER_COURTS``.
+
+This module holds only the deterministic halves — the CAPTCHA-cookie parse, the
+result-page parse, DocumentSource shaping, the backlog selection query, and the
+``extra_data`` order-state machine — so they are unit-testable without a network.
+The HTTP + storage + DB orchestration lives in the ``scrape_court_orders``
+management command (the recurring CronJob entrypoint).
+
+Output contract (unchanged from the historical corpus):
+  * ``document_sources`` on the ``CourtCase`` gets ONE canonical DocumentSource:
+    ``{"document_id", "source_type": "COURT_ORDER", "url": [{"link", "role"}]}`` —
+    ``url`` is the roled-link LIST (RAW = PDF-preferred primary, rest ALTERNATE),
+    the shape ``materials.jsonld.media_objects_from_document_sources`` reads.
+  * each order file becomes a Material MediaObject on the standalone
+    ``court_order`` Material (built by ``court_order_to_jsonld`` /
+    ``_materialize_orders``), carrying its capture provenance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from re import compile as re_compile
+from urllib.parse import unquote, urljoin
+
+from bs4 import BeautifulSoup
+from django.db.models import Case, F, IntegerField, Q, QuerySet, TextField, Value, When
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast
+
+from courts.models import CourtCase
+
+#: Courts that publish order documents on the ``/cp`` portal.
+ORDER_COURTS = ("supreme", "special")
+
+#: ``(court_type, court_id)`` search-form params per court (from the retired
+#: ``ngm.utils.court_mapping``; Supreme/Special take fixed numeric ids).
+_COURT_FORM_PARAMS = {
+    "supreme": ("S", "264"),
+    "special": ("T", "116"),
+}
+
+HOMEPAGE_URL = "https://supremecourt.gov.np/cp/"
+ORIGIN = "https://supremecourt.gov.np"
+
+# ── extra_data order-state markers (mirror the retired pipeline) ──────────────
+#: Presence marks a case as captured — the backlog query excludes non-null.
+K_ORDERS = "court_orders"
+K_SCRAPED_AT = "court_orders_scraped_at"
+K_FAILED = "orders_failed"
+K_ERROR = "orders_error"
+K_FAILED_AT = "orders_failed_at"
+K_TOO_RECENT = "orders_too_recent"
+K_TOO_RECENT_AT = "orders_too_recent_checked_at"
+K_TRANSIENT_ERROR = "orders_transient_error"
+K_TRANSIENT_AT = "orders_transient_at"
+K_TRANSIENT_RETRIES = "orders_transient_retries"
+
+#: Days since the last hearing before an order document is expected on the site.
+MIN_DAYS_FOR_DOCUMENT_AVAILABILITY = 365
+#: How often a soft-skipped ("too recent") case is re-checked.
+TOO_RECENT_RECHECK_DAYS = 30
+#: Transient (download/network) failures tolerated before a permanent give-up.
+MAX_TRANSIENT_RETRIES = 5
+
+#: Page markers on the CAPTCHA search-result page.
+VALID_RESULTS_MARKER = "फैसला / आदेश को पुर्ण पाठ"
+NO_RECORD_MARKER = "रेकर्ड भेटिएन"
+INVALID_CAPTCHA_MARKER = "Invalid CAPTCHA"
+
+#: The PHP-serialised session cookie embeds the answer as
+#: ``...s:12:"captcha_word";s:5:"hello";...``.
+_CAPTCHA_RE = re_compile(r'"captcha_word";s:\d+:"([^"]+)"')
+
+
+def court_form_params(court_identifier: str) -> tuple[str, str]:
+    """``(court_type, court_id)`` for the ``/cp`` search form.
+
+    Raises ``ValueError`` for a court that does not publish orders on this portal.
+    """
+    try:
+        return _COURT_FORM_PARAMS[court_identifier]
+    except KeyError:
+        raise ValueError(
+            f"{court_identifier!r} has no court-order form params "
+            f"(only {', '.join(ORDER_COURTS)} publish orders)"
+        ) from None
+
+
+def extract_captcha(cookie_value: str | None) -> str | None:
+    """Pull the CAPTCHA answer out of a raw ``court_session`` cookie value.
+
+    ``cookie_value`` is the raw (percent-encoded) cookie string set on the
+    homepage GET. Returns the answer, or ``None`` when absent/unparseable.
+    """
+    if not cookie_value:
+        return None
+    match = _CAPTCHA_RE.search(unquote(cookie_value))
+    return match.group(1) if match else None
+
+
+def order_form_data(
+    court_identifier: str, case_number: str, registration_date_bs: str | None, captcha: str
+) -> dict[str, str]:
+    """The POST body for the ``/cp`` order search (mirrors the retired spider)."""
+    court_type, court_id = court_form_params(court_identifier)
+    return {
+        "court_type": court_type,
+        "court_id": court_id,
+        "regno": case_number,
+        "darta_date": registration_date_bs or "",
+        "faisala_date": "",
+        "captcha": captcha,
+        "submit": "submit",
+    }
+
+
+# ── result-page parse ────────────────────────────────────────────────────────
+
+#: Result-page classifications.
+DOCS = "docs"
+NO_RECORD = "no_record"
+INVALID_CAPTCHA = "invalid_captcha"
+SERVER_ERROR = "server_error"
+NOT_RESULTS_PAGE = "not_results_page"
+
+
+@dataclass
+class OrderResult:
+    """Outcome of one ``/cp`` search POST."""
+
+    status: str
+    doc_urls: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+def parse_order_results(html: str, *, base_url: str = HOMEPAGE_URL) -> OrderResult:
+    """Classify a ``/cp`` search response and extract order document URLs.
+
+    Mirrors the retired spider's ``_do_parse_results`` order of checks:
+      1. ``bgcolor="#FF6600"`` error table → ``invalid_captcha`` (retry a fresh
+         session) or ``server_error`` (leave re-crawlable).
+      2. missing the ``फैसला / आदेश को पुर्ण पाठ`` marker → ``not_results_page``.
+      3. ``रेकर्ड भेटिएन`` → ``no_record``.
+      4. else collect ``cells[9] a.download_content`` hrefs → ``docs``; an empty
+         collection is treated as ``no_record``.
+    """
+    html = html or ""
+    soup = BeautifulSoup(html, "html.parser")
+
+    error_table = soup.find("table", attrs={"bgcolor": "#FF6600"})
+    if error_table is not None:
+        text = error_table.get_text(strip=True)
+        if INVALID_CAPTCHA_MARKER in text:
+            return OrderResult(INVALID_CAPTCHA, detail=text)
+        return OrderResult(SERVER_ERROR, detail=text)
+
+    if VALID_RESULTS_MARKER not in html:
+        return OrderResult(NOT_RESULTS_PAGE)
+
+    if NO_RECORD_MARKER in html:
+        return OrderResult(NO_RECORD)
+
+    table = soup.find(
+        "table", class_="table table-bordered sc-table"
+    ) or soup.find("table", class_="table")
+    tbody = table.find("tbody") if table is not None else None
+    if tbody is None:
+        return OrderResult(NOT_RESULTS_PAGE)
+
+    doc_urls: list[str] = []
+    seen: set[str] = set()
+    for row in tbody.find_all("tr"):
+        cells = row.find_all("td")
+        if len(cells) < 10:
+            continue
+        link = cells[9].find("a", class_="download_content")
+        href = link.get("href") if link else None
+        if not href:
+            continue
+        url = urljoin(base_url, href)
+        if url not in seen:
+            seen.add(url)
+            doc_urls.append(url)
+
+    if not doc_urls:
+        return OrderResult(NO_RECORD)
+    return OrderResult(DOCS, doc_urls=doc_urls)
+
+
+# ── DocumentSource shaping ───────────────────────────────────────────────────
+
+
+def order_file_links(files: list[dict]) -> list[dict[str, str]]:
+    """Roled links for a case's order files — the sole PDF-preferred primary is
+    ``RAW``, every other file ``ALTERNATE`` (mirrors the retired
+    ``document_sources.file_links``).
+
+    ``files`` is a list of ``{"link": <durable url>, "is_pdf": bool}`` in download
+    order. The primary is chosen by ``is_pdf`` (a stable flag) rather than the URL
+    suffix, because the durable store hashes filenames so the link no longer ends
+    ``.pdf``.
+    """
+    ordered = sorted(
+        [f for f in files if f.get("link")], key=lambda f: 0 if f.get("is_pdf") else 1
+    )
+    return [
+        {"link": f["link"], "role": "RAW" if i == 0 else "ALTERNATE"}
+        for i, f in enumerate(ordered)
+    ]
+
+
+def build_order_document_source(
+    court_identifier: str, case_number: str, files: list[dict]
+) -> dict | None:
+    """The canonical ``document_sources`` entry for a case's captured orders.
+
+    Shape: ``{"document_id", "source_type": "COURT_ORDER", "url": [{"link",
+    "role"}]}`` — ``url`` is the roled-link LIST (the shape read by
+    ``media_objects_from_document_sources`` / ``court_order_to_jsonld`` and by the
+    ``/documents`` API), NOT the retired spider's ``url``-scalar + ``links`` pair.
+    Returns ``None`` when there are no usable files.
+    """
+    links = order_file_links(files)
+    if not links:
+        return None
+    return {
+        "document_id": f"ngm:court-order:{court_identifier}:{case_number}",
+        "source_type": "COURT_ORDER",
+        "url": links,
+    }
+
+
+# ── extra_data order-state transitions (mutate + return the dict) ─────────────
+
+_TERMINAL_KEYS = (K_FAILED, K_ERROR, K_FAILED_AT)
+_TOO_RECENT_KEYS = (K_TOO_RECENT, K_TOO_RECENT_AT)
+_TRANSIENT_KEYS = (K_TRANSIENT_ERROR, K_TRANSIENT_AT, K_TRANSIENT_RETRIES)
+
+
+def mark_success(
+    extra_data: dict | None, *, links: list[str], now_iso: str
+) -> dict:
+    """Clear all failure/too-recent/transient state and stamp the capture.
+
+    ``court_orders`` holds the durable file URLs (non-null → excluded from the
+    backlog query); ``court_orders_scraped_at`` records when. Mirrors the retired
+    pipeline's ``_mark_success`` minus the SQLAlchemy plumbing.
+    """
+    data = dict(extra_data or {})
+    data[K_ORDERS] = list(links)
+    data[K_SCRAPED_AT] = now_iso
+    for key in (*_TERMINAL_KEYS, *_TOO_RECENT_KEYS, *_TRANSIENT_KEYS):
+        data.pop(key, None)
+    return data
+
+
+def mark_too_recent(extra_data: dict | None, *, now_iso: str) -> dict:
+    """Soft-skip: the case is too recent for a document to exist yet. Re-picked
+    after ``TOO_RECENT_RECHECK_DAYS``; a later capture clears these markers."""
+    data = dict(extra_data or {})
+    data[K_TOO_RECENT] = True
+    data[K_TOO_RECENT_AT] = now_iso
+    return data
+
+
+def mark_failed(extra_data: dict | None, *, error: str, now_iso: str) -> dict:
+    """Permanent failure — excluded from all future runs until manually cleared."""
+    data = dict(extra_data or {})
+    data[K_FAILED] = True
+    data[K_ERROR] = error
+    data[K_FAILED_AT] = now_iso
+    return data
+
+
+def mark_transient(extra_data: dict | None, *, error: str, now_iso: str) -> dict:
+    """Non-terminal failure (download/network) — bump the retry counter and leave
+    the case re-crawlable, escalating to a permanent failure only after
+    ``MAX_TRANSIENT_RETRIES`` so a genuinely-dead URL eventually stops re-queuing.
+    """
+    data = dict(extra_data or {})
+    retries = int(data.get(K_TRANSIENT_RETRIES, 0) or 0) + 1
+    data[K_TRANSIENT_RETRIES] = retries
+    data[K_TRANSIENT_ERROR] = error
+    data[K_TRANSIENT_AT] = now_iso
+    for key in _TERMINAL_KEYS:
+        data.pop(key, None)
+    if retries >= MAX_TRANSIENT_RETRIES:
+        data[K_FAILED] = True
+        data[K_ERROR] = f"transient_exhausted after {retries} retries: {error}"
+        data[K_FAILED_AT] = now_iso
+    return data
+
+
+def is_document_expected(last_hearing_date: date | None, *, today: date) -> bool:
+    """True once the last hearing is old enough that an order document should be
+    published — the line between a permanent no-document failure and a soft
+    "too recent" re-check."""
+    if last_hearing_date is None:
+        return False
+    return (today - last_hearing_date).days >= MIN_DAYS_FOR_DOCUMENT_AVAILABILITY
+
+
+# ── backlog selection ────────────────────────────────────────────────────────
+
+_CAPTURE_PRIORITY = Case(
+    When(Q(court_id="special") & Q(case_number__regex=r"^\d+-CR-"), then=Value(1)),
+    When(Q(court_id="supreme") & Q(case_number__regex=r"^\d+-WH-"), then=Value(2)),
+    When(Q(court_id="supreme") & Q(case_number__regex=r"^\d+-WF-"), then=Value(3)),
+    When(Q(court_id="supreme") & Q(case_number__regex=r"^\d+-WO-"), then=Value(4)),
+    When(Q(court_id="special") & ~Q(case_number__regex=r"^\d+-OA-"), then=Value(5)),
+    When(Q(court_id="supreme"), then=Value(6)),
+    When(Q(court_id="special") & Q(case_number__regex=r"^\d+-OA-"), then=Value(7)),
+    default=Value(99),
+    output_field=IntegerField(),
+)
+
+
+def orders_backlog_queryset(
+    *, courts: tuple[str, ...] = ORDER_COURTS, today: date
+) -> QuerySet:
+    """Decided Supreme/Special cases still needing an order-document fetch.
+
+    Ports the retired spider's ``_get_cases_to_scrape`` to the Django ORM (``ngm``
+    DB): decided (``case_status`` contains फैसला, not ongoing), not already
+    captured (``court_orders`` null), not permanently failed, and a too-recent
+    case only once its recheck window has elapsed. Ordered by capture priority
+    then newest registration. Caller slices ``[:limit]``.
+    """
+    recheck_cutoff = (today - timedelta(days=TOO_RECENT_RECHECK_DAYS)).isoformat()
+
+    # A negated JSON-key match (``~Q(key=True)`` / ``.exclude(key=True)``) DROPS a
+    # row whose ``extra_data`` is a non-null dict that merely LACKS the key —
+    # SQLite evaluates the absent key to NULL and treats ``NOT NULL`` as no-match,
+    # and the behaviour differs from Postgres, so it is a cross-backend
+    # correctness trap. ``__isnull=True`` on a JSON key DOES keep absent-key rows,
+    # so both "not permanently failed" and "not recently soft-skipped" are
+    # expressed as positive ``__isnull`` predicates. ``orders_failed`` is only
+    # ever set to ``True`` or popped, so its absence ≡ "not failed".
+    not_failed = Q(extra_data__orders_failed__isnull=True)
+    # A soft-skipped case is eligible again once its recheck window has elapsed.
+    # The timestamp is compared AS TEXT (``KeyTextTransform`` → JSON_EXTRACT text,
+    # cast to text — mirroring the retired spider's ``.astext``); a raw JSON key
+    # ``__lt`` compares with JSON-quoting semantics that break the ISO ordering
+    # (and errors on SQLite).
+    too_recent_ready = (
+        Q(extra_data__orders_too_recent__isnull=True)
+        | Q(_orders_too_recent_at__isnull=True)
+        | Q(_orders_too_recent_at__lt=recheck_cutoff)
+    )
+
+    return (
+        CourtCase.objects.using("ngm")
+        .filter(court_id__in=courts, is_deleted=False)
+        .annotate(
+            _orders_too_recent_at=Cast(
+                KeyTextTransform("orders_too_recent_checked_at", "extra_data"),
+                TextField(),
+            )
+        )
+        .filter(case_status__contains="फैसला")  # decided
+        .exclude(case_status__contains="चालु")  # not ongoing (text field — safe)
+        .exclude(case_status__contains="चलिरहेको")
+        .filter(extra_data__court_orders__isnull=True)  # not already captured
+        .filter(not_failed)
+        .filter(too_recent_ready)
+        .annotate(capture_priority=_CAPTURE_PRIORITY)
+        .order_by("capture_priority", F("registration_date_ad").desc(nulls_last=True))
+    )

--- a/courts/tests/test_scraper_orders.py
+++ b/courts/tests/test_scraper_orders.py
@@ -320,6 +320,8 @@ class OrdersBacklogTests(TestCase):
             cls.supreme, "082-WO-0007",
             orders_too_recent=True, orders_too_recent_checked_at="2026-07-23T00:00:00",
         )
+        # transient failure short of the permanent-fail threshold → re-crawlable
+        cls.transient = mk(cls.supreme, "082-WO-0008", orders_transient_retries=2)
 
     def test_backlog_selects_and_prioritises(self):
         rows = list(O.orders_backlog_queryset(today=_TODAY))
@@ -333,6 +335,7 @@ class OrdersBacklogTests(TestCase):
         assert ("supreme", "082-WO-0005") not in keys  # failed
         assert ("kathmandudc", "082-CR-0009") not in keys  # wrong court
         assert ("supreme", "082-WO-0007") not in keys  # recheck window open
+        assert ("supreme", "082-WO-0008") in keys  # transient (not yet permanent)
         # Special/CR (priority 1) sorts ahead of Supreme/WO (priority 4).
         assert keys.index(("special", "082-CR-0001")) < keys.index(("supreme", "082-WO-0001"))
 
@@ -356,7 +359,9 @@ class OrdersCommandTests(TestCase):
     def _run(self, client, *extra):
         with patch(f"{CMD}.build_http_client", return_value=client), patch(
             f"{CMD}.store_file_as_link", side_effect=_fake_store
-        ), patch.dict("os.environ", {"ENABLE_COURT_ORDER_CAPTURE": "1"}):
+        ), patch("time.sleep"), patch.dict(
+            "os.environ", {"ENABLE_COURT_ORDER_CAPTURE": "1"}
+        ):
             call_command(
                 "scrape_court_orders", "--write", "--delay", "0",
                 "--case", "supreme:082-WO-0123", *extra,
@@ -439,3 +444,21 @@ class OrdersCommandTests(TestCase):
         case = self._reload()
         assert case.extra_data["orders_too_recent"] is True
         assert "orders_failed" not in case.extra_data
+
+    def test_download_failure_marks_transient_and_leaves_recrawlable(self):
+        # A found document that fails to download → no capture, case left
+        # re-crawlable (transient), NOT permanently failed and NOT captured.
+        client = _FakeClient(
+            homepage=(200, COOKIE, None),
+            search=(200, DOCS_HTML, None),
+            downloads={"https://supremecourt.gov.np/court/media/2081/order.pdf": (503, b"")},
+        )
+        self._run(client)
+        case = self._reload()
+        assert case.extra_data["orders_transient_retries"] == 1
+        assert "orders_failed" not in case.extra_data
+        assert "court_orders" not in case.extra_data
+        assert case.document_sources in (None, [])
+        assert not Material.objects.using("ngm").filter(
+            iri=court_order_material_iri("supreme", "082-WO-0123")
+        ).exists()

--- a/courts/tests/test_scraper_orders.py
+++ b/courts/tests/test_scraper_orders.py
@@ -1,0 +1,441 @@
+"""Court-order capture (``courts.scraper.orders`` + ``scrape_court_orders``).
+
+The pure halves — CAPTCHA-cookie parse, result-page parse, DocumentSource
+shaping, the ``extra_data`` state machine — are exercised with fabricated portal
+HTML matching the retired ``supreme_court_orders`` spider's contract. The backlog
+selection and the command's download→store→materialize path run against the
+sqlite fallback (managed court tables), with the HTTP transport and durable store
+faked so the test is hermetic.
+
+Run (DB-less) from the repo root::
+
+    SECRET_KEY=dev ALLOWED_HOSTS='*' uv run pytest courts/tests/test_scraper_orders.py
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from courts.models import Court, CourtCase, CourtCaseHearing
+from courts.scraper import orders as O
+from materials.jsonld import build_courtcase_iri, court_order_material_iri
+from materials.models import Material
+
+CMD = "courts.management.commands.scrape_court_orders"
+
+# ── portal HTML fixtures ─────────────────────────────────────────────────────
+
+# A valid results page carrying two order files: a PDF (→ RAW) and a DOCX
+# (→ ALTERNATE), each an <a class="download_content"> in the 10th cell (index 9).
+_ROW = (
+    "<tr>"
+    + "".join(f"<td>c{i}</td>" for i in range(9))
+    + '<td><a class="download_content" href="{href}">डाउनलोड</a></td>'
+    + "</tr>"
+)
+DOCS_HTML = (
+    "<html><body><h3>फैसला / आदेश को पुर्ण पाठ</h3>"
+    '<table class="table table-bordered sc-table"><tbody>'
+    + _ROW.format(href="/court/media/2081/order.pdf")
+    + _ROW.format(href="/court/media/2081/order.docx")
+    + "</tbody></table></body></html>"
+)
+NO_RECORD_HTML = (
+    "<html><body><h3>फैसला / आदेश को पुर्ण पाठ</h3>"
+    "<p>रेकर्ड भेटिएन</p></body></html>"
+)
+INVALID_CAPTCHA_HTML = (
+    '<html><body><table bgcolor="#FF6600"><tr><td>Invalid CAPTCHA</td></tr>'
+    "</table></body></html>"
+)
+SERVER_ERROR_HTML = (
+    '<html><body><table bgcolor="#FF6600"><tr><td>Database error</td></tr>'
+    "</table></body></html>"
+)
+NOT_RESULTS_HTML = "<html><body><p>माफ गर्नुहोस्</p></body></html>"
+
+# A court_session cookie value embedding the CAPTCHA answer (PHP-serialised).
+COOKIE = 'a:2:{s:12:"captcha_word";s:5:"AB12X";s:2:"id";s:1:"x";}'
+
+
+# ── pure: form params + CAPTCHA ──────────────────────────────────────────────
+
+
+def test_court_form_params():
+    assert O.court_form_params("supreme") == ("S", "264")
+    assert O.court_form_params("special") == ("T", "116")
+
+
+def test_court_form_params_rejects_non_order_court():
+    for bad in ("kathmandudc", "patanhc", ""):
+        try:
+            O.court_form_params(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+def test_extract_captcha():
+    assert O.extract_captcha(COOKIE) == "AB12X"
+    assert O.extract_captcha("no-captcha-here") is None
+    assert O.extract_captcha(None) is None
+    assert O.extract_captcha("") is None
+
+
+def test_order_form_data_shape():
+    form = O.order_form_data("supreme", "082-WO-0123", "2081-05-12", "AB12X")
+    assert form == {
+        "court_type": "S",
+        "court_id": "264",
+        "regno": "082-WO-0123",
+        "darta_date": "2081-05-12",
+        "faisala_date": "",
+        "captcha": "AB12X",
+        "submit": "submit",
+    }
+    assert O.order_form_data("special", "x", None, "z")["darta_date"] == ""
+
+
+# ── pure: result-page parse ──────────────────────────────────────────────────
+
+
+def test_parse_docs_extracts_absolute_urls():
+    result = O.parse_order_results(DOCS_HTML)
+    assert result.status == O.DOCS
+    assert result.doc_urls == [
+        "https://supremecourt.gov.np/court/media/2081/order.pdf",
+        "https://supremecourt.gov.np/court/media/2081/order.docx",
+    ]
+
+
+def test_parse_no_record():
+    assert O.parse_order_results(NO_RECORD_HTML).status == O.NO_RECORD
+
+
+def test_parse_invalid_captcha():
+    assert O.parse_order_results(INVALID_CAPTCHA_HTML).status == O.INVALID_CAPTCHA
+
+
+def test_parse_server_error():
+    assert O.parse_order_results(SERVER_ERROR_HTML).status == O.SERVER_ERROR
+
+
+def test_parse_not_results_page():
+    assert O.parse_order_results(NOT_RESULTS_HTML).status == O.NOT_RESULTS_PAGE
+    assert O.parse_order_results("").status == O.NOT_RESULTS_PAGE
+
+
+def test_parse_dedups_and_skips_short_rows():
+    html = (
+        "<html><body>फैसला / आदेश को पुर्ण पाठ"
+        '<table class="table"><tbody>'
+        # a short row (< 10 cells) is ignored
+        "<tr><td>only</td><td>two</td></tr>"
+        + _ROW.format(href="/d/1.pdf")
+        + _ROW.format(href="/d/1.pdf")  # duplicate href → deduped
+        + "</tbody></table></body></html>"
+    )
+    result = O.parse_order_results(html)
+    assert result.status == O.DOCS
+    assert result.doc_urls == ["https://supremecourt.gov.np/d/1.pdf"]
+
+
+def test_parse_valid_page_no_download_links_is_no_record():
+    html = (
+        "<html><body>फैसला / आदेश को पुर्ण पाठ"
+        '<table class="table"><tbody><tr>'
+        + "".join(f"<td>c{i}</td>" for i in range(11))
+        + "</tr></tbody></table></body></html>"
+    )
+    assert O.parse_order_results(html).status == O.NO_RECORD
+
+
+# ── pure: DocumentSource shaping ─────────────────────────────────────────────
+
+
+def test_order_file_links_pdf_is_raw_rest_alternate():
+    links = O.order_file_links(
+        [
+            {"link": "https://s3/x/a", "is_pdf": False},
+            {"link": "https://s3/x/b", "is_pdf": True},
+            {"link": "https://s3/x/c", "is_pdf": False},
+        ]
+    )
+    assert links[0] == {"link": "https://s3/x/b", "role": "RAW"}  # pdf floated
+    assert [lk["role"] for lk in links[1:]] == ["ALTERNATE", "ALTERNATE"]
+
+
+def test_order_file_links_empty():
+    assert O.order_file_links([]) == []
+    assert O.order_file_links([{"link": ""}]) == []
+
+
+def test_build_order_document_source_canonical_shape():
+    src = O.build_order_document_source(
+        "supreme",
+        "082-WO-0123",
+        [
+            {"link": "https://s3/1.docx", "is_pdf": False},
+            {"link": "https://s3/2.pdf", "is_pdf": True},
+        ],
+    )
+    assert src["document_id"] == "ngm:court-order:supreme:082-WO-0123"
+    assert src["source_type"] == "COURT_ORDER"
+    # url is the roled-link LIST (the monolith-canonical shape), PDF-first RAW.
+    assert src["url"] == [
+        {"link": "https://s3/2.pdf", "role": "RAW"},
+        {"link": "https://s3/1.docx", "role": "ALTERNATE"},
+    ]
+
+
+def test_build_order_document_source_empty():
+    assert O.build_order_document_source("supreme", "x", []) is None
+
+
+# ── pure: extra_data state machine ───────────────────────────────────────────
+
+_NOW = "2026-07-24T10:00:00"
+
+
+def test_mark_success_clears_prior_state():
+    prior = {
+        "orders_failed": True,
+        "orders_error": "old",
+        "orders_too_recent": True,
+        "orders_transient_retries": 3,
+    }
+    data = O.mark_success(prior, links=["https://s3/a", "https://s3/b"], now_iso=_NOW)
+    assert data["court_orders"] == ["https://s3/a", "https://s3/b"]
+    assert data["court_orders_scraped_at"] == _NOW
+    for key in ("orders_failed", "orders_error", "orders_too_recent",
+                "orders_transient_retries"):
+        assert key not in data
+
+
+def test_mark_too_recent():
+    data = O.mark_too_recent(None, now_iso=_NOW)
+    assert data["orders_too_recent"] is True
+    assert data["orders_too_recent_checked_at"] == _NOW
+
+
+def test_mark_failed():
+    data = O.mark_failed(None, error="no_document_old_case", now_iso=_NOW)
+    assert data["orders_failed"] is True
+    assert data["orders_error"] == "no_document_old_case"
+
+
+def test_mark_transient_escalates_after_max_retries():
+    data = None
+    for _ in range(O.MAX_TRANSIENT_RETRIES - 1):
+        data = O.mark_transient(data, error="timeout", now_iso=_NOW)
+        assert "orders_failed" not in data  # still re-crawlable
+    data = O.mark_transient(data, error="timeout", now_iso=_NOW)
+    assert data["orders_transient_retries"] == O.MAX_TRANSIENT_RETRIES
+    assert data["orders_failed"] is True  # escalated
+
+
+def test_is_document_expected():
+    today = date(2026, 7, 24)
+    assert O.is_document_expected(date(2024, 1, 1), today=today) is True
+    assert O.is_document_expected(date(2026, 7, 1), today=today) is False
+    assert O.is_document_expected(None, today=today) is False
+
+
+# ── DB: backlog selection + the command ──────────────────────────────────────
+
+_TODAY = date(2026, 7, 24)
+
+
+class _FakeClient:
+    """A scripted stand-in for ``OrdersHttpClient`` (no network)."""
+
+    def __init__(self, *, homepage, search, downloads=None):
+        self._homepage = homepage
+        self._search = search
+        self._downloads = downloads or {}
+        self.forms = []
+
+    def new_session(self):
+        pass
+
+    def homepage(self):
+        return self._homepage
+
+    def search(self, form):
+        self.forms.append(form)
+        return self._search
+
+    def download(self, url):
+        return self._downloads.get(url, (404, b""))
+
+
+def _fake_store(uploaded_file, role="RAW"):
+    return {"link": f"https://s3.jawafdehi.org/case_uploads/{uploaded_file.name}", "role": role}
+
+
+class OrdersBacklogTests(TestCase):
+    databases = "__all__"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.supreme = Court.objects.create(
+            identifier="supreme", court_type="supreme", full_name_nepali="सर्वोच्च"
+        )
+        cls.special = Court.objects.create(
+            identifier="special", court_type="special", full_name_nepali="विशेष"
+        )
+        cls.district = Court.objects.create(
+            identifier="kathmandudc", court_type="district", full_name_nepali="जिल्ला"
+        )
+
+        def mk(court, num, status="फैसला भएको", **extra):
+            return CourtCase.objects.create(
+                court=court, case_number=num, case_status=status,
+                registration_date_ad=date(2024, 1, 1), extra_data=extra or None,
+            )
+
+        cls.eligible_special_cr = mk(cls.special, "082-CR-0001")   # priority 1
+        cls.eligible_supreme_wo = mk(cls.supreme, "082-WO-0001")   # priority 4
+        # excluded: not decided
+        mk(cls.supreme, "082-WO-0002", status="चालु")
+        # excluded: ongoing wording despite फैसला
+        mk(cls.supreme, "082-WO-0003", status="फैसला चलिरहेको")
+        # excluded: already captured
+        mk(cls.supreme, "082-WO-0004", court_orders=["https://s3/x"])
+        # excluded: permanently failed
+        mk(cls.supreme, "082-WO-0005", orders_failed=True)
+        # excluded: district court (no orders on this portal)
+        mk(cls.district, "082-CR-0009")
+        # too-recent but overdue for recheck → INCLUDED
+        cls.recheck = mk(
+            cls.supreme, "082-WO-0006",
+            orders_too_recent=True, orders_too_recent_checked_at="2026-01-01T00:00:00",
+        )
+        # too-recent, checked yesterday → still excluded
+        mk(
+            cls.supreme, "082-WO-0007",
+            orders_too_recent=True, orders_too_recent_checked_at="2026-07-23T00:00:00",
+        )
+
+    def test_backlog_selects_and_prioritises(self):
+        rows = list(O.orders_backlog_queryset(today=_TODAY))
+        keys = [(c.court_id, c.case_number) for c in rows]
+        assert ("special", "082-CR-0001") in keys
+        assert ("supreme", "082-WO-0001") in keys
+        assert ("supreme", "082-WO-0006") in keys  # recheck window elapsed
+        assert ("supreme", "082-WO-0002") not in keys  # not decided
+        assert ("supreme", "082-WO-0003") not in keys  # ongoing
+        assert ("supreme", "082-WO-0004") not in keys  # captured
+        assert ("supreme", "082-WO-0005") not in keys  # failed
+        assert ("kathmandudc", "082-CR-0009") not in keys  # wrong court
+        assert ("supreme", "082-WO-0007") not in keys  # recheck window open
+        # Special/CR (priority 1) sorts ahead of Supreme/WO (priority 4).
+        assert keys.index(("special", "082-CR-0001")) < keys.index(("supreme", "082-WO-0001"))
+
+    def test_court_filter_scopes_to_one_court(self):
+        rows = list(O.orders_backlog_queryset(courts=("special",), today=_TODAY))
+        assert {c.court_id for c in rows} == {"special"}
+
+
+class OrdersCommandTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.court = Court.objects.create(
+            identifier="supreme", court_type="supreme", full_name_nepali="सर्वोच्च"
+        )
+        self.case = CourtCase.objects.create(
+            court=self.court, case_number="082-WO-0123", case_status="फैसला भएको",
+            registration_date_bs="2081-05-12", registration_date_ad=date(2024, 6, 1),
+        )
+
+    def _run(self, client, *extra):
+        with patch(f"{CMD}.build_http_client", return_value=client), patch(
+            f"{CMD}.store_file_as_link", side_effect=_fake_store
+        ), patch.dict("os.environ", {"ENABLE_COURT_ORDER_CAPTURE": "1"}):
+            call_command(
+                "scrape_court_orders", "--write", "--delay", "0",
+                "--case", "supreme:082-WO-0123", *extra,
+            )
+
+    def test_capture_gate_refuses_without_optin(self):
+        from django.core.management.base import CommandError
+        with patch.dict("os.environ", {"ENABLE_COURT_ORDER_CAPTURE": ""}):
+            try:
+                call_command("scrape_court_orders", "--case", "supreme:082-WO-0123")
+            except CommandError:
+                return
+        raise AssertionError("expected the capture opt-in gate to refuse")
+
+    def _reload(self):
+        return CourtCase.objects.using("ngm").get(
+            court_id="supreme", case_number="082-WO-0123"
+        )
+
+    def test_captures_documents_and_materializes(self):
+        pdf, docx = b"%PDF-1.4 bytes", b"docx bytes"
+        client = _FakeClient(
+            homepage=(200, COOKIE, None),
+            search=(200, DOCS_HTML, None),
+            downloads={
+                "https://supremecourt.gov.np/court/media/2081/order.pdf": (200, pdf),
+                "https://supremecourt.gov.np/court/media/2081/order.docx": (200, docx),
+            },
+        )
+        self._run(client)
+
+        case = self._reload()
+        # the POST carried the extracted CAPTCHA + Supreme form params
+        assert client.forms[0]["captcha"] == "AB12X"
+        assert client.forms[0]["court_type"] == "S"
+
+        # canonical DocumentSource (url = roled link LIST, PDF-first RAW)
+        src = case.document_sources[0]
+        assert src["document_id"] == "ngm:court-order:supreme:082-WO-0123"
+        assert [lk["role"] for lk in src["url"]] == ["RAW", "ALTERNATE"]
+        assert src["url"][0]["link"].endswith("supreme-082-WO-0123.1.pdf")
+
+        # extra_data marked captured, no failure residue
+        assert case.extra_data["court_orders"]
+        assert "orders_failed" not in case.extra_data
+
+        # the standalone court_order Material, linked to the ngm case + provenance
+        material = Material.objects.using("ngm").get(
+            iri=court_order_material_iri("supreme", "082-WO-0123")
+        )
+        data = material.data
+        assert data["isPartOf"]["@id"] == build_courtcase_iri("supreme", "082-WO-0123")
+        media = data["associatedMedia"]
+        assert len(media) == 2
+        raw = next(m for m in media if m["jawafdehi:linkRole"] == "RAW")
+        import hashlib
+
+        assert raw["jawafdehi:provenance"]["sha256"] == hashlib.sha256(pdf).hexdigest()
+
+    def test_no_record_old_case_marks_failed(self):
+        CourtCaseHearing.objects.create(
+            court=self.court, case_number="082-WO-0123",
+            hearing_date_bs="2078-01-01", hearing_date_ad=date(2021, 4, 14),
+            scraped_at="2026-01-01T00:00:00Z",
+        )
+        client = _FakeClient(homepage=(200, COOKIE, None), search=(200, NO_RECORD_HTML, None))
+        self._run(client)
+        case = self._reload()
+        assert case.extra_data["orders_failed"] is True
+        assert case.document_sources in (None, [])
+
+    def test_no_record_recent_case_marks_too_recent(self):
+        CourtCaseHearing.objects.create(
+            court=self.court, case_number="082-WO-0123",
+            hearing_date_bs="2083-03-01", hearing_date_ad=date(2026, 6, 15),
+            scraped_at="2026-06-15T00:00:00Z",
+        )
+        client = _FakeClient(homepage=(200, COOKIE, None), search=(200, NO_RECORD_HTML, None))
+        self._run(client)
+        case = self._reload()
+        assert case.extra_data["orders_too_recent"] is True
+        assert "orders_failed" not in case.extra_data


### PR DESCRIPTION
## What

Ports the retired `jawafdehi/ngm` `supreme_court_orders` Scrapy spider into the monolith as a **recurring** management command, restoring ongoing court-order capture (frozen since the 2026-07-02 v2 cutover — the old spider ran on the now-read-only `ngm_v1`).

Order documents live behind a **CAPTCHA-gated search form** on `supremecourt.gov.np/cp/`, which is *separate* from the cause-list / case-detail pages `scrape_courtcases` walks (recon confirmed those pages carry zero order links). Only **Supreme + Special** courts publish orders there (district/high empirically 0/400).

For each decided Supreme/Special case still missing its order, the command:
1. GETs the homepage (seeding the CAPTCHA answer, which the portal leaks in its own `court_session` session cookie),
2. POSTs the search form with the case params + CAPTCHA,
3. parses the result page for `download_content` links,
4. downloads each order file to the **durable** store (`s3.jawafdehi.org`),
5. mints a standalone `court_order` **Material** (`isPartOf` the ngm case, with capture provenance sha256),
6. records a **canonical DocumentSource** (`{document_id, source_type, url:[{link,role}]}`) on the case's `document_sources` — the shape `media_objects_from_document_sources` / `_materialize_orders` / the `/documents` API read.

This is the "orders → metadata on the court record + files as linked Materials" the historical 23K supreme+special corpus already has; this keeps it flowing for newly-decided cases (and the ~7k never-fetched backlog).

## Files

- **`courts/scraper/orders.py`** — pure, unit-tested core: CAPTCHA-cookie parse, result-page classify/extract, DocumentSource shaping, the `extra_data` order-state machine (`court_orders`/`orders_failed`/`orders_too_recent` + too-recent recheck window + capture priority), and the backlog selection query.
- **`courts/management/commands/scrape_court_orders.py`** — the recurring entrypoint: the GET→CAPTCHA→POST cycle (fresh session per case, bounded homepage/CAPTCHA retries), download→store→materialize, polite exponential 5xx backoff honoring `Retry-After`, and an **opt-in gate** (`ENABLE_COURT_ORDER_CAPTURE`, mirroring the spider's `ENABLE_CAPTCHA_COOKIE_EXTRACT`) so it never touches the live government portal unattended. **Dry-run by default**; `--write` persists.
- **`courts/tests/test_scraper_orders.py`** — 26 tests (pure parse/shape/state + sqlite backlog selection + the full command capture / no-record / gate paths, HTTP + storage faked).

## Notes for reviewers

- **Query robustness:** the backlog uses positive `__isnull` predicates, *not* `~Q(json_key=True)` / `.exclude(json_key=True)` — the latter silently drop rows whose `extra_data` is a non-null dict merely *lacking* the key on SQLite, and the NULL-handling differs from Postgres. The recheck timestamp is compared as text (`KeyTextTransform` cast to text), mirroring the old spider's `.astext`.
- **Storage:** the durable store hashes the *name* (not the bytes), so per-file names are index-suffixed (`{case}.{n}{ext}`) to avoid same-extension collisions on multi-doc cases.
- **Out of scope (follow-up infra):** the recurring **CronJob** (`ngm-court-orders` on the platform image, `ENABLE_COURT_ORDER_CAPTURE=1`, off-peak NPT schedule) lands in `services/infra` separately. The June rate experiment proved a ~1,200 cases/hr/IP polite ceiling; prod pacing is `--delay 3.0`.

## Test

```
uv run pytest courts/tests/test_scraper_orders.py   # 26 passed
```
Neighboring courts/materials suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated capture of Supreme and Special Court order documents.
  * Downloads, stores, and links available order files to the relevant case.
  * Tracks successful, failed, recent, and temporary capture outcomes.
  * Supports dry-run reporting and prioritizes eligible decided cases.
* **Reliability**
  * Handles CAPTCHA, network, search, and download failures with retry tracking.
* **Tests**
  * Added comprehensive coverage for parsing, document handling, outcomes, and capture workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->