### PR TITLE
fix(courts): separate multi-judge benches instead of run-on judge names

### DIFF
--- a/courts/scraper/district.py
+++ b/courts/scraper/district.py
@@ -35,6 +35,8 @@ from courts.normalize import best_effort_normalize
 from courts.scraper.rows import ParsedCase, ParsedEnrichment, ParsedHearing
 from courts.scraper.text import (
     coerce_count,
+    desep_judges,
+    extract_judges,
     nepali_to_roman_numerals,
     normalize_date,
     normalize_whitespace,
@@ -82,7 +84,9 @@ def parse_daily_list(
                 if bench_td:
                     current_bench = normalize_whitespace(bench_td.get_text())[:100] or None
                 if judge_td:
-                    current_judge = normalize_whitespace(judge_td.get_text()) or None
+                    # District benches are single-judge today, but keep the shared
+                    # ", "-separated extractor so a co-signed bench never runs on.
+                    current_judge = extract_judges(judge_td)
 
         for tr in table.find_all("tr"):
             if tr.find("th"):  # header row
@@ -257,7 +261,7 @@ def _extract_detail_fields(soup: BeautifulSoup) -> dict[str, object]:
                     data["verdict_date_bs"] = date_bs
                     data["verdict_date_ad"] = bs_to_ad(date_bs)
                 elif label == "फैसला गर्ने मा. न्यायाधीश":
-                    data["verdict_judge"] = value[:500]
+                    data["verdict_judge"] = (desep_judges(value) or "")[:500]
                 elif label == "पेशी चढेको संख्या":
                     data["hearing_count"] = value
 
@@ -352,7 +356,7 @@ def _parse_hearing_table(table) -> list[dict[str, str]]:
                     "date": cells[0].get_text(strip=True),
                     "type": cells[1].get_text(strip=True),
                     "division": cells[2].get_text(strip=True),
-                    "judge": cells[3].get_text(strip=True),
+                    "judge": extract_judges(cells[3]) or "",
                     "order": cells[4].get_text(strip=True),
                 }
             )

--- a/courts/scraper/high.py
+++ b/courts/scraper/high.py
@@ -36,6 +36,7 @@ from courts.normalize import best_effort_normalize
 from courts.scraper.rows import ParsedCase, ParsedEnrichment, ParsedHearing
 from courts.scraper.text import (
     coerce_count,
+    extract_judges,
     nepali_to_roman_numerals,
     normalize_date,
     normalize_whitespace,
@@ -82,7 +83,10 @@ def parse_bench_list(html: str) -> list[dict[str, str]]:
             {
                 "bench_id": match.group(1),
                 "bench_no": match.group(2),
-                "judge_name": normalize_whitespace(cells[1].get_text()),
+                # A high-court bench can seat 2-3 judges (one per <br> in this cell);
+                # extract_judges keeps them ", "-separated instead of glueing the next
+                # judge's honorific onto the previous name (the run-on DQ bug).
+                "judge_name": extract_judges(cells[1]) or "",
             }
         )
     return benches
@@ -274,7 +278,9 @@ def _parse_detail_fields(soup: BeautifulSoup) -> tuple[dict, dict]:
                 core_fields["verdict_date_bs"] = normalize_date(value)
                 core_fields["verdict_date_ad"] = bs_to_ad(normalize_date(value))
         elif label == "फैसला गर्ने न्यायाधीश":
-            core_fields["verdict_judge"] = value[:500]
+            # A multi-judge verdict panel is <br>-separated inside this <p>; keep the
+            # judges ", "-separated rather than run-on.
+            core_fields["verdict_judge"] = (extract_judges(value_elem) or value)[:500]
         elif label == "पेशी चढेको संख्या":
             # v2: hearing_count is a typed int column — coerce the scraped count.
             core_fields["hearing_count"] = coerce_count(value)
@@ -406,7 +412,7 @@ def _parse_detail_hearings(soup: BeautifulSoup) -> list[dict]:
                         "hearing_date": normalize_date(
                             normalize_whitespace(cells[0].get_text())
                         ),
-                        "judges": normalize_whitespace(cells[1].get_text()),
+                        "judges": extract_judges(cells[1]) or "",
                         "case_status": normalize_whitespace(cells[2].get_text()),
                         "decision_type": normalize_whitespace(cells[3].get_text()),
                     }

