### PR TITLE
feat(scrapers): resolve the cron write-bearer via OIDC client-credentials

### DIFF
--- a/courts/management/commands/scrape_ppmo_blacklist.py
+++ b/courts/management/commands/scrape_ppmo_blacklist.py
@@ -9,9 +9,12 @@ plane (``POST /api/ingestion/firms/``) — the server owns the idempotent upsert
 validation, and auditlog. This command is a thin CLIENT; it never touches the ORM.
 
 Dry-run by default (fetch + parse, report counts, POST nothing); ``--write``
-posts. The ingestion endpoint is NGM-role gated, so ``--write`` needs an
-``sa-ingestion`` (Caseworker) bearer via ``INGESTION_API_TOKEN`` (the CronJob
-injects it from OpenBao) and a base URL via ``INGESTION_API_BASE``.
+posts. The ingestion endpoint is NGM-role gated, so ``--write`` needs a Caseworker
+bearer (base URL via ``INGESTION_API_BASE``). The bearer is resolved by
+``review.oidc_client_credentials.resolve_service_bearer``: a static
+``INGESTION_API_TOKEN`` (local dev), else an OIDC client-credentials grant as the
+``sa-ingestion`` account (``INGESTION_OIDC_CLIENT_ID/SECRET``) or the shared
+``CASEWORK_OIDC_*`` service account — so the CronJob carries no static token.
 
     manage.py scrape_ppmo_blacklist                          # dry-run recon
     INGESTION_API_TOKEN=… manage.py scrape_ppmo_blacklist --write   # the CronJob run
@@ -187,11 +190,19 @@ class Command(BaseCommand):
         return P.parse_company_list(payload)
 
     def _ingestion_client(self, o):
+        # Lazy import: keeps the (review) OIDC dep off the module-load path so a
+        # dry-run / --help never needs it, and avoids any app-import cycle.
+        from review.oidc_client_credentials import OIDCTokenError, resolve_service_bearer
+
         base = o["api_base"] or os.environ.get("INGESTION_API_BASE") or _DEFAULT_API_BASE
-        token = o["api_token"] or os.environ.get("INGESTION_API_TOKEN")
+        try:
+            token = resolve_service_bearer(o["api_token"])
+        except OIDCTokenError as exc:
+            raise CommandError(f"--write bearer: OIDC client-credentials grant failed: {exc}") from exc
         if not token:
             raise CommandError(
-                "--write needs an ingestion bearer token: set INGESTION_API_TOKEN "
-                "(the CronJob injects the sa-ingestion token) or pass --api-token."
+                "--write needs an ingestion bearer: set INGESTION_API_TOKEN, or the "
+                "OIDC client-credentials env (INGESTION_OIDC_CLIENT_ID/SECRET, else the "
+                "CASEWORK_OIDC_* service account), or pass --api-token."
             )
         return build_ingestion_client(base, token, o["timeout"])

--- a/materials/management/commands/scrape_ciaa_press_releases.py
+++ b/materials/management/commands/scrape_ciaa_press_releases.py
@@ -18,9 +18,13 @@ Gaps self-heal (a missing id is re-fetched). The crawl stops after
 ``--max-consecutive-missing`` real 302/404s from CIAA (the end of the id range).
 
 Dry-run by default (fetch + parse + report, write nothing); ``--write`` posts. The
-material write endpoints are NGM-role gated, so ``--write`` needs an ``sa-ingestion``
-(Caseworker) bearer via ``INGESTION_API_TOKEN`` (the CronJob injects it from
-OpenBao) and a base URL via ``MATERIAL_API_BASE`` / ``INGESTION_API_BASE``.
+material write endpoints are NGM-role gated, so ``--write`` needs a Caseworker
+bearer (base URL via ``MATERIAL_API_BASE`` / ``INGESTION_API_BASE``). The bearer is
+resolved by ``review.oidc_client_credentials.resolve_service_bearer``: a static
+``INGESTION_API_TOKEN`` (local dev), else an OIDC client-credentials grant as the
+``sa-ingestion`` account (``INGESTION_OIDC_CLIENT_ID/SECRET``) or the shared
+``CASEWORK_OIDC_*`` service account — so the CronJob carries no static token. The
+existence GET used for resume is public, so a dry run needs no bearer.
 
     manage.py scrape_ciaa_press_releases --start-id 3400            # dry-run recon
     INGESTION_API_TOKEN=… manage.py scrape_ciaa_press_releases --write   # the CronJob run
@@ -360,10 +364,25 @@ class Command(BaseCommand):
             or os.environ.get("INGESTION_API_BASE")
             or _DEFAULT_API_BASE
         )
