### PR TITLE
casework: DRAFT-only bulk selection, keep the API token out of argv

### DIFF
--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -441,7 +441,7 @@ def _plan_to_dict(p):
 
 def build_parser():
     parser = argparse.ArgumentParser(description="Bind lake materials to case evidence.")
-    add_common_args(parser)
+    add_common_args(parser, state_flag=False)
     parser.add_argument("--batch-csv", required=True,
                         help="CSV with a `slug` column and material-IRI columns.")
     parser.add_argument("--report", default="",

--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from casework.common.api import CaseworkApi
 from casework.common.cli import (
     _utc_iso_now, add_common_args, basic_auth_from_env, configure_run_logging,
-    log_run_footer, log_run_header, print_summary,
+    log_run_footer, log_run_header, print_summary, resolve_api_token,
 )
 from casework.common.materials import material_iri, probe_material
 
@@ -244,9 +244,14 @@ def _build_api(args):
     enricher use. Without this Basic branch a bare loopback bind (this tool's
     primary use) could not authenticate: a local DEV_AUTH server rejects Bearer
     (it routes to OIDC), so token-only would raise "exactly one of token/basic"
-    on every local run."""
-    if args.api_token:
-        return CaseworkApi(base_url=args.api_base_url, token=args.api_token,
+    on every local run.
+
+    The token itself comes from `resolve_api_token` ($JAWAFDEHI_API_TOKEN, or
+    the discouraged `--api-token` flag, which warns), not from `args` directly
+    -- a token on argv is readable by any local user via `ps -af`."""
+    token = resolve_api_token(args)
+    if token:
+        return CaseworkApi(base_url=args.api_base_url, token=token,
                            allow_remote_writes=args.allow_remote_writes)
     return CaseworkApi(base_url=args.api_base_url, basic=basic_auth_from_env(),
                        allow_remote_writes=args.allow_remote_writes)

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -68,8 +68,19 @@ def resolve_api_token(args):
     return os.environ.get(API_TOKEN_ENV, "") or ""
 
 
-def add_common_args(parser):
+def add_common_args(parser, *, state_flag=True):
     """Register the CLI flags every ported enricher shares.
+
+    `state_flag=False` omits `--state`. Only the five enrichers route their
+    selection through `select_cases`, so only they can honour it. `convert`
+    has no state gate at all, and `bind_materials` enforces its own DRAFT-only
+    invariant against the LIVE case (`plan_case`'s `required_state`) rather
+    than against a selection filter. Offering them the flag registers an
+    argument nothing reads: `--state IN_REVIEW` on the binder would parse
+    cleanly, change nothing, and leave the operator believing they had
+    unlocked review-queue cases. Fail-safe, but a CLI that silently ignores a
+    flag is a defect -- so the two tools that cannot honour it do not
+    advertise it.
 
     `--dry-run` defaults to True and `--apply` opts into writes. This
     deliberately INVERTS the donor's default: the donor's `add_common_args`
@@ -87,15 +98,16 @@ def add_common_args(parser):
     parser.add_argument("--limit", type=int, default=0)
     parser.add_argument("--fiscal-year", default="")
     parser.add_argument("--force", action="store_true")
-    parser.add_argument(
-        "--state", default=DEFAULT_ENRICHABLE_STATE,
-        help=f"Workflow state bulk selection gates on (default "
-             f"{DEFAULT_ENRICHABLE_STATE}). Bulk runs previously took DRAFT *and* "
-             "IN_REVIEW, silently rewriting cases a moderator already had open; "
-             "IN_REVIEW is now refused outright for bulk selection (pass an "
-             "explicit --slug/--court-case to act on one such case knowingly). "
-             "Ignored when --slug/--court-case is given -- those bypass the "
-             "state gate by design.")
+    if state_flag:
+        parser.add_argument(
+            "--state", default=DEFAULT_ENRICHABLE_STATE,
+            help=f"Workflow state bulk selection gates on (default "
+                 f"{DEFAULT_ENRICHABLE_STATE}). Bulk runs previously took DRAFT "
+                 "*and* IN_REVIEW, silently rewriting cases a moderator already "
+                 "had open; IN_REVIEW is now refused outright for bulk selection "
+                 "(pass an explicit --slug/--court-case to act on one such case "
+                 "knowingly). Ignored when --slug/--court-case is given -- those "
+                 "bypass the state gate by design.")
     parser.add_argument("--dry-run", action="store_true", default=True)
     parser.add_argument("--apply", dest="dry_run", action="store_false")
     parser.add_argument(

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -9,7 +9,15 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+from casework.common.select import DEFAULT_ENRICHABLE_STATE
+
 QUIET_LOGGERS = ("httpx", "urllib3", "boto3", "botocore", "s3transfer")
+
+# Env var carrying the Bearer token. This is the documented, default path --
+# see `resolve_api_token` for why the `--api-token` flag is not.
+API_TOKEN_ENV = "JAWAFDEHI_API_TOKEN"
+
+logger = logging.getLogger("casework.cli")
 
 # casework/common/cli.py -> casework/common -> casework -> <repo-root>
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -25,10 +33,39 @@ def basic_auth_from_env():
     password = os.environ.get("CASEWORK_API_PASSWORD")
     if not (user and password):
         raise SystemExit(
-            "API credentials required: pass --api-token (or set "
-            "JAWAFDEHI_API_TOKEN) for Bearer auth, or set CASEWORK_API_USER + "
-            "CASEWORK_API_PASSWORD for local DEV_AUTH Basic auth.")
+            f"API credentials required: set {API_TOKEN_ENV} for Bearer auth, or "
+            "set CASEWORK_API_USER + CASEWORK_API_PASSWORD for local DEV_AUTH "
+            "Basic auth.")
     return user, password
+
+
+def resolve_api_token(args):
+    """Bearer token for `CaseworkApi`: `$JAWAFDEHI_API_TOKEN` by default.
+
+    The env var is the documented path because argparse is not a safe place
+    to put a credential: a token passed as `--api-token <secret>` sits in
+    `/proc/<pid>/cmdline` for the whole run and is readable by *any* local
+    user with a plain `ps -af` (and lands in shell history). That was observed
+    happening for real, which is why this indirection exists at all.
+
+    The flag still works -- removing it outright would break every existing
+    runbook/wrapper mid-port -- but it wins over the env var (so an explicit
+    flag is never silently ignored, which would be its own class of bug) and
+    warns through the logger, not `print`, so the warning shares the run log
+    with everything else instead of vanishing into stdout.
+
+    Returns "" when neither source is set; callers treat that as "no Bearer
+    token" and fall back to local DEV_AUTH Basic auth.
+    """
+    flag_token = getattr(args, "api_token", "") or ""
+    if flag_token:
+        logger.warning(
+            "--api-token was passed on the command line: the bearer token is "
+            "visible in /proc/<pid>/cmdline (`ps -af`) to every local user for "
+            "the duration of this run, and is now in your shell history. Set "
+            "%s in the environment instead.", API_TOKEN_ENV)
+        return flag_token
+    return os.environ.get(API_TOKEN_ENV, "") or ""
 
 
 def add_common_args(parser):
@@ -50,6 +87,15 @@ def add_common_args(parser):
     parser.add_argument("--limit", type=int, default=0)
     parser.add_argument("--fiscal-year", default="")
     parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--state", default=DEFAULT_ENRICHABLE_STATE,
+        help=f"Workflow state bulk selection gates on (default "
+             f"{DEFAULT_ENRICHABLE_STATE}). Bulk runs previously took DRAFT *and* "
+             "IN_REVIEW, silently rewriting cases a moderator already had open; "
+             "IN_REVIEW is now refused outright for bulk selection (pass an "
+             "explicit --slug/--court-case to act on one such case knowingly). "
+             "Ignored when --slug/--court-case is given -- those bypass the "
+             "state gate by design.")
     parser.add_argument("--dry-run", action="store_true", default=True)
     parser.add_argument("--apply", dest="dry_run", action="store_false")
     parser.add_argument(
@@ -71,7 +117,13 @@ def add_common_args(parser):
              "neither the flag nor the env var is set, the client raises rather "
              "than silently targeting a host. Local DEV_AUTH server: "
              "http://127.0.0.1:48010")
-    parser.add_argument("--api-token", default="")
+    parser.add_argument(
+        "--api-token", default="",
+        help=f"DISCOURAGED. Bearer token; prefer ${API_TOKEN_ENV} in the "
+             "environment, which is what every client here reads by default. A "
+             "token passed here is readable by any local user via `ps -af` for "
+             "the whole run -- see resolve_api_token(). Kept only so existing "
+             "runbooks keep working; it warns when used.")
     parser.add_argument(
         "--allow-remote-writes", action="store_true", default=False,
         help=(

--- a/casework/common/select.py
+++ b/casework/common/select.py
@@ -2,7 +2,24 @@
 
 COURTCASE_SEGMENT = "/courtcase/"
 SPECIAL_COURT = "special"
-ENRICHABLE_STATES = ("DRAFT", "IN_REVIEW")
+
+# Bulk enrichment is DRAFT-only. `ENRICHABLE_STATES` used to be
+# `("DRAFT", "IN_REVIEW")`, which meant every bulk run (any run not scoped by
+# an explicit --slug/--court-case) also swept in cases a human moderator
+# already had open in the review queue. Rewriting a case out from under its
+# reviewer is a scope violation for this project, so IN_REVIEW is gone from
+# the default -- and, below, is refused outright for bulk selection.
+DEFAULT_ENRICHABLE_STATE = "DRAFT"
+ENRICHABLE_STATES = (DEFAULT_ENRICHABLE_STATE,)
+
+# States bulk selection may never gate on, whatever the caller asks for.
+# A default is not a guarantee: with only the narrowed `ENRICHABLE_STATES`
+# above, `--state IN_REVIEW` (or a caller passing `states=("IN_REVIEW",)`)
+# walks straight back into the violation the DRAFT default exists to prevent.
+# The invariant is "bulk never touches IN_REVIEW", so it is enforced here --
+# in the single function every enricher's bulk selection goes through -- and
+# fails loud (ValueError) rather than quietly enriching review-queue cases.
+FORBIDDEN_BULK_STATES = frozenset({"IN_REVIEW"})
 
 
 def _refs(case):
@@ -69,19 +86,42 @@ def matches_fiscal_year(case, fiscal_year):
     return False
 
 
-def is_enrichable_state(case):
-    return case.get("state") in ENRICHABLE_STATES
+def is_enrichable_state(case, states=ENRICHABLE_STATES):
+    return case.get("state") in states
 
 
-def select_cases(cases, *, fiscal_year=None, slugs=(), court_cases=()):
-    """Explicit slugs/court-cases bypass the state gate; bulk selection does not."""
+def select_cases(cases, *, fiscal_year=None, slugs=(), court_cases=(),
+                 states=ENRICHABLE_STATES):
+    """Explicit slugs/court-cases bypass the state gate; bulk selection does not.
+
+    That bypass is deliberate and is kept: naming `--slug X` (or
+    `--court-case 081-CR-0098`) is one operator asking for one case they have
+    already looked at, and the run is still dry by default (`--apply` is the
+    only way to write). It is also the only way to re-run a single case that
+    has moved past DRAFT, which is how these enrichers are actually debugged.
+    The hazard this module guards is the *bulk* sweep, where nobody has looked
+    at the individual cases -- so the state gate, and the IN_REVIEW refusal
+    below, apply to the bulk branch only.
+
+    `states` is what the caller's `--state` resolved to (default DRAFT); it is
+    a parameter rather than a hard-coded constant so the choice is visible at
+    the call site instead of buried in this module.
+    """
     slugs, court_cases = set(slugs), {c.lower() for c in court_cases}
     if slugs or court_cases:
         return [
             c for c in cases
             if c.get("slug") in slugs or court_number(c) in court_cases
         ]
+    forbidden = sorted(FORBIDDEN_BULK_STATES.intersection(states))
+    if forbidden:
+        raise ValueError(
+            f"bulk case selection may not target state(s) {', '.join(forbidden)}: "
+            "cases in the review queue are out of scope for enrichment. Select "
+            "them one at a time with --slug/--court-case if that is really what "
+            "you mean."
+        )
     return [
         c for c in cases
-        if is_enrichable_state(c) and matches_fiscal_year(c, fiscal_year)
+        if is_enrichable_state(c, states) and matches_fiscal_year(c, fiscal_year)
     ]

--- a/casework/convert.py
+++ b/casework/convert.py
@@ -47,6 +47,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 from casework.common.materials import markdown_link, raw_links
@@ -203,10 +204,17 @@ def upload_markdown(api, material_iri, text, timeout=120):
 
 
 def build_api(args):
-    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
-    if args.api_token:
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given.
+
+    The Bearer token comes from `resolve_api_token` -- i.e. from
+    $JAWAFDEHI_API_TOKEN, or from the discouraged `--api-token` flag (which
+    warns) -- never straight off `args.api_token`, so a token is not required
+    to appear in this process's argv where `ps -af` exposes it.
+    """
+    token = resolve_api_token(args)
+    if token:
         return CaseworkApi(
-            args.api_base_url, token=args.api_token,
+            args.api_base_url, token=token,
             allow_remote_writes=args.allow_remote_writes,
         )
     return CaseworkApi(

--- a/casework/convert.py
+++ b/casework/convert.py
@@ -224,12 +224,18 @@ def build_api(args):
     )
 
 
-def main(argv=None):
+def build_parser():
+    """Split out of `main` so the CLI surface is testable without running a
+    conversion (mirrors `bind_materials.build_parser`)."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    add_common_args(parser)
+    add_common_args(parser, state_flag=False)
     parser.add_argument("--material-type", action="append", default=[],
                         help=f"defaults to {'/'.join(DEFAULT_TYPES)}")
-    args = parser.parse_args(argv)
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
     setup_logging(args.verbose)
     logger, run_id, paths = configure_run_logging("convert", verbose=args.verbose)
     start_time = time.monotonic()

--- a/casework/enrich_allegations.py
+++ b/casework/enrich_allegations.py
@@ -59,6 +59,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 from casework.common.llm import bootstrap, tier_for
@@ -220,10 +221,17 @@ def _parse_allegations_response(response_text: str) -> Optional[list]:
 
 
 def build_api(args):
-    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
-    if args.api_token:
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given.
+
+    The Bearer token comes from `resolve_api_token` -- i.e. from
+    $JAWAFDEHI_API_TOKEN, or from the discouraged `--api-token` flag (which
+    warns) -- never straight off `args.api_token`, so a token is not required
+    to appear in this process's argv where `ps -af` exposes it.
+    """
+    token = resolve_api_token(args)
+    if token:
         return CaseworkApi(
-            args.api_base_url, token=args.api_token,
+            args.api_base_url, token=token,
             allow_remote_writes=args.allow_remote_writes,
         )
     return CaseworkApi(
@@ -266,6 +274,7 @@ def main(argv=None):
         fiscal_year=args.fiscal_year,
         slugs=args.slug,
         court_cases=args.court_case,
+        states=(args.state,),
     )
     if args.limit:
         cases = cases[: args.limit]

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -40,6 +40,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 from casework.common.llm import bootstrap, tier_for
@@ -354,10 +355,17 @@ def _extract_bigo(source_text_, case, invoke_text, usage) -> Optional[int]:
 
 
 def build_api(args):
-    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
-    if args.api_token:
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given.
+
+    The Bearer token comes from `resolve_api_token` -- i.e. from
+    $JAWAFDEHI_API_TOKEN, or from the discouraged `--api-token` flag (which
+    warns) -- never straight off `args.api_token`, so a token is not required
+    to appear in this process's argv where `ps -af` exposes it.
+    """
+    token = resolve_api_token(args)
+    if token:
         return CaseworkApi(
-            args.api_base_url, token=args.api_token,
+            args.api_base_url, token=token,
             allow_remote_writes=args.allow_remote_writes,
         )
     return CaseworkApi(
@@ -400,6 +408,7 @@ def main(argv=None):
         fiscal_year=args.fiscal_year,
         slugs=args.slug,
         court_cases=args.court_case,
+        states=(args.state,),
     )
     if args.limit:
         cases = cases[: args.limit]

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -96,6 +96,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 from casework.common.llm import bootstrap, tier_for
@@ -348,10 +349,16 @@ def build_api(args):
     `patch_field`/`replace_list` -- see module docstring (EXTRACTION ONLY).
     Passing it is harmless: it only changes what `CaseworkApi._patch` would
     do, and `_patch` is never reached from this file.
+
+    The Bearer token comes from `resolve_api_token` -- i.e. from
+    $JAWAFDEHI_API_TOKEN, or from the discouraged `--api-token` flag (which
+    warns) -- never straight off `args.api_token`, so a token is not required
+    to appear in this process's argv where `ps -af` exposes it.
     """
-    if args.api_token:
+    token = resolve_api_token(args)
+    if token:
         return CaseworkApi(
-            args.api_base_url, token=args.api_token,
+            args.api_base_url, token=token,
             allow_remote_writes=args.allow_remote_writes,
         )
     return CaseworkApi(
@@ -399,6 +406,7 @@ def main(argv=None):
         fiscal_year=args.fiscal_year,
         slugs=args.slug,
         court_cases=args.court_case,
+        states=(args.state,),
     )
     if args.limit:
         cases = cases[: args.limit]

--- a/casework/enrich_tags.py
+++ b/casework/enrich_tags.py
@@ -60,6 +60,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 from casework.common.llm import bootstrap, tier_for
@@ -1048,10 +1049,17 @@ def parse_llm_response(response: str) -> list:
 
 
 def build_api(args):
-    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
-    if args.api_token:
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given.
+
+    The Bearer token comes from `resolve_api_token` -- i.e. from
+    $JAWAFDEHI_API_TOKEN, or from the discouraged `--api-token` flag (which
+    warns) -- never straight off `args.api_token`, so a token is not required
+    to appear in this process's argv where `ps -af` exposes it.
+    """
+    token = resolve_api_token(args)
+    if token:
         return CaseworkApi(
-            args.api_base_url, token=args.api_token,
+            args.api_base_url, token=token,
             allow_remote_writes=args.allow_remote_writes,
         )
     return CaseworkApi(
@@ -1099,6 +1107,7 @@ def main(argv=None):
         fiscal_year=args.fiscal_year,
         slugs=args.slug,
         court_cases=args.court_case,
+        states=(args.state,),
     )
     if args.limit:
         cases = cases[: args.limit]

--- a/casework/enrich_timeline.py
+++ b/casework/enrich_timeline.py
@@ -139,6 +139,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 from casework.common.llm import bootstrap, tier_for
@@ -747,10 +748,17 @@ def _clean_entry(item: dict) -> Optional[dict]:
 
 
 def build_api(args):
-    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
-    if args.api_token:
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given.
+
+    The Bearer token comes from `resolve_api_token` -- i.e. from
+    $JAWAFDEHI_API_TOKEN, or from the discouraged `--api-token` flag (which
+    warns) -- never straight off `args.api_token`, so a token is not required
+    to appear in this process's argv where `ps -af` exposes it.
+    """
+    token = resolve_api_token(args)
+    if token:
         return CaseworkApi(
-            args.api_base_url, token=args.api_token,
+            args.api_base_url, token=token,
             allow_remote_writes=args.allow_remote_writes,
         )
     return CaseworkApi(
@@ -793,6 +801,7 @@ def main(argv=None):
         fiscal_year=args.fiscal_year,
         slugs=args.slug,
         court_cases=args.court_case,
+        states=(args.state,),
     )
     if args.limit:
         cases = cases[: args.limit]

--- a/casework/select_batch.py
+++ b/casework/select_batch.py
@@ -31,6 +31,7 @@ import sys
 
 from casework.bind_materials import candidates_from_row, missing_candidates
 from casework.common.api import CaseworkApi
+from casework.common.cli import API_TOKEN_ENV, resolve_api_token
 
 # Columns copied through to the batch CSV so the binder can read them. The
 # material-IRI columns are exactly the `*_iri` names bind_materials already
@@ -152,13 +153,21 @@ def build_parser():
                         "--drop match_tier=D_CONTRADICTED.")
     p.add_argument("--api-base-url", default=os.environ.get("JAWAFDEHI_API_BASE"),
                    help="Base URL of the case API; defaults to $JAWAFDEHI_API_BASE.")
