### PR TITLE
feat(materials): port ciaa_press_releases → Materials via the REST ingestion plane

### DIFF
--- a/materials/management/commands/scrape_ciaa_press_releases.py
+++ b/materials/management/commands/scrape_ciaa_press_releases.py
@@ -1,0 +1,350 @@
+"""Ingest CIAA press releases (प्रेस विज्ञप्ति) into Materials via the API plane.
+
+Replaces the retired ``ciaa_press_releases`` Scrapy spider (archived
+``Jawafdehi/ngm``). The old pipeline was three hops — spider → R2 files + the
+``ngm_v1`` DocumentSource index → ``sync_materials_from_index`` → Materials — but
+``ngm_v1`` is now FROZEN, so no NEW press release can reach the archive. This
+command closes that gap: it walks CIAA's sequential press-release ids, shapes each
+into Material JSON-LD (``materials.sourcing.ciaa``), and writes it through the
+material REST plane — ``PUT /api/materials/<source>/<ident>`` for the doc, then
+``POST …/file`` for each attachment. It is a thin CLIENT; it never touches the ORM.
+
+Idempotency + resume, without a checkpoint file: before fetching an id it asks the
+material API whether ``/material/ciaa_press_release/<id>`` already exists (a public
+GET) and SKIPS it if so. The ~thousands of historical press releases already exist
+as Materials (from the frozen-index sync), so they are skipped cheaply and their
+durable R2 links are preserved; only genuinely-new ids are fetched and ingested.
+Gaps self-heal (a missing id is re-fetched). The crawl stops after
+``--max-consecutive-missing`` real 302/404s from CIAA (the end of the id range).
+
+Dry-run by default (fetch + parse + report, write nothing); ``--write`` posts. The
+material write endpoints are NGM-role gated, so ``--write`` needs an ``sa-ingestion``
+(Caseworker) bearer via ``INGESTION_API_TOKEN`` (the CronJob injects it from
+OpenBao) and a base URL via ``MATERIAL_API_BASE`` / ``INGESTION_API_BASE``.
+
+    manage.py scrape_ciaa_press_releases --start-id 3400            # dry-run recon
+    INGESTION_API_TOKEN=… manage.py scrape_ciaa_press_releases --write   # the CronJob run
+    manage.py scrape_ciaa_press_releases --start-id 3000 --limit 5  # bounded smoke test
+
+The pure parse/shape halves live in ``materials.sourcing.ciaa`` (unit-tested).
+"""
+
+from __future__ import annotations
+
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+
+from materials.sourcing.ciaa.parse import parse_press_release
+from materials.sourcing.ciaa.shaper import CIAA_PRESS_SOURCE, press_release_to_jsonld
+
+#: CIAA press-release page base (``…/pressrelease/<id>``) and the one-shot language
+#: toggle that pins the session to Nepali for Devanagari titles.
+PRESS_RELEASE_BASE = "https://ciaa.gov.np/pressrelease/"
+CHANGE_LANG_URL = "https://ciaa.gov.np/changeLang/1"
+
+_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) Jawafdehi-ciaa-crawler"
+
+#: Default material-API base (local/dev). The CronJob overrides it with the
+#: in-cluster platform service via ``MATERIAL_API_BASE`` / ``INGESTION_API_BASE``.
+_DEFAULT_API_BASE = "http://127.0.0.1:8080"
+
+#: HTTP statuses CIAA returns for a non-existent press release (302 → site root).
+_MISSING_STATUSES = frozenset({301, 302, 404})
+
+
+class CiaaSourceClient:
+    """Fetches CIAA press-release pages + attachments over one session.
+
+    Redirects are NOT followed on the page fetch so a missing id reads as its raw
+    302 (following it would land on the 200 homepage and look like a hit). The
+    language is pinned to Nepali once per session. Never raises — a transport
+    failure returns ``status=None`` so the caller treats it as transient, not as
+    the end of the range.
+    """
+
+    def __init__(self, timeout: int = 60):
+        import requests
+
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": _USER_AGENT})
+        self._timeout = timeout
+        self._lang_pinned = False
+
+    def _ensure_nepali(self) -> None:
+        if self._lang_pinned:
+            return
+        try:
+            self._session.get(CHANGE_LANG_URL, timeout=self._timeout, allow_redirects=False)
+        except Exception:  # noqa: BLE001 — best-effort; content is Devanagari regardless.
+            pass
+        self._lang_pinned = True
+
+    def get_press_release(self, press_id: int) -> tuple[int | None, str]:
+        self._ensure_nepali()
+        try:
+            resp = self._session.get(
+                f"{PRESS_RELEASE_BASE}{press_id}", timeout=self._timeout, allow_redirects=False
+            )
+        except Exception:  # noqa: BLE001
+            return None, ""
+        return resp.status_code, resp.text
+
+    def page_url(self, press_id: int) -> str:
+        return f"{PRESS_RELEASE_BASE}{press_id}"
+
+    def download(self, url: str) -> tuple[int | None, bytes, str]:
+        try:
+            resp = self._session.get(url, timeout=self._timeout, allow_redirects=True)
+        except Exception:  # noqa: BLE001
+            return None, b"", ""
+        return resp.status_code, resp.content, resp.headers.get("Content-Type", "")
+
+
+class MaterialApiClient:
+    """Thin client for the material REST plane (existence GET + PUT doc + /file).
+
+    ``token`` is optional: the existence GET is public (unauthenticated), so a
+    dry-run recon against prod needs no credentials; ``PUT`` / ``/file`` are
+    NGM-role gated and require the bearer.
+    """
+
+    def __init__(self, base_url: str, token: str | None, timeout: int = 60):
+        import requests
+
+        self._base = base_url.rstrip("/")
+        self._session = requests.Session()
+        self._session.headers.update({"Accept": "application/json"})
+        if token:
+            self._session.headers.update({"Authorization": f"Bearer {token}"})
+        self._timeout = timeout
+
+    def _url(self, source: str, ident: str, suffix: str = "") -> str:
+        return f"{self._base}/api/materials/{source}/{ident}{suffix}"
+
+    def exists(self, source: str, ident: str) -> bool:
+        """True iff a live material is stored at this ``@id``. A transport error
+        returns False (can't confirm → don't skip; the upsert is idempotent so
+        re-ingesting is safe, just wasteful)."""
+        try:
+            resp = self._session.get(self._url(source, ident), timeout=self._timeout)
+        except Exception:  # noqa: BLE001
+            return False
+        return resp.status_code == 200
+
+    def put_document(self, source: str, ident: str, doc: dict, material_type: str) -> tuple[int, object]:
+        resp = self._session.put(
+            self._url(source, ident),
+            json={"material": doc, "material_type": material_type},
+            timeout=self._timeout,
+        )
+        return resp.status_code, _safe_json(resp)
+
+    def upload_file(
+        self,
+        source: str,
+        ident: str,
+        *,
+        filename: str,
+        content: bytes,
+        content_type: str,
+        role: str,
+        source_url: str,
+        skip_convert: bool,
+        material_type: str,
+    ) -> tuple[int, object]:
+        files = {"file": (filename, content, content_type or "application/octet-stream")}
+        data = {
+            "role": role,
+            "source_url": source_url or "",
+            "material_type": material_type,
+        }
+        if skip_convert:
+            data["skip_convert"] = "true"
+        resp = self._session.post(
+            self._url(source, ident, "/file"), files=files, data=data, timeout=self._timeout
+        )
+        return resp.status_code, _safe_json(resp)
+
+
+def _safe_json(resp) -> object:
+    try:
+        return resp.json()
+    except Exception:  # noqa: BLE001
+        return (resp.text or "")[:200]
+
+
+def build_source_client(timeout: int) -> CiaaSourceClient:
+    """Factory (a seam for tests to inject a fake source transport)."""
+    return CiaaSourceClient(timeout=timeout)
+
+
+def build_material_client(base_url: str, token: str | None, timeout: int) -> MaterialApiClient:
+    """Factory (a seam for tests to inject a fake material client)."""
+    return MaterialApiClient(base_url, token, timeout=timeout)
+
+
+def attachment_roles(file_urls: list[str]) -> list[tuple[str, str]]:
+    """Assign an upload role to each attachment: the (first) PDF is RAW, the rest
+    ALTERNATE — matching the legacy index's promotion. With no PDF, the first file
+    is RAW."""
+    if not file_urls:
+        return []
+    raw_index = next((i for i, url in enumerate(file_urls) if url.lower().endswith(".pdf")), 0)
+    return [(url, "RAW" if i == raw_index else "ALTERNATE") for i, url in enumerate(file_urls)]
+
+
+def _filename_for(url: str, press_id: int) -> str:
+    name = url.rsplit("/", 1)[-1].split("?", 1)[0].strip()
+    return name or f"{press_id}"
+
+
+class Command(BaseCommand):
+    help = "Ingest CIAA press releases into Materials via the material REST plane."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--start-id", type=int, default=1,
+            help="first press-release id to scan (default 1)",
+        )
+        parser.add_argument(
+            "--limit", type=int, default=0,
+            help="max NEW press releases to ingest this run (0 = no limit)",
+        )
+        parser.add_argument(
+            "--max-consecutive-missing", type=int, default=10,
+            help="stop after this many consecutive 302/404s from CIAA (default 10)",
+        )
+        parser.add_argument(
+            "--force", action="store_true",
+            help="re-ingest ids that already exist as materials (skip the existence check)",
+        )
+        parser.add_argument("--timeout", type=int, default=60, help="HTTP timeout (s)")
+        parser.add_argument(
+            "--api-base", default=None,
+            help="material API base URL (default: $MATERIAL_API_BASE / $INGESTION_API_BASE / loopback)",
+        )
+        parser.add_argument(
+            "--api-token", default=None,
+            help="bearer token for writes (default: $INGESTION_API_TOKEN)",
+        )
+        parser.add_argument(
+            "--write", action="store_true",
+            help="POST to the material API (default: dry-run — fetch + parse only)",
+        )
+
+    def handle(self, *args, **o):
+        write = o["write"]
+        source = build_source_client(o["timeout"])
+        material = self._material_client(o, require_token=write)
+
+        mode = "WRITE" if write else "DRY-RUN"
+        self.stdout.write(
+            f"scrape_ciaa_press_releases [{mode}] start-id={o['start_id']} "
+            f"stop-after={o['max_consecutive_missing']} missing"
+        )
+
+        stats = {
+            "scanned": 0, "skipped": 0, "fetched": 0, "missing": 0,
+            "transient": 0, "put": 0, "files": 0, "failed": 0,
+        }
+        consecutive_missing = 0
+        press_id = o["start_id"]
+
+        while consecutive_missing < o["max_consecutive_missing"]:
+            if o["limit"] and stats["fetched"] >= o["limit"]:
+                self.stdout.write(f"stop: reached --limit {o['limit']} new ingested")
+                break
+            stats["scanned"] += 1
+
+            if not o["force"] and material.exists(CIAA_PRESS_SOURCE, str(press_id)):
+                stats["skipped"] += 1
+                consecutive_missing = 0
+                press_id += 1
+                continue
+
+            status, html = source.get_press_release(press_id)
+            if status in _MISSING_STATUSES:
+                stats["missing"] += 1
+                consecutive_missing += 1
+                press_id += 1
+                continue
+            if status != 200 or not html:
+                # Transient (timeout / 5xx): don't count toward the end-of-range
+                # stop, don't advance the missing run — just move on.
+                stats["transient"] += 1
+                self.stderr.write(f"  id {press_id}: HTTP {status} (transient, skipped)")
+                press_id += 1
+                continue
+
+            consecutive_missing = 0
+            stats["fetched"] += 1
+            record = parse_press_release(html, press_id=press_id, source_url=source.page_url(press_id))
+            self.stdout.write(
+                f"  id {press_id}: {record.title[:60]!r} "
+                f"({len(record.file_urls)} file(s), date {record.publication_date_bs or '—'})"
+            )
+            if write:
+                self._ingest(material, source, record, stats)
+            press_id += 1
+
+        self.stdout.write(
+            f"done [{mode}]: " + " ".join(f"{key}={value}" for key, value in stats.items())
+        )
+
+    def _ingest(self, material, source, record, stats) -> None:
+        """PUT the doc, then upload each attachment. One failure is logged and
+        counted, never fatal to the run."""
+        doc, material_type = press_release_to_jsonld(record)
+        try:
+            status, body = material.put_document(
+                CIAA_PRESS_SOURCE, str(record.press_id), doc, material_type
+            )
+        except Exception as exc:  # noqa: BLE001
+            stats["failed"] += 1
+            self.stderr.write(f"  id {record.press_id}: PUT raised: {exc}")
+            return
+        if status not in (200, 201):
+            stats["failed"] += 1
+            self.stderr.write(f"  id {record.press_id}: PUT {status}: {body}")
+            return
+        stats["put"] += 1
+
+        # We already scraped the body text, so suppress the server-side re-OCR —
+        # UNLESS there is no text (an image-only release), where OCR is worth it.
+        skip_convert = bool((record.full_text or "").strip())
+        for url, role in attachment_roles(record.file_urls):
+            dstatus, content, ctype = source.download(url)
+            if dstatus != 200 or not content:
+                self.stderr.write(f"  id {record.press_id}: attachment {dstatus} {url}")
+                continue
+            try:
+                ustatus, ubody = material.upload_file(
+                    CIAA_PRESS_SOURCE, str(record.press_id),
+                    filename=_filename_for(url, record.press_id),
+                    content=content, content_type=ctype, role=role,
+                    source_url=record.source_url, skip_convert=skip_convert,
+                    material_type=material_type,
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.stderr.write(f"  id {record.press_id}: /file raised: {exc}")
+                continue
+            if ustatus in (200, 201):
+                stats["files"] += 1
+            else:
+                self.stderr.write(f"  id {record.press_id}: /file {ustatus}: {ubody}")
+
+    def _material_client(self, o, *, require_token: bool) -> MaterialApiClient:
+        base = (
+            o["api_base"]
+            or os.environ.get("MATERIAL_API_BASE")
+            or os.environ.get("INGESTION_API_BASE")
+            or _DEFAULT_API_BASE
+        )
+        token = o["api_token"] or os.environ.get("INGESTION_API_TOKEN")
+        if require_token and not token:
+            raise CommandError(
+                "--write needs a bearer token: set INGESTION_API_TOKEN (the CronJob "
+                "injects the sa-ingestion token) or pass --api-token."
+            )
+        return build_material_client(base, token, o["timeout"])

--- a/materials/management/commands/scrape_ciaa_press_releases.py
+++ b/materials/management/commands/scrape_ciaa_press_releases.py
@@ -216,6 +216,11 @@ class Command(BaseCommand):
             help="stop after this many consecutive 302/404s from CIAA (default 10)",
         )
         parser.add_argument(
+            "--max-consecutive-transient", type=int, default=25,
+            help="give up after this many consecutive transient failures (timeout / "
+            "5xx / non-result) so a source outage can't loop forever (default 25)",
+        )
+        parser.add_argument(
             "--force", action="store_true",
             help="re-ingest ids that already exist as materials (skip the existence check)",
         )
