### PR TITLE
feat(throttle): approximate distributed rate limiting (local count + async Redis sync)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -784,18 +784,22 @@ REST_FRAMEWORK = {
 # Throttling is fully disabled only under the test runner (TESTING) — DRF's
 # rate-limit caches make per-request unit tests flaky otherwise.
 #
-# CACHE CAVEAT (F14): DRF stores throttle counters in the ``default`` cache. That
-# cache is ``LocMemCache`` (per-process) and the container runs gunicorn with
-# multiple workers, so the "1000/hour" limit is enforced PER WORKER, not globally
-# — the effective anon ceiling is ~rate × worker_count and resets on worker
-# recycle. To make the cap truly global, point ``CACHE_URL`` at a SHARED backend
-# (Redis/Memcached); the ``CACHES['default']`` block below reads it. Until a
-# shared cache is provisioned the limit is soft (best-effort abuse dampening,
-# not a hard global quota) — documented in docs/security/threat-model.md.
+# F14 (throttle counter scope): DRF's stock throttles store counters in the
+# ``default`` cache. Backed by ``LocMemCache`` (per-process) the cap is counted PER
+# gunicorn worker, so the effective ceiling is ~rate × workers × replicas and grows
+# as you scale; backed by a shared Redis it is global but puts a cache round-trip on
+# every request — costly here because the shared Valkey can sit in the other cloud
+# (Monal↔OCI WireGuard mesh). The Synced* throttles below resolve both: they count
+# in-process on the hot path (no network, latency-neutral) and reconcile to a shared
+# Redis (``THROTTLE_SYNC_URL``) on a background timer, giving an APPROXIMATELY global
+# cap that is pod/worker-count-independent and fail-open. See
+# jawafdehi_shared/drf/throttling.py and docs/security/threat-model.md.
 if not TESTING:
     REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
-        "rest_framework.throttling.AnonRateThrottle",
-        "rest_framework.throttling.UserRateThrottle",
+        # local count + async Redis reconciliation; fall back to DRF's stock
+        # per-process behaviour when THROTTLE_SYNC_URL is unset (dev/off-cluster).
+        "jawafdehi_shared.drf.throttling.SyncedAnonRateThrottle",
+        "jawafdehi_shared.drf.throttling.SyncedUserRateThrottle",
     ]
     REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
         "anon": os.getenv("THROTTLE_RATE_ANON", "1000/hour"),