-    p.add_argument("--api-token", default="")
+    p.add_argument(
+        "--api-token", default="",
+        help=f"DISCOURAGED. Bearer token; prefer ${API_TOKEN_ENV} in the "
+             "environment. A token passed here is readable by any local user "
+             "via `ps -af` for the whole run. Kept for compatibility; warns.")
     return p
 
 
 def run(args, api=None, rows=None):
     """Load rows, select live, write the batch CSV, return ``(selected, stats)``."""
-    api = api or CaseworkApi(base_url=args.api_base_url, token=args.api_token or None)
+    # `resolve_api_token` prefers $JAWAFDEHI_API_TOKEN over the flag precisely
+    # so the credential never has to enter this process's argv, where
+    # /proc/<pid>/cmdline exposes it to every local user for the whole run.
+    api = api or CaseworkApi(base_url=args.api_base_url,
+                             token=resolve_api_token(args) or None)
     if rows is None:
         with open(args.master_csv, newline="", encoding="utf-8") as f:
             rows = list(csv.DictReader(f))

--- a/tests/casework/conftest.py
+++ b/tests/casework/conftest.py
@@ -17,3 +17,14 @@ def _isolate_casework_run_logs(monkeypatch, tmp_path):
     for itself.
     """
     monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _unset_api_token_env(monkeypatch):
+    """`resolve_api_token` falls back to `$JAWAFDEHI_API_TOKEN`, so a developer
+    who happens to have that exported would otherwise silently flip every
+    `build_api` test from the Basic branch to the Bearer branch -- and
+    `test_basic_branch_requires_credentials` would stop raising. Tests that
+    want the env var `monkeypatch.setenv` it back for themselves.
+    """
+    monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)

--- a/tests/casework/test_bind_materials.py
+++ b/tests/casework/test_bind_materials.py
@@ -302,6 +302,21 @@ def test_build_api_prefers_bearer_when_token_given(monkeypatch):
     assert api.basic is None
 
 
+def test_build_api_takes_the_bearer_token_from_the_environment(monkeypatch):
+    # The documented path: $JAWAFDEHI_API_TOKEN, with nothing on argv. A token
+    # passed as `--api-token <secret>` is exposed in /proc/<pid>/cmdline to
+    # every local user (`ps -af`) for the whole run.
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "env-tok")
+    monkeypatch.setenv("CASEWORK_API_USER", "abgen")
+    monkeypatch.setenv("CASEWORK_API_PASSWORD", "secret")
+    args = types.SimpleNamespace(
+        api_base_url="https://api.jawafdehi.org", api_token="",
+        allow_remote_writes=False)
+    api = _build_api(args)
+    assert api.token == "env-tok"
+    assert api.basic is None
+
+
 def test_run_skips_published_case_even_on_apply(tmp_path, monkeypatch):
     monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
     api = FakeApi(exists={"ciaa_press_release/2037"},

--- a/tests/casework/test_build_api_guard_wiring.py
+++ b/tests/casework/test_build_api_guard_wiring.py
@@ -86,3 +86,38 @@ class TestBuildApiGuardWiring:
         )
         api = module.build_api(args)
         assert api.allow_remote_writes is False
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+class TestBuildApiTokenSource:
+    """Every `build_api` must take its Bearer token from `resolve_api_token`
+    (i.e. `$JAWAFDEHI_API_TOKEN`), not from `args.api_token` alone.
+
+    A token passed as `--api-token <secret>` lands in `/proc/<pid>/cmdline`,
+    where any local user can read it with `ps -af` for the whole run. These
+    tests fail if a `build_api` regresses to branching on `args.api_token`:
+    with the env var set and no flag, such a version silently takes the Basic
+    branch (or raises for missing Basic credentials) instead of Bearer.
+    """
+
+    def test_env_var_token_reaches_caseworkapi_with_no_flag(self, module, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "env-token")
+        api = module.build_api(_args(api_base_url="https://example.invalid"))
+        assert api.token == "env-token"
+        assert api.basic is None
+
+    def test_env_var_token_is_used_even_when_basic_creds_also_exist(
+            self, module, monkeypatch):
+        # Bearer and Basic are mutually exclusive in CaseworkApi; having local
+        # DEV_AUTH creds lying around must not shadow an explicit env token.
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "env-token")
+        monkeypatch.setenv("CASEWORK_API_USER", "dev-user")
+        monkeypatch.setenv("CASEWORK_API_PASSWORD", "dev-pass")
+        api = module.build_api(_args(api_base_url="https://example.invalid"))
+        assert api.token == "env-token"
+
+    def test_flag_token_still_works_for_compatibility(self, module, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        api = module.build_api(
+            _args(api_base_url="https://example.invalid", api_token="flag-token"))
+        assert api.token == "flag-token"

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -70,6 +70,42 @@ def test_state_flag_accepts_an_override():
     assert _parse(["--state", "PUBLISHED"]).state == "PUBLISHED"
 
 
+def test_state_flag_can_be_omitted_for_tools_that_cannot_honour_it():
+    """`state_flag=False` must actually remove the argument, not neuter it.
+
+    Registering a flag nothing reads is worse than not offering it: it parses
+    cleanly and silently does nothing. `bind_materials` and `convert` opt out
+    (see the two tests below); this pins the mechanism they rely on.
+    """
+    parser = argparse.ArgumentParser()
+    add_common_args(parser, state_flag=False)
+    args = parser.parse_args([])
+    assert not hasattr(args, "state")
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--state", "IN_REVIEW"])
+
+
+def test_bind_materials_does_not_advertise_state():
+    """The binder gates on the LIVE case state (plan_case's `required_state`),
+    not on a selection filter, so `--state` has nothing to act on. Accepting it
+    would let `--state IN_REVIEW` parse and leave the operator believing they
+    had unlocked review-queue cases when the DRAFT-only invariant still held.
+    """
+    from casework import bind_materials
+
+    with pytest.raises(SystemExit):
+        bind_materials.build_parser().parse_args(
+            ["--batch-csv", "x.csv", "--state", "IN_REVIEW"])
+
+
+def test_convert_does_not_advertise_state():
+    """convert has no state gate at all -- same reasoning as the binder."""
+    from casework import convert
+
+    with pytest.raises(SystemExit):
+        convert.build_parser().parse_args(["--state", "DRAFT"])
+
+
 # ---------------------------------------------------------------------------
 # resolve_api_token: the Bearer token must not have to travel through argv.
 # ---------------------------------------------------------------------------

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from casework.common.cli import (
+    API_TOKEN_ENV,
     QUIET_LOGGERS,
     add_common_args,
     basic_auth_from_env,
@@ -16,6 +17,7 @@ from casework.common.cli import (
     log_run_header,
     new_run_id,
     print_summary,
+    resolve_api_token,
     setup_logging,
 )
 
@@ -52,6 +54,82 @@ def test_model_default_is_empty_not_haiku():
 
 def test_provider_default_is_claude_cli():
     assert _parse([]).provider == "claude_cli"
+
+
+def test_state_flag_defaults_to_draft():
+    """Bulk selection gates on DRAFT unless the caller says otherwise.
+
+    The flag exists so the state a bulk run targets is visible at the call
+    site (`states=(args.state,)`) instead of being an invisible module
+    constant -- and its default is the safe one.
+    """
+    assert _parse([]).state == "DRAFT"
+
+
+def test_state_flag_accepts_an_override():
+    assert _parse(["--state", "PUBLISHED"]).state == "PUBLISHED"
+
+
+# ---------------------------------------------------------------------------
+# resolve_api_token: the Bearer token must not have to travel through argv.
+# ---------------------------------------------------------------------------
+
+
+def _token_args(api_token=""):
+    return argparse.Namespace(api_token=api_token)
+
+
+def test_resolve_api_token_reads_the_env_var(monkeypatch):
+    monkeypatch.setenv(API_TOKEN_ENV, "env-token")
+    assert resolve_api_token(_token_args()) == "env-token"
+
+
+def test_resolve_api_token_is_empty_when_neither_source_is_set(monkeypatch):
+    # "" means "no Bearer token"; callers then fall back to DEV_AUTH Basic.
+    monkeypatch.delenv(API_TOKEN_ENV, raising=False)
+    assert resolve_api_token(_token_args()) == ""
+
+
+def test_resolve_api_token_flag_wins_over_env(monkeypatch):
+    # An explicitly passed flag must never be silently ignored -- that would
+    # be its own class of bug (a run authenticating as someone else).
+    monkeypatch.setenv(API_TOKEN_ENV, "env-token")
+    assert resolve_api_token(_token_args("flag-token")) == "flag-token"
+
+
+def test_resolve_api_token_warns_when_the_token_came_from_argv(monkeypatch, caplog):
+    """A token in argv sits in /proc/<pid>/cmdline for the whole run and is
+    readable by any local user via `ps -af`. Observed for real -- so using the
+    flag must say so, at WARNING."""
+    monkeypatch.delenv(API_TOKEN_ENV, raising=False)
+    with caplog.at_level(logging.WARNING, logger="casework.cli"):
+        resolve_api_token(_token_args("flag-token"))
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "--api-token" in message
+    assert "ps -af" in message
+    assert API_TOKEN_ENV in message
+    # The secret itself must never be echoed back into the log.
+    assert "flag-token" not in message
+
+
+def test_resolve_api_token_env_path_is_silent(monkeypatch, caplog):
+    monkeypatch.setenv(API_TOKEN_ENV, "env-token")
+    with caplog.at_level(logging.WARNING, logger="casework.cli"):
+        resolve_api_token(_token_args())
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def test_resolve_api_token_warning_goes_through_the_logger_not_stdout(
+        monkeypatch, capsys):
+    """Warn via the logger, not `print`: the run log is the record of what a
+    run did, and a bare `print` bypasses it (and the run's log file)."""
+    monkeypatch.delenv(API_TOKEN_ENV, raising=False)
+    resolve_api_token(_token_args("flag-token"))
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 def test_basic_auth_from_env_returns_credentials(monkeypatch):

--- a/tests/casework/test_select.py
+++ b/tests/casework/test_select.py
@@ -1,6 +1,9 @@
+import pytest
+
 from casework.common.select import (
-    court_number, is_ciaa_special_court_case, is_enrichable_state,
-    matches_fiscal_year, select_cases,
+    DEFAULT_ENRICHABLE_STATE, ENRICHABLE_STATES, court_number,
+    is_ciaa_special_court_case, is_enrichable_state, matches_fiscal_year,
+    select_cases,
 )
 
 SPECIAL = "https://jawafdehi.org/courtcase/special/081-cr-0098"
@@ -67,10 +70,61 @@ def test_fiscal_year_no_cr_marker_never_matches():
     assert not matches_fiscal_year({"court_cases": [SUPREME]}, "075")
 
 
-def test_state_gate_allows_draft_and_in_review_only():
+def test_state_gate_allows_draft_only():
+    # IN_REVIEW was in ENRICHABLE_STATES and is deliberately gone: a bulk run
+    # gating on it rewrites cases a moderator already has open for review.
     assert is_enrichable_state({"state": "DRAFT"})
-    assert is_enrichable_state({"state": "IN_REVIEW"})
+    assert not is_enrichable_state({"state": "IN_REVIEW"})
     assert not is_enrichable_state({"state": "PUBLISHED"})
+
+
+def test_default_state_is_draft_and_nothing_else():
+    # Pinned as an exact tuple, not `"DRAFT" in ENRICHABLE_STATES`: the latter
+    # still passes if IN_REVIEW is added back alongside it, which is the exact
+    # regression this constant exists to prevent.
+    assert ENRICHABLE_STATES == ("DRAFT",)
+    assert DEFAULT_ENRICHABLE_STATE == "DRAFT"
+
+
+def test_bulk_selection_skips_in_review_cases():
+    cases = [
+        {"slug": "d", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "r", "state": "IN_REVIEW", "court_cases": [SPECIAL]},
+    ]
+    assert [c["slug"] for c in select_cases(cases)] == ["d"]
+
+
+def test_bulk_selection_refuses_an_explicit_in_review_state():
+    # The DRAFT default is not the guarantee -- this is. Without the refusal,
+    # `--state IN_REVIEW` (or any caller passing it) quietly re-opens exactly
+    # the hole the narrowed default closed.
+    cases = [{"slug": "r", "state": "IN_REVIEW", "court_cases": [SPECIAL]}]
+    with pytest.raises(ValueError, match="IN_REVIEW"):
+        select_cases(cases, states=("IN_REVIEW",))
+    with pytest.raises(ValueError, match="IN_REVIEW"):
+        select_cases(cases, states=("DRAFT", "IN_REVIEW"))
+
+
+def test_bulk_selection_honours_an_explicitly_requested_state():
+    # `states` is a real parameter (wired to --state), not decoration: a state
+    # that is neither the default nor forbidden must actually select.
+    cases = [
+        {"slug": "d", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "p", "state": "PUBLISHED", "court_cases": [SPECIAL]},
+    ]
+    assert [c["slug"] for c in select_cases(cases, states=("PUBLISHED",))] == ["p"]
+
+
+def test_explicit_slug_still_reaches_an_in_review_case():
+    # The bypass is retained on purpose: naming one case is an operator acting
+    # on a case they have already looked at, and the run is dry by default.
+    # Only the *bulk* sweep is barred from IN_REVIEW.
+    cases = [{"slug": "r", "state": "IN_REVIEW", "court_cases": [SPECIAL]}]
+    assert select_cases(cases) == []
+    assert len(select_cases(cases, slugs=("r",))) == 1
+    # ...and the forbidden-state refusal must not fire on the bypass path,
+    # where it would break single-case runs for no safety gain.
+    assert len(select_cases(cases, slugs=("r",), states=("IN_REVIEW",))) == 1
 
 
 def test_explicit_slug_bypasses_state_gate():

--- a/tests/casework/test_select_batch.py
+++ b/tests/casework/test_select_batch.py
@@ -3,6 +3,7 @@ import csv
 
 import pytest
 
+from casework import select_batch as select_batch_module
 from casework.select_batch import (
     in_year_scope, parse_bigo, select_batch, write_batch,
 )
@@ -155,3 +156,34 @@ def test_write_batch_emits_binder_columns(tmp_path):
     assert got[0]["slug"] == "a"
     assert got[0]["press_release_iri"] == PR
     assert "extra_col" not in got[0]      # only OUTPUT_COLUMNS are written
+
+
+# ---------------------------------------------------------------------------
+# Auth wiring: the Bearer token comes from $JAWAFDEHI_API_TOKEN, not argv.
+# ---------------------------------------------------------------------------
+
+
+def test_run_takes_the_bearer_token_from_the_environment(monkeypatch, tmp_path):
+    """`run()` builds its own `CaseworkApi`; that token must be able to come
+    from the environment. Passing it as `--api-token <secret>` puts it in
+    /proc/<pid>/cmdline, readable by any local user via `ps -af` for the whole
+    run -- so the env var is the default path here too, even though this
+    driver is read-only.
+
+    `CaseworkApi` is replaced with a recorder, so no client is constructed and
+    `rows=[]` means no case is ever read: nothing leaves the machine.
+    """
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "env-tok")
+    built = {}
+    monkeypatch.setattr(
+        select_batch_module, "CaseworkApi",
+        lambda **kwargs: built.update(kwargs) or FakeApi({}))
+
+    args = select_batch_module.build_parser().parse_args([
+        "--master-csv", str(tmp_path / "in.csv"),
+        "--out", str(tmp_path / "out.csv"),
+        "--api-base-url", "https://example.invalid",
+    ])
+    select_batch_module.run(args, rows=[])
+
+    assert built["token"] == "env-tok"

--- a/tests/casework/test_state_gate_wiring.py
+++ b/tests/casework/test_state_gate_wiring.py
@@ -1,0 +1,140 @@
+"""End-to-end state-gate wiring: every enricher `main()` -> `select_cases`.
+
+`casework/common/select.py` is where "bulk enrichment is DRAFT-only" is
+decided, and `tests/casework/test_select.py` pins that function's behaviour.
+This file pins the other half -- that all five enrichers actually *reach* it
+with the right `states`. A `main()` that dropped `states=(args.state,)` from
+its `select_cases(...)` call would still pass every test in `test_select.py`
+while quietly falling back to whatever the module default happens to be, so
+the wiring needs its own mutation-sensitive coverage.
+
+NO NETWORK: `build_api` is replaced with a stub that returns a fake client, so
+no `CaseworkApi` is constructed and `urlopen` is never reached. `bootstrap`
+and the `llm.*` modules are stubbed too, so no LLM provider is invoked.
+"""
+import sys
+import types
+
+import pytest
+
+from casework import enrich_allegations as c_allegations
+from casework import enrich_missing_bigo as c_bigo
+from casework import enrich_related_entities as c_entities
+from casework import enrich_tags as c_tags
+from casework import enrich_timeline as c_timeline
+
+ENRICHERS = [c_bigo, c_tags, c_timeline, c_allegations, c_entities]
+
+# Loopback: `main()` never makes a request here (the API is stubbed), but the
+# base URL still has to be one this project would tolerate.
+LOOPBACK_BASE_URL = "http://127.0.0.1:48010"
+
+SPECIAL = "https://jawafdehi.org/courtcase/special/081-cr-0098"
+
+
+class _StubApi:
+    """Stands in for `CaseworkApi`. Only `iter_cases` is ever reached: every
+    test here selects zero cases, so `main()` returns before touching the
+    per-case read/write methods."""
+
+    def __init__(self, cases):
+        self._cases = cases
+
+    def iter_cases(self):
+        return iter(self._cases)
+
+
+def _stub_runtime(monkeypatch, module, cases):
+    """Neutralise everything `main()` does before selection: Django/LLM
+    bootstrap, the `llm.*` imports it performs at runtime, and API
+    construction."""
+    monkeypatch.setattr(module, "bootstrap", lambda *a, **k: None)
+    monkeypatch.setattr(module, "build_api", lambda args: _StubApi(cases))
+
+    fake_invoke = types.ModuleType("llm.invoke")
+    fake_invoke.invoke_text = lambda **kw: pytest.fail(
+        "no case should have been selected, so no LLM call should happen")
+    # `enrich_timeline` imports this name too; the others do not.
+    fake_invoke.invoke_with_tools = fake_invoke.invoke_text
+
+    class _FakeUsage:
+        def as_dict(self):
+            return {"by_provider": []}
+
+    fake_usage = types.ModuleType("llm.usage")
+    fake_usage.UsageAccumulator = _FakeUsage
+    fake_usage.render_usage_table = lambda by_provider, title=None: ""
+
+    monkeypatch.setitem(sys.modules, "llm.invoke", fake_invoke)
+    monkeypatch.setitem(sys.modules, "llm.usage", fake_usage)
+
+
+def _record_select_cases(monkeypatch, module):
+    """Replace `module.select_cases` with a recorder that selects nothing, so
+    `main()` returns immediately after selection. Returns the kwargs dict,
+    populated by the call."""
+    captured = {}
+
+    def recorder(cases, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(module, "select_cases", recorder)
+    return captured
+
+
+@pytest.mark.parametrize("module", ENRICHERS, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+class TestStateGateReachesSelectCases:
+
+    def test_bulk_run_asks_for_draft_by_default(self, module, monkeypatch):
+        """A bare bulk run must gate on DRAFT -- not on the old
+        `("DRAFT", "IN_REVIEW")` pair, and not on "whatever `select_cases`
+        defaults to" either. The default is asserted as an exact tuple so
+        adding IN_REVIEW back anywhere in the chain fails here."""
+        _stub_runtime(monkeypatch, module, cases=[])
+        captured = _record_select_cases(monkeypatch, module)
+
+        module.main(["--api-base-url", LOOPBACK_BASE_URL, "--dry-run"])
+
+        assert captured["states"] == ("DRAFT",)
+
+    def test_state_flag_is_threaded_through(self, module, monkeypatch):
+        """`--state` is not decorative: it reaches the selector."""
+        _stub_runtime(monkeypatch, module, cases=[])
+        captured = _record_select_cases(monkeypatch, module)
+
+        module.main([
+            "--api-base-url", LOOPBACK_BASE_URL, "--dry-run",
+            "--state", "PUBLISHED",
+        ])
+
+        assert captured["states"] == ("PUBLISHED",)
+
+    def test_bulk_run_selects_no_in_review_case(self, module, monkeypatch):
+        """The real `select_cases`, a corpus of nothing but IN_REVIEW cases:
+        the run must select zero. Enriching a case a moderator already has
+        open for review is a scope violation, and this is the path that used
+        to do it on every bulk run."""
+        in_review = [
+            {"slug": f"review-{i}", "state": "IN_REVIEW", "court_cases": [SPECIAL]}
+            for i in range(3)
+        ]
+        _stub_runtime(monkeypatch, module, cases=in_review)
+
+        report = module.main(["--api-base-url", LOOPBACK_BASE_URL, "--dry-run"])
+
+        assert report.rows == []
+
+    def test_bulk_run_refuses_an_explicit_in_review_state(self, module, monkeypatch):
+        """`--state IN_REVIEW` must fail loud rather than enrich the review
+        queue. It surfaces as the `ValueError` `select_cases` raises -- an
+        unhandled crash before any case is touched, which is the intended
+        outcome: nothing quietly proceeds."""
+        in_review = [{"slug": "r", "state": "IN_REVIEW", "court_cases": [SPECIAL]}]
+        _stub_runtime(monkeypatch, module, cases=in_review)
+
+        with pytest.raises(ValueError, match="IN_REVIEW"):
+            module.main([
+                "--api-base-url", LOOPBACK_BASE_URL, "--dry-run",
+                "--state", "IN_REVIEW",
+            ])


### PR DESCRIPTION
Two independent hardening fixes to the `casework/` CLIs, plus a follow-up that
closes a defect the first one introduced. Found while verifying the binding
scripts ahead of a production materials-binding run.

## 1. Bulk enricher selection is now DRAFT-only

`ENRICHABLE_STATES` was `("DRAFT", "IN_REVIEW")`, so **every bulk enricher run**
(any run not scoped by an explicit `--slug`/`--court-case`) also swept in cases a
moderator already had open in the review queue and rewrote them. Rewriting a case
out from under its reviewer is a scope violation.

- `IN_REVIEW` is dropped from the default.
- A `--state` flag (default `DRAFT`) makes the gated state visible at the call
  site instead of buried in a module constant.
- `select_cases` **refuses** `IN_REVIEW` for bulk selection outright — a default
  is not a guarantee, and `--state IN_REVIEW` would otherwise walk straight back
  into the same hole.

The explicit `--slug`/`--court-case` bypass of the state gate is retained
deliberately: naming one case is an operator acting on a case they have already
looked at, the run is dry by default, and it is the only way to re-run a single
case that has moved past DRAFT (which is how these enrichers are debugged). Only
the unattended bulk sweep is barred.

**Scope note:** this hole was enricher-only. `bind_materials` and `select_batch`
never import `select_cases`; both hard-code `REQUIRED_STATE = "DRAFT"` and check
the live case state, before and after this change.

## 2. The bearer token no longer has to travel through argv

`--api-token <secret>` puts the token in `/proc/<pid>/cmdline` for the whole run,
where any local user can read it with `ps -af` — observed happening.
`resolve_api_token` reads `$JAWAFDEHI_API_TOKEN` (mirroring how `--api-base-url`
already defaults to `$JAWAFDEHI_API_BASE`) and is now the sole token source for
every client builder: the five enrichers, `convert`, `bind_materials` and
`select_batch`. The flag still works so existing runbooks do not break, and still
wins over the env var so an explicit token is never silently ignored, but it now
warns through the logger (not `print`, so the warning lands in the run log)
without echoing the secret.

## 3. Follow-up: `--state` is no longer offered where it means nothing

Adding `--state` to the shared `add_common_args` gave it to all seven CLIs, but
only the five enrichers read it. `convert` has no state gate; `bind_materials`
enforces DRAFT-only against the **live** case in `plan_case(required_state=...)`,
not against a selection filter. Both registered an argument nothing consumed, so
`--state IN_REVIEW` on the binder parsed cleanly, changed nothing, and left the
operator believing they had unlocked review-queue cases. Fail-safe, but the wrong
direction for a flag to be wrong in.

`add_common_args(parser, state_flag=False)` omits it, so passing it is now an
argparse error. `convert.main` grows a `build_parser()` split (mirroring
`bind_materials`) so its CLI surface is testable without running a conversion.

## Verification

- `uv run pytest tests/casework/` — **645 passed**
- `uv run ruff check casework/ tests/casework/` — clean
- Production read-only conformance (GET/OPTIONS only): **12/12**, including that
  the client's write-guard raises before `urlopen` on both PATCH and POST to a
  non-loopback host, and that `basic=` is refused off-loopback.
- Local write-path proof against the sqlite harness, asserting the **database**
  after each real HTTP write: **8/8** — fresh bind, idempotent NOOP (row PKs
  unchanged), pre-existing evidence preserved through the destructive whole-list
  replace, stale `If-Match` → 412 with no write, missing ETag refused, absent
  material dropped, uncertain probe aborts without a partial write, non-DRAFT
  case skipped.

No production write was performed at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183JqcakZDzG3VCMxwLBxXh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based API token authentication, with CLI tokens retained for compatibility and accompanied by a security warning.
  * Added state-aware bulk case selection, defaulting to Draft cases.
* **Bug Fixes**
  * Bulk processing now rejects In Review cases while preserving explicit single-case selection.
* **Tests**
  * Expanded coverage for authentication precedence, CLI options, and state-selection safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->