@@ -249,9 +254,19 @@ class Command(BaseCommand):
             "transient": 0, "put": 0, "files": 0, "failed": 0,
         }
         consecutive_missing = 0
+        consecutive_transient = 0
         press_id = o["start_id"]
 
         while consecutive_missing < o["max_consecutive_missing"]:
+            if consecutive_transient >= o["max_consecutive_transient"]:
+                # A persistent outage (every fetch times out / 5xx) never produces a
+                # 302 to trip the missing-stop, so bound it here rather than loop the
+                # id space forever.
+                self.stderr.write(
+                    f"stop: {consecutive_transient} consecutive transient failures "
+                    f"at id ~{press_id} (source likely down)"
+                )
+                break
             if o["limit"] and stats["fetched"] >= o["limit"]:
                 self.stdout.write(f"stop: reached --limit {o['limit']} new ingested")
                 break
@@ -260,6 +275,7 @@ class Command(BaseCommand):
             if not o["force"] and material.exists(CIAA_PRESS_SOURCE, str(press_id)):
                 stats["skipped"] += 1
                 consecutive_missing = 0
+                consecutive_transient = 0
                 press_id += 1
                 continue
 
@@ -267,17 +283,20 @@ class Command(BaseCommand):
             if status in _MISSING_STATUSES:
                 stats["missing"] += 1
                 consecutive_missing += 1