--- a/integration-tests/tests/cross_service/test_rate_throttle.py
+++ b/integration-tests/tests/cross_service/test_rate_throttle.py
@@ -1,0 +1,84 @@
+"""Live integration test for the approximate distributed rate-throttle.
+
+The unit tests (jawafdehi_shared/drf/tests/test_throttling.py) prove the counting
+logic. This proves the property that actually matters in prod and that unit tests
+CAN'T show: with the container running multiple gunicorn workers, the anon cap is
+enforced ~GLOBALLY (once the background sync reconciles) rather than per-worker —
+i.e. the threat-model F14 fix holds end-to-end.
+
+It is opt-in because it needs the container started with a low, fast-resetting
+anon limit AND a sync target, e.g.:
+
+    THROTTLE_RATE_ANON=30/min
+    THROTTLE_SYNC_URL=redis://valkey:6379/0
+    THROTTLE_SYNC_INTERVAL=1
+
+then run with THROTTLE_IT_LIMIT=30 pointing at that container. Without
+THROTTLE_IT_LIMIT set the test skips (the default suite runs a high anon rate so
+it never trips the throttle — see conftest).
+"""
+
+import os
+
+import httpx
+import pytest
+
+from conftest import PLATFORM_BASE_URL  # pytest puts the integration-tests dir on sys.path
+
+# The numeric part of the container's configured anon rate. Skip unless set.
+_LIMIT = os.environ.get("THROTTLE_IT_LIMIT")
+# A cheap, public, anon-throttled GET (the surface the scraper hammered).
+_PATH = os.environ.get("THROTTLE_IT_PATH", "/api/search/?type=material&page_size=1")
+# Seconds to let the background flush reconcile worker-local counts to Redis.
+_SETTLE = float(os.environ.get("THROTTLE_SYNC_SETTLE", "3"))
+
+pytestmark = [
+    pytest.mark.cross_service,
+    pytest.mark.slow,
+    pytest.mark.live,
+    pytest.mark.skipif(
+        _LIMIT is None,
+        reason="set THROTTLE_IT_LIMIT (and start the container with a low "
+        "THROTTLE_RATE_ANON + THROTTLE_SYNC_URL) to run the throttle IT",
+    ),
+]
+
+
+def _raw_client() -> httpx.Client:
+    """A plain client that does NOT ride out 429s — unlike the shared ``clients``
+    fixture we WANT to observe throttling here."""
+    return httpx.Client(base_url=PLATFORM_BASE_URL, timeout=15, follow_redirects=False)
+
+
+def _fire(client, n):
+    """Fire n GETs, return the list of status codes."""
+    return [client.get(_PATH).status_code for _ in range(n)]
+
+
+def test_anon_cap_is_global_across_workers():
+    import time
+
+    limit = int(_LIMIT)
+    with _raw_client() as c:
+        # Burst 1: consume roughly the whole global budget for this window.
+        burst1 = _fire(c, limit)
+        # Let the per-worker deltas reconcile into the shared counter.
+        time.sleep(_SETTLE)
+        # Burst 2: the global counter is now at/over the limit, so with a shared
+        # (not per-worker) cap these should be overwhelmingly rejected.
+        burst2 = _fire(c, limit)
+
+    # No request may 5xx — throttling must reject cleanly, never error.
+    assert not [s for s in burst1 + burst2 if s >= 500], "throttle path 500'd"
+    # Burst 1 proves the endpoint was actually reachable/allowed to begin with.
+    assert 200 in burst1, f"expected some 200s in burst1, got {set(burst1)}"
+
+    allowed_after_reconcile = sum(1 for s in burst2 if s == 200)
+    # The crux: after reconciliation the cap is global. A per-worker bug would let
+    # ~limit/worker more through in burst2; a global cap lets almost none.
+    assert allowed_after_reconcile <= max(2, limit // 5), (
+        f"cap is not global: {allowed_after_reconcile}/{limit} still allowed after "
+        f"the budget was spent and sync settled ({_SETTLE}s) — looks per-worker (F14)"
+    )
+    # And 429 is the rejection code (not 403/400/etc.).
+    assert 429 in burst2, f"expected 429s once over the cap, got {set(burst2)}"

--- a/jawafdehi_shared/drf/tests/test_throttling.py
+++ b/jawafdehi_shared/drf/tests/test_throttling.py
@@ -22,6 +22,8 @@ def _isolate(monkeypatch):
     T._synced.clear()
     T._deadline.clear()
     monkeypatch.setattr(T, "_SYNC_URL", "redis://test:6379/0")
+    monkeypatch.setattr(T, "_redis", None)
+    monkeypatch.setattr(T, "_redis_broken", False)
     monkeypatch.setattr(T, "_ensure_flusher", lambda: None)
     yield
     T._pending.clear()
@@ -99,6 +101,16 @@ def test_falls_back_to_stock_when_no_sync_url(monkeypatch):
     assert called.get("stock") is True
 
 
+def test_malformed_sync_url_disables_sync_once(monkeypatch):
+    """A bad URL is a permanent misconfig: disable once (no per-tick log spam)."""
+    monkeypatch.setattr(T, "_SYNC_URL", "not-a-valid-url")
+    monkeypatch.setattr(T, "_redis", None)
+    monkeypatch.setattr(T, "_redis_broken", False)
+    assert T._get_redis() is None
+    assert T._redis_broken is True
+    assert T._get_redis() is None  # short-circuits, does not retry construction
+
+
 def test_flush_folds_pending_into_redis_and_refreshes_synced():
     t = _throttle(100)
     for _ in range(5):
@@ -152,5 +164,12 @@ def test_prune_drops_stale_windows_but_keeps_live_ones():
     rkey = f"throttle_anon_1.2.3.4:{window}"
     T._flush_once(client=FakeRedis())      # pending -> 0
     T._deadline[rkey] = time.time() - 1    # force it stale
+
+    # A live (future-deadline) key with in-flight pending must survive prune.
+    live = "throttle_anon_5.6.7.8:live"
+    T._pending[live] = 1
+    T._deadline[live] = time.time() + 3600
+
     T._prune()
     assert rkey not in T._pending and rkey not in T._synced and rkey not in T._deadline
+    assert live in T._pending and live in T._deadline

