### PR TITLE
feat(courts): self-heal the verdict_judge gap at import time

### DIFF
--- a/courts/importer.py
+++ b/courts/importer.py
@@ -46,6 +46,7 @@ from courts.normalize import (
     is_verdict_sentinel,
     normalize_case_type,
 )
+from courts.scraper.text import desep_judges
 from materials.jsonld import (
     MaterialType,
     case_order_sources,
@@ -81,6 +82,11 @@ _COPY_HEARING_FIELDS = (
     "lawyer_names", "serial_no", "case_status", "decision_type", "remarks",
     "scraped_at", "extra_data",
 )
+
+#: Decision markers that identify the DECISIVE sitting on a verdict date — when a
+#: case has several hearings on its verdict day, the one whose decision_type /
+#: case_status names a verdict is the deciding bench (used by _derive_verdict_judge).
+_VERDICT_MARKERS = ("फैसला", "अन्तिम आदेश")
 
 
 class ImportMode(str, Enum):
@@ -119,6 +125,7 @@ class ImportResult:
     dq_hc_recovered: int = 0
     dq_special_flagged: int = 0
     dq_case_type_normalized: int = 0
+    dq_verdict_judge_derived: int = 0
     skipped: int = 0
     failed: int = 0
     errors: list[dict[str, Any]] = field(default_factory=list)
@@ -132,6 +139,7 @@ class ImportResult:
             "dq_hc_recovered": self.dq_hc_recovered,
             "dq_special_flagged": self.dq_special_flagged,
             "dq_case_type_normalized": self.dq_case_type_normalized,
+            "dq_verdict_judge_derived": self.dq_verdict_judge_derived,
             "skipped": self.skipped,
             "failed": self.failed,
             "errors": list(self.errors),
@@ -580,6 +588,12 @@ class CourtCaseImporter:
         # after (3) so a just-recovered high-court case_type is normalised too.
         self._normalize_case_type(case)
 
+        # (5) verdict_judge gap — a DECIDED case with no deciding judge: recover it
+        # from the verdict-date hearing so the gap self-heals on every import (the
+        # enrichment detail page never carries it for special court, and only
+        # inconsistently for high/district) instead of re-accumulating.
+        self._derive_verdict_judge(case, row)
+
     def _flag_special_defendants(self, case: CourtCase, row: Any) -> None:
         if self._read_only and not isinstance(row, CourtCase):
             has_defendant = any(
@@ -645,6 +659,68 @@ class CourtCaseImporter:
         else:
             self._update_case(case, case_type=canonical)
         self.res.dq_case_type_normalized += 1
+
+    def _derive_verdict_judge(self, case: CourtCase, row: Any) -> None:
+        """Fill an EMPTY ``verdict_judge`` on a decided case from its verdict-date
+        hearing, marking ``extra_data._dq.verdict_judge_derived`` (reversible).
+
+        Only fires when the case is decided (``verdict_date_ad`` set) and has no
+        judge; a case that already carries one is never overwritten. Idempotent —
+        a re-run finds ``verdict_judge`` populated and does nothing."""
+        if case.verdict_judge or not case.verdict_date_ad:
+            return
+        judge = self._verdict_date_judge(case, row)
+        if not judge:
+            return
+        if case.extra_data is None or isinstance(case.extra_data, dict):
+            extra = dict(case.extra_data or {})
+            existing_dq = extra.get("_dq")
+            dq = dict(existing_dq) if isinstance(existing_dq, dict) else {}
+            dq["verdict_judge_derived"] = True
+            extra["_dq"] = dq
+            self._update_case(case, verdict_judge=judge, extra_data=extra)
+        else:
+            self._update_case(case, verdict_judge=judge)
+        self.res.dq_verdict_judge_derived += 1
+
+    def _verdict_date_judge(self, case: CourtCase, row: Any) -> str | None:
+        """The deciding bench: ``judge_names`` on the case's verdict-date hearing,
+        preferring a decisive फैसला/अन्तिम-आदेश sitting, de-run-on and capped to 500.
+
+        Reads the in-memory ``row['hearings']`` for a COPY dict; queries the ``ngm``
+        DB for an INPLACE ``CourtCase`` (whose hearings already exist). Returns
+        ``None`` when no verdict-date hearing carries a judge."""
+        verdict_date = case.verdict_date_ad
+        if not verdict_date:
+            return None
+        if isinstance(row, dict):
+            hearings = [
+                h for h in (row.get("hearings") or [])
+                if h.get("hearing_date_ad") == verdict_date
+                and (h.get("judge_names") or "").strip()
+            ]
+        else:
+            hearings = list(
+                CourtCaseHearing.objects.using("ngm")
+                .filter(
+                    court_id=case.court_id,
+                    case_number=case.case_number,
+                    hearing_date_ad=verdict_date,
+                )
+                .exclude(judge_names__isnull=True)
+                .exclude(judge_names="")
+                .values("judge_names", "decision_type", "case_status", "id")
+            )
+        if not hearings:
+            return None
+
+        def _decisive(h: dict[str, Any]) -> bool:
+            blob = f"{h.get('decision_type') or ''} {h.get('case_status') or ''}"
+            return any(marker in blob for marker in _VERDICT_MARKERS)
+
+        hearings.sort(key=lambda h: (0 if _decisive(h) else 1, h.get("id") or 0))
+        judge = desep_judges(hearings[0].get("judge_names"))
+        return judge[:500] if judge else None
 
     @staticmethod
     def _court_type(case: CourtCase, row: Any) -> str | None:

--- a/courts/tests/test_import_courtcases.py
+++ b/courts/tests/test_import_courtcases.py
@@ -262,6 +262,89 @@ class CopyModeLoadTests(_NgmTestCase):
             _copy([_src_row(case="081-CR-0002")]).run()  # target nonempty, no flag
 
 
+class VerdictJudgeDeriveTests(_NgmTestCase):
+    _VDATE = date(2024, 6, 1)
+
+    def test_derives_from_verdict_date_hearing_and_de_run_ons(self):
+        # Decided case, no verdict_judge; the verdict-date hearing carries the bench
+        # (glued, as legacy hearings are) → filled, de-run-on to ", "-separated.
+        row = _src_row(
+            case="081-CR-0091", verdict_date_ad=self._VDATE, verdict_judge=None,
+            hearings=[
+                _hearing(hearing_date_ad=date(2024, 5, 15), judge_names="मा. न्या. श्री क"),
+                _hearing(
+                    hearing_date_ad=self._VDATE, decision_type="फैसला",
+                    judge_names="मा. न्या. श्री राममा. न्या. श्री श्याम",
+                ),
+            ],
+        )
+        res = _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(case_number="081-CR-0091")
+        self.assertEqual(case.verdict_judge, "मा. न्या. श्री राम, मा. न्या. श्री श्याम")
+        self.assertTrue(case.extra_data["_dq"]["verdict_judge_derived"])
+        self.assertEqual(res.dq_verdict_judge_derived, 1)
+
+    def test_does_not_overwrite_existing_verdict_judge(self):
+        row = _src_row(
+            case="081-CR-0092", verdict_date_ad=self._VDATE,
+            verdict_judge="मा. न्या. श्री मौजुदा",
+            hearings=[_hearing(hearing_date_ad=self._VDATE, judge_names="मा. न्या. श्री अर्को")],
+        )
+        res = _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(case_number="081-CR-0092")
+        self.assertEqual(case.verdict_judge, "मा. न्या. श्री मौजुदा")
+        self.assertEqual(res.dq_verdict_judge_derived, 0)
+
+    def test_undecided_or_no_matching_hearing_leaves_null(self):
+        # Not decided (no verdict_date_ad) → skip; and decided but the only hearing
+        # with a judge is on a DIFFERENT date → nothing to derive.
+        undecided = _src_row(case="081-CR-0093", verdict_date_ad=None, verdict_judge=None,
+                             hearings=[_hearing(hearing_date_ad=self._VDATE, judge_names="मा. न्या. श्री क")])
+        no_hit = _src_row(case="081-CR-0094", verdict_date_ad=self._VDATE, verdict_judge=None,
+                          hearings=[_hearing(hearing_date_ad=date(2024, 1, 1), judge_names="मा. न्या. श्री क")])
+        res = _copy([undecided, no_hit]).run()
+        self.assertIsNone(CourtCase.objects.using("ngm").get(case_number="081-CR-0093").verdict_judge)
+        self.assertIsNone(CourtCase.objects.using("ngm").get(case_number="081-CR-0094").verdict_judge)
+        self.assertEqual(res.dq_verdict_judge_derived, 0)
+
+    def test_prefers_decisive_sitting_when_several_on_verdict_date(self):
+        row = _src_row(
+            case="081-CR-0095", verdict_date_ad=self._VDATE, verdict_judge=None,
+            hearings=[
+                _hearing(hearing_date_ad=self._VDATE, case_status="पेशी",
+                         judge_names="मा. न्या. श्री पेशी"),
+                _hearing(hearing_date_ad=self._VDATE, decision_type="फैसला",
+                         judge_names="मा. न्या. श्री फैसला"),
+            ],
+        )
+        _copy([row]).run()
+        case = CourtCase.objects.using("ngm").get(case_number="081-CR-0095")
+        self.assertEqual(case.verdict_judge, "मा. न्या. श्री फैसला")
+
+    def test_inplace_derives_from_db_hearing_and_is_idempotent(self):
+        court = Court.objects.using("ngm").create(
+            identifier="special", court_type="special", full_name_nepali="वि"
+        )
+        CourtCase.objects.using("ngm").create(
+            court=court, case_number="082-CR-0007", verdict_date_ad=self._VDATE,
+            verdict_judge=None,
+        )
+        CourtCaseHearing.objects.using("ngm").create(
+            court=court, case_number="082-CR-0007", hearing_date_ad=self._VDATE,
+            decision_type="अन्तिम आदेश", judge_names="मा. न्या. श्री एकमा. न्या. श्री दुई",
+            scraped_at=_SCRAPED,
+        )
+        cfg = dict(mode=ImportMode.INPLACE, courts=["special"])
+        first = CourtCaseImporter(ImportConfig(**cfg)).run()
+        self.assertEqual(first.dq_verdict_judge_derived, 1)
+        case = CourtCase.objects.using("ngm").get(case_number="082-CR-0007")
+        self.assertEqual(case.verdict_judge, "मा. न्या. श्री एक, मा. न्या. श्री दुई")
+        self.assertTrue(case.extra_data["_dq"]["verdict_judge_derived"])
+        # Re-run finds it populated → no further derivation.
+        second = CourtCaseImporter(ImportConfig(**cfg)).run()
+        self.assertEqual(second.dq_verdict_judge_derived, 0)
+
+
 class InplaceModeTests(_NgmTestCase):
     def test_inplace_leaves_nes_id_and_status_untouched(self):
         court = Court.objects.using("ngm").create(


### PR DESCRIPTION
## Why

The round-2 DQ backfill recovered ~464k missing `verdict_judge` values from each case's verdict-date hearing. But that gap **re-accumulates**: the enrichment detail page never carries the deciding bench for **special court**, and only inconsistently for high/district — so every fresh enrichment run reintroduces decided-but-empty cases. This makes the fix self-maintaining.

## What

New importer DQ-guard (5) `_derive_verdict_judge`, alongside the existing verdict-sentinel / high-court-recovery / case-type / special-defendant guards:

- Fires only when a case is **decided** (`verdict_date_ad` set) and has **no** `verdict_judge`.
- Takes `judge_names` from the **verdict-date hearing**, preferring a decisive `फैसला`/`अन्तिम आदेश` sitting when several hearings fall on that date.
- Runs it through `desep_judges` (the helper from #376) so a multi-judge bench is `, `-separated, not glued.
- Caps to 500, marks `extra_data._dq.verdict_judge_derived` (reversible), counts `dq_verdict_judge_derived`.
- Reads `row['hearings']` for a COPY dict (no extra query); queries the `ngm` DB for an INPLACE `CourtCase` (whose hearings already exist).

**Never overwrites** an existing `verdict_judge`; **idempotent** — a re-run finds it populated and does nothing.

## Tests

New `VerdictJudgeDeriveTests`: derive + de-run-on, no-overwrite, undecided/no-matching-hearing → null, decisive-sitting preference, and inplace derive + idempotency. Full importer suite: **29 passed**.

## Notes

- Pairs with #376 (parse-time de-sep) — together, fresh scrapes produce clean `, `-separated hearing judges, and the importer fills any decided case's `verdict_judge` from them. The ~2.1M-row historical corpus was already repaired by the one-time backfills.
- Scoped to `verdict_judge` only; hearing `judge_names` de-sep stays at parse time (#376) since COPY re-imports from the frozen ngm_v1 source are not a live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)