--- a/courts/scraper/supreme.py
+++ b/courts/scraper/supreme.py
@@ -34,6 +34,8 @@ from courts.normalize import best_effort_normalize
 from courts.scraper.rows import ParsedCase, ParsedEnrichment, ParsedHearing
 from courts.scraper.text import (
     coerce_count,
+    desep_judges,
+    extract_judges,
     nepali_to_roman_numerals,
     normalize_date,
     normalize_whitespace,
@@ -159,17 +161,13 @@ def _clean_division(division: str) -> str:
 
 
 def _parse_judges(cell) -> str | None:
-    """Newline-join a judges cell, honouring its ``<br>`` line breaks."""
-    if not cell:
-        return None
-    for br in cell.find_all("br"):
-        br.replace_with("\n")
-    names = [
-        normalize_whitespace(name)
-        for name in cell.get_text().split("\n")
-        if normalize_whitespace(name)
-    ]
-    return "\n".join(names) if names else None
+    """``, ``-join a judges cell, honouring its ``<br>`` line breaks.
+
+    Thin wrapper over the shared :func:`extract_judges` so every court's multi-judge
+    bench uses the one ``, `` separator (matching the seed fixtures) instead of glueing
+    run-on names.
+    """
+    return extract_judges(cell)
 
 
 def _parse_row(
@@ -282,7 +280,8 @@ def _map_field(data: dict, label: str, value: str) -> None:
         data["verdict_type"] = value[:100]
 
     elif label in ["फैसला गर्ने मा. न्यायाधीश", "न्यायाधीश"]:
-        data["verdict_judge"] = value[:200]
+        # value is already flattened here (no cell), so de-run-on any glued honorifics.
+        data["verdict_judge"] = (desep_judges(value) or "")[:200]
 
     elif label in ["फाँट", "इजलास"]:
         data["division"] = value[:100]
@@ -376,7 +375,7 @@ def parse_hearings_and_timeline(soup: BeautifulSoup) -> dict[str, list[dict]]:
                 cells = row.find_all("td")
                 if len(cells) >= 2:
                     hearing_date = normalize_whitespace(cells[0].get_text())
-                    judges = normalize_whitespace(cells[1].get_text())
+                    judges = extract_judges(cells[1]) or ""
                     if judges and hearing_date and hearing_date not in [
                         "सुनवाइ मिती",
                         "मिती",

--- a/courts/scraper/text.py
+++ b/courts/scraper/text.py
@@ -73,3 +73,45 @@ def coerce_count(value: object) -> int | None:
         return None
     digits = "".join(ch for ch in nepali_to_roman_numerals(value) if ch in "0123456789")
     return int(digits) if digits else None
+
+
+#: The leading honorific token that begins every judge entry — ``मा.`` (माननीय,
+#: abbreviated) or the spelled-out ``माननीय``. Each judge on a multi-judge bench is
+#: ``मा. न्या. श्री <name>`` / ``मा. मु. न्या. …`` / ``मा.न्या. …`` / ``माननीय … न्यायाधीश …``;
+#: the honorific always opens with one of these, and no judge NAME contains ``मा.``
+#: (a bare ``मा`` + period) mid-string, so it is a safe split anchor. The mid-token
+#: parts (``न्या.``/``मु.``/``प्र.``) are deliberately NOT anchors — matching them would
+#: split inside a single honorific.
+_JUDGE_HONORIFIC_RE = re.compile(r"(\S)(मा\.|माननीय)")
+
+
+def desep_judges(text: object) -> str | None:
+    """Re-insert the separator a run-on judges cell lost, joining judges with ``, ``.
+
+    A bench's judges are listed one-per-line (``<br>``) in a single portal cell; a
+    bare ``get_text()`` with no separator glues them, so the next judge's honorific
+    sticks onto the previous judge's name (``…श्री राममा. न्या. श्री श्याम…``). Every judge
+    opens with the माननीय honorific (:data:`_JUDGE_HONORIFIC_RE`), so a comma-space is
+    inserted before any honorific glued to a preceding non-space char. Idempotent: an
+    already-separated (space/comma/newline-delimited) list is returned unchanged, and
+    the FIRST judge (honorific at string start) is never prefixed.
+    """
+    normalized = normalize_whitespace(text)
+    if not normalized:
+        return None
+    return _JUDGE_HONORIFIC_RE.sub(r"\1, \2", normalized)
+
+
+def extract_judges(cell) -> str | None:
+    """Extract a judges cell as a ``, ``-joined list, honouring ``<br>`` line breaks.
+
+    Replaces ``<br>`` with the separator BEFORE flattening (so structurally-delimited
+    benches survive) and runs :func:`desep_judges` as a backstop for cells whose
+    judges are split by sibling elements rather than ``<br>``. Returns ``None`` when the
+    cell is missing or empty.
+    """
+    if cell is None:
+        return None
+    for br in cell.find_all("br"):
+        br.replace_with(", ")
+    return desep_judges(cell.get_text())

--- a/courts/tests/test_scraper_high.py
+++ b/courts/tests/test_scraper_high.py
@@ -108,6 +108,22 @@ def test_parse_bench_list_discovers_benches():
     assert benches[0]["judge_name"] == "न्या. गोपाल राई"
 
 
+def test_parse_bench_list_separates_multi_judge_bench():
+    # A high-court bench seats 2-3 judges, one per <br>; a bare get_text() glued the
+    # next judge's honorific onto the previous name (the run-on DQ bug that affected
+    # ~1.56M hearings). They must stay ", "-separated.
+    html = """
+    <html><body>
+      <table class="table table-striped table-bordered table-hover"><tbody>
+        <tr onclick="send_data('201', '३', '20820105')"><td>३</td>
+          <td>मा. न्या. श्री राम<br>मा. न्या. श्री श्याम</td></tr>
+      </tbody></table>
+    </body></html>
+    """
+    benches = parse_bench_list(html)
+    assert benches[0]["judge_name"] == "मा. न्या. श्री राम, मा. न्या. श्री श्याम"
+
+
 def test_parse_bench_page_maps_rows_and_normalizes():
     rows = parse_bench_page(
         _BENCH_PAGE,

--- a/courts/tests/test_scraper_supreme.py
+++ b/courts/tests/test_scraper_supreme.py
@@ -80,10 +80,10 @@ def test_cause_list_maps_rows_and_normalizes():
     assert hearing0.hearing_date_ad is not None
     assert hearing0.bench_type == "संयुक्त इजलास"
     assert hearing0.serial_no == "1"  # Devanagari serial transliterated
-    # judge_names = the "must hear" cell, br-joined with newlines.
-    assert hearing0.judge_names == "मा. न्या. राम\nमा. न्या. श्याम"
+    # judge_names = the "must hear" cell, br-joined with ", " (the shared separator).
+    assert hearing0.judge_names == "मा. न्या. राम, मा. न्या. श्याम"
     assert hearing0.extra_data["judges_cannot_hear"] == "मा. न्या. क"
-    assert hearing0.extra_data["judges_must_hear"] == "मा. न्या. राम\nमा. न्या. श्याम"
+    assert hearing0.extra_data["judges_must_hear"] == "मा. न्या. राम, मा. न्या. श्याम"
 
 
 def test_cause_list_party_fallback_without_delimiter():

--- a/courts/tests/test_scraper_text.py
+++ b/courts/tests/test_scraper_text.py
@@ -65,3 +65,46 @@ def test_extract_judges_honours_br_then_backstops_glue():
     )
     assert extract_judges(_cell("<td>   </td>")) is None
     assert extract_judges(None) is None
+
+
+def test_desep_judges_keeps_name_ending_in_ma_intact():
+    # THE over-split trap: a judge NAME ending in the akshara मा (रमा / …शर्मा) glued
+    # to the next honorific. The anchor is मा + a literal PERIOD (मा\.), and a name
+    # never carries a period, so only the honorific's मा. is split — the name is whole.
+    assert desep_judges("मा. न्या. श्री रमामा. न्या. श्री सीता") == (
+        "मा. न्या. श्री रमा, मा. न्या. श्री सीता"
+    )
+    assert desep_judges("मा. न्या. श्री पूर्णिमामा. न्या. श्री गंगा") == (
+        "मा. न्या. श्री पूर्णिमा, मा. न्या. श्री गंगा"
+    )
+
+
+def test_desep_judges_acting_chief_title_soup_not_split_internally():
+    # Real acting-chief title "मा.का.मु.मु.न्या." has interior periods, but only its
+    # LEADING मा. is an anchor (का./मु./न्या. are not), so a glued entry splits at the
+    # boundary and the title stays intact.
+    glued = "मा. न्या. श्री राममा.का.मु.मु.न्या. श्री श्याम"
+    assert desep_judges(glued) == "मा. न्या. श्री राम, मा.का.मु.मु.न्या. श्री श्याम"
+
+
+def test_desep_judges_quadruple_glue_and_double_application():
+    glued = "मा. न्या. एकमा. न्या. दुईमा. न्या. तीनमा. न्या. चार"
+    once = desep_judges(glued)
+    assert once == "मा. न्या. एक, मा. न्या. दुई, मा. न्या. तीन, मा. न्या. चार"
+    # Idempotent under re-application (the backfill must be safe to re-run).
+    assert desep_judges(once) == once
+
+
+def test_desep_judges_mixed_glued_and_already_spaced():
+    # First boundary already space-delimited (clean), second boundary glued.
+    mixed = "मा. न्या. श्री एक मा. न्या. श्री दुईमा. न्या. श्री तीन"
+    assert desep_judges(mixed) == (
+        "मा. न्या. श्री एक मा. न्या. श्री दुई, मा. न्या. श्री तीन"
+    )
+
+
+def test_extract_judges_self_closing_br_and_multiline():
+    # Portals emit both <br> and <br/>; both become the separator.
+    assert extract_judges(_cell("<td>मा. न्या. राम<br/>मा. न्या. श्याम</td>")) == (
+        "मा. न्या. राम, मा. न्या. श्याम"
+    )

--- a/courts/tests/test_scraper_text.py
+++ b/courts/tests/test_scraper_text.py
@@ -1,0 +1,67 @@
+"""Unit tests for the shared court-portal text helpers, focused on the judge
+run-on de-separator — the fix for the multi-judge concatenation DQ bug where a
+bare ``get_text()`` glued the next judge's honorific onto the previous name
+(``…प्याकुरेलमा. न्या. श्री…``) across ~1.56M high-court + ~212k Supreme hearings."""
+
+from bs4 import BeautifulSoup
+
+from courts.scraper.text import desep_judges, extract_judges
+
+
+def _cell(html: str):
+    return BeautifulSoup(html, "html.parser").find("td")
+
+
+def test_desep_judges_splits_glued_high_honorific():
+    # High court honorific "मा. न्या." (with a space). A ", " is inserted before the
+    # second judge; the FIRST judge (honorific at string start) is left unprefixed.
+    glued = "मा. न्या. श्री राममा. न्या. श्री श्याम"
+    assert desep_judges(glued) == "मा. न्या. श्री राम, मा. न्या. श्री श्याम"
+
+
+def test_desep_judges_splits_glued_supreme_honorific():
+    # Supreme uses "मा.न्या." with NO space after मा. — the anchor matches both forms.
+    glued = "मा.न्या. श्री एकमा.न्या. श्री दुई"
+    assert desep_judges(glued) == "मा.न्या. श्री एक, मा.न्या. श्री दुई"
+
+
+def test_desep_judges_splits_glued_chief_judge():
+    # Chief-judge honorific "मा. मु. न्या." is anchored on the LEADING मा.; the mid
+    # tokens (मु./न्या.) are never split inside a single honorific.
+    glued = "मा. न्या. श्री राममा. मु. न्या. श्री श्याम"
+    assert desep_judges(glued) == "मा. न्या. श्री राम, मा. मु. न्या. श्री श्याम"
+
+
+def test_desep_judges_three_judge_bench():
+    glued = "मा. न्या. एकमा. न्या. दुईमा. न्या. तीन"
+    assert desep_judges(glued) == "मा. न्या. एक, मा. न्या. दुई, मा. न्या. तीन"
+
+
+def test_desep_judges_is_idempotent_on_already_separated():
+    comma = "मा. न्या. श्री राम, मा. न्या. श्री श्याम"
+    assert desep_judges(comma) == comma
+    # space-delimited (honorific preceded by whitespace) is NOT glued → left as-is.
+    spaced = "मा. न्या. श्री राम मा. न्या. श्री श्याम"
+    assert desep_judges(spaced) == spaced
+
+
+def test_desep_judges_noop_on_single_judge_and_empty():
+    assert desep_judges("मा. न्या. श्री एक जना") == "मा. न्या. श्री एक जना"
+    # District's spelled-out "माननीय … न्यायाधीश" single judge is untouched (honorific
+    # at start, no interior माननीय/मा.).
+    assert desep_judges("माननीय जिल्ला न्यायाधीश सीता") == "माननीय जिल्ला न्यायाधीश सीता"
+    assert desep_judges("") is None
+    assert desep_judges(None) is None
+
+
+def test_extract_judges_honours_br_then_backstops_glue():
+    # <br> is turned into the separator structurally…
+    assert extract_judges(_cell("<td>मा. न्या. राम<br>मा. न्या. श्याम</td>")) == (
+        "मा. न्या. राम, मा. न्या. श्याम"
+    )
+    # …and a cell whose judges are run-on with no <br> is still de-separated.
+    assert extract_judges(_cell("<td>मा. न्या. राममा. न्या. श्याम</td>")) == (
+        "मा. न्या. राम, मा. न्या. श्याम"
+    )
+    assert extract_judges(_cell("<td>   </td>")) is None
+    assert extract_judges(None) is None


### PR DESCRIPTION
## Problem

The court-portal scrapers extract each bench's judges with a bare `cell.get_text()`, which BeautifulSoup joins with **no separator**. On a multi-judge bench (judges listed one-per-`<br>`), this glues them together — the next judge's honorific runs onto the previous judge's name:

```
मा. न्या. श्री शेषराज सिवाकोटीमा. न्या. श्री रमेश बहादुर थापा
                             └── two judges, no separator
```

### Blast radius (measured on `ngm_v2`)

| court | hearings w/ judges | run-on (glued) |
|---|--:|--:|
| **high** | 1,884,902 | **1,555,965** (82%) |
| **supreme** | 271,581 | **211,908** (78%) |
| district | 2,947,803 | 0 — single-judge benches (`माननीय जिल्ला न्यायाधीश`) |
| special | 36,434 | 0 — judge_names sourced from the charge sheet |

`judge_names` is **not** indexed in OpenSearch (display-only via the hearing serializer), so this is a display/data-quality bug, not a search bug. The glued values also propagated into `court_cases.verdict_judge` for the decided cases whose judge was derived from the verdict-date hearing.

## Fix

Add a shared, idempotent pair in `courts/scraper/text.py`:

- **`desep_judges(text)`** — every judge entry opens with the माननीय honorific (`मा.` or spelled-out `माननीय`), and no judge *name* contains `मा.` mid-string, so the honorific is a safe anchor: insert `, ` before any honorific glued to a preceding non-space char. The mid-honorific tokens (`न्या.`/`मु.`/`प्र.`) are deliberately **not** anchors, so a single `मा. मु. न्या.` chief-judge honorific is never split. The first judge (honorific at string start) is never prefixed.
- **`extract_judges(cell)`** — turns `<br>` into the separator structurally, with `desep_judges()` as a backstop for cells split by sibling elements.

Applied at every judge-cell extraction across **high** / **supreme** / **district** (cause-list bench judge, enrichment hearing judges, `verdict_judge`). Supreme's local `_parse_judges` (which already handled `<br>`, but joined with `\n`) is folded into the shared helper so all courts emit the one `, ` separator — matching the project's own seed fixtures (`seed_courtcases.py`: `"मा. न्या. उदाहरण एक, मा. न्या. उदाहरण दुई"`).

## Notes

- **Idempotent**: already comma/space/newline-delimited lists are unchanged, so this is safe to re-run and safe against already-clean rows.
- **Scrapers are currently paused** (no CronJob) — this is the permanent correctness fix for when scraping resumes; the ~1.77M already-loaded rows are repaired by a separate one-time in-pod backfill using the same `desep_judges` transform (not part of this PR).
- Existing single-judge test fixtures were unaffected (no glued honorific → helper is a no-op); added unit + parser tests for glued high/supreme/chief-judge/3-judge benches, `<br>` cells, and idempotency.

## Tests

`courts/tests/test_scraper_text.py` (new) + `test_scraper_high.py` / `test_scraper_supreme.py` updated — all green (`50 passed` across the scraper suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved judge-name parsing across district, high, and supreme court records.
  * Correctly separates multiple judges in bench, verdict, and hearing information.
  * Standardized judge names with consistent comma-separated formatting.
  * Handles HTML line breaks and previously concatenated judge names more reliably.

* **Tests**
  * Added coverage for multi-judge benches, formatting consistency, and edge cases in judge-name extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->