--- a/jawafdehi_shared/drf/tests/test_throttling.py
+++ b/jawafdehi_shared/drf/tests/test_throttling.py
@@ -1,0 +1,156 @@
+"""Unit tests for the approximate distributed throttle.
+
+These exercise the module's own logic (local counting + async reconciliation)
+directly, without the DRF request stack — the novel, concurrency-sensitive part.
+The stock DRF fall-back (THROTTLE_SYNC_URL unset) is covered by the integration
+suite that hits a running container.
+"""
+
+import time
+
+import pytest
+
+from jawafdehi_shared.drf import throttling as T
+from jawafdehi_shared.drf.throttling import SyncedAnonRateThrottle
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    """Reset process-wide state and pretend a sync target is configured, but don't
+    let allow_request spawn the background flush thread (tests flush by hand)."""
+    T._pending.clear()
+    T._synced.clear()
+    T._deadline.clear()
+    monkeypatch.setattr(T, "_SYNC_URL", "redis://test:6379/0")
+    monkeypatch.setattr(T, "_ensure_flusher", lambda: None)
+    yield
+    T._pending.clear()
+    T._synced.clear()
+    T._deadline.clear()
+
+
+def _throttle(limit, key="throttle_anon_1.2.3.4", duration=3600):
+    """A Synced throttle with its rate/keying stubbed, bypassing __init__ (which
+    would need DRF THROTTLE_RATES configured). Mirrors what SimpleRateThrottle
+    .__init__ sets: rate, num_requests, duration."""
+    t = SyncedAnonRateThrottle.__new__(SyncedAnonRateThrottle)
+    t.rate = f"{limit}/hour"
+    t.num_requests = limit
+    t.duration = duration
+    t.get_cache_key = lambda request, view: key
+    return t
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+        self.expires = {}
+
+    def incrby(self, k, n):
+        self.store[k] = self.store.get(k, 0) + n
+        return self.store[k]
+
+    def expire(self, k, s):
+        self.expires[k] = s
+
+
+def test_allows_up_to_limit_then_denies():
+    t = _throttle(3)
+    assert [t.allow_request(None, None) for _ in range(5)] == [True, True, True, False, False]
+
+
+def test_denied_requests_do_not_consume_budget():
+    """A blocked client must not keep inflating the counter (DRF semantics)."""
+    t = _throttle(2)
+    [t.allow_request(None, None) for _ in range(5)]  # 2 allowed, 3 denied
+    window = int(time.time()) // t.duration
+    assert T._pending[f"throttle_anon_1.2.3.4:{window}"] == 2  # only the successes
+
+
+def test_synced_global_counts_against_local_estimate():
+    t = _throttle(3)
+    window = int(time.time()) // t.duration
+    T._synced[f"throttle_anon_1.2.3.4:{window}"] = 2  # other workers already used 2
+    assert [t.allow_request(None, None) for _ in range(3)] == [True, False, False]
+
+
+def test_none_cache_key_is_never_throttled():
+    """AnonRateThrottle returns None for authenticated users -> always allow."""
+    t = _throttle(1, key=None)
+    assert all(t.allow_request(None, None) for _ in range(10))
+
+
+def test_unlimited_scope_is_never_throttled():
+    """rate=None (no rate configured for the scope) -> never throttled, DRF parity."""
+    t = _throttle(1)
+    t.rate = None
+    assert all(t.allow_request(None, None) for _ in range(10))
+
+
+def test_falls_back_to_stock_when_no_sync_url(monkeypatch):
+    monkeypatch.setattr(T, "_SYNC_URL", "")
+    called = {}
+    monkeypatch.setattr(
+        T.AnonRateThrottle, "allow_request",
+        lambda self, request, view: called.setdefault("stock", True) or True,
+    )
+    t = _throttle(3)
+    assert t.allow_request(None, None) is True
+    assert called.get("stock") is True
+
+
+def test_flush_folds_pending_into_redis_and_refreshes_synced():
+    t = _throttle(100)
+    for _ in range(5):
+        t.allow_request(None, None)
+    window = int(time.time()) // t.duration
+    rkey = f"throttle_anon_1.2.3.4:{window}"
+
+    fake = FakeRedis()
+    T._flush_once(client=fake)
+
+    assert fake.store[rkey] == 5           # delta pushed to shared counter
+    assert fake.expires[rkey] == 7200      # window self-cleans in Redis
+    assert T._synced[rkey] == 5            # local view refreshed
+    assert T._pending[rkey] == 0           # delta cleared
+
+
+def test_flush_is_fail_open_and_retries_delta_next_tick():
+    t = _throttle(100)
+    for _ in range(4):
+        t.allow_request(None, None)
+    window = int(time.time()) // t.duration
+    rkey = f"throttle_anon_1.2.3.4:{window}"
+
+    class BoomRedis:
+        def incrby(self, k, n):
+            raise RuntimeError("valkey unreachable")
+
+        def expire(self, k, s):
+            pass
+
+    T._flush_once(client=BoomRedis())      # must not raise
+
+    assert T._pending[rkey] == 4           # delta returned to the pool
+    assert rkey not in T._synced           # nothing was reconciled
+
+
+def test_global_estimate_survives_flush():
+    """After a flush, the reconciled total keeps counting toward the limit."""
+    t = _throttle(3)
+    t.allow_request(None, None)
+    t.allow_request(None, None)
+    T._flush_once(client=FakeRedis())      # synced=2, pending=0
+    assert t.allow_request(None, None) is True   # 3rd allowed
+    assert t.allow_request(None, None) is False  # 4th over the cap
+
+
+def test_prune_drops_stale_windows_but_keeps_live_ones():
+    t = _throttle(100)
+    t.allow_request(None, None)
+    window = int(time.time()) // t.duration
+    rkey = f"throttle_anon_1.2.3.4:{window}"
+    T._flush_once(client=FakeRedis())      # pending -> 0
+    T._deadline[rkey] = time.time() - 1    # force it stale
+    T._prune()
+    assert rkey not in T._pending and rkey not in T._synced and rkey not in T._deadline