+                consecutive_transient = 0  # a definitive 302/404 is progress
                 press_id += 1
                 continue
             if status != 200 or not html:
                 # Transient (timeout / 5xx): don't count toward the end-of-range
-                # stop, don't advance the missing run — just move on.
+                # stop, but DO bound it (above) so an outage can't loop forever.
                 stats["transient"] += 1
+                consecutive_transient += 1
                 self.stderr.write(f"  id {press_id}: HTTP {status} (transient, skipped)")
                 press_id += 1
                 continue
 
             consecutive_missing = 0
+            consecutive_transient = 0
             stats["fetched"] += 1
             record = parse_press_release(html, press_id=press_id, source_url=source.page_url(press_id))
             self.stdout.write(

--- a/materials/sourcing/README.md
+++ b/materials/sourcing/README.md
@@ -1,7 +1,8 @@
 # `materials/sourcing/` — external-source ingestion
 
 One subpackage per external source that feeds Materials into the archive
-(`nkp/` — Nepal Law Journal precedents; `ag/` — Attorney-General indictments).
+(`nkp/` — Nepal Law Journal precedents; `ag/` — Attorney-General indictments;
+`ciaa/` — CIAA press releases, `प्रेस विज्ञप्ति`).
 
 ## Convention
 

--- a/materials/sourcing/README.md
+++ b/materials/sourcing/README.md
@@ -20,7 +20,7 @@ Each source lives in `materials/sourcing/<source>/` and owns:
 The shaper's `(doc, material_type)` tuple is the single shape across sources — a
 generic dict shaped for `POST /api/materials/` plus the promoted-column token.
 
-## Ingestion is via the API plane — never a management command
+## Ingestion is via the API plane — never ORM-direct
 
 Sourcing pipelines are **HTTP clients** of the material API; they do not reach
 into the ORM. A pipeline `POST`s the shaped doc to `/api/materials/` (or uploads
@@ -30,3 +30,11 @@ every write funnels through the one upsert primitive
 `@id`, `created_at`-preserving, and revive-on-re-upsert. Keeping ingestion on the
 API plane respects the service boundary (the scrape→OCR→shape loop lives outside
 the Django app) and means there is exactly one write path to reason about.
+
+The rule is about the ORM, not about *where* the client lives. A recurring
+in-repo `manage.py` command (e.g. `scrape_ciaa_press_releases`) is fine **as long
+as it is only an HTTP client** — it fetches, shapes, and calls the material API
+exactly like an external pipeline; it must not import models and write rows. This
+keeps the acquisition on a CronJob against the platform's own API (one auth-gated,
+audited write path) while the source-specific scrape/shape code lives here beside
+the other sources.

--- a/materials/sourcing/ciaa/parse.py
+++ b/materials/sourcing/ciaa/parse.py
@@ -1,0 +1,154 @@
+"""Parse a CIAA press-release page (``ciaa.gov.np/pressrelease/<id>``) into a record.
+
+The pure parse half of the ``scrape_ciaa_press_releases`` command. CIAA publishes
+press releases (प्रेस विज्ञप्ति) at sequential integer ids; each page carries a
+title, a body, and zero or more downloadable attachments (PDF/DOC/images) under
+``/uploads/``. A missing id 302-redirects to the site root — that "missing" signal
+is an HTTP-status concern the command handles; this module only parses a fetched
+200 page and never decides existence.
+
+Ported from the retired ``ciaa_press_releases`` Scrapy spider (archived
+``Jawafdehi/ngm``): the xpath selectors are translated to BeautifulSoup (the
+parser lib the courts scrapers already use). ``press_id`` is preserved verbatim so
+the shaper can mint the SAME ``@id`` the legacy index used
+(``ngm:ciaa-press-release:<id>`` → ``/material/ciaa_press_release/<id>``), keeping
+a re-ingest idempotent with the materials already synced from the frozen index.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+
+# The sourcing text helpers live once, in the nkp normalizer (same subsystem);
+# reuse them rather than mint a fourth copy of whitespace/numeral normalization.
+from materials.sourcing.nkp.normalizer import (
+    nepali_to_roman_numerals,
+    normalize_whitespace,
+)
+
+#: The single content column the whole record lives in (title, body, links). bs4
+#: class matching is membership (``col-sm-8`` among the element's classes), which
+#: is slightly more lenient than the legacy ``@class="col-sm-8"`` xpath and so
+#: strictly more robust to an added utility class.
+_CONTAINER_ATTRS = {"class": "col-sm-8"}
+
+#: Link/UI label text that is page chrome, never body text (the download badge and
+#: the social buttons), dropped from the extracted full text.
+_JUNK_TEXT = frozenset({"Download", "Tweet", "डाउनलोड"})
+
+#: Attachment link classes: ``badge`` (PDF/DOC download badges) and
+#: ``mailbox-attachment-name`` (inline image attachments). Only ``/uploads/`` hrefs
+#: are attachments (the site logo / nav links are excluded by that path filter).
+_ATTACHMENT_CLASSES = ("badge", "mailbox-attachment-name")
+
+# Publication-date forms seen in the corpus, tried in order against the
+# Devanagari→ASCII-digit-normalized text. All yield a Bikram Sambat YYYY-MM-DD.
+_DATE_PATTERNS = (
+    re.compile(r"Press\s+Release[-\s]*(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})", re.IGNORECASE),
+    re.compile(r"मिति\s*(\d{4})[।./\-]\s*(\d{1,2})[।./\-]\s*(\d{1,2})"),
+    re.compile(r"प्रेस\s*विज्ञप्ति\s*(\d{4})[।./\-]\s*(\d{1,2})[।./\-]\s*(\d{1,2})"),
+)
+# A bare leading date (``२०८१/०९/२८``) — matched against the STRIPPED text so the
+# ``^`` anchor holds even when the body starts with whitespace.
+_BARE_DATE_PATTERN = re.compile(r"^(\d{4})[।./\-]\s*(\d{1,2})[।./\-]\s*(\d{1,2})")
+
+
+@dataclass
+class ParsedPressRelease:
+    """One CIAA press release, parsed from its (200-response) page."""
+
+    press_id: int
+    title: str = ""
+    full_text: str = ""
+    publication_date_bs: str = ""
+    file_urls: list[str] = field(default_factory=list)
+    source_url: str = ""
+
+
+def parse_press_release(html: object, *, press_id: int, source_url: str) -> ParsedPressRelease:
+    """Parse a fetched press-release page into a ``ParsedPressRelease``.
+
+    Always returns a record for a 200 page (title/body may be empty for a thin
+    page); the caller decides "missing" from the HTTP status, not from an empty
+    parse. Attachment links are read BEFORE the body text so stripping the
+    download-badge chrome doesn't drop them.
+    """
+    soup = BeautifulSoup(str(html or ""), "html.parser")
+    container = soup.find("div", attrs=_CONTAINER_ATTRS) or soup
+
+    title = _extract_title(container)
+    file_urls = _extract_file_urls(container, source_url)
+    full_text = _extract_full_text(container)
+    publication_date_bs = guess_publication_date(f"{title}\n{full_text}")
+
+    return ParsedPressRelease(
+        press_id=press_id,
+        title=title,
+        full_text=full_text,
+        publication_date_bs=publication_date_bs,
+        file_urls=file_urls,
+        source_url=source_url,
+    )
+
+
+def _extract_title(container) -> str:
+    """Title text — the ``<strong>`` inside the header ``<h4>``, else the h4 itself."""
+    h4 = container.find("h4")
+    if h4 is None:
+        return ""
+    strong = h4.find("strong")
+    return normalize_whitespace((strong or h4).get_text())
+
+
+def _extract_file_urls(container, source_url: str) -> list[str]:
+    """Absolute attachment URLs (badges + image attachments), deduped in order."""
+    urls: list[str] = []
+    for anchor in container.find_all("a", href=True):
+        if "/uploads/" not in anchor["href"]:
+            continue
+        classes = anchor.get("class") or []
+        if any(cls in classes for cls in _ATTACHMENT_CLASSES):
+            urls.append(urljoin(source_url, anchor["href"]))
+    return list(dict.fromkeys(urls))
+
+
+def _extract_full_text(container) -> str:
+    """The press-release body text, with download/social chrome removed.
+
+    Decomposes the badges, social embeds, and attachment icons first (attachment
+    links were already read out), then flattens the remaining text line-by-line,
+    dropping empty and pure-chrome lines. This mutates ``container`` — call it last.
+    """
+    for junk in container.select(
+        '[class*="fb-"], a.badge, .badge, .mailbox-attachment-icon, script, style'
+    ):
+        junk.decompose()
+    lines = (
+        normalize_whitespace(line)
+        for line in container.get_text(separator="\n").split("\n")
+    )
+    return "\n".join(line for line in lines if line and line not in _JUNK_TEXT)
+
+
+def guess_publication_date(text: object) -> str:
+    """Best-effort Bikram Sambat publication date (``YYYY-MM-DD``) from the text.
+
+    Ported from the legacy spider: matches the labelled forms ("Press Release-
+    2072-08-15", "मिति २०७९।१२।१२", "प्रेस विज्ञप्ति २०७२/०८/१६") and a bare
+    leading date, in that order. Returns "" when none match. Zero-pads month/day.
+    """
+    if not text:
+        return ""
+    roman = nepali_to_roman_numerals(str(text))
+    candidates = [(pattern, roman) for pattern in _DATE_PATTERNS]
+    candidates.append((_BARE_DATE_PATTERN, roman.strip()))
+    for pattern, target in candidates:
+        match = pattern.search(target)
+        if match:
+            year, month, day = match.groups()
+            return f"{year}-{month.zfill(2)}-{day.zfill(2)}"
+    return ""

--- a/materials/sourcing/ciaa/parse.py
+++ b/materials/sourcing/ciaa/parse.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -44,6 +44,13 @@ _JUNK_TEXT = frozenset({"Download", "Tweet", "डाउनलोड"})
 #: ``mailbox-attachment-name`` (inline image attachments). Only ``/uploads/`` hrefs
 #: are attachments (the site logo / nav links are excluded by that path filter).
 _ATTACHMENT_CLASSES = ("badge", "mailbox-attachment-name")
+
+#: The command downloads every attachment URL this parser emits, from inside the
+#: cluster — so a page that injected an absolute href to another host (cloud
+#: metadata, an internal service) would be an SSRF vector. The ``/uploads/``
+#: substring alone does NOT bound the host (``http://169.254.169.254/x/uploads/y``
+#: contains it), so attachments are hard-restricted to the CIAA host here.
+_ALLOWED_ATTACHMENT_HOSTS = frozenset({"ciaa.gov.np", "www.ciaa.gov.np"})
 
 # Publication-date forms seen in the corpus, tried in order against the
 # Devanagari→ASCII-digit-normalized text. All yield a Bikram Sambat YYYY-MM-DD.
@@ -83,7 +90,11 @@ def parse_press_release(html: object, *, press_id: int, source_url: str) -> Pars
     title = _extract_title(container)
     file_urls = _extract_file_urls(container, source_url)
     full_text = _extract_full_text(container)
-    publication_date_bs = guess_publication_date(f"{title}\n{full_text}")
+    # Guess against the BODY first: the bare-``^`` date form is anchored to the
+    # start of the text, and a press release usually opens with its date — folding
+    # the title in front (as the legacy spider did) would defeat that anchor. The
+    # labelled forms still match wherever they appear, so fall back to the title.
+    publication_date_bs = guess_publication_date(full_text) or guess_publication_date(title)
 
     return ParsedPressRelease(
         press_id=press_id,
@@ -105,26 +116,37 @@ def _extract_title(container) -> str:
 
 
 def _extract_file_urls(container, source_url: str) -> list[str]:
-    """Absolute attachment URLs (badges + image attachments), deduped in order."""
+    """Absolute attachment URLs (badges + image attachments), deduped in order.
+
+    Restricted to the CIAA host after resolution: a relative ``/uploads/…`` href
+    resolves onto ``source_url`` (kept), while an absolute href to any other host
+    is DROPPED so the command never fetches an attacker-supplied internal URL.
+    """
     urls: list[str] = []
     for anchor in container.find_all("a", href=True):
         if "/uploads/" not in anchor["href"]:
             continue
         classes = anchor.get("class") or []
-        if any(cls in classes for cls in _ATTACHMENT_CLASSES):
-            urls.append(urljoin(source_url, anchor["href"]))
+        if not any(cls in classes for cls in _ATTACHMENT_CLASSES):
+            continue
+        absolute = urljoin(source_url, anchor["href"])
+        if (urlparse(absolute).hostname or "").lower() in _ALLOWED_ATTACHMENT_HOSTS:
+            urls.append(absolute)
     return list(dict.fromkeys(urls))
 
 
 def _extract_full_text(container) -> str:
-    """The press-release body text, with download/social chrome removed.
+    """The press-release BODY text, with the title and download/social chrome removed.
 
-    Decomposes the badges, social embeds, and attachment icons first (attachment
-    links were already read out), then flattens the remaining text line-by-line,
-    dropping empty and pure-chrome lines. This mutates ``container`` — call it last.
+    Decomposes the header ``h4`` (its text is already captured as the title), the
+    badges, social embeds, and attachment icons (attachment links were already read
+    out), then flattens the remaining text line-by-line, dropping empty and
+    pure-chrome lines. Dropping the title keeps the body clean — search doesn't get
+    a duplicated title, and a bare date opening the body stays at position 0 for the
+    ``^``-anchored date guess. This mutates ``container`` — call it last.
     """
     for junk in container.select(
-        '[class*="fb-"], a.badge, .badge, .mailbox-attachment-icon, script, style'
+        'h4, [class*="fb-"], a.badge, .badge, .mailbox-attachment-icon, script, style'
     ):
         junk.decompose()
     lines = (

--- a/materials/sourcing/ciaa/shaper.py
+++ b/materials/sourcing/ciaa/shaper.py
@@ -1,0 +1,106 @@
+"""Shape a CIAA press release (प्रेस विज्ञप्ति) into Material JSON-LD.
+
+A press release is an inherently SINGLE-SOURCE public document — one authority
+(the Commission for the Investigation of Abuse of Authority) publishes it — so it
+maps to ``MaterialType.PRESS_RELEASE`` (schema.org ``CreativeWork`` +
+``jawafdehi:PressRelease``). It is keyed under the ``ciaa_press_release`` IRI
+source segment with the press id as the ident, which REPRODUCES the legacy index
+``@id`` (the index document_id ``ngm:ciaa-press-release:<id>`` was slugged to
+``/material/ciaa_press_release/<id>`` by ``jsonld._manuscript_material_iri``) — so
+this go-forward writer and the materials already synced from the frozen ``ngm_v1``
+index reconcile to ONE row, never a hyphen/underscore IRI fork.
+
+Pure + DB-free: takes a ``ParsedPressRelease`` (not ORM objects), returns
+``(jsonld_doc, material_type)`` — the same shape as the AG / NKP shapers.
+Persisted through the material API plane (see ``materials/sourcing/README.md``):
+``PUT`` this doc, then ``POST`` each attachment to ``…/file`` (RAW for the PDF,
+ALTERNATE for the rest), which appends those MediaObjects to this doc. The CIAA
+landing page rides here as a ``SOURCE_PAGE`` reference (a link, not a rehost).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jawafdehi_shared.dates import bs_to_ad_iso
+from jawafdehi_shared.entities.ids import build_material_iri
+
+from materials.jsonld import (
+    MATERIAL_CONTEXT,
+    MaterialType,
+    media_objects_from_document_sources,
+    type_for,
+)
+from materials.sourcing.ciaa.parse import ParsedPressRelease
+
+#: IRI source segment: ``/material/ciaa_press_release/<press_id>``. MUST equal the
+#: underscored form of the legacy index document_id ``ngm:ciaa-press-release:<id>``
+#: so re-ingest is idempotent with the synced rows (the idempotency anchor).
+CIAA_PRESS_SOURCE = "ciaa_press_release"
+
+#: Legacy Jawafdehi ``SourceType`` token — kept on the doc for provenance and as
+#: the ``INDEX_SOURCE_TYPE_TO_MATERIAL`` / ``JAWAF_SOURCE_TYPE_TO_MATERIAL`` key.
+SOURCE_TYPE = "CIAA_PRESS_RELEASE"
+
+#: The publishing authority (CIAA), as a schema.org publisher Organization node.
+_CIAA_NAME_NE = "अख्तियार दुरुपयोग अनुसन्धान आयोग"
+
+
+def press_release_iri(press_id: object) -> str:
+    """The canonical Material ``@id`` for a press release — the idempotency anchor."""
+    return build_material_iri(CIAA_PRESS_SOURCE, str(press_id))
+
+
+def press_release_to_jsonld(record: ParsedPressRelease) -> tuple[dict[str, Any], str]:
+    """Shape one press release → ``(jsonld_doc, material_type)``.
+
+    The doc carries the title (``name.ne``), body (``text.ne`` — the unified-search
+    feed, so search never re-OCRs), the Bikram Sambat publication date
+    (``jawafdehi:datePublishedBS``, the authoritative Nepali date) plus its AD
+    conversion (``datePublished``, what search sorts on), the CIAA landing page as
+    a ``SOURCE_PAGE`` MediaObject, and the legacy index id as ``identifier`` for
+    cross-system trace. Binary attachments are NOT embedded here — the command
+    uploads them via ``…/file``.
+    """
+    material_type = MaterialType.PRESS_RELEASE
+    schema_type, additional_type = type_for(material_type)
+    iri = press_release_iri(record.press_id)
+
+    title = (record.title or "").strip() or f"CIAA press release {record.press_id}"
+    doc: dict[str, Any] = {
+        "@context": MATERIAL_CONTEXT,
+        "@type": schema_type,
+        "@id": iri,
+        "name": {"ne": title},
+        "jawafdehi:sourceType": SOURCE_TYPE,
+        "identifier": f"ngm:ciaa-press-release:{record.press_id}",
+        "publisher": {"@type": "GovernmentOrganization", "name": {"ne": _CIAA_NAME_NE}},
+    }
+    if additional_type:
+        doc["additionalType"] = additional_type
+
+    # BS is authoritative; datePublished (schema.org, AD) is what search sorts on —
+    # prefer the converted AD date, else fall back to the BS string so the date is
+    # never dropped when conversion is unavailable.
+    date_bs = (record.publication_date_bs or "").strip()
+    date_ad = bs_to_ad_iso(date_bs)
+    if date_bs:
+        doc["jawafdehi:datePublishedBS"] = date_bs
+    if date_ad:
+        doc["datePublished"] = date_ad
+    elif date_bs:
+        doc["datePublished"] = date_bs
+
+    # CIAA landing page as a SOURCE_PAGE reference link (reuse the shared shaper).
+    if record.source_url:
+        media = media_objects_from_document_sources(
+            [{"url": [{"link": record.source_url, "role": "SOURCE_PAGE"}]}]
+        )
+        if media:
+            doc["associatedMedia"] = media
+
+    body = (record.full_text or "").strip()
+    if body:
+        doc["text"] = {"ne": body}
+
+    return doc, material_type

--- a/materials/tests/test_ciaa_press_ingest.py
+++ b/materials/tests/test_ciaa_press_ingest.py
@@ -1,0 +1,103 @@
+"""End-to-end (local-DB smoke): the CIAA shaper's doc through the REAL material API.
+
+Drives ``PUT /api/materials/ciaa_press_release/<id>`` then ``POST …/file`` exactly
+as ``scrape_ciaa_press_releases`` does — through the actual URLconf + NGM-role-gated
+views, against the real (sqlite, managed materials table) DB. Asserts the Material
+row lands with the shaped @id / dates / text / SOURCE_PAGE+RAW media, the /file
+upload preserves the PUT metadata, and a re-PUT is idempotent (one row).
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APITestCase
+
+from materials.models import Material
+from materials.sourcing.ciaa.parse import ParsedPressRelease
+from materials.sourcing.ciaa.shaper import press_release_to_jsonld
+
+User = get_user_model()
+
+
+class CiaaPressIngestE2ETests(APITestCase):
+    databases = "__all__"
+    IRI = "https://jawafdehi.org/material/ciaa_press_release/3540"
+    DOC_URL = "/api/materials/ciaa_press_release/3540"
+    FILE_URL = "/api/materials/ciaa_press_release/3540/file"
+
+    @classmethod
+    def setUpTestData(cls):
+        g, _ = Group.objects.get_or_create(name="Caseworker")
+        cls.user = User.objects.create(username="oidc-writer")
+        cls.user.groups.add(g)
+
+    @staticmethod
+    def _record():
+        return ParsedPressRelease(
+            press_id=3540,
+            title="भ्रष्टाचार मुद्दा दायर सम्बन्धी प्रेस विज्ञप्ति",
+            full_text="मिति २०८१।०९।२८ गते आयोगले मुद्दा दायर गरेको ।",
+            publication_date_bs="2081-09-28",
+            file_urls=["https://ciaa.gov.np/uploads//pressRelease/abc.pdf"],
+            source_url="https://ciaa.gov.np/pressrelease/3540",
+        )
+
+    def test_put_then_file_lands_row_and_is_idempotent(self):
+        self.client.force_authenticate(user=self.user)
+        record = self._record()
+        doc, material_type = press_release_to_jsonld(record)
+
+        # 1) PUT the doc (mirrors MaterialApiClient.put_document).
+        resp = self.client.put(
+            self.DOC_URL, {"material": doc, "material_type": material_type}, format="json"
+        )
+        self.assertIn(resp.status_code, (200, 201), getattr(resp, "data", resp))
+
+        row = Material.objects.get(pk=self.IRI)
+        self.assertEqual(row.material_type, "press_release")
+        self.assertEqual(row.source, "ciaa_press_release")
+        self.assertEqual(row.ident, "3540")
+        self.assertEqual(row.data["datePublished"], "2025-01-12")
+        self.assertTrue(row.data["text"]["ne"].startswith("मिति"))
+        self.assertIn(
+            "SOURCE_PAGE",
+            [m["jawafdehi:linkRole"] for m in row.data.get("associatedMedia", [])],
+        )
+
+        # 2) Upload the PDF attachment (mirrors MaterialApiClient.upload_file).
+        pdf = SimpleUploadedFile("abc.pdf", b"%PDF-1.4 ...", content_type="application/pdf")
+        up = self.client.post(
+            self.FILE_URL,
+            {
+                "file": pdf, "role": "RAW", "material_type": material_type,
+                "source_url": record.source_url, "skip_convert": "true",
+            },
+            format="multipart",
+        )
+        self.assertIn(up.status_code, (200, 201), getattr(up, "data", up))
+
+        row.refresh_from_db()
+        roles = [m["jawafdehi:linkRole"] for m in row.data["associatedMedia"]]
+        self.assertIn("RAW", roles)                       # attachment attached
+        self.assertIn("SOURCE_PAGE", roles)               # PUT metadata preserved
+        self.assertTrue(row.data["text"]["ne"].startswith("मिति"))  # skip_convert kept text
+
+        # 3) Re-PUT is idempotent — still exactly one row at the @id.
+        again = self.client.put(
+            self.DOC_URL, {"material": doc, "material_type": material_type}, format="json"
+        )
+        self.assertIn(again.status_code, (200, 201))
+        self.assertEqual(Material.objects.filter(pk=self.IRI).count(), 1)
+
+    def test_file_upload_requires_ngm_role(self):
+        # Reader without the Caseworker group is 401/403 on the write (gate holds).
+        norole = User.objects.create(username="oidc-norole")
+        self.client.force_authenticate(user=norole)
+        doc, material_type = press_release_to_jsonld(self._record())
+        resp = self.client.put(
+            self.DOC_URL, {"material": doc, "material_type": material_type}, format="json"
+        )
+        self.assertIn(resp.status_code, (401, 403))
+        self.assertFalse(Material.objects.filter(pk=self.IRI).exists())

--- a/materials/tests/test_ciaa_press_parse.py
+++ b/materials/tests/test_ciaa_press_parse.py
@@ -1,0 +1,85 @@
+"""ciaa_press_releases port: pure page-parse tests (no network, no DB).
+
+Verifies the BeautifulSoup translation of the retired spider's xpath: the title
+(``h4 > strong``), the attachment links (badges + image attachments under
+``/uploads/``, deduped, the page logo excluded), the body text (download/social
+chrome stripped), and the Bikram Sambat publication-date guesser.
+"""
+
+from materials.sourcing.ciaa.parse import guess_publication_date, parse_press_release
+
+_PDF_URL = "https://ciaa.gov.np/uploads//pressRelease/abc.pdf"
+_DOC_URL = "https://ciaa.gov.np/uploads//pressRelease/def.docx"
+_IMG_URL = "https://ciaa.gov.np/uploads//pressRelease/img.jpg"
+
+# A press-release page: title in h4>strong, a dated body, two download badges and
+# one image attachment, plus a social embed and the site logo that must NOT be
+# picked up as attachments/body.
+_PAGE_HTML = f"""
+<html><body>
+  <div class="col-sm-4"><a href="https://ciaa.gov.np/uploads/images/logo.jpg">logo</a></div>
+  <div class="col-sm-8">
+    <h4><strong>भ्रष्टाचार मुद्दा दायर सम्बन्धी प्रेस विज्ञप्ति</strong></h4>
+    <p>मिति २०८१।०९।२८ गते आयोगले मुद्दा दायर गरेको व्यहोरा जानकारी गराइन्छ ।</p>
+    <a class="badge badge-info" href="{_PDF_URL}">डाउनलोड</a>
+    <a class="badge badge-danger" href="{_DOC_URL}">Download</a>
+    <a class="mailbox-attachment-name" href="{_IMG_URL}">image</a>
+    <a class="badge badge-info" href="{_PDF_URL}">डाउनलोड</a>
+    <div class="fb-share-button">Tweet</div>
+  </div>
+</body></html>
+"""
+
+_URL = "https://ciaa.gov.np/pressrelease/3540"
+
+
+def test_parse_extracts_title():
+    rec = parse_press_release(_PAGE_HTML, press_id=3540, source_url=_URL)
+    assert rec.title == "भ्रष्टाचार मुद्दा दायर सम्बन्धी प्रेस विज्ञप्ति"
+    assert rec.press_id == 3540
+    assert rec.source_url == _URL
+
+
+def test_parse_collects_attachment_urls_deduped_logo_excluded():
+    rec = parse_press_release(_PAGE_HTML, press_id=3540, source_url=_URL)
+    # pdf + docx + image, absolute + order-preserving + deduped (pdf listed twice);
+    # the header logo is outside col-sm-8 AND not an attachment class → excluded.
+    assert rec.file_urls == [_PDF_URL, _DOC_URL, _IMG_URL]
+
+
+def test_parse_body_text_strips_chrome():
+    rec = parse_press_release(_PAGE_HTML, press_id=3540, source_url=_URL)
+    assert "मुद्दा दायर गरेको" in rec.full_text
+    assert "Download" not in rec.full_text
+    assert "डाउनलोड" not in rec.full_text
+    assert "Tweet" not in rec.full_text
+
+
+def test_parse_guesses_bs_date():
+    rec = parse_press_release(_PAGE_HTML, press_id=3540, source_url=_URL)
+    assert rec.publication_date_bs == "2081-09-28"
+
+
+def test_parse_thin_page_yields_empty_record_not_error():
+    rec = parse_press_release("<html><body>nope</body></html>", press_id=9, source_url=_URL)
+    assert rec.press_id == 9
+    assert rec.title == ""
+    assert rec.file_urls == []
+
+
+class TestGuessPublicationDate:
+    def test_labelled_press_release_ascii(self):
+        assert guess_publication_date("Press Release- 2072-08-15") == "2072-08-15"
+
+    def test_miti_devanagari(self):
+        assert guess_publication_date("मिति २०७९।१२।१२ गते ।") == "2079-12-12"
+
+    def test_press_bigyapti_devanagari(self):
+        assert guess_publication_date("प्रेस विज्ञप्ति २०७२/०८/१६") == "2072-08-16"
+
+    def test_bare_leading_date_zero_pads(self):
+        assert guess_publication_date("२०८१/९/२८ ...") == "2081-09-28"
+
+    def test_no_date_returns_empty(self):
+        assert guess_publication_date("no date here") == ""
+        assert guess_publication_date("") == ""

--- a/materials/tests/test_ciaa_press_parse.py
+++ b/materials/tests/test_ciaa_press_parse.py
@@ -67,6 +67,34 @@ def test_parse_thin_page_yields_empty_record_not_error():
     assert rec.file_urls == []
 
 
+def test_parse_drops_offhost_attachment_ssrf():
+    # An injected absolute href to a non-CIAA host (e.g. cloud metadata) contains
+    # "/uploads/" but must NOT be emitted — the command would otherwise fetch it.
+    html = """
+    <div class="col-sm-8">
+      <h4><strong>t</strong></h4>
+      <a class="badge" href="https://ciaa.gov.np/uploads/ok.pdf">ok</a>
+      <a class="badge" href="http://169.254.169.254/latest/uploads/evil">evil</a>
+      <a class="badge" href="https://evil.example/uploads/x.pdf">evil2</a>
+    </div>
+    """
+    rec = parse_press_release(html, press_id=1, source_url=_URL)
+    assert rec.file_urls == ["https://ciaa.gov.np/uploads/ok.pdf"]
+
+
+def test_parse_bare_date_in_body_matches_despite_title():
+    # A title is present AND the body opens with a bare date — the date must still
+    # be recovered (the guess runs against the body, not title+body).
+    html = """
+    <div class="col-sm-8">
+      <h4><strong>कुनै शीर्षक</strong></h4>
+      <p>२०८१/०९/२८ आयोगले मुद्दा दायर गर्‍यो ।</p>
+    </div>
+    """
+    rec = parse_press_release(html, press_id=1, source_url=_URL)
+    assert rec.publication_date_bs == "2081-09-28"
+
+
 class TestGuessPublicationDate:
     def test_labelled_press_release_ascii(self):
         assert guess_publication_date("Press Release- 2072-08-15") == "2072-08-15"

--- a/materials/tests/test_ciaa_press_shaper.py
+++ b/materials/tests/test_ciaa_press_shaper.py
@@ -1,0 +1,93 @@
+"""ciaa_press_releases port: the press-release → Material JSON-LD shaper (pure).
+
+The critical property is IDEMPOTENCY with the legacy sync path: the ``@id`` this
+shaper mints must equal the one ``sync_materials_from_index`` derives from the
+index document_id ``ngm:ciaa-press-release:<id>`` — otherwise the go-forward
+writer forks a duplicate row from the already-synced historical corpus. The doc
+must also validate under the material contract.
+"""
+
+from jawafdehi_shared.entities.ids import is_valid_material_iri
+from materials.jsonld import (
+    MaterialType,
+    _manuscript_material_iri,
+    validate_material_jsonld,
+)
+from materials.models import Material
+from materials.sourcing.ciaa.parse import ParsedPressRelease
+from materials.sourcing.ciaa.shaper import (
+    CIAA_PRESS_SOURCE,
+    press_release_iri,
+    press_release_to_jsonld,
+)
+
+
+def _record(**over):
+    base = dict(
+        press_id=3540,
+        title="भ्रष्टाचार मुद्दा दायर सम्बन्धी प्रेस विज्ञप्ति",
+        full_text="मिति २०८१।०९।२८ गते आयोगले मुद्दा दायर गरेको ।",
+        publication_date_bs="2081-09-28",
+        file_urls=["https://ciaa.gov.np/uploads//pressRelease/abc.pdf"],
+        source_url="https://ciaa.gov.np/pressrelease/3540",
+    )
+    base.update(over)
+    return ParsedPressRelease(**base)
+
+
+def test_iri_matches_legacy_index_scheme():
+    # THE idempotency anchor: same @id as the frozen-index sync path.
+    iri = press_release_iri(3540)
+    assert iri == "https://jawafdehi.org/material/ciaa_press_release/3540"
+    assert iri == _manuscript_material_iri("ngm:ciaa-press-release:3540")
+    assert is_valid_material_iri(iri)
+
+
+def test_shaper_core_shape():
+    doc, material_type = press_release_to_jsonld(_record())
+    assert material_type == MaterialType.PRESS_RELEASE
+    assert doc["@id"] == "https://jawafdehi.org/material/ciaa_press_release/3540"
+    assert doc["@type"] == "CreativeWork"
+    assert doc["additionalType"] == "jawafdehi:PressRelease"
+    assert doc["name"] == {"ne": "भ्रष्टाचार मुद्दा दायर सम्बन्धी प्रेस विज्ञप्ति"}
+    assert doc["jawafdehi:sourceType"] == "CIAA_PRESS_RELEASE"
+    assert doc["identifier"] == "ngm:ciaa-press-release:3540"
+    assert doc["publisher"]["@type"] == "GovernmentOrganization"
+
+
+def test_shaper_dates_bs_and_ad():
+    doc, _ = press_release_to_jsonld(_record())
+    assert doc["jawafdehi:datePublishedBS"] == "2081-09-28"
+    # 2081-09-28 BS → 2025-01-12 AD (schema.org datePublished, what search sorts on).
+    assert doc["datePublished"] == "2025-01-12"
+
+
+def test_shaper_body_and_source_page():
+    doc, _ = press_release_to_jsonld(_record())
+    assert doc["text"]["ne"].startswith("मिति")
+    media = doc["associatedMedia"]
+    assert any(m.get("jawafdehi:linkRole") == "SOURCE_PAGE" for m in media)
+
+
+def test_shaper_falls_back_to_synthetic_title_and_bs_only_date():
+    # No title, an unconvertible BS date → name falls back, datePublished keeps BS.
+    doc, _ = press_release_to_jsonld(_record(title="", publication_date_bs="9999-99-99"))
+    assert doc["name"] == {"ne": "CIAA press release 3540"}
+    assert doc["jawafdehi:datePublishedBS"] == "9999-99-99"
+    assert doc["datePublished"] == "9999-99-99"
+
+
+def test_shaper_no_date_omits_date_fields():
+    doc, _ = press_release_to_jsonld(_record(publication_date_bs=""))
+    assert "datePublished" not in doc
+    assert "jawafdehi:datePublishedBS" not in doc
+
+
+def test_produced_doc_validates_and_loads():
+    doc, material_type = press_release_to_jsonld(_record())
+    # Both the JSON-LD contract check and the ORM promotion must accept it.
+    validate_material_jsonld(doc)
+    material = Material.from_jsonld(doc, material_type=material_type)
+    assert material.source == CIAA_PRESS_SOURCE
+    assert material.ident == "3540"
+    assert material.material_type == MaterialType.PRESS_RELEASE

--- a/materials/tests/test_scrape_ciaa_press_command.py
+++ b/materials/tests/test_scrape_ciaa_press_command.py
@@ -27,14 +27,17 @@ _PAGE_HTML = f"""
 
 
 class _FakeSource:
-    """press_id → (status, html); unknown ids 302 (missing). Downloads by URL."""
+    """press_id → (status, html); unknown ids fall back to ``default``. Downloads
+    by URL. ``default`` lets a test simulate the end-of-range (302) or a source
+    outage (None transient)."""
 
-    def __init__(self, pages, downloads=None):
+    def __init__(self, pages, downloads=None, default=(302, "")):
         self.pages = pages
         self.downloads = downloads or {}
+        self.default = default
 
     def get_press_release(self, press_id):
-        return self.pages.get(press_id, (302, ""))
+        return self.pages.get(press_id, self.default)
 
     def page_url(self, press_id):
         return f"https://ciaa.gov.np/pressrelease/{press_id}"
@@ -108,6 +111,14 @@ class CiaaCommandTests(SimpleTestCase):
         src = _FakeSource(pages={})
         mat = _FakeMaterial()
         self._run(src, mat, "--write")
+        assert mat.puts == []
+
+    def test_stops_after_consecutive_transient_no_infinite_loop(self):
+        # Every fetch is a transient (status None) — this never yields a 302 to
+        # trip the missing-stop, so the transient bound must halt the run.
+        src = _FakeSource(pages={}, default=(None, ""))
+        mat = _FakeMaterial()
+        self._run(src, mat, "--write", "--max-consecutive-transient", "3")
         assert mat.puts == []
 
     def test_limit_caps_new_ingests(self):

--- a/materials/tests/test_scrape_ciaa_press_command.py
+++ b/materials/tests/test_scrape_ciaa_press_command.py
@@ -1,0 +1,134 @@
+"""ciaa_press_releases port: the command client (fake source + fake material API).
+
+Injects a fake CIAA transport AND a fake material client via the ``build_*`` seams
+and asserts the command's control flow: skip ids that already exist (resume +
+reconciliation), PUT the doc then upload attachments for new ids, honour dry-run,
+and stop after N consecutive 302s. The server-side upsert is exercised elsewhere
+(the material API tests); here nothing hits the DB or network.
+"""
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase
+
+from materials.management.commands import scrape_ciaa_press_releases as C
+
+CMD = "materials.management.commands.scrape_ciaa_press_releases"
+
+_PDF_URL = "https://ciaa.gov.np/uploads//pressRelease/abc.pdf"
+_PAGE_HTML = f"""
+<div class="col-sm-8">
+  <h4><strong>प्रेस विज्ञप्ति</strong></h4>
+  <p>मिति २०८१।०९।२८ गते मुद्दा दायर ।</p>
+  <a class="badge badge-info" href="{_PDF_URL}">डाउनलोड</a>
+</div>
+"""
+
+
+class _FakeSource:
+    """press_id → (status, html); unknown ids 302 (missing). Downloads by URL."""
+
+    def __init__(self, pages, downloads=None):
+        self.pages = pages
+        self.downloads = downloads or {}
+
+    def get_press_release(self, press_id):
+        return self.pages.get(press_id, (302, ""))
+
+    def page_url(self, press_id):
+        return f"https://ciaa.gov.np/pressrelease/{press_id}"
+
+    def download(self, url):
+        return self.downloads.get(url, (404, b"", ""))
+
+
+class _FakeMaterial:
+    def __init__(self, existing=()):
+        self.existing = set(existing)   # idents already stored
+        self.puts = []                  # (ident, doc, material_type)
+        self.uploads = []               # (ident, filename, role, skip_convert)
+
+    def exists(self, source, ident):
+        return ident in self.existing
+
+    def put_document(self, source, ident, doc, material_type):
+        self.puts.append((ident, doc, material_type))
+        return 201, {"@id": doc["@id"]}
+
+    def upload_file(self, source, ident, *, filename, content, content_type,
+                    role, source_url, skip_convert, material_type):
+        self.uploads.append((ident, filename, role, skip_convert))
+        return 201, {}
+
+
+class CiaaCommandTests(SimpleTestCase):
+    def _run(self, source, material, *extra):
+        with patch(f"{CMD}.build_source_client", return_value=source), patch(
+            f"{CMD}.build_material_client", return_value=material
+        ):
+            call_command(
+                "scrape_ciaa_press_releases",
+                "--api-token", "t", "--api-base", "http://api",
+                "--start-id", "1", "--max-consecutive-missing", "2",
+                *extra,
+            )
+
+    def test_write_ingests_new_id_and_uploads_pdf_as_raw(self):
+        src = _FakeSource(
+            pages={1: (200, _PAGE_HTML)},
+            downloads={_PDF_URL: (200, b"%PDF-1.4 ...", "application/pdf")},
+        )
+        mat = _FakeMaterial()
+        self._run(src, mat, "--write")
+
+        assert [p[0] for p in mat.puts] == ["1"]
+        _ident, doc, mtype = mat.puts[0]
+        assert doc["@id"].endswith("/material/ciaa_press_release/1")
+        assert mtype == "press_release"
+        # one attachment, PDF → RAW, skip_convert True (body text was scraped).
+        assert mat.uploads == [("1", "abc.pdf", "RAW", True)]
+
+    def test_existing_ids_are_skipped(self):
+        src = _FakeSource(pages={1: (200, _PAGE_HTML), 2: (200, _PAGE_HTML)})
+        mat = _FakeMaterial(existing={"1"})
+        self._run(src, mat, "--write")
+        # id 1 already stored → skipped (no PUT); id 2 ingested.
+        assert [p[0] for p in mat.puts] == ["2"]
+
+    def test_dry_run_writes_nothing(self):
+        src = _FakeSource(pages={1: (200, _PAGE_HTML)})
+        mat = _FakeMaterial()
+        self._run(src, mat)  # no --write
+        assert mat.puts == []
+        assert mat.uploads == []
+
+    def test_stops_after_consecutive_missing(self):
+        # Every id 302s; --max-consecutive-missing 2 → stop, nothing ingested.
+        src = _FakeSource(pages={})
+        mat = _FakeMaterial()
+        self._run(src, mat, "--write")
+        assert mat.puts == []
+
+    def test_limit_caps_new_ingests(self):
+        src = _FakeSource(pages={1: (200, _PAGE_HTML), 2: (200, _PAGE_HTML), 3: (200, _PAGE_HTML)})
+        mat = _FakeMaterial()
+        self._run(src, mat, "--write", "--limit", "2")
+        assert [p[0] for p in mat.puts] == ["1", "2"]
+
+
+def test_attachment_roles_promotes_pdf_to_raw():
+    urls = ["https://x/img.jpg", "https://x/doc.pdf", "https://x/extra.docx"]
+    assert C.attachment_roles(urls) == [
+        ("https://x/img.jpg", "ALTERNATE"),
+        ("https://x/doc.pdf", "RAW"),
+        ("https://x/extra.docx", "ALTERNATE"),
+    ]
+
+
+def test_attachment_roles_no_pdf_first_is_raw():
+    urls = ["https://x/a.jpg", "https://x/b.png"]
+    assert C.attachment_roles(urls) == [
+        ("https://x/a.jpg", "RAW"),
+        ("https://x/b.png", "ALTERNATE"),
+    ]


### PR DESCRIPTION
## What

Second of the three scraper ports (after `ppmo_blacklist` #384): move CIAA press-release acquisition off the retired `ciaa_press_releases` Scrapy spider and into the monolith, writing **Materials** through the material REST plane.

## Why

The old flow was three hops — spider → R2 files + the `ngm_v1` DocumentSource index → `sync_materials_from_index` → Materials. **`ngm_v1` is now frozen**, so no *new* press release can reach the archive. This closes that gap with a go-forward writer that skips the frozen detour entirely.

## How

- **`materials/sourcing/ciaa/parse.py`** — pure BeautifulSoup parser (the retired spider's xpath translated to bs4, the lib the courts scrapers use): title, body text, `/uploads/` attachments, and the Bikram Sambat publication-date guesser.
- **`materials/sourcing/ciaa/shaper.py`** — `ParsedPressRelease → (JSON-LD, material_type)`, mirroring the `ag`/`nkp` shapers. **Idempotency anchor:** the `@id` is `/material/ciaa_press_release/<press_id>`, matching the legacy index document_id `ngm:ciaa-press-release:<id>` (proven by a test asserting `press_release_iri(id) == _manuscript_material_iri(...)`), so re-ingest reconciles to the already-synced historical rows — no duplicate fork.
- **`scrape_ciaa_press_releases`** — REST-client management command (never touches the ORM). **Resume + reconciliation with no checkpoint file:** it asks the material API whether an id already exists (a public GET) and skips it — so the thousands of historical releases are skipped cheaply (their durable R2 links preserved) and only genuinely-new ids are fetched + ingested; gaps self-heal. Stops after N consecutive 302/404s (the end of the id range). PUTs the doc, then POSTs each attachment to `…/file` (PDF → RAW, rest → ALTERNATE); server OCR is suppressed when the body text was already scraped (kept for image-only releases). CIAA landing page rides as a `SOURCE_PAGE` reference.
- Writes are NGM-role gated → `--write` needs the `sa-ingestion` (Caseworker) bearer via `INGESTION_API_TOKEN`; **dry-run by default**.

## Verification

- **24 new tests** + full materials suite (**337 passed, 4 skipped**); ruff clean.
- **Live dry-run against `ciaa.gov.np`**: parses real press-release pages end-to-end (titles, BS→AD dates incl. BS2083, PDF+DOC attachments, `@id`s, full text); ids past the tip correctly detected as 302-missing.

## Not in this PR (follow-up, after merge + image build)

Retarget the `ngm-ciaa-press-releases` CronJob in `services/infra` to run this command on the platform image + inject the `sa-ingestion` token from OpenBao + un-suspend. Not merging this myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ingestion of CIAA press releases into the Materials platform, including publication details and attachments.
  * Supports dry-run previews, controlled writing, duplicate detection, limits, and configurable stopping conditions.
  * Preserves Nepali-language content and publication dates, with support for PDF and other attachments.
* **Documentation**
  * Updated sourcing documentation to describe CIAA press releases.
* **Tests**
  * Added coverage for parsing, date extraction, document formatting, attachment handling, and ingestion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->