### PR TITLE
feat(courts): open the SQL SELECT plane to any authenticated caller

### DIFF
--- a/courts/permissions.py
+++ b/courts/permissions.py
@@ -6,10 +6,12 @@ request (``moderator``/``contributor`` -> ``Caseworker``, etc.). So role checks
 here are just Django Group-membership checks on ``request.user.groups`` — no
 token re-parsing.
 
-``HasNgmRole`` gates the internal write/query planes (the gated SQL endpoint and
-ingestion). Unauthenticated requests fail with 401 (the authenticator returns a
+``HasNgmRole`` gates the internal WRITE plane (ingestion + mutations).
+Unauthenticated requests fail with 401 (the authenticator returns a
 ``WWW-Authenticate`` header so DRF answers 401, not 403); an authenticated user
 without an NGM-capable role gets 403.
+
+The raw-SQL SELECT plane is NOT gated from this module — see the note below.
 """
 
 from __future__ import annotations
@@ -26,36 +28,18 @@ NGM_ROLE_GROUPS = frozenset(
     }
 )
 
-# OAuth scope that grants the gated SQL plane on its own. The FastAPI route this
-# was ported from gated POST /query on this scope (``require_scope("ngm.query")``).
-# We honor it alongside the Django-role check so scope-issued tokens (e.g. MCP /
-# service-account clients granted only the scope) are not silently dropped.
-NGM_QUERY_SCOPE = "ngm.query"
-
-# Django Groups that may run the gated SELECT plane (``HasNgmQueryAccess``).
-# WIDER than NGM_ROLE_GROUPS (the write gate): the org-wide ReadOnly read role is
-# admitted here because querying is a read — the guard is SELECT-only and the
-# rows are already public via the REST read plane. ReadOnly stays OUT of
-# NGM_ROLE_GROUPS, so it remains excluded from ingestion / mutations.
-NGM_QUERY_GROUPS = frozenset({"ReadOnly"}) | NGM_ROLE_GROUPS
-
-
-def token_scopes(request) -> set[str]:
-    """Return the set of OAuth scopes from the token's ``scope`` claim.
-
-    OIDCAuthentication puts the decoded claims dict on ``request.auth``. The
-    ``scope`` claim is the standard space-delimited string; some IdPs emit it as
-    ``scp`` (a list). Tolerate both shapes; return an empty set when absent.
-    """
-    claims = getattr(request, "auth", None)
-    if not isinstance(claims, dict):
-        return set()
-    raw = claims.get("scope") or claims.get("scp")
-    if isinstance(raw, str):
-        return set(raw.split())
-    if isinstance(raw, (list, tuple)):
-        return {str(s) for s in raw}
-    return set()
+# NOTE: the raw-SQL SELECT plane (``POST /query``) is deliberately NOT gated
+# here. It reads the same rows the public REST read plane already serves
+# anonymously (``courtcases`` + its hearings/entities sub-resources), so it
+# requires only authentication — DRF's stock ``IsAuthenticated`` on
+# ``courts.views.QueryView``, with no role and no ``ngm.query`` scope. Requiring
+# an admin-granted role there made our own published analysis impossible for an
+# outside reader to reproduce, which defeats the point of publishing it. What
+# bounds that surface is ``courts.query_guard`` plus the row cap and statement
+# timeout, not a permission class.
+#
+# This module therefore gates WRITES only. Keep it that way: ``NGM_ROLE_GROUPS``
+# must never widen to a read role.
 
 
 class HasNgmRole(permissions.BasePermission):
@@ -75,43 +59,3 @@ class HasNgmRole(permissions.BasePermission):
             return True
         user_groups = set(user.groups.values_list("name", flat=True))
         return bool(user_groups & NGM_ROLE_GROUPS)
-
-
-class HasNgmQueryAccess(permissions.BasePermission):
-    """Gate the SELECT plane on the ``ngm.query`` OAuth scope OR a read role.
-
-    The FastAPI POST /query route gated on the OAuth scope ``ngm.query`` via
-    ``require_scope``; the initial Django port gated purely on role/group, which
-    silently dropped the scope control. This restores scope-awareness without
-    breaking role-based access: a token bearing the ``ngm.query`` scope is
-    accepted (so scope-only clients like MCP keep working), and so is a principal
-    in a query-capable Django Group. Either is sufficient.
-
-    Query-capable is WIDER than ``HasNgmRole`` (the write gate): it is superuser,
-    the NGM content role (Caseworker), OR the org-wide ReadOnly read role.
-    Querying is a read — the guard is SELECT-only and the rows are already public
-    via the REST read plane — so ReadOnly is admitted here even though it is
-    excluded from every write gate. (This deliberately shares no logic with
-    ``HasNgmRole``, so it subclasses ``BasePermission`` directly rather than
-    that gate.)
-
-    Unauthenticated -> 401; authenticated but lacking scope and a read role -> 403.
-    """
-
-    message = (
-        "The 'ngm.query' OAuth scope or a read-capable role "
-        "(ReadOnly or Caseworker) is required."
-    )
-
-    def has_permission(self, request, view) -> bool:
-        user = getattr(request, "user", None)
-        if not (user and user.is_authenticated):
-            return False  # 401 via the authenticator's WWW-Authenticate header
-        if user.is_superuser:
-            return True
-        if NGM_QUERY_SCOPE in token_scopes(request):
-            return True
-        # ONE group query over the read-capable set. Note this is NGM_QUERY_GROUPS
-        # (ReadOnly + NGM roles), NOT HasNgmRole's NGM_ROLE_GROUPS, which excludes
-        # ReadOnly and gates writes only.
-        return user.groups.filter(name__in=NGM_QUERY_GROUPS).exists()

--- a/courts/tests/test_api.py
+++ b/courts/tests/test_api.py
@@ -184,10 +184,13 @@ class QueryGateTests(_DbAPITestCase):
         resp = self.client.post("/api/query/", {"query": "SELECT 1"}, format="json")
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_authed_without_ngm_role_is_403(self):
+    def test_authed_without_any_role_may_query(self):
+        # The SELECT plane requires authentication but NOT a role: it returns
+        # rows already public via the REST read plane, and gating it on an
+        # admin-granted role left our published analysis unreproducible.
         self.client.force_authenticate(user=self.nobody)
         resp = self.client.post("/api/query/", {"query": "SELECT 1"}, format="json")
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_non_select_is_400(self):
         self.client.force_authenticate(user=self.user)
@@ -234,13 +237,14 @@ class QueryGateTests(_DbAPITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
-    def test_other_scope_without_role_is_403(self):
-        # An authenticated principal with neither the scope nor an NGM role -> 403.
+    def test_other_scope_without_role_may_query(self):
+        # Authentication is the whole gate now, so a principal with neither the
+        # ngm.query scope nor an NGM role is admitted just the same.
         self.client.force_authenticate(
             user=self.nobody, token={"scope": "openid profile"}
         )
         resp = self.client.post("/api/query/", {"query": "SELECT 1"}, format="json")
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
 
 class IngestionGateTests(_DbAPITestCase):

--- a/courts/tests/test_query_guard_security.py
+++ b/courts/tests/test_query_guard_security.py
@@ -1,15 +1,19 @@
-"""Penetration tests for the gated raw-SQL endpoint (``POST /api/query/``).
+"""Penetration tests for the raw-SQL endpoint (``POST /api/query/``).
 
-Target: :class:`courts.views.QueryView` — a gated, SELECT-only raw-SQL surface
-over the ngm DB, guarded by :func:`courts.query_guard.validate_query`
-(SELECT-only, forbidden-keyword denylist, ``scraped_dates`` block, table
-allowlist, row cap, statement timeout) and gated by
-:class:`courts.permissions.HasNgmQueryAccess` (``ngm.query`` scope OR NGM role).
+Target: :class:`courts.views.QueryView` — a SELECT-only raw-SQL surface over the
+ngm DB, open to ANY authenticated principal (no role, no scope) and bounded by
+:func:`courts.query_guard.validate_query` (SELECT-only, forbidden-keyword
+denylist, ``scraped_dates`` block, table allowlist, row cap, statement timeout).
+
+Because the role gate is gone, ``query_guard`` is the ONLY thing standing
+between an ordinary signed-in account and the ngm DB. That makes this suite the
+load-bearing control on this surface, not a belt-and-braces extra — every
+rejection below must hold for a caller with no privileges whatsoever.
 
 These are adversarial tests: every attack asserts the endpoint REJECTS the
-input (400 from the guard, or 401/403 from the auth gate) — NEVER a
-200-with-data and NEVER a 500. A legitimate SELECT for an authorized caller is
-asserted to be ALLOWED so the guard is not merely blanket-denying.
+input (400 from the guard, or 401 when unauthenticated) — NEVER a
+200-with-data and NEVER a 500. A legitimate SELECT is asserted to be ALLOWED so
+the guard is not merely blanket-denying.
 
 The test DB is sqlite; the guard is a *string-level* policy check that runs
 BEFORE execution, so every rejection test is decided by the guard without
@@ -17,8 +21,9 @@ needing Postgres. Tests that would need Postgres-specific execution (e.g. real
 ``pg_sleep``) assert the guard-level decision instead.
 
 Auth mirrors ``courts/tests/test_api.py``: rather than mint real Zitadel JWTs,
-we ``force_authenticate`` a user whose synced Django Groups grant an NGM role,
-or attach a token dict carrying the ``ngm.query`` scope.
+we ``force_authenticate`` a user — either one whose synced Django Groups grant
+an NGM role, or ``nobody``, who has no groups at all and stands in for an
+ordinary signed-in account.
 
     DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true \\
         uv run pytest -q courts/tests/test_query_guard_security.py
@@ -88,18 +93,31 @@ class _QuerySecurityBase(APITestCase):
         return self.client.post(QUERY_URL, body, format="json")
 
     def _assert_rejected(self, resp):
-        """A rejected query is a clean 400 (or 403) — never 200-with-data, never 500."""
-        self.assertIn(
+        """A rejected query is a clean 400 — never 200-with-data, never 500.
+
+        Tightened from ``400 or 403`` now that the role gate is gone: with an
+        authenticated caller there is no longer any path that legitimately
+        answers 403 here, so every rejection must come from the guard itself.
+        """
+        self.assertEqual(
             resp.status_code,
-            (status.HTTP_400_BAD_REQUEST, status.HTTP_403_FORBIDDEN),
+            status.HTTP_400_BAD_REQUEST,
             msg=f"expected rejection, got {resp.status_code}: {getattr(resp, 'data', None)}",
         )
 
 
 # ---------------------------------------------------------------------------
-# 7. Auth gate — checked BEFORE the SELECT guard.
+# 7. Auth gate — authentication required, role NOT required.
 # ---------------------------------------------------------------------------
 class TestAuthGate(_QuerySecurityBase):
+    """Authentication is required; a ROLE is not.
+
+    This plane reads the same rows the public REST plane already serves
+    anonymously, so any authenticated principal may query it. Authentication is
+    kept so every query is attributable to an identity and metered by the
+    ``user`` throttle rather than the anon one.
+    """
+
     def test_unauthenticated_is_401(self):
         resp = self.client.post(QUERY_URL, {"query": "SELECT 1"}, format="json")
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -109,26 +127,44 @@ class TestAuthGate(_QuerySecurityBase):
         resp = self.client.post(QUERY_URL, {"query": "SELECT 1"}, format="json")
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_authenticated_without_ngm_role_or_scope_is_403(self):
+    def test_authenticated_without_any_role_or_scope_is_allowed(self):
+        # The point of the change: a signed-in principal with NO granted role
+        # (empty Zitadel role claim -> groups.set([])) can reproduce our
+        # published analysis without an admin first granting them ReadOnly.
         self.client.force_authenticate(user=self.nobody)
         resp = self.client.post(QUERY_URL, {"query": "SELECT 1"}, format="json")
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
-    def test_non_ngm_scope_without_role_is_403(self):
+    def test_non_ngm_scope_without_role_is_allowed(self):
         self.client.force_authenticate(
             user=self.nobody, token={"scope": "openid profile"}
         )
         resp = self.client.post(QUERY_URL, {"query": "SELECT 1"}, format="json")
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
-    def test_auth_gate_precedes_guard_write_still_403_not_400(self):
-        # An unauthorized caller sending a WRITE must be stopped by auth (403),
-        # never reach — nor be triaged by — the SQL guard.
+    def test_role_less_caller_sending_a_write_is_still_rejected(self):
+        # Dropping the ROLE gate must not let a write through. Auth now passes,
+        # so the SQL guard is the only thing stopping this -> 400, never 200.
         self.client.force_authenticate(user=self.nobody)
         resp = self.client.post(
             QUERY_URL, {"query": "DROP TABLE court_cases"}, format="json"
         )
-        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_role_less_caller_cannot_reach_blocked_tables(self):
+        # Same idea for the allowlist: the guard, not the role gate, is what
+        # keeps a role-less caller out of scraped_dates, the auth tables and the
+        # system catalogs. These were previously masked by the 403.
+        self.client.force_authenticate(user=self.nobody)
+        for sql in (
+            "SELECT * FROM scraped_dates",
+            "SELECT * FROM auth_user",
+            "SELECT * FROM pg_catalog.pg_authid",
+            "SELECT * FROM information_schema.tables",
+        ):
+            with self.subTest(sql=sql):
+                resp = self.client.post(QUERY_URL, {"query": sql}, format="json")
+                self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 # ---------------------------------------------------------------------------
@@ -334,6 +370,8 @@ class TestLegitimateSelectAllowed(_QuerySecurityBase):
 
     def test_ngm_query_scope_without_role_is_allowed(self):
         # Scope-only principals (e.g. MCP service accounts) must keep working.
+        # They now pass on plain authentication rather than on the scope, but
+        # the observable contract for those clients is unchanged.
         self.client.force_authenticate(
             user=self.nobody, token={"scope": "openid ngm.query"}
         )
@@ -341,6 +379,13 @@ class TestLegitimateSelectAllowed(_QuerySecurityBase):
             QUERY_URL, {"query": "SELECT identifier FROM courts"}, format="json"
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_row_cap_is_500_per_request(self):
+        # The bulk-pull budget callers rely on: one request may return up to
+        # 500 rows, and the cap is applied by wrapping the caller's SELECT.
+        self.assertEqual(query_guard.default_max_rows(), 500)
+        capped = query_guard.apply_row_cap("SELECT identifier FROM courts", 500)
+        self.assertIn("LIMIT 500", capped)
 
     def test_columns_resembling_keywords_are_not_false_positives(self):
         # Column names that merely CONTAIN a forbidden keyword as a substring

--- a/courts/views.py
+++ b/courts/views.py
@@ -7,9 +7,10 @@ Ports the FastAPI NGM API plane to DRF:
   firms. List endpoints use the shared ``PlatformCursorPagination`` so the wire
   shape is the platform ``{results, next}`` (the existing converted read plane's
   contract), not the FastAPI ``{items, next_cursor}``.
-- Gated SQL plane (``POST /query``): OIDC + NGM-role gated; the query_guard
-  policy (SELECT-only, allowlist, scraped_dates blocked, row cap, statement
-  timeout) is enforced in the view.
+- SQL SELECT plane (``POST /query``): any authenticated principal (no role or
+  scope needed — it reads the same rows the public REST plane already serves);
+  the query_guard policy (SELECT-only, allowlist, scraped_dates blocked, row
+  cap, statement timeout) is what actually bounds it.
 - Ingestion plane (``POST /ingestion/*``): OIDC + NGM-role gated write stubs
   (501), mirroring the FastAPI ingestion routes.
 
@@ -30,14 +31,14 @@ from rest_framework import mixins, status, viewsets
 from jawafdehi_shared.drf.auditlog import AuditlogActorMixin
 from jawafdehi_shared.entities.ids import is_valid_entity_iri
 from rest_framework.exceptions import ValidationError as DRFValidationError
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from . import query_guard, search_index
 from .models import BlacklistedFirm, CaseEntity, Court, CourtCase, CourtCaseHearing
 from .normalize import best_effort_normalize
-from .permissions import HasNgmQueryAccess, HasNgmRole
+from .permissions import HasNgmRole
 from .serializers import (
     BlacklistedFirmSerializer,
     BlacklistedFirmWriteSerializer,
@@ -270,18 +271,28 @@ class BlacklistedFirmViewSet(
 
 
 class QueryView(APIView):
-    """``POST /query`` — gated raw-SQL for power users / MCP.
+    """``POST /query`` — raw-SQL SELECT plane for any authenticated caller.
 
-    OIDC-gated on EITHER the ``ngm.query`` OAuth scope OR an NGM role (see
-    ``HasNgmQueryAccess`` — restores the FastAPI route's scope control while
-    keeping role-based access). The body is
-    ``{"query": "<SELECT ...>", "timeout_seconds"?}``. Enforces the query_guard
-    policy then runs the validated, row-capped SELECT with a per-statement
-    timeout. DB errors surface as a generic 400 (no internals leaked), matching
-    the FastAPI route.
+    Authentication only: ANY OIDC-authenticated principal may query, with no
+    role or scope requirement. The rows reachable here are the same ones the
+    public REST read plane already serves anonymously (``courtcases`` and its
+    hearings/entities sub-resources) — the SQL surface just makes them
+    practical to pull in bulk, which is what an outside reader needs to
+    independently reproduce our published analysis. Gating that behind an
+    admin-granted role made our own numbers unverifiable.
+
+    Authentication is still required so every query is attributable to an
+    identity and metered by the ``user`` throttle rather than the anon one.
+
+    What actually bounds this surface is ``query_guard`` (SELECT-only, single
+    statement, no comments, table allowlist, blocked system schemas, and a
+    denylist of DoS/file-read functions) plus the row cap and per-statement
+    timeout applied below — NOT the permission class. The body is
+    ``{"query": "<SELECT ...>", "timeout_seconds"?}``. DB errors surface as a
+    generic 400 (no internals leaked), matching the FastAPI route.
     """
 
-    permission_classes = [HasNgmQueryAccess]
+    permission_classes = [IsAuthenticated]
 
     def post(self, request):
         body = request.data if isinstance(request.data, dict) else {}

--- a/docs/control-plane-api-design.md
+++ b/docs/control-plane-api-design.md
@@ -117,7 +117,7 @@ This doc is **grounded in the code on `v2` as it stands today** (audited 2026-06
 | `/cases/{court}/{case_number}/{hearings,entities,documents}/` | GET | public | ✅ |
 | `/entities/`, `/firms/` | GET | public | ✅ |
 | `/firms/`, `/firms/{id}/` | POST/PUT/PATCH | `HasNgmRole` | ✅ |
-| `/query/` | POST | `HasNgmQueryAccess` (scope **or** role) | ✅ SELECT-only guard |
+| `/query/` | POST | `IsAuthenticated` (any signed-in principal; no role/scope) | ✅ SELECT-only guard |
 | `/materials/?iri=` | GET / POST | public / `HasNgmRole` | ✅ JSON-LD upsert |
 | `/materials/{source}/{ident}/` | GET / PUT | public / `HasNgmRole` | ✅ JSON-LD upsert; GET falls back to on-the-fly court-case materialization |
 | `/ingestion/cases/` | POST | `HasNgmRole` | ⛔ **501** |

--- a/docs/security/authz-model.md
+++ b/docs/security/authz-model.md
@@ -109,7 +109,7 @@ Superuser (R1) is allow for every row and omitted from columns.
 | See PRIVATE (draft-only) material | ❌ | ✅ (ReadOnly) · ❌ (Public) | ✅ | ✅ | ✅ | `materials._can_see_nonpublic`: any staff-ish/NGM-role/superuser principal. |
 | Write court (POST/PUT) | ❌ | ❌ | ✅ | ✅ | ✅ | `HasNgmRole` (writes). |
 | Write / upsert material | ❌ | ❌ | ✅ | ✅ | ✅ | `HasNgmRole` enforced manually in `@api_view` handlers. |
-| Gated SQL query plane | ❌ | ❌ | ✅ | ✅ | ✅ | `HasNgmQueryAccess` = `HasNgmRole` **OR** OAuth scope `ngm.query` (**cond**: scope-only tokens like MCP pass without a role). |
+| SQL SELECT plane (`POST /api/query/`) | ❌ | ✅ | ✅ | ✅ | ✅ | `IsAuthenticated` only — **no role, no scope**. Reads the same rows the public REST plane already serves anonymously; bounded by `courts.query_guard` + 500-row cap + statement timeout, not by a role. Auth is kept so queries are attributable and metered by the `user` throttle. |
 | NGM ingestion | ❌ | ❌ | ✅ | ✅ | ✅ | `HasNgmRole`. |
 
 ### 4d. Review system (`review/`)
@@ -160,9 +160,12 @@ explicitly in any centralization:
 3. **Model-permission gate on delete.** Case delete needs `cases.delete_case`
    (a Django model permission Caseworker isn't granted) **in addition to**
    `can_change_case`.
-4. **OAuth scope bypass (NGM SQL).** `HasNgmQueryAccess` accepts the
-   `ngm.query` scope on the token *instead of* a role — for scope-only machine
-   clients (MCP).
+4. **No role gate on the NGM SQL plane.** `POST /api/query/` is
+   `IsAuthenticated` only. Any signed-in principal — including one with an
+   empty role claim — may run a guarded SELECT, because the rows are already
+   public via the REST read plane and gating them behind an admin-granted role
+   made our own published research unreproducible by outside readers. The
+   control is `courts.query_guard`, not a permission class.
 5. **Service-account subject allowlist.** `/caseworker/me` gates on `sub ∈
    OIDC_SERVICE_ACCOUNT_SUBJECTS`, orthogonal to Group roles.
 6. **Superuser sync + admin `is_staff`.** `admin` role ⇒ `is_superuser`;

--- a/docs/unified-api-refactor-plan.md
+++ b/docs/unified-api-refactor-plan.md
@@ -56,7 +56,7 @@ ngm/                                       was services/jawafdehi/ngm (proxy app
 | `/api/courtcases` | court-case records (composite key) + hearings/parties | courts | NGM role write |
 | `/api/cases` | Jawafdehi **corruption** cases (unchanged) | cases | caseworker |
 | ~~`/api/sources`~~ | **REMOVED (ADR 2026-07-01)** — sources collapse into `/api/materials`; evidence links by `material_iri` | — | — |
-| `/api/query` | gated SELECT over court tables | courts | `HasNgmQueryAccess` |
+| `/api/query` | guarded SELECT over court tables | courts | `IsAuthenticated` (no role) |
 | `/api/ingestion/*` | batch write (make the 501s real) | courts/materials | NGM role |
 | `/api/search`, `/api/casework/*`, discovery | unchanged | search/review/discovery | mixed |
 

--- a/tests/security/test_write_endpoint_escalation.py
+++ b/tests/security/test_write_endpoint_escalation.py
@@ -25,8 +25,9 @@ pytestmark = [pytest.mark.security, pytest.mark.django_db]
 # (method, url, json-body) for each role-gated write endpoint.
 #
 # NOTE: ``/api/query/`` is deliberately NOT here — it is a SELECT-only READ
-# surface, so the org-wide ReadOnly role is admitted to it (see
-# ``test_query_plane_is_read_not_write`` below), unlike these write planes.
+# surface open to ANY authenticated principal (see
+# ``test_query_plane_is_read_not_write`` below), unlike these write planes,
+# which stay role-gated.
 WRITE_ENDPOINTS = [
     ("post", "/api/entities", {"@type": "Person", "@id": "x"}),
     ("post", "/api/courtcases/", {}),
@@ -75,28 +76,54 @@ def test_readonly_can_still_read_but_not_write_cases():
 
 @pytest.mark.django_db(databases="__all__")
 def test_query_plane_is_read_not_write():
-    """``/api/query/`` is a SELECT-only READ surface, so its role contract differs
-    from the write planes above: anon → 401, a lower-privilege authenticated role
-    (Public) → 403, but the org-wide ReadOnly read role is ADMITTED (passes the
-    auth gate). Writes still can't ride through it — the SELECT-only guard is
-    covered by courts/tests/test_query_guard_security.py."""
+    """``/api/query/`` is a SELECT-only READ surface, so its contract differs from
+    the write planes above: anon → 401, but EVERY authenticated role is admitted,
+    including the lowest-privilege ones (Public, ReadOnly). It reads rows the
+    public REST plane already serves anonymously, so there is no role to earn.
+
+    Writes still can't ride through it — the SELECT-only guard is covered by
+    courts/tests/test_query_guard_security.py, which is now the load-bearing
+    control on this surface (see test_query_plane_low_privilege_cannot_write)."""
     body = {"query": "SELECT 1"}
 
-    # Anonymous: 401 (authenticator sets WWW-Authenticate).
+    # Anonymous: 401 (authenticator sets WWW-Authenticate). Auth is still required
+    # so queries stay attributable and land on the `user` throttle, not `anon`.
     assert APIClient().post("/api/query/", body, format="json").status_code == 401
 
-    # Public (authenticated, no query role): still forbidden.
-    public = create_user_with_role("esc-pub-q", "esc-pub-q@example.com", "Public")
-    pc = APIClient()
-    pc.force_authenticate(user=public)
-    assert pc.post("/api/query/", body, format="json").status_code == 403
+    # Every authenticated role clears the gate — the response is then a normal
+    # query outcome (200, or a guard/DB 400), never an authz rejection.
+    for role in ("Public", "ReadOnly"):
+        user = create_user_with_role(f"esc-{role}-q", f"esc-{role}-q@example.com", role)
+        client = APIClient()
+        client.force_authenticate(user=user)
+        code = client.post("/api/query/", body, format="json").status_code
+        assert code not in (401, 403), (
+            f"{role} must clear the /api/query/ auth gate, got {code}"
+        )
 
-    # ReadOnly: admitted — it must clear the auth gate (NOT 401/403); the response
-    # is then a normal query outcome (200, or a guard/DB 400), never a rejection.
-    readonly = create_user_with_role("esc-ro-q", "esc-ro-q@example.com", "ReadOnly")
-    rc = APIClient()
-    rc.force_authenticate(user=readonly)
-    ro_status = rc.post("/api/query/", body, format="json").status_code
-    assert ro_status not in (401, 403), (
-        f"ReadOnly must clear the /api/query/ auth gate, got {ro_status}"
-    )
+
+@pytest.mark.django_db(databases="__all__")
+def test_query_plane_low_privilege_cannot_write():
+    """The escalation line that matters now that /api/query/ takes any signed-in
+    caller: the SELECT-only guard — not a role — is what stops the lowest-
+    privilege account turning the query plane into a write plane, or reaching
+    tables outside the allowlist. Rejections must be 400 (from the guard), and
+    must never be 2xx."""
+    user = create_user_with_role("esc-pub-qw", "esc-pub-qw@example.com", "Public")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    for sql in (
+        "DELETE FROM court_cases",
+        "UPDATE court_cases SET case_number = 'x'",
+        "DROP TABLE court_cases",
+        "WITH x AS (DELETE FROM court_cases RETURNING *) SELECT * FROM x",
+        "SELECT * FROM auth_user",
+        "SELECT * FROM scraped_dates",
+        "SELECT * FROM pg_catalog.pg_authid",
+    ):
+        resp = client.post("/api/query/", {"query": sql}, format="json")
+        assert resp.status_code == 400, (
+            f"guard must reject {sql!r} for a low-privilege caller, "
+            f"got {resp.status_code}"
+        )


### PR DESCRIPTION
## Why

`POST /api/query/` required the admin-granted `ReadOnly` role (or the `ngm.query` scope). That made our own published research unreproducible: an outside reader could not re-pull the corpus behind [jawafdehi.org/research/corruption-accountability](https://jawafdehi.org/research/corruption-accountability) to check our numbers without us first granting them a role.

**The gate was never protecting anything.** The rows reachable through the guard's table allowlist are the same ones the public REST read plane already serves **anonymously**. `courts/permissions.py` said so in its own comment: *"the guard is SELECT-only and the rows are already public via the REST read plane."*

Verified against prod:

| Endpoint | Anon | Gate |
|---|---|---|
| `POST /api/query/` | **401** | `HasNgmQueryAccess` |
| `GET /api/courtcases/?court=special` | **200** | `AllowAny` |
| `GET /api/courtcases/{court}/{n}/hearings/` | **200** | `AllowAny` |
| `GET /api/courtcases/{court}/{n}/entities/` | **200** | `AllowAny` |

The SQL surface only makes those rows practical to pull in **bulk**. Via REST the corpus takes ~6,400 requests — page size is pinned to 20 (`settings.py` `PAGE_SIZE: 20`, no `page_size_query_param`; I probed `page_size`/`limit`/`per_page`/`size`, all ignored) and the hearings/entities sub-resources have no bulk filter, forcing one request per case — against a **1,000/hour** anon throttle.

## What

Gate on authentication alone: `IsAuthenticated`. No role, no scope.

Authentication is kept — not for authorization, but so every query is attributable to an identity and metered by the `user` throttle (5,000/hr) rather than `anon`. Anonymous callers still get 401. The **500-row cap** and statement timeout are unchanged.

`HasNgmQueryAccess`, `NGM_QUERY_GROUPS`, `NGM_QUERY_SCOPE` and `token_scopes` are **removed** rather than left dangling, so nobody reattaches a gate that no longer reflects the model. `courts/permissions.py` now gates writes only; `NGM_ROLE_GROUPS` is untouched and still gates every write.

## Security review — read this part

This shifts the burden onto `courts/query_guard`, which is now the **only** control on the surface rather than a second layer behind a role check. The tests follow that shift: the low-privilege escalation cases previously asserted `403` *from the role gate*, which masked whether the guard itself holds. They now assert the **guard** rejects, with `400`, for a caller with no privileges at all:

- `DELETE` / `UPDATE` / `DROP`, and CTE-wrapped writes
- `auth_user`, `scraped_dates`, `pg_catalog.pg_authid`, `information_schema.tables`

`_assert_rejected` is tightened from `400 or 403` to `400` only — with the role gate gone there is no longer any path that legitimately answers 403 here, so a 403 would now indicate something unexpected.

Worth a reviewer's judgement, since I'm widening who reaches this surface:

1. **Blast radius is bulk-extraction speed, not new data.** Everything reachable here is already anonymously readable via REST; this makes it efficient. The allowlisted `court_cases` / `court_case_entities` include the full 1.6M-case docket and party names/addresses — which is the same set the pending court-case-search privacy decision covers (~320K sensitive family/GBV records). That decision is unaffected either way, but this does make bulk pulls of it cheaper, so flagging it explicitly.
2. **Who can get an account?** "Any authenticated user" is only as strong as Zitadel registration policy. If self-registration is open, this is effectively public + attributable. That's a deliberate call, but it should be a conscious one.
3. **Compute, not rows.** The row cap bounds output, not work. An expensive aggregate is still bounded by `statement_timeout` and the `user` throttle.

## Testing

- `courts/` + `tests/security/`: **444 passed**, ruff clean
- Full suite: **2557 passed**, 8 skipped, 2 xfailed. The 57 errors are all `integration-tests/` (`monolith unreachable at localhost:48000`) — environmental, needing a live stack, pre-existing. Both gated-query integration tests assert *unauthenticated → 401*, which this preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Changes**
  * Authenticated users can now run permitted read-only queries without requiring a specific role or OAuth scope.
  * Anonymous requests remain blocked.
  * Write operations and access to restricted data remain rejected by SQL safety controls.

* **Security**
  * Read queries continue to enforce a 500-row limit and statement timeout.

* **Documentation**
  * Updated API and security documentation to reflect the revised query access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->