-        token = o["api_token"] or os.environ.get("INGESTION_API_TOKEN")
-        if require_token and not token:
-            raise CommandError(
-                "--write needs a bearer token: set INGESTION_API_TOKEN (the CronJob "
-                "injects the sa-ingestion token) or pass --api-token."
-            )
+        if require_token:
+            # Lazy import (keeps the OIDC dep off dry-run / --help).
+            from review.oidc_client_credentials import OIDCTokenError, resolve_service_bearer
+
+            try:
+                token = resolve_service_bearer(o["api_token"])
+            except OIDCTokenError as exc:
+                raise CommandError(
+                    f"--write bearer: OIDC client-credentials grant failed: {exc}"
+                ) from exc
+            if not token:
+                raise CommandError(
+                    "--write needs a bearer: set INGESTION_API_TOKEN, or the OIDC "
+                    "client-credentials env (INGESTION_OIDC_CLIENT_ID/SECRET, else the "
+                    "CASEWORK_OIDC_* service account), or pass --api-token."
+                )
+        else:
+            # Dry-run: the existence GET is public, so no token is needed and we
+            # never mint one (no reason to hit Zitadel for a read-only run). Use a
+            # static/explicit token only if one happens to be set.
+            token = o["api_token"] or os.environ.get("INGESTION_API_TOKEN")
         return build_material_client(base, token, o["timeout"])

--- a/review/oidc_client_credentials.py
+++ b/review/oidc_client_credentials.py
@@ -23,6 +23,7 @@ See ``/damodaha-volunteer/think-big/shared/research/oidc-zitadel-integration.md`
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 
@@ -211,3 +212,51 @@ def get_access_token(force_refresh: bool = False) -> str:
 def bearer_header(force_refresh: bool = False) -> dict[str, str]:
     """Return ``{"Authorization": "Bearer <token>"}`` from the shared provider."""
     return {"Authorization": f"Bearer {get_access_token(force_refresh=force_refresh)}"}
+
+
+def resolve_service_bearer(explicit_token: str | None = None) -> str | None:
+    """Resolve the outbound Bearer for a service-account HTTP client.
+
+    Used by the scraper cron commands (``scrape_ppmo_blacklist``,
+    ``scrape_ciaa_press_releases``) which POST to the NGM-role-gated write API. In
+    priority order:
+
+    1. an explicit token (``--api-token``) or a static ``INGESTION_API_TOKEN`` env
+       — local dev / tests / a pre-minted bearer;
+    2. the dedicated **sa-ingestion** identity, when ``INGESTION_OIDC_CLIENT_ID`` +
+       ``INGESTION_OIDC_CLIENT_SECRET`` are set (client-credentials grant, scope/
+       audience default to the casework settings);
+    3. the shared **casework** service account (``CASEWORK_OIDC_*`` settings) — the
+       zero-extra-config fallback, already provisioned on the consumer image.
+
+    Returns ``None`` when nothing is configured, so the caller decides whether that
+    is fatal (a dry run needs no token; ``--write`` does). Propagates
+    ``OIDCTokenError`` when a *configured* grant fails, so a real auth error
+    surfaces instead of masquerading as "no token".
+    """
+    if explicit_token:
+        return explicit_token
+    static = os.environ.get("INGESTION_API_TOKEN")
+    if static:
+        return static
+
+    client_id = os.environ.get("INGESTION_OIDC_CLIENT_ID")
+    client_secret = os.environ.get("INGESTION_OIDC_CLIENT_SECRET")
+    if client_id and client_secret:
+        provider = ClientCredentialsTokenProvider(
+            issuer=os.environ.get("OIDC_ISSUER", "") or getattr(settings, "OIDC_ISSUER", ""),
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=os.environ.get("INGESTION_OIDC_SCOPE")
+            or getattr(settings, "CASEWORK_OIDC_SCOPE", ""),
+            audience=os.environ.get("INGESTION_OIDC_AUDIENCE")
+            or getattr(settings, "CASEWORK_OIDC_AUDIENCE", ""),
+        )
+        return provider.get_token()
+
+    # Fall back to the shared casework service account, when it is configured.
+    if getattr(settings, "CASEWORK_OIDC_CLIENT_ID", "") and getattr(
+        settings, "CASEWORK_OIDC_CLIENT_SECRET", ""
+    ):
+        return get_access_token()
+    return None

--- a/tests/test_oidc_resolve_bearer.py
+++ b/tests/test_oidc_resolve_bearer.py
@@ -1,0 +1,57 @@
+"""resolve_service_bearer: how the scraper cron commands get their write bearer.
+
+Priority: explicit/static token → sa-ingestion OIDC (INGESTION_OIDC_*) → the shared
+casework service account (CASEWORK_OIDC_* settings) → None. No network: the
+client-credentials grant is mocked at the provider / convenience-function seam.
+"""
+
+import os
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from review import oidc_client_credentials as O
+
+
+class ResolveServiceBearerTests(SimpleTestCase):
+    def test_explicit_token_wins_over_everything(self):
+        with mock.patch.dict(os.environ, {"INGESTION_API_TOKEN": "envtok"}, clear=True):
+            self.assertEqual(O.resolve_service_bearer("explicit"), "explicit")
+
+    def test_static_env_token(self):
+        with mock.patch.dict(os.environ, {"INGESTION_API_TOKEN": "envtok"}, clear=True):
+            self.assertEqual(O.resolve_service_bearer(), "envtok")
+
+    @override_settings(OIDC_ISSUER="https://auth.example", CASEWORK_OIDC_SCOPE="sc", CASEWORK_OIDC_AUDIENCE="aud")
+    def test_ingestion_oidc_client_credentials_mint(self):
+        env = {"INGESTION_OIDC_CLIENT_ID": "cid", "INGESTION_OIDC_CLIENT_SECRET": "sec"}
+        with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+            O.ClientCredentialsTokenProvider, "get_token", return_value="minted"
+        ) as get_token:
+            self.assertEqual(O.resolve_service_bearer(), "minted")
+            get_token.assert_called_once()
+
+    @override_settings(CASEWORK_OIDC_CLIENT_ID="ccid", CASEWORK_OIDC_CLIENT_SECRET="csec")
+    def test_casework_service_account_fallback(self):
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            O, "get_access_token", return_value="casework-token"
+        ) as get_access_token:
+            self.assertEqual(O.resolve_service_bearer(), "casework-token")
+            get_access_token.assert_called_once()
+
+    @override_settings(CASEWORK_OIDC_CLIENT_ID="", CASEWORK_OIDC_CLIENT_SECRET="")
+    def test_nothing_configured_returns_none(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(O.resolve_service_bearer())
+
+    @override_settings(OIDC_ISSUER="https://auth.example", CASEWORK_OIDC_SCOPE="sc")
+    def test_configured_grant_failure_propagates(self):
+        # A configured-but-failing grant surfaces the OIDC error rather than
+        # silently returning None (which would look like "no token").
+        env = {"INGESTION_OIDC_CLIENT_ID": "cid", "INGESTION_OIDC_CLIENT_SECRET": "sec"}
+        with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+            O.ClientCredentialsTokenProvider, "get_token",
+            side_effect=O.OIDCTokenError("boom"),
+        ):
+            with self.assertRaises(O.OIDCTokenError):
+                O.resolve_service_bearer()


### PR DESCRIPTION
## What
Give the ported scraper cron commands (`scrape_ppmo_blacklist`, `scrape_ciaa_press_releases`) a way to authenticate to the NGM-role-gated write API **without a static token**, so the CronJobs (task: retarget in `services/infra`) can run.

## Why
In-cluster, the platform service DNS isn't in `ALLOWED_HOSTS` (verified in prod: `[api.jawafdehi.org, <pod-ip>]`), so these clients call the API over `https://api.jawafdehi.org` and must present a Caseworker bearer. There is no static long-lived token to inject — the deployed pattern (the `review_poller` jobs-processor) mints a bearer at runtime via Zitadel client-credentials.

