### PR TITLE
chore(email): disable Wagtail notification emails (dummy backend)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -675,6 +675,23 @@ WAGTAIL_SITE_NAME = "Jawafdehi Newsroom"
 WAGTAILADMIN_BASE_URL = os.getenv(
     "WAGTAILADMIN_BASE_URL", "https://portal.jawafdehi.org"
 )
+# ---------------------------------------------------------------------------
+# Outbound email — DISABLED.
+# ---------------------------------------------------------------------------
+# Wagtail sends notification emails synchronously on the edit screen (comment-
+# subscriber notifications and workflow/moderation transitions) and on admin
+# password reset. The platform has no mail relay, so Django's default SMTP
+# backend dialed localhost:25, raised ConnectionRefusedError, and returned a
+# 500 from the triggering save — and because the comment had already committed,
+# each retry re-inserted it as a duplicate. We don't want these notifications,
+# so route mail to the dummy backend: messages are accepted and discarded
+# without ever opening a connection. Editorial features (comments, workflow)
+# keep working; they simply don't email. The newsletter is unaffected — it
+# posts to SendPulse's REST API, not through Django's mail backend. Set
+# EMAIL_BACKEND in the environment to re-enable delivery.
+EMAIL_BACKEND = os.getenv(
+    "EMAIL_BACKEND", "django.core.mail.backends.dummy.EmailBackend"
+)
 # Headless preview: the edit-screen preview iframe 302-redirects to the public
 # SPA's article preview route (which fetches the unsaved draft from the
 # page_preview API by token), so editors see the real styled article instead of


### PR DESCRIPTION
## Problem
Saving a Wagtail page (e.g. `POST /newsroom/pages/41/edit/`) returned **HTTP 500** with `ConnectionRefusedError(111)`. Wagtail sends notification emails **synchronously on save** (comment-subscriber notifications, workflow/moderation transitions) and on password reset. The platform has no mail relay, so Django's default SMTP backend hit `localhost:25` and threw — 500ing the save. Because the comment had already committed, each retry re-inserted it (one page accumulated 14 identical duplicate comments).

## Decision
We don't want these notifications, so rather than stand up a relay we **disable outbound email**.

## Fix
Default `EMAIL_BACKEND` to Django's **dummy backend** — messages are accepted and discarded without opening a connection, so no send can fail.
- Editorial features (comments, workflow) keep working; they just don't email.
- The newsletter is unaffected — it posts to **SendPulse's REST API**, not through Django's mail backend (verified: only `newsletter/views.py` uses it, via the REST client).
- Backend stays **env-overridable** (`EMAIL_BACKEND=...`) so delivery can be re-enabled later without a code change.

## Deploy
Merge → image builds → keel deploys `:main` → pods restart. No migration, no secret change required.

## Note
Supersedes #378 (which wired Amazon SES); that approach was dropped and its Bao `kv/jawafdehi/platform/env` keys were reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)