### PR TITLE
fix(search): explicit, configurable OpenSearch client timeout + retry

### DIFF
--- a/jawafdehi_shared/search/opensearch.py
+++ b/jawafdehi_shared/search/opensearch.py
@@ -18,6 +18,19 @@ def get_opensearch_url() -> str:
     return os.getenv("OPENSEARCH_URL", "http://localhost:9200")
 
 
+def get_opensearch_timeout() -> float:
+    """Per-request timeout (seconds) for the client, from env (OPENSEARCH_TIMEOUT).
+
+    Defaults to 30s — well above opensearch-py's own 10s default, which is too
+    short for bulk indexing of large OCR'd material docs: a full ``reindex_all``
+    of ngm-materials otherwise trips the 10s read-timeout on a batch of oversized
+    documents and fails deterministically part-way through. Bulk/reindex jobs can
+    raise this further (e.g. ``OPENSEARCH_TIMEOUT=120``) without changing the
+    serving-path default.
+    """
+    return float(os.getenv("OPENSEARCH_TIMEOUT", "30"))
+
+
 def make_client(url: str | None = None):
     """Construct an opensearch-py client. Imported lazily so the package is
     importable without the optional dependency installed (e.g. in a service that
@@ -27,12 +40,23 @@ def make_client(url: str | None = None):
     (self-hosted with the security plugin enabled), HTTP basic auth is used and
     TLS verification is left on. With no creds (dev compose, security disabled)
     the client connects anonymously.
+
+    Timeout/retries: the per-request timeout is set explicitly (see
+    ``get_opensearch_timeout``) rather than left at opensearch-py's 10s default,
+    with a small bounded retry on timeout. ``retry_on_timeout`` is safe for our
+    bulk indexers because every unified-search doc is keyed by a deterministic
+    IRI ``_id`` (see ``indexing.stream_bulk``), so a re-sent bulk is idempotent.
     """
     from opensearchpy import OpenSearch  # lazy: optional dependency
 
     user = os.getenv("OPENSEARCH_USER")
     password = os.getenv("OPENSEARCH_PASSWORD")
-    kwargs: dict[str, Any] = {"hosts": [url or get_opensearch_url()]}
+    kwargs: dict[str, Any] = {
+        "hosts": [url or get_opensearch_url()],
+        "timeout": get_opensearch_timeout(),
+        "max_retries": int(os.getenv("OPENSEARCH_MAX_RETRIES", "3")),
+        "retry_on_timeout": True,
+    }
     if user and password:
         kwargs["http_auth"] = (user, password)
     return OpenSearch(**kwargs)

--- a/jawafdehi_shared/search/tests/test_opensearch.py
+++ b/jawafdehi_shared/search/tests/test_opensearch.py
@@ -105,3 +105,44 @@ def test_make_client_anonymous_without_creds(monkeypatch):
 
     opensearch.make_client("http://localhost:9200")
     assert "http_auth" not in captured
+
+
+def _capture_make_client(monkeypatch):
+    """Stub opensearchpy.OpenSearch and return the dict of kwargs it's built with."""
+    import sys
+    import types
+
+    captured = {}
+
+    class FakeOpenSearch:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    fake_mod = types.ModuleType("opensearchpy")
+    fake_mod.OpenSearch = FakeOpenSearch
+    monkeypatch.setitem(sys.modules, "opensearchpy", fake_mod)
+    return captured
+
+
+def test_make_client_sets_timeout_and_retries_by_default(monkeypatch):
+    # No opensearch-py 10s default: an explicit 30s timeout + bounded retry so
+    # bulk indexing of large OCR docs doesn't trip the short read-timeout.
+    monkeypatch.delenv("OPENSEARCH_TIMEOUT", raising=False)
+    monkeypatch.delenv("OPENSEARCH_MAX_RETRIES", raising=False)
+    captured = _capture_make_client(monkeypatch)
+
+    opensearch.make_client("http://localhost:9200")
+    assert captured["timeout"] == 30.0
+    assert captured["max_retries"] == 3
+    assert captured["retry_on_timeout"] is True
+
+
+def test_make_client_timeout_and_retries_overridable_via_env(monkeypatch):
+    # Bulk/reindex jobs raise the timeout without touching the serving default.
+    monkeypatch.setenv("OPENSEARCH_TIMEOUT", "120")
+    monkeypatch.setenv("OPENSEARCH_MAX_RETRIES", "5")
+    captured = _capture_make_client(monkeypatch)
+
+    opensearch.make_client("http://localhost:9200")
+    assert captured["timeout"] == 120.0
+    assert captured["max_retries"] == 5


### PR DESCRIPTION
## Problem

`jawafdehi_shared.search.opensearch.make_client()` builds the opensearch-py client with **no `timeout`**, so it falls back to the library default of **10s per request, with no retry** — and there is no env knob to change it.

A full `reindex_all` of **ngm-materials** trips that 10s read-timeout on a batch of large, OCR'd material documents and fails **deterministically** part-way through (independent of heap/memory). This surfaced during the platform-namespace split, where a from-Postgres rebuild of the new node's index couldn't complete and had to be worked around with a server-side remote reindex.

## Fix

`make_client()` now sets the per-request timeout explicitly and adds a bounded retry:

- `OPENSEARCH_TIMEOUT` — per-request timeout in seconds, **default 30** (up from opensearch-py's 10).
- `OPENSEARCH_MAX_RETRIES` — **default 3**, with `retry_on_timeout=True`.

Bulk/reindex jobs can raise `OPENSEARCH_TIMEOUT` (e.g. `120`) in their own env **without** changing the serving-path default. The client `timeout` flows through to the bulk path because `indexing.stream_bulk` calls `helpers.bulk(client, ...)` with no per-call override.

`retry_on_timeout` is **idempotent-safe** here: every unified-search doc is keyed by a deterministic IRI `_id` (`indexing.stream_bulk`), so a re-sent bulk overwrites rather than duplicates.

## Tests

Extends `jawafdehi_shared/search/tests/test_opensearch.py` (mocked client, no live OpenSearch): asserts the default timeout/retry kwargs and the env override. Full module — 10 passed locally.

## Rollout note

No behavior change for existing deployments unless the new env vars are set. Optionally set `OPENSEARCH_TIMEOUT=120` on the reindex CronJob/Job env so a future from-Postgres `reindex_all` of ngm-materials completes in one shot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenSearch request timeouts.
  * Added automatic retries for timed-out requests, with configurable retry limits.
  * Defaults are set to a 30-second timeout and up to three retries.

* **Bug Fixes**
  * Improved resilience when OpenSearch requests are slow or temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->