### PR TITLE
fix(entities): stop reindex_entities resurrecting soft-deleted entities

### DIFF
--- a/entities/management/commands/reindex_entities.py
+++ b/entities/management/commands/reindex_entities.py
@@ -1,8 +1,16 @@
 """``reindex_entities`` — bulk-(re)index NES entities into ``nes-entities``.
 
-Streams every ``StoredEntity`` through the entity indexer's ``build_doc`` into
-OpenSearch. ``--rebuild`` drops + recreates the index first (mapping changes).
-The DB router pins ``StoredEntity`` reads to the ``nes`` DB automatically.
+Streams the SEARCHABLE ``StoredEntity`` set through the entity indexer's
+``build_doc`` into OpenSearch. ``--rebuild`` drops + recreates the index first
+(mapping changes). The DB router pins ``StoredEntity`` reads to the ``nes`` DB
+automatically.
+
+Only ``is_deleted=False`` rows are indexed — the SAME gate the live ``post_save``
+signal applies (``entities.signals``: a soft-deleted row is EVICTED, not indexed,
+because DELETE flips the flag rather than removing the row). Streaming ``.all()``
+here instead RESURRECTS every tombstone: an entity deleted from the read plane
+comes back in anonymous unified search on the next reindex. Mirrors the identical
+gate in ``reindex_materials``.
 """
 
 from __future__ import annotations
@@ -26,9 +34,13 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        # Mirror the live indexer's gate (entities.signals): index ONLY the rows
+        # still on the read plane. Without this a reindex re-adds soft-deleted
+        # entities to public search — the exact rows the signal evicted.
+        records = StoredEntity.objects.filter(is_deleted=False).iterator()
         result = reindex(
             index=ENTITY_INDEX,
-            records=StoredEntity.objects.all().iterator(),
+            records=records,
             build_doc=search_index.build_doc,
             rebuild=options["rebuild"],
         )

--- a/entities/tests/test_reindex_entities_command.py
+++ b/entities/tests/test_reindex_entities_command.py
@@ -1,0 +1,95 @@
+"""``reindex_entities`` must index ONLY rows still on the read plane.
+
+DELETE on the NES entity plane is a SOFT delete (``is_deleted=True``; the row and
+its version history survive), and ``entities.signals`` reacts by EVICTING the doc
+from ``nes-entities``. A bulk reindex that streams ``.all()`` therefore resurrects
+every tombstone — a deleted entity reappears in anonymous unified search. These
+tests pin the gate, since the reindex now runs on a schedule and would otherwise
+re-add tombstones on every run.
+
+Run under the platform settings (DB-less: sqlite fallback) from the repo root::
+
+    DATABASE_URL=sqlite:// NES_DB_URL=sqlite:// NGM_DATABASE_URL=sqlite:// \
+        uv run pytest entities/tests/test_reindex_entities_command.py
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from entities.models import StoredEntity
+
+IRI_BASE = "https://jawafdehi.org/entity"
+
+
+def _seed(slug: str, *, is_deleted: bool = False) -> StoredEntity:
+    """A minimal StoredEntity; signals are stubbed by the tests so no I/O happens."""
+    iri = f"{IRI_BASE}/organization/{slug}"
+    return StoredEntity.objects.create(
+        iri=iri,
+        entity_type="Organization",
+        prefix="organization",
+        slug=slug,
+        data={"@id": iri, "@type": "Organization", "name": {"en": slug}},
+        is_deleted=is_deleted,
+    )
+
+
+class ReindexEntitiesGateTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        # The post_save signal would otherwise attempt a live OpenSearch upsert.
+        for target in ("entities.search_index.index", "entities.search_index.delete"):
+            patcher = patch(target)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _run(self, **kwargs):
+        """Run the command with the bulk driver stubbed; return the indexed IRIs."""
+        sent: list[str] = []
+
+        def fake_stream_bulk(client, index, docs):
+            sent.extend(d["iri"] for d in docs)
+            return len(docs)
+
+        with (
+            patch("jawafdehi_shared.search.reindex.make_client"),
+            patch("jawafdehi_shared.search.reindex.create_index"),
+            patch("jawafdehi_shared.search.reindex.stream_bulk", fake_stream_bulk),
+        ):
+            call_command("reindex_entities", **kwargs)
+        return sent
+
+    def test_soft_deleted_entities_are_not_reindexed(self):
+        _seed("alpha-holdings")
+        _seed("beta-traders")
+        _seed("gamma-supplies", is_deleted=True)
+
+        sent = self._run()
+
+        assert sorted(sent) == [
+            f"{IRI_BASE}/organization/alpha-holdings",
+            f"{IRI_BASE}/organization/beta-traders",
+        ]
+        # The tombstone must never be resurrected into public search.
+        assert f"{IRI_BASE}/organization/gamma-supplies" not in sent
+
+    def test_rebuild_also_honours_the_gate(self):
+        """--rebuild drops the index first, so the gate is what refills it."""
+        _seed("alpha-holdings")
+        _seed("gamma-supplies", is_deleted=True)
+
+        sent = self._run(rebuild=True)
+
+        assert sent == [f"{IRI_BASE}/organization/alpha-holdings"]
+
+    def test_all_live_entities_are_indexed(self):
+        """Guard against the gate over-filtering (e.g. an inverted flag)."""
+        for slug in ("alpha-holdings", "beta-traders", "delta-works"):
+            _seed(slug)
+
+        assert len(self._run()) == 3


### PR DESCRIPTION
## Problem

NES entity `DELETE` is a **soft** delete (`is_deleted=True`; the row and its version history survive), and `entities.signals` reacts by **evicting** the doc from `nes-entities`.

`reindex_entities` streamed `StoredEntity.objects.all()`, so every bulk reindex **re-added those tombstones** — an entity removed from the read plane reappears in anonymous unified search.

**This is live, not hypothetical.** An audit of the prod index found all 3 soft-deleted entities present in the public index:

```
StoredEntity rows total=184,662  soft-deleted=3  live=184,659
nes-entities index docs        : 184,662
  MISSING (in DB, not indexed) : 0
  EXTRA (indexed, not searchable): 3
indexed docs that are SOFT-DELETED in the DB: 3 of 3 tombstones
```

## Fix

Gate the queryset on `is_deleted=False`, mirroring the **identical** gate `reindex_materials` already applies — whose docstring calls out this exact failure mode ("a `--rebuild` would re-add every soft-deleted material (tombstones resurrected)"). `reindex_entities` was simply missing it.

## Why now

The reindex is moving onto a schedule (a weekly reconciliation cron, since write-time indexing is best-effort and drops docs silently on any OpenSearch hiccup). Without this gate, every scheduled run would re-publish deleted entities.

## Tests

`entities/tests/test_reindex_entities_command.py` — covers the plain path, `--rebuild` (which drops the index, so the gate is what refills it), and a guard against the gate *over*-filtering. The two tombstone assertions **fail without the fix** (verified: 2 failed / 1 passed on the pre-fix code, 3 pass after).

`entities/` + `search/` suites: 199 passed.

## Follow-up (not in this PR)

The 3 tombstones already in the prod index need evicting operationally — the gate stops new ones, it doesn't retract existing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)