### PR TITLE
feat(statistics): add total_bigo to /api/statistics

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -1313,6 +1313,8 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
     - `cases_ciaa`: Number of CIAA corruption cases (case_type CORRUPTION)
     - `cases_non_ciaa`: Number of cases handled outside CIAA (all other types)
     - `entities_tracked`: Number of unique entities involved in published cases
+    - `total_bigo`: Sum of the bigo (बिगो — the disputed/embezzled amount, NPR)
+      across published cases; 0 when no published case carries an amount
     - `nes`: NES (entities) coverage — total, by-prefix / by-type breakdowns,
       persons-by-sector (`persons_by_sector`, derived from the office each person
       holds), and completeness percentages (identifier / provenance / bilingual
@@ -1346,6 +1348,7 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 "cases_ciaa": {"type": "integer", "example": 88},
                 "cases_non_ciaa": {"type": "integer", "example": 39},
                 "entities_tracked": {"type": "integer", "example": 89},
+                "total_bigo": {"type": "integer", "example": 4519830000},
                 "nes": {"type": "object", "description": "NES coverage metrics"},
                 "ngm": {
                     "type": "object",

--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 
 from django.db import connections
-from django.db.models import Count, Q
+from django.db.models import Count, Q, Sum
 from django.db.models.functions import ExtractYear
 from django.utils import timezone
 
@@ -145,6 +145,12 @@ def _case_counts() -> dict:
         # (bribery, forgery, embezzlement, ...) runs through other bodies.
         ciaa=Count("pk", filter=Q(case_type=CaseType.CORRUPTION)),
         non_ciaa=Count("pk", filter=~Q(case_type=CaseType.CORRUPTION)),
+        # Total bigo (बिगो) — the summed disputed/embezzled amount (NPR) across
+        # PUBLISHED cases only, matching the public framing of the other headline
+        # metrics (entities_tracked is likewise published-only). Sum is NULL when
+        # no published case carries an amount; the ``or 0`` below keeps the key an
+        # integer so the payload shape never varies.
+        total_bigo=Sum("bigo", filter=Q(state=CaseState.PUBLISHED)),
     )
     return {
         "published_cases": by_state["published"],
@@ -153,6 +159,7 @@ def _case_counts() -> dict:
         "cases_closed": by_state["closed"],
         "cases_ciaa": by_state["ciaa"],
         "cases_non_ciaa": by_state["non_ciaa"],
+        "total_bigo": by_state["total_bigo"] or 0,
         # Unique NES entities tracked across published cases (binds hold the
         # nes_id directly; NES owns the entity records).
         "entities_tracked": (

--- a/tests/api/test_statistics_api.py
+++ b/tests/api/test_statistics_api.py
@@ -69,6 +69,7 @@ class TestStatisticsEndpoint:
         assert "cases_closed" in data
         assert "cases_ciaa" in data
         assert "cases_non_ciaa" in data
+        assert "total_bigo" in data
         assert "last_updated" in data
         # NGM court-cases-per-year aggregations for the coverage matrix.
         assert "by_year" in data["ngm"]
@@ -94,6 +95,7 @@ class TestStatisticsEndpoint:
         assert data["entities_tracked"] == 0
         assert data["cases_under_investigation"] == 0
         assert data["cases_closed"] == 0
+        assert data["total_bigo"] == 0
 
 
 @pytest.mark.django_db
@@ -307,6 +309,51 @@ class TestStatisticsCounting:
 
         assert data["cases_in_review"] == 2
         assert data["cases_under_investigation"] == 3
+
+    def test_total_bigo_sums_published_case_amounts(self, api_client):
+        """total_bigo sums the bigo (disputed/embezzled NPR) of PUBLISHED cases,
+        skips cases with no amount recorded, and ignores unpublished cases."""
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.PUBLISHED,
+            title="Published bigo 1",
+            bigo=10_000_000,
+        )
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.PUBLISHED,
+            title="Published bigo 2",
+            bigo=5_000_000,
+        )
+        # Published but no amount recorded (bigo NULL) — contributes nothing.
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.PUBLISHED,
+            title="Published no bigo",
+        )
+        # A large amount on an unpublished case must NOT be counted.
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.DRAFT,
+            title="Draft bigo",
+            bigo=999_000_000,
+        )
+
+        data = api_client.get("/api/statistics/").json()
+
+        assert data["total_bigo"] == 15_000_000
+
+    def test_total_bigo_zero_when_no_published_amounts(self, api_client):
+        """total_bigo is 0 (never None) when no published case carries a bigo."""
+        Case.objects.create(
+            case_type=CaseType.CORRUPTION,
+            state=CaseState.PUBLISHED,
+            title="Published no bigo",
+        )
+
+        data = api_client.get("/api/statistics/").json()
+
+        assert data["total_bigo"] == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What
Adds a `total_bigo` field to the `/api/statistics` payload — the summed **bigo** (बिगो, the disputed/embezzled amount in NPR) across **published** cases.

## How
- `cases/services/statistics.py`: `Sum("bigo", filter=Q(state=PUBLISHED))` added to the existing `_case_counts()` aggregate (one query, no extra round-trip), coalesced to `0`. Because it lives in `_case_counts()`, both the real payload and the bootstrap placeholder carry the key, so the shape-parity test stays green automatically.
- `cases/api_views.py`: documents the new key in the endpoint description + OpenAPI response schema.
- Tests: presence + zero-on-empty, plus dedicated tests for the published-only filter, NULL-skipping, and zero-when-no-amounts.

**Scope:** summed over **published** cases only (matching `entities_tracked`), and `bigo` is nullable — so the figure reflects published cases that actually have an amount recorded.

## Verification
`tests/api/test_statistics_api.py` — all 35 statistics tests pass.

## Deploy note
The endpoint serves a snapshot refreshed by the `platform-refresh-statistics` CronJob, so `total_bigo` appears after the next refresh (or a manual `manage.py refresh_statistics`) once deployed. The frontend tile (`Jawafdehi` repo, branch `feat/hero-total-bigo`) depends on this shipping first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `total_bigo` metric to case statistics, showing the combined disputed or embezzled amount for published cases.
  * Returns `0` when no applicable amount is available.
  * Included the new metric in the statistics API response documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->