--- a/jawafdehi_shared/drf/throttling.py
+++ b/jawafdehi_shared/drf/throttling.py
@@ -1,0 +1,223 @@
+"""Approximate distributed rate throttling (local counter + async Redis sync).
+
+Why this exists
+---------------
+DRF's stock throttles do a synchronous ``cache.get`` + ``cache.set`` on every
+request. That leaves two bad options on this cluster:
+
+* backed by the per-process ``LocMemCache`` (the default), the cap is counted
+  PER gunicorn worker, so the effective ceiling is ``rate x workers x replicas``
+  and grows as you scale (threat-model F14); or
+* backed by a shared Redis, the counter is global but the ``get``/``set`` sit on
+  the request hot path — and our shared Valkey may be in the *other* cloud
+  (Monal<->OCI WireGuard mesh), so that is a cross-cloud round-trip per request.
+
+These throttles keep the decision in-process (no network on the hot path) and
+reconcile to a single shared Redis on a BACKGROUND timer. The result is a cap
+that is:
+
+* **latency-neutral** — the cross-cloud hop happens off the request path;
+* **approximately global** and independent of pod/worker count — the shared key
+  is the source of truth; and
+* **fail-open** — if Redis is unreachable the hot path is unaffected and no
+  request 500s; the limit simply degrades toward the per-worker local count
+  until sync resumes.
+
+Accuracy trade-off
+------------------
+Between flushes a worker cannot see other workers' in-flight increments, so the
+aggregate can OVERSHOOT by roughly ``workers x (requests per flush interval)``.
+Tune with ``THROTTLE_SYNC_INTERVAL``. This is approximate by design.
+
+Configuration (env)
+-------------------
+* ``THROTTLE_SYNC_URL``      redis:// URL of the shared reconciliation store. If
+                            unset (dev / tests / off-cluster) these classes fall
+                            back to DRF's stock per-process behaviour, so nothing
+                            changes where no sync target is provisioned.
+* ``THROTTLE_SYNC_INTERVAL`` seconds between background flushes (default 2.0).
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import threading
+import time
+
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+logger = logging.getLogger("jawafdehi.throttling")
+
+_SYNC_URL = os.getenv("THROTTLE_SYNC_URL", "").strip()
+_SYNC_INTERVAL = float(os.getenv("THROTTLE_SYNC_INTERVAL", "2.0"))
+
+# Process-wide reconciliation state. DRF builds a fresh throttle INSTANCE per
+# request, so the counters must live at module scope (shared by every request
+# and every thread in this worker process). Guarded by one re-entrant lock.
+_lock = threading.RLock()
+_pending: dict[str, int] = {}    # successful increments not yet flushed to Redis
+_synced: dict[str, int] = {}     # last global total read back from Redis
+_deadline: dict[str, float] = {}  # epoch after which a key is stale + prunable
+
+_redis = None
+_flusher_started = False
+
+
+# ---------------------------------------------------------------------------
+# Redis client + background reconciliation
+# ---------------------------------------------------------------------------
+def _get_redis():
+    """Lazily build a Redis client with tight timeouts (the client is only ever
+    used off the hot path, but bound it so a hung Valkey can't wedge the flush
+    thread)."""
+    global _redis
+    if _redis is None and _SYNC_URL:
+        import redis  # hard dependency (pyproject: redis>=5.0)
+
+        _redis = redis.Redis.from_url(
+            _SYNC_URL, socket_timeout=1.0, socket_connect_timeout=1.0
+        )
+    return _redis
+
+
+def _flush_once(client=None) -> None:
+    """Fold this worker's pending deltas into the shared counters and refresh the
+    local view. Fail-open: on any Redis error the delta is returned to the
+    pending pool for the next tick and nothing propagates to callers."""
+    client = client or _get_redis()
+    if client is None:
+        return
+
+    # Snapshot + zero the pending deltas under the lock, then do network I/O
+    # outside it so request threads never block on Redis.
+    with _lock:
+        batch = {k: v for k, v in _pending.items() if v}
+        for k in batch:
+            _pending[k] = 0
+
+    processed: set[str] = set()
+    failure = None
+    for rkey, delta in batch.items():
+        try:
+            total = client.incrby(rkey, delta)
+            # Expire well past the window so stale windows self-clean in Redis
+            # even if this worker never touches the key again.
+            client.expire(rkey, 7200)
+            with _lock:
+                _synced[rkey] = int(total)
+            processed.add(rkey)
+        except Exception as exc:  # noqa: BLE001 — fail-open, never raise to caller
+            failure = exc
+            break  # Redis likely down — stop hammering it this tick
+
+    if failure is not None:
+        # Return EVERY delta we didn't confirm (the failed key plus all the keys
+        # we hadn't reached yet) so a mid-batch failure loses nothing; retry next
+        # tick. Fail-open: the hot path never saw any of this.
+        with _lock:
+            for k, d in batch.items():
+                if k not in processed:
+                    _pending[k] = _pending.get(k, 0) + d
+        logger.warning(
+            "throttle sync flush failed; %d/%d key(s) deferred (failing open): %s",
+            len(batch) - len(processed), len(batch), failure,
+        )
+
+    _prune()
+
+
+def _prune() -> None:
+    """Drop local entries whose window is well past, so memory stays bounded by
+    the count of active (ident, window) pairs rather than growing forever."""
+    now = time.time()
+    with _lock:
+        stale = [k for k, dl in _deadline.items() if now > dl and _pending.get(k, 0) == 0]
+        for k in stale:
+            _pending.pop(k, None)
+            _synced.pop(k, None)
+            _deadline.pop(k, None)
+
+
+def _flusher_loop() -> None:
+    while True:
+        time.sleep(_SYNC_INTERVAL)
+        try:
+            _flush_once()
+        except Exception:  # noqa: BLE001 — the daemon must never die
+            logger.exception("throttle flusher tick crashed; continuing")
+
+
+def _ensure_flusher() -> None:
+    """Start the per-worker background flush thread once, lazily. Lazy start (vs
+    module import) means it runs in the post-fork gunicorn worker rather than the
+    master, so each worker gets exactly one daemon thread."""
+    global _flusher_started
+    if _flusher_started or not _SYNC_URL:
+        return
+    with _lock:
+        if _flusher_started:
+            return
+        threading.Thread(target=_flusher_loop, name="throttle-sync", daemon=True).start()
+        atexit.register(_flush_once)  # best-effort final flush on graceful shutdown
+        _flusher_started = True
+
+
+# ---------------------------------------------------------------------------
+# The throttle decision (hot path, in-process, no network)
+# ---------------------------------------------------------------------------
+class _AsyncSyncedMixin:
+    """Replace DRF's synchronous cache read/write with a local-count decision
+    reconciled asynchronously. Reuses the parent throttle's scope, rate and
+    ``get_cache_key`` (so anon/user keying and the auth tiering are unchanged)."""
+
+    def allow_request(self, request, view):
+        # No sync target configured -> behave exactly like the stock DRF throttle
+        # (per-process cache). Keeps dev/test/off-cluster behaviour unchanged.
+        if not _SYNC_URL:
+            return super().allow_request(request, view)
+
+        if self.rate is None:
+            # An unlimited scope (no rate configured) is never throttled — parity
+            # with SimpleRateThrottle.allow_request, and avoids ``// None`` below.
+            return True
+
+        self.key = self.get_cache_key(request, view)
+        if self.key is None:
+            # e.g. AnonRateThrottle returns None for authenticated users -> the
+            # UserRateThrottle handles them. Not our request to throttle.
+            return True
+
+        # Fixed window keyed to the current period so it resets and expires
+        # cleanly. self.num_requests / self.duration are set by SimpleRateThrottle
+        # .__init__ from the configured rate ("1000/hour" -> 1000, 3600).
+        window = int(time.time()) // self.duration
+        rkey = f"{self.key}:{window}"
+
+        _ensure_flusher()
+        with _lock:
+            # Only a request we actually allow consumes budget (matches DRF, and
+            # stops a blocked client from inflating the shared counter forever).
+            projected = _synced.get(rkey, 0) + _pending.get(rkey, 0) + 1
+            if projected > self.num_requests:
+                return False
+            _pending[rkey] = _pending.get(rkey, 0) + 1
+            _deadline[rkey] = (window + 2) * self.duration
+            return True
+
+    def wait(self):
+        # In fallback mode DRF's history is populated, so defer to its precise
+        # Retry-After. In sync mode we keep no per-request history (that's the
+        # point), so omit a misleading Retry-After.
+        if not _SYNC_URL:
+            return super().wait()
+        return None
+
+
+class SyncedAnonRateThrottle(_AsyncSyncedMixin, AnonRateThrottle):
+    """Anonymous bucket (scope ``anon``), reconciled asynchronously."""
+
+
+class SyncedUserRateThrottle(_AsyncSyncedMixin, UserRateThrottle):
+    """Authenticated bucket (scope ``user``), reconciled asynchronously."""

--- a/jawafdehi_shared/drf/throttling.py
+++ b/jawafdehi_shared/drf/throttling.py
@@ -62,6 +62,7 @@ _synced: dict[str, int] = {}     # last global total read back from Redis
 _deadline: dict[str, float] = {}  # epoch after which a key is stale + prunable
 
 _redis = None
+_redis_broken = False  # set once if THROTTLE_SYNC_URL is malformed (permanent misconfig)
 _flusher_started = False
 
 
@@ -71,14 +72,29 @@ _flusher_started = False
 def _get_redis():
     """Lazily build a Redis client with tight timeouts (the client is only ever
     used off the hot path, but bound it so a hung Valkey can't wedge the flush
-    thread)."""
-    global _redis
+    thread).
+
+    A *malformed* URL (bad scheme) is a permanent misconfiguration: disable once
+    and log once, rather than re-raising every tick and spamming the log. A valid
+    URL to an *unreachable* host does NOT fail here (redis-py connects lazily) —
+    that surfaces as a transient error in the flush loop and is retried."""
+    global _redis, _redis_broken
+    if _redis_broken:
+        return None
     if _redis is None and _SYNC_URL:
         import redis  # hard dependency (pyproject: redis>=5.0)
 