## How
- Add `resolve_service_bearer()` beside the existing provider in `review/oidc_client_credentials.py` (reuses the proven `ClientCredentialsTokenProvider`). Resolution order:
  1. explicit/static token (`--api-token` / `INGESTION_API_TOKEN`) — local dev + tests;
  2. dedicated **sa-ingestion** identity (`INGESTION_OIDC_CLIENT_ID/SECRET`) via client-credentials;
  3. shared **casework** service account (`CASEWORK_OIDC_*` settings) — the zero-extra-config fallback already on the consumer image.
  Returns `None` when nothing is configured (dry run needs no bearer); a *configured-but-failing* grant raises `OIDCTokenError` rather than looking like "no token".
- Both commands resolve the bearer through this on `--write` (imported lazily, so dry-run / `--help` never needs the OIDC dep). The ciaa dry-run stays token-free — its resume existence-GET is public.
- Backward compatible: an explicit `--api-token` still wins, so the existing command tests are unchanged.

## Tests
`tests/test_oidc_resolve_bearer.py` — explicit/static token, sa-ingestion mint, casework fallback, nothing-configured→None, configured-grant-failure→raises. 21 tests green (resolver + both command suites); ruff clean.

## Follow-up (not here)
The `services/infra` CronJob retarget: run these on the consumer image over `https://api.jawafdehi.org`, inject the service-account client-id/secret from OpenBao, un-suspend. Gated on merge + explicit OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible authentication for ingestion operations, supporting explicit tokens, local static tokens, and OIDC client-credentials.
  * Write actions now provide clearer guidance when authentication is missing or cannot be resolved.
  * Dry-run operations can proceed without authentication when only public data is required.

* **Bug Fixes**
  * Authentication failures now surface clearly instead of being silently ignored.

* **Tests**
  * Added coverage for token priority, fallback behavior, missing configuration, and authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->