### PR TITLE
fix(courts): force UTF-8 decode of /cp order-search responses

### DIFF
--- a/courts/management/commands/scrape_court_orders.py
+++ b/courts/management/commands/scrape_court_orders.py
@@ -120,7 +120,16 @@ class OrdersHttpClient:
             return None
 
     def search(self, form: dict) -> tuple[int | None, str, str | None]:
-        """POST the search form → ``(status, html, retry_after)``."""
+        """POST the search form → ``(status, html, retry_after)``.
+
+        The ``/cp`` result page is UTF-8 Devanagari but serves no ``charset`` in
+        its ``Content-Type``, so ``requests`` falls back to its RFC-2616 default
+        of ISO-8859-1 and ``resp.text`` mojibakes every marker (the result-page
+        marker then never matches → every case looks like ``not_results_page``).
+        The page declares ``<meta charset="utf-8">``, so decode as UTF-8 always.
+        (The retired Scrapy spider dodged this because Scrapy honours the meta
+        tag; plain ``requests.text`` does not.)
+        """
         headers = {"Origin": O.ORIGIN, "Referer": O.HOMEPAGE_URL}
         try:
             resp = self._session.post(
@@ -128,6 +137,7 @@ class OrdersHttpClient:
             )
         except Exception:
             return None, "", None
+        resp.encoding = "utf-8"
         return resp.status_code, resp.text, resp.headers.get("Retry-After")
 
     def download(self, url: str) -> tuple[int | None, bytes]:

--- a/courts/tests/test_scraper_orders.py
+++ b/courts/tests/test_scraper_orders.py
@@ -277,6 +277,53 @@ def _fake_store(uploaded_file, role="RAW"):
     return {"link": f"https://s3.jawafdehi.org/case_uploads/{uploaded_file.name}", "role": role}
 
 
+class _FakeRequestsResponse:
+    """A stand-in for ``requests.Response`` whose ``.text`` honours ``.encoding``
+    exactly as the real one does — so a test can prove ``search`` overrides the
+    ISO-8859-1 default before reading text."""
+
+    def __init__(self, content: bytes, *, status_code=200, encoding="ISO-8859-1"):
+        self.content = content
+        self.status_code = status_code
+        self.encoding = encoding
+        self.headers = {}
+
+    @property
+    def text(self) -> str:
+        return self.content.decode(self.encoding or "ISO-8859-1", errors="replace")
+
+
+class _FakeRequestsSession:
+    def __init__(self, response):
+        self._response = response
+        self.headers = {}
+
+    def post(self, *args, **kwargs):
+        return self._response
+
+
+class OrdersHttpClientDecodeTests(TestCase):
+    """The ``/cp`` result page is UTF-8 Devanagari served with NO ``charset`` in
+    ``Content-Type``, so ``requests`` defaults ``resp.encoding`` to ISO-8859-1 and
+    mojibakes every marker. ``search`` must force UTF-8 or the whole capture
+    misreads every case as ``not_results_page`` (the bug that shipped in #375)."""
+
+    def test_search_forces_utf8_on_charsetless_devanagari(self):
+        from courts.management.commands.scrape_court_orders import OrdersHttpClient
+
+        resp = _FakeRequestsResponse(DOCS_HTML.encode("utf-8"), encoding="ISO-8859-1")
+        client = OrdersHttpClient(timeout=1)
+        client._session = _FakeRequestsSession(resp)
+
+        status, html, _ = client.search({"regno": "x"})
+
+        self.assertEqual(status, 200)
+        # Without the UTF-8 override this marker would be latin-1 mojibake and the
+        # parse would collapse to NOT_RESULTS_PAGE.
+        self.assertIn(O.VALID_RESULTS_MARKER, html)
+        self.assertEqual(O.parse_order_results(html).status, O.DOCS)
+
+
 class OrdersBacklogTests(TestCase):
     databases = "__all__"
 


### PR DESCRIPTION
## Problem

`scrape_court_orders` (shipped in #375) captured **zero** documents against the live portal. Every case came back `not_results_page`.

Root cause: the Supreme Court `/cp` order-search result page is UTF-8 Devanagari but serves **no `charset`** in its `Content-Type` header. `requests` therefore falls back to its RFC-2616 default of **ISO-8859-1**, and `resp.text` mojibakes the whole page — the result-page marker `फैसला / आदेश को पुर्ण पाठ` becomes `à¤«à¥à¤¸à¤²à¤¾ / ...` and never matches, so `parse_order_results` classifies every response as `not_results_page`.

The retired Scrapy spider never hit this because Scrapy honours the in-body `<meta charset="utf-8">`; plain `requests.text` does not.

## Fix

Force `resp.encoding = "utf-8"` in `OrdersHttpClient.search()` before reading `.text`. The page always declares `<meta charset="utf-8">`, so this is deterministic (no chardet guessing).

## Verification

- **In-pod, live portal:** a known-captured case (`supreme 063-CI-0042`) that returned `not_results_page` now parses to `docs` with the real order URL (`.../assets/uploads/supreme_54655.doc`). `resp.encoding` observed as `ISO-8859-1`, `apparent_encoding` as `utf-8`.
- **Regression test:** `OrdersHttpClientDecodeTests` decodes a charsetless UTF-8 response through the real `search()` and asserts the marker survives and the parse yields `DOCS`. Whole module: 28 passed.

Blocks the court-order backfill/CronJob until merged and carried in `jawafdehi-platform:main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved court order search results handling for pages with missing or incorrect character-set metadata.
  * Prevented non-Latin text from being misread, ensuring valid results pages are recognized correctly.

* **Tests**
  * Added coverage for UTF-8 content, including pages containing Devanagari text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->