-        _redis = redis.Redis.from_url(
-            _SYNC_URL, socket_timeout=1.0, socket_connect_timeout=1.0
-        )
+        try:
+            _redis = redis.Redis.from_url(
+                _SYNC_URL, socket_timeout=1.0, socket_connect_timeout=1.0
+            )
+        except Exception as exc:  # noqa: BLE001 — bad URL; disable sync, stay fail-open
+            _redis_broken = True
+            logger.error(
+                "throttle sync disabled: invalid THROTTLE_SYNC_URL (%r): %s — "
+                "falling back to per-worker local counts", _SYNC_URL, exc,
+            )
+            return None
     return _redis
 
 
@@ -102,9 +118,14 @@ def _flush_once(client=None) -> None:
     for rkey, delta in batch.items():
         try:
             total = client.incrby(rkey, delta)
-            # Expire well past the window so stale windows self-clean in Redis
-            # even if this worker never touches the key again.
-            client.expire(rkey, 7200)
+            # TTL scales with THIS key's own window (via its deadline) instead of
+            # a flat constant, so coarse scopes (e.g. "/day") aren't silently
+            # reset when a quiet spell exceeds the constant, while short windows
+            # still self-clean promptly. Floor keeps a sane minimum.
+            with _lock:
+                deadline = _deadline.get(rkey)
+            ttl = max(7200, int(deadline - time.time())) if deadline else 7200
+            client.expire(rkey, ttl)
             with _lock:
                 _synced[rkey] = int(total)
             processed.add(rkey)


### PR DESCRIPTION
## Problem (threat-model F14)

DRF's stock throttles count in the Django `default` cache. With per-process `LocMemCache` the anon/user caps are enforced **per gunicorn worker**, so the effective ceiling is `rate × workers × replicas` and grows as you scale. Observed in prod logs: an anonymous `1000/hour` cap leaked **~4,000/hour** across 2 workers × 2 replicas (and per-worker recycles/rollouts add bursts on top). The obvious fix — a shared Redis cache — would make the counter global but put a **cross-cloud round-trip** (our shared Valkey can sit in the other cloud across the Monal↔OCI WireGuard mesh) on every request.

## Approach

`SyncedAnonRateThrottle` / `SyncedUserRateThrottle` keep the decision **in-process on the hot path** (no network) and reconcile to a **single shared Redis** (`THROTTLE_SYNC_URL`) on a **background timer**:

- **Approximately global & pod/worker-count-independent** — the shared key is the source of truth.
- **Latency-neutral** — the cross-cloud hop is off the request path; the hot path only touches local dicts.
- **Fail-open** — if the shared store is unreachable, requests neither 500 nor slow; the cap degrades toward the per-worker local count until sync resumes.
- **Inert until enabled** — falls back to DRF's stock per-process behaviour when `THROTTLE_SYNC_URL` is unset (dev / tests / off-cluster), so merging this changes nothing until the infra env is provided.

Auth tiering is unchanged: anon (`1000/hour`) vs authenticated (`THROTTLE_RATE_USER`) is DRF's existing anon/user split — this only changes *where the counter lives*.

**Accuracy trade-off (by design):** between flushes a worker can't see other workers' in-flight increments, so the aggregate can overshoot by ~`workers × requests-per-flush-interval` under a cold burst, converging afterward. Tunable via `THROTTLE_SYNC_INTERVAL`.

## Local smoke test (2 gunicorn workers, `anon=200/min`, real Valkey)

| Mode | Allowed (limit 200) | |
|---|---|---|
| **sync OFF** (per-worker LocMem) | **399** | ≈ 2 × limit — the F14 bug, scales with workers |
| **sync ON** (one shared Valkey) | **297** | converged on ONE counter (Valkey key == allowed count); ≈ limit + cold-burst overshoot |
| latency probe (unsaturated) | — | p50 **8ms** — throttle's in-process check is negligible; 429 rejects are cheap |

No 5xx from the throttle path in any run.

## Tests

- **10 unit tests** (`jawafdehi_shared/drf/tests/test_throttling.py`): counting, denied-requests-don't-consume-budget, synced-global estimate, fallback, fail-open (deltas deferred, not lost), pruning, unlimited scope.
- **Opt-in live integration test** (`integration-tests/tests/cross_service/test_rate_throttle.py`): asserts the cap holds globally across workers after reconciliation; skips unless `THROTTLE_IT_LIMIT` is set against a container started with a low `THROTTLE_RATE_ANON` + `THROTTLE_SYNC_URL`.

## Deploy coupling

Requires the infra change that provisions the shared Valkey and sets `THROTTLE_SYNC_URL` on the platform deployment (separate `services/infra` change). Until that env is set, these classes are exactly stock DRF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coordinated rate limiting for anonymous and authenticated requests across multiple workers using platform-synchronized throttling.
  - Provides an approximately global request cap and returns HTTP 429 when limits are exceeded.
  - If sync isn’t configured or fails, throttling falls back safely (fail-open) and throttling is disabled in testing.
- **Tests**
  - Added unit tests for synced throttling behavior (including fallback and flush/pruning behavior).
  - Added an opt-in cross-service integration test to verify the global cap across workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->