### PR TITLE
fix(courts): reach Supreme's real detail page, and stop not-found pages counting as enrichment

### DIFF
--- a/courts/management/commands/repair_enrichment.py
+++ b/courts/management/commands/repair_enrichment.py
@@ -1,0 +1,106 @@
+"""Re-enrich cases that were marked ``enriched`` without ever being enriched.
+
+Two bugs let an empty detail-page parse through :func:`courts.scraper.base.apply_enrichment`:
+
+* ``_Supreme.crawl_detail`` fetched the ``regno`` **search result list** and handed
+  it to the detail parser, which found nothing in it — so every Supreme enrichment
+  produced an empty ``ParsedEnrichment``.
+* The guard was ``core_fields or extra_data or entities``, and the supreme/district/
+  high parsers always emit their ``enrichment_hearings``/``enrichment_timeline``
+  keys — so ``extra_data`` was truthy even for a page that identified nothing.
+
+The write went ahead and set ``status = "enriched"``. ``crawl._enrich_pending``
+excludes that status, so those cases are now permanently skipped: the fix alone
+does not reach them. This command does.
+
+It targets rows marked enriched that carry **no** enrichment evidence — no
+``registration_number``, no ``hearing_count``, no hearings JSON — and simply
+re-runs the (now correct) enrichment over them. Nothing is reset first: a case
+that enriches successfully overwrites its own state, and one that doesn't is left
+exactly as it was rather than downgraded.
+
+    manage.py repair_enrichment --court supreme              # dry run: count + sample
+    manage.py repair_enrichment --court supreme --apply
+
+This writes to the live mirror and takes ~2 fetches per case, so run it as a Job
+rather than ``kubectl exec`` — a rollout SIGKILLs exec'd processes mid-run.
+"""
+
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from courts.models import CourtCase
+from courts.scraper import base, registry
+from courts.scraper.fetch import Fetcher
+
+#: Marked enriched, yet holding nothing an enrichment would have written.
+DAMAGED = (
+    Q(status="enriched")
+    & Q(registration_number__isnull=True)
+    & Q(hearing_count__isnull=True)
+    & (Q(extra_data__enrichment_hearings=[]) | Q(extra_data__enrichment_hearings__isnull=True))
+)
+
+
+class Command(BaseCommand):
+    help = "Re-enrich cases falsely marked enriched by the empty-parse bug."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--court", required=True,
+                            help="registry key: special | district | high | supreme")
+        parser.add_argument("--court-id", default=None,
+                            help="restrict to one leaf court (default: every court in the tier)")
+        parser.add_argument("--apply", action="store_true",
+                            help="actually re-fetch and write (default: dry run)")
+        parser.add_argument("--limit", type=int, default=None,
+                            help="cap the number of cases repaired this run")
+        parser.add_argument("--delay", type=float, default=1.0,
+                            help="seconds between cases (default 1.0)")
+
+    def handle(self, *args, **o):
+        try:
+            keys = registry.resolve(o["court"])
+        except KeyError as exc:
+            raise CommandError(str(exc)) from exc
+        if len(keys) != 1:
+            raise CommandError("--court must name a single tier, not 'all'.")
+        module = registry.REGISTRY[keys[0]]
+        if not hasattr(module, "crawl_detail"):
+            raise CommandError(f"{keys[0]} has no crawl_detail; nothing to repair.")
+
+        damaged = CourtCase.objects.using(base.NGM_DB).filter(DAMAGED)
+        if o["court_id"]:
+            damaged = damaged.filter(court_id=o["court_id"])
+        else:
+            damaged = damaged.filter(court_id__in=module.court_ids(None))
+        targets = list(damaged.values_list("court_id", "case_number")[: o["limit"]])
+
+        self.stdout.write(f"{len(targets)} case(s) marked enriched with no enrichment.")
+        if not o["apply"]:
+            for court_id, case_number in targets[:10]:
+                self.stdout.write(f"  {court_id}/{case_number}")
+            self.stdout.write(self.style.WARNING("dry run — pass --apply to repair."))
+            return
+
+        fetch = Fetcher()
+        repaired = failed = 0
+        for court_id, case_number in targets:
+            try:
+                enrichment = module.crawl_detail(fetch, court_id, case_number)
+            except Exception as exc:  # a portal flake must not abandon the rest
+                failed += 1
+                self.stderr.write(f"  {court_id}/{case_number}: {exc}")
+                time.sleep(o["delay"])
+                continue
+            if enrichment is not None and base.apply_enrichment(
+                court_id, case_number, enrichment
+            ):
+                repaired += 1
+            else:
+                # Still nothing on the portal. Left untouched rather than
+                # downgraded — the row is no worse off than before this ran.
+                failed += 1
+            time.sleep(o["delay"])
+        self.stdout.write(f"repaired {repaired}, still unenriched {failed}.")

--- a/courts/scraper/base.py
+++ b/courts/scraper/base.py
@@ -150,7 +150,6 @@ def _fallback_date() -> date:
     return date(1900, 1, 1)
 
 
-@transaction.atomic(using=NGM_DB)
 def apply_enrichment(
     court_id: str, case_number: str, enrichment: ParsedEnrichment, *, using: str = NGM_DB
 ) -> bool:
@@ -160,6 +159,10 @@ def apply_enrichment(
     :mod:`courts.case_status`: header artifacts are dropped, and ``verdict_type`` /
     ``verdict_date_*`` are derived (from the status, else the final decisive
     hearing) when not already set. ``extra_data`` is UNIONed (never replaced).
+
+    The atomic block is opened on ``using``. As an ``@transaction.atomic(using=NGM_DB)``
+    decorator it bound to that one alias at import time, so any other alias ran the
+    save + ``_replace_entities`` delete-and-recreate with no transaction at all.
     """
     case = (
         CourtCase.objects.using(using)
@@ -169,12 +172,18 @@ def apply_enrichment(
     if case is None:
         return False
 
-    # A WAF-rejection / error / empty detail page parses into an empty
+    # A WAF-rejection / error / not-found detail page parses into an empty
     # ParsedEnrichment. Applying it would flip status to "enriched" (so it never
     # retries) AND delete the existing parties — silent data loss. Require at
     # least one usable signal; otherwise leave the row untouched and report
     # not-enriched so the case is retried on the next run.
-    if not (enrichment.core_fields or enrichment.extra_data or enrichment.entities):
+    #
+    # NB: the test is core_fields/entities only, NOT the truthiness of extra_data.
+    # The supreme/district/high parsers always emit their enrichment_hearings /
+    # enrichment_timeline keys, so an EMPTY parse still carries a truthy
+    # extra_data — an ``or extra_data`` guard passes a not-found page on three of
+    # the four courts and destroys the parties it exists to protect.
+    if not enrichment.identifies_a_case():
         return False
 
     core = {k: v for k, v in enrichment.core_fields.items() if k in _ENRICH_COLUMNS}
@@ -194,13 +203,14 @@ def apply_enrichment(
         core["verdict_date_bs"] = parsed.verdict_date_bs
         core["verdict_date_ad"] = parsed.verdict_date_ad
 
-    for key, value in core.items():
-        setattr(case, key, value)
-    case.extra_data = {**(case.extra_data or {}), **extra}
-    case.status = "enriched"
-    case.save(using=using)
+    with transaction.atomic(using=using):
+        for key, value in core.items():
+            setattr(case, key, value)
+        case.extra_data = {**(case.extra_data or {}), **extra}
+        case.status = "enriched"
+        case.save(using=using)
 
-    _replace_entities(court_id, case_number, enrichment.entities, using=using)
+        _replace_entities(court_id, case_number, enrichment.entities, using=using)
     return True
 
 

--- a/courts/scraper/errors.py
+++ b/courts/scraper/errors.py
@@ -1,0 +1,24 @@
+"""Exceptions shared by the court-portal parsers.
+
+Kept in their own module so the pure parsers can raise them without importing
+:mod:`courts.scraper.base` (which pulls in the ORM).
+"""
+
+from __future__ import annotations
+
+
+class UnexpectedPage(RuntimeError):
+    """The portal served something that is not the page we asked for.
+
+    The distinction that matters is **"no such case" vs "no answer"**. Both arrive
+    as HTTP 200 — the courts' F5 front end serves challenges, maintenance notices
+    and truncated bodies with a 200 — so ``raise_for_status`` never sees them and a
+    parser that returns "nothing found" for both is indistinguishable from a court
+    that genuinely has no such docket.
+
+    That conflation is expensive in exactly one place: the register sweep records a
+    not-found in ``RegisterProbe`` and skips the number for 90 days. One soft block
+    would otherwise write a whole budget's worth of false absences and report a
+    clean run. Raising instead keeps the failure inside the sweep's error path,
+    where it counts toward the abort threshold and is retried.
+    """

--- a/courts/scraper/registry.py
+++ b/courts/scraper/registry.py
@@ -12,6 +12,8 @@ paths are unit/DB-tested; the live fetch is exercised only on a real run.
 
 from __future__ import annotations
 
+from urllib.parse import urljoin
+
 from django.utils import timezone
 
 from courts.scraper import district, high, special, supreme
@@ -36,10 +38,28 @@ class _Supreme:
         return supreme.parse_cause_list(html, date_bs=date_bs)
 
     def crawl_detail(self, fetch, court_id, case_number):
-        html = fetch(self.DETAIL_URL, data={
+        """Two-stage: search by case number, then follow the result to the page.
+
+        A ``regno`` search returns a RESULT LIST, not the detail page. Handing that
+        list to ``parse_supreme_detail`` yields an entirely empty enrichment — which
+        is why the Django enrichment path has never populated a single Supreme
+        ``hearing_count``. Stage 2 follows the row's ``…&mode=view&caseno=<id>`` link,
+        matched to ``case_number`` so a multi-row result can't enrich the wrong case.
+
+        ``None`` means the court has no such docket. A response that isn't a search
+        result at all raises ``UnexpectedPage`` rather than posing as one.
+        """
+        listing = fetch(self.DETAIL_URL, data={
             "syy": "", "smm": "", "sdd": "", "mode": "show", "list": "list",
             "regno": case_number, "tyy": "", "tmm": "", "tdd": "",
         })
+        if not listing:
+            return None
+        href = supreme.parse_search_result_link(listing, case_number)
+        if not href:
+            return None  # "Total 0 Records Found" — no such docket
+        # Joined against DETAIL_URL itself, so the two can never drift apart.
+        html = fetch(urljoin(self.DETAIL_URL, href))
         return supreme.parse_supreme_detail(html) if html else None
 
 

--- a/courts/scraper/rows.py
+++ b/courts/scraper/rows.py
@@ -56,3 +56,16 @@ class ParsedEnrichment:
     core_fields: dict[str, Any] = field(default_factory=dict)
     extra_data: dict[str, Any] = field(default_factory=dict)
     entities: list[dict[str, Any]] = field(default_factory=list)
+
+    def identifies_a_case(self) -> bool:
+        """Did this parse actually find a case, or is it a not-found/error page?
+
+        Deliberately ignores ``extra_data``: the supreme/district/high parsers
+        always emit their ``enrichment_hearings``/``enrichment_timeline`` keys,
+        so an EMPTY parse still yields a truthy ``extra_data`` dict. Testing
+        truthiness of the whole payload therefore passes a not-found page —
+        which would mark the case enriched (so it never retries) and drop its
+        parties. Only ``core_fields`` and ``entities`` distinguish a real hit;
+        verified against captured not-found fixtures for all four portals.
+        """
+        return bool(self.core_fields) or bool(self.entities)

--- a/courts/scraper/supreme.py
+++ b/courts/scraper/supreme.py
@@ -31,6 +31,7 @@ from courts.case_status import (
     verdict_from_hearings,
 )
 from courts.normalize import best_effort_normalize
+from courts.scraper.errors import UnexpectedPage
 from courts.scraper.rows import ParsedCase, ParsedEnrichment, ParsedHearing
 from courts.scraper.text import (
     coerce_count,
@@ -420,6 +421,56 @@ def parse_hearings_and_timeline(soup: BeautifulSoup) -> dict[str, list[dict]]:
                         data["timeline"].append(entry)
 
     return data
+
+
+#: The result list's own record count. Its presence is what proves the response is
+#: a search result at all, rather than an F5 challenge or a maintenance notice.
+_RECORDS_FOUND = re.compile(r"Total\s+(\d+)\s+Records?\s+Found", re.I)
+
+
+def parse_search_result_link(html: str, case_number: str | None = None) -> str | None:
+    """The detail-page href for ``case_number`` within a ``regno`` search result.
+
+    Searching the Supreme portal by case number does NOT return the detail page —
+    it returns a result LIST ("Total N Records Found") whose rows link to
+    ``sys.php?…&mode=view&caseno=<id>``. Feeding that list straight to
+    :func:`parse_supreme_detail` yields an entirely empty enrichment, which is why
+    the Django enrichment path has never populated a single Supreme ``hearing_count``.
+    Callers must follow this link to reach the real page.
+
+    Three outcomes, deliberately distinct:
+
+    * **href** — the row whose docket cell equals ``case_number``. The row is matched
+      rather than taken in document order: the list is N-row capable (its hrefs carry
+      a per-row ``num=<ordinal>``), and following the wrong row would enrich a case
+      with a *different* docket's parties and verdict. With ``case_number=None`` the
+      first linked row is taken.
+    * **None** — "Total 0 Records Found", or a list holding no row for this docket.
+      The court does not have it: a legitimate answer, not a failure.
+    * :class:`~courts.scraper.errors.UnexpectedPage` — no record count at all, i.e.
+      not a search result. See that class for why this must not read as ``None``.
+    """
+    if _RECORDS_FOUND.search(html or "") is None:
+        raise UnexpectedPage("supreme search response carries no record count")
+
+    want = best_effort_normalize(case_number) if case_number else None
+    soup = BeautifulSoup(html, "html.parser")
+    for row in soup.find_all("tr"):
+        href = next(
+            (
+                a["href"].strip()
+                for a in row.find_all("a", href=True)
+                if "caseno=" in a["href"] and "mode=view" in a["href"]
+            ),
+            None,
+        )
+        if href is None:
+            continue
+        if want is None:
+            return href
+        if want in [best_effort_normalize(td.get_text(strip=True)) for td in row.find_all("td")]:
+            return href
+    return None
 
 
 def parse_supreme_detail(html: str) -> ParsedEnrichment:

--- a/courts/tests/fixtures/notfound/district_found.html
+++ b/courts/tests/fixtures/notfound/district_found.html
@@ -1,0 +1,755 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<!-- Website Title -->
+<title>दैनिक साप्तहिक पेशी सूची</title>
+<link rel="shortcut icon" type="image/x-icon" href="https://www.supremecourt.gov.np/cp/assets/favicon.ico">
+<!-- Meta data for SEO -->
+<meta name="description" content="">
+<meta name="keywords" content="">
+<link rel="stylesheet" href="https://supremecourt.gov.np/weekly_dainik/assets/main.css" type="text/css" media="all">
+<script type="text/javascript" src="https://supremecourt.gov.np/weekly_dainik/assets/jquery.js"></script>
+<script type="text/javascript" src="https://supremecourt.gov.np/weekly_dainik/assets/jquery_002.js"></script>
+<script type="text/javascript" src="https://supremecourt.gov.np/weekly_dainik/assets/jquery.idTabs.min.js"></script>
+<script type="text/javascript">
+$(document).ready( function() { 
+	// $('ul.idTabs li:first a').addClass('active');
+	
+	$('.tab_button').click( function() {
+		$('.tab_button').removeClass('active');
+		$(this).addClass('active');
+	}); 
+	$(window).scroll(function(){
+		if ($(this).scrollTop() > 100) {
+		$('.scrollup').fadeIn();
+		} else {
+		$('.scrollup').fadeOut();
+		}
+		});
+		$('.scrollup').click(function(){
+		$("html, body").animate({ scrollTop: 0 },1000);
+		return false;
+		}); 	
+ 	});
+ </script>
+<style type="text/css" charset="utf-8">
+/* See license.txt for terms of usage */
+/** reset styling **/
+.firebugResetStyles {
+	z-index: 2147483646 !important;
+	top: 0 !important;
+	left: 0 !important;
+	display: block !important;
+	border: 0 none !important;
+	margin: 0 !important;
+	padding: 0 !important;
+	outline: 0 !important;
+	min-width: 0 !important;
+	max-width: none !important;
+	min-height: 0 !important;
+	max-height: none !important;
+	position: fixed !important;
+	transform: rotate(0deg) !important;
+	transform-origin: 50% 50% !important;
+	border-radius: 0 !important;
+	box-shadow: none !important;
+	background: transparent none !important;
+	pointer-events: none !important;
+	white-space: normal !important;
+}
+.firebugBlockBackgroundColor {
+	background-color: transparent !important;
+}
+.firebugResetStyles:before, .firebugResetStyles:after {
+	content: "" !important;
+}
+/**actual styling to be modified by firebug theme**/
+.firebugCanvas {
+	display: none !important;
+}
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+.firebugLayoutBox {
+	width: auto !important;
+	position: static !important;
+}
+.firebugLayoutBoxOffset {
+	opacity: 0.8 !important;
+	position: fixed !important;
+}
+.firebugLayoutLine {
+	opacity: 0.4 !important;
+	background-color: #000000 !important;
+}
+.firebugLayoutLineLeft, .firebugLayoutLineRight {
+	width: 1px !important;
+	height: 100% !important;
+}
+.firebugLayoutLineTop, .firebugLayoutLineBottom {
+	width: 100% !important;
+	height: 1px !important;
+}
+.firebugLayoutLineTop {
+	margin-top: -1px !important;
+	border-top: 1px solid #999999 !important;
+}
+.firebugLayoutLineRight {
+	border-right: 1px solid #999999 !important;
+}
+.firebugLayoutLineBottom {
+	border-bottom: 1px solid #999999 !important;
+}
+.firebugLayoutLineLeft {
+	margin-left: -1px !important;
+	border-left: 1px solid #999999 !important;
+}
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+.firebugLayoutBoxParent {
+	border-top: 0 none !important;
+	border-right: 1px dashed #E00 !important;
+	border-bottom: 1px dashed #E00 !important;
+	border-left: 0 none !important;
+	position: fixed !important;
+	width: auto !important;
+}
+.firebugRuler {
+	position: absolute !important;
+}
+.firebugRulerH {
+	top: -15px !important;
+	left: 0 !important;
+	width: 100% !important;
+	height: 14px !important;
+	background: url("data:image/png,") repeat-x !important;
+	border-top: 1px solid #BBBBBB !important;
+	border-right: 1px dashed #BBBBBB !important;
+	border-bottom: 1px solid #000000 !important;
+}
+.firebugRulerV {
+	top: 0 !important;
+	left: -15px !important;
+	width: 14px !important;
+	height: 100% !important;
+	background: url("data:image/png,") repeat-y !important;
+	border-left: 1px solid #BBBBBB !important;
+	border-right: 1px solid #000000 !important;
+	border-bottom: 1px dashed #BBBBBB !important;
+}
+.overflowRulerX > .firebugRulerV {
+	left: 0 !important;
+}
+.overflowRulerY > .firebugRulerH {
+	top: 0 !important;
+}
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+.fbProxyElement {
+	position: fixed !important;
+	pointer-events: auto !important;
+}
+</style>
+</head>
+<body>
+
+<!-- Begin control panel wrapper -->
+<div id="wrapper">
+  <div id="top_bar">
+    <div class="logo"> <img src="https://supremecourt.gov.np/weekly_dainik/assets/logo.png"> </div>
+    <div>
+      <h1 style="padding-top:30px; font-family:kalimati">अछाम जिल्ला अदालत</h1>
+      <p  style="padding-top:10px; margin-left:5%; font-size:18px; color:#FFF; display: inline-block;font-family:kalimati">पेशी स्थिती विवरण </p>
+    </div>
+  </div>
+  
+  <!-- Begin content -->
+  <div id="content_wrapper"> <script type="text/javascript">
+
+$(function(){
+
+    $('#weeklytab').click(function(){
+         // $(this).addClass('active');
+         // $('#dailytab').removeClass('active');
+         // $('#dailytab').addClass('selected');
+     
+    });
+
+        $('#supplementarytab').click(function(){
+         // $(this).addClass('active');
+         // $('#dailytab').removeClass('active');
+         // $('#dailytab').addClass('selected');
+     
+    });
+
+    $('#dailytab').click(function(){
+         // $(this).addClass('active');
+         // $('#weeklytab').removeClass('active');
+         // $('#weeklytab').addClass('selected');
+     
+    });
+
+  
+});
+
+function validate_caseprocess(){
+  mudda_no = document.getElementById('mudda_no').value;
+   if(mudda_no==''){
+      alert('कृपया मुद्दा न. हाल्नुहोला');
+      document.getElementById('mudda_no').focus();
+      return false;
+   }
+  return true;
+}
+
+function validate_dainik(){
+   
+   pesi_date = document.getElementById('pesi_date').value;
+   todays_date = document.getElementById('todays_date').value;
+   
+
+
+   if(pesi_date=='____-__-__'){
+     alert('कृपया पेशी मिति हाल्नुहोला');
+      document.getElementById('pesi_date').focus();
+      return false;
+   }
+   
+   if(pesi_date==''){
+      alert('कृपया पेशी मिति हाल्नुहोला');
+      document.getElementById('pesi_date').focus();
+      return false;
+   }
+
+  var partsOfStr = pesi_date.split('-');
+  var todays_date_arr = todays_date.split('-'); 
+
+   // Convert to Roman Digit
+   
+
+   var engDigit = {
+  '०': '0',
+  '१': '1',
+  '२': '2',
+  '३': '3',
+  '४': '4',
+  '५': '5',
+  '६': '6',
+  '७': '7',
+  '८': '8',
+  '९': '9'
+};
+
+var nepDigit = {
+  '0': '०',
+  '1': '१',
+  '2': '२',
+  '3': '३',
+  '4': '४',
+  '5': '५',
+  '6': '६',
+  '7': '७',
+  '8': '८',
+  '9': '९'
+};
+    strMahina = partsOfStr[1].replace(/[०१२३४५६७८९]/g, function(s) {
+        return engDigit[s];
+    });
+
+     strDin = partsOfStr[2].replace(/[०१२३४५६७८९]/g, function(s) {
+        return engDigit[s];
+    });
+
+     strSal = partsOfStr[0].replace(/[०१२३४५६७८९]/g, function(s) {
+        return engDigit[s];
+    });
+
+
+     if(strSal > todays_date_arr[0]){
+      alert('कृपया साल मिलेन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+    
+    if(strMahina>12 ){
+      alert('कृपया पेशी मितिको महिना मिलेन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+
+    if(strMahina > todays_date_arr[1] && strSal > todays_date_arr[0]){
+      alert('कृपया पेशी महिना हालको महिना भन्दा बढि हुनुहुदैन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+
+   if(strDin>32){
+      alert('कृपया पेशी मितिको गते मिलेन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+
+
+  //  if(strMahina >= todays_date_arr[1]){
+
+  //    if(strDin > todays_date_arr[2] ){
+  //       alert('कृपया पेशी मिति आजको मिति भन्दा बढि हुनुहुदैन');
+  //       document.getElementById('pesi_date').focus();
+  //       return false;
+
+  //    }
+  // }
+
+    // added on 2020-10-04 db to not allowing accessing data greater than today
+    if(strSal+strMahina+strDin > todays_date_arr[0]+todays_date_arr[1]+todays_date_arr[2]){
+
+        // return true;
+
+     // if(strDin > todays_date_arr[2] ){
+        alert('कृपया पेशी मिति आजको मिति भन्दा बढि हुनुहुदैन');
+        document.getElementById('pesi_date').focus();
+        return false;
+
+     // }
+  }
+
+  
+
+   return true;
+}
+
+$(function(){
+  $('#pesi_date').mask('9999-99-99');
+});
+</script>
+<style type="text/css">
+body {
+	font-family: kalimati;
+}
+dl {
+	margin-bottom:50px;
+	width:50%;
+	float:left;
+}
+dl dt {
+	line-height:30px;
+	background:#FFDCCB;
+	color:#000;
+	float:left;
+	font-weight:bold;
+	margin-right:10px;
+	height:40px;
+	width:200px;
+	font-size:14px;
+	padding-left:10px;
+}
+dl dd {
+	height:30px;
+	padding:5px 0;
+	margin:1px;
+	background:#FAF5DA;
+	font-size:14px;
+}
+</style>
+<ul class="first_level_tab idTabs">
+  <li> <a href="#tab1" class="tab_button " id="dailytab">दैनिक पेशी सूची</a> </li>
+  <li> <a href="#tab2" class="tab_button " id="weeklytab">साप्ताहिक पेशी सूची</a> </li>
+  <li> <a href="#tab4" class="tab_button " id="supplementarytab">पूरक पेशी सूची</a> </li>
+
+  <li> <a href="#tab3" class="tab_button selected active" id="casedetailtab">विस्तृत विवरण</a> </li>
+</ul>
+<br class="clear">
+<div class="onecolumn">
+  <div class="content" id="tab1"> 
+<form  action="https://supremecourt.gov.np/weekly_dainik/pesi/daily/86" method="post" id="form1" onsubmit="return validate_dainik();">
+  <input type="hidden" name="todays_date" id="todays_date" value="2083-04-15">
+  <table width="100%" class="global" style="border:1px solid #CCC;">
+    <tbody>
+      <tr class="">
+        <td width="273">&nbsp;</td>
+        <td width="143"><label for="pesidate"> मिति:</label></td>
+        <td width="535"><img style="display:none;" id="ajaxLoader" src="http://www.supremecourt.gov.np/cp/assets/images/ajax-loader-dark.gif">
+          <input type="text" name="pesi_date" id="pesi_date" class="smallText" value="२०८३-०४-१५" />
+          [yyyy-mm-dd]
+          <!-- added on 2021 jan 17 db to show estagit pesi list -->
+         
+          <a href="https://supremecourt.gov.np/weekly_dainik/pesi/viewStagit/86/20830415" target="_blank">आजको स्थगित</a>
+       
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        &nbsp;
+        <td></td>
+        <td><div class="">
+            <input type="submit" value="खोज्नु होस्" class="button_dark" name="submit">
+          </div></td>
+      </tr>
+    </tbody>
+  </table>
+  
+  <!-- End form elements -->
+  
+</form>
+
+<!-- List of Daily --> 
+<br/>
+<div class="pageTitle">
+   
+  
+</div>
+<center>
+  <span style="font-size:16px; color:#C00;">
+    </span>
+</center>
+<!-- Begin one column box --><!-- Begin two column box --><br/>
+
+<br class="clear"/>
+
+ </div>
+  <div class="content" id="tab2"> 
+    
+    <form id="form2" method="post"  action="https://supremecourt.gov.np/weekly_dainik/pesi/weekly_pesi/86">
+          <table width="100%" class="global" style="border:1px solid #ccc; margin:0 auto;" align="center">
+            <tbody>
+              <tr class="">
+                <td width="273">&nbsp;</td>
+                <td width="142"><label > सुनवाइ मिति:</label></td>
+                <td width="536"><span style="color:#C30">२०८३-०४-१०</span>&nbsp; देखि&nbsp; <span style="color:#C30">२०८३-०४-१५</span>&nbsp;सम्मको साप्‍ताहिक पेशी सूची</td>
+              </tr>
+               <tr class="">
+                 <td width="273">&nbsp;</td>
+                <td width="142"><label for="pesi_bar">बारः</label></td>
+                <td width="536"><select name="pesi_bar" selected>
+                					<option value="all">सबै </option>
+                                    <option value="२०८३-०४-१०" >आईतबार </option>
+                                    <option value="२०८३-०४-११"  >सोमबार </option>
+                                    <option value="२०८३-०४-१२" >मंगलबार </option>
+                                    <option value="२०८३-०४-१३">बुधबार </option>
+                                    <option value="२०८३-०४-१४ " >बिहीबार </option>
+                                    <option value="२०८३-०४-१५" >शुक्रबार </option>
+                				</select>
+                </td>
+                
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              <td>&nbsp;</td>
+              <td>
+              <div class="">
+            <input type="submit" name="submit" class="button_dark" value="खोज्नु होस्">
+          </div>
+              </td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <!-- End form elements -->
+      
+    </form>
+
+       <center><span style="font-size:16px; color:#C00;"> </span></center>
+    <!-- Begin one column box --><!-- Begin two column box --><br/>
+        <br class="clear"/>
+    <br/>
+  
+ </div>
+  <div class="content" id="tab4"> 
+    
+    <form id="form4" method="post"  action="https://supremecourt.gov.np/weekly_dainik/pesi/supplementary_pesi/86">
+          <table width="100%" class="global" style="border:1px solid #ccc; margin:0 auto;" align="center">
+            <tbody>
+              <tr class="">
+               <td width="273">&nbsp;</td>
+              <td width="143"><label for="pesidate"> मिति:</label></td>
+              <td width="535"><img style="display:none;" id="ajaxLoader" src="https://www.supremecourt.gov.np/cp/assets/images/ajax-loader-dark.gif">
+                <input type="text" name="pesi_date" id="pesi_date" class="smallText" value="२०८३-०४-१५" />
+                [yyyy-mm-dd]</td>
+                
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              <td>&nbsp;</td>
+              <td>
+              <div class="">
+            <input type="submit" name="submit" class="button_dark" value="खोज्नु होस्">
+          </div>
+              </td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <!-- End form elements -->
+      
+    </form>
+
+       <center><span style="font-size:16px; color:#C00;"> </span></center>
+    <!-- Begin one column box --><!-- Begin two column box --><br/>
+        <br class="clear"/>
+    <br/>
+  
+<!-- added on 2022 jan 7 db  --> </div>
+ 
+  <div class="content" id="tab3"> 
+  <form  action="https://supremecourt.gov.np/weekly_dainik/pesi/case_process_detail/86" method="post" id="form3" onsubmit="return validate_caseprocess(); ">
+    <table width="100%" class="global" style="border:1px solid #CCC;">
+      <tbody>
+        <tr class="">
+          <td width="273">&nbsp;</td>
+          <td width="143"><label for="pesidate"> मुद्दा न:</label></td>
+          <td width="535"><img style="display:none;" id="ajaxLoader" src="https://www.supremecourt.gov.np/cp/assets/images/ajax-loader-dark.gif">
+            <input type="text" name="mudda_no" id="mudda_no" value="०८१-C१-०००१" />
+            </td>
+        </tr>
+        <tr>
+          <td></td>
+          &nbsp;
+          <td></td>
+          <td><div class="">
+              <input type="submit" value="खोज्नु होस्" class="button_dark" name="submit">
+            </div></td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <!-- End form elements -->
+    
+  </form>
+  
+  <!-- List of Daily --> 
+  <br/>
+  <center>
+    <span style="font-size:16px; color:#C00;">
+        </span>
+  </center>
+  <!-- Begin one column box --><!-- Begin two column box --><br/>
+    <!-- Begin one column box -->
+  <div class="onecolumn">
+    <div class="header">
+      <h2>मुद्दा ०८१-C१-०००१-बिवरण  <span><span> &nbsp;(सरल मार्ग )</span>
+             </span></h2>
+
+      
+      <!-- Begin 2nd level tab --> 
+      <h2> &nbsp;&nbsp;&nbsp;||&nbsp;&nbsp;&nbsp;रजिष्ट्रेशन नं : 86-081-00004</h2>
+      <!-- End 2nd level tab --> 
+
+      <h2> &nbsp;&nbsp;&nbsp;||&nbsp;&nbsp;&nbsp;अभिलेख नं : ७६८</h2>
+      
+    </div>
+    <div class="content">
+      <dl>
+        <dt>दर्ता मिति :</dt>
+        <dd>२०८१-०४-२१</dd>
+        <dt>मुद्दाको किसिम : </dt>
+        <dd>जबरजस्ती करणी गरेको (दफा 219)</dd>
+        <dt>मुद्दाको बिषय :</dt>
+        <dd>करणी सम्बन्धी उद्योग</dd>
+        <dt>फाँट :</dt>
+        <dd>मुद्दा फाँट</dd>
+      </dl>
+      <dl>
+        <dt>पेशी चढेको संख्या :</dt>
+        <dd>७</dd>
+        <dt>मुद्दाको स्थिति: </dt>
+        <dd>फैसला / अन्तिम आदेश >> अभियोग दावी पुग्ने </dd>
+        <dt>फैसला मिति: </dt>
+        <dd>
+          २०८१-०९-११        </dd>
+        <dt>फैसला गर्ने मा. न्यायाधीश:</dt>
+        <dd>ग </dd>
+      </dl>
+      <br>
+            <table width="100%" cellspacing="0" cellpadding="0" border="0">
+        <tbody>
+          <tr>
+            <th valign="top" align="left" scope="row"><h4>तारेख  विवरण</h4></th>
+          </tr>
+          <tr>
+            <th valign="top" align="left" scope="row"><table width="100%" cellspacing="0" cellpadding="0" border="1" class="record_display">
+                <tbody>
+                  <tr>
+                    <th valign="top" align="center">तारेख मिति</th>
+                    <th valign="top" align="center">पेशी प्रकार</th>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०९-११</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०९-०२</td>
+                    <td width="16%" valign="top" align="center">साप्ताहिक</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०८-०४</td>
+                    <td width="16%" valign="top" align="center">साप्ताहिक</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०६-०९</td>
+                    <td width="16%" valign="top" align="center">साप्ताहिक</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०५-२०</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०५-१९</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०४-२२</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                  </tr>
+                                  </tbody>
+              </table></th>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+        </tbody>
+      </table>
+            <br>
+      <table width="100%" cellspacing="0" cellpadding="0" border="0">
+        <tbody>
+          <tr>
+            <th valign="top" align="left" scope="row"><h4>वादी/प्रतिवादीको विवरण</h4></th>
+          </tr>
+          <tr>
+            <th valign="top" align="left" scope="row" width="50%"> <table cellspacing="0" cellpadding="0" border="1" class="record_display">
+                <tbody>
+                  <tr>
+                    <th valign="top" align="center" colspan="2">वादीहरु </th>
+                  </tr>
+                  <tr>
+                    <th valign="top" align="center">नाम:</th>
+                    <th valign="top" align="center">ठेगाना</th>
+                  </tr>
+                                    <tr>
+                    <td width="25%" valign="top" align="center">ख  </td>
+                    <td width="25%" valign="top" align="center">जिल्ला नखुलेको  ,  न.पा गा.वि. स नखुलेको  वडा न. -  नखुलेको  , घर न. -   नखुलेको </td>
+                  </tr>
+                                  </tbody>
+              </table>
+            </th>
+            <th valign="top" align="left" scope="row"> <table  cellspacing="0" cellpadding="0" border="1" class="record_display">
+                <tbody>
+                  <tr>
+                    <th valign="top" align="center" colspan="2">प्रतिवादीहरु </th>
+                  </tr>
+                  <tr>
+                    <th valign="top" align="center">नाम:</th>
+                    <th valign="top" align="center">ठेगाना</th>
+                  </tr>
+                                    <tr>
+                    <td width="25%" valign="top" align="center">क</td>
+                    <td width="25%" valign="top" align="center">अछाम  , कमलबजार नगरपालिका वडा न. - ५ , घर न. -   नखुलेको </td>
+                  </tr>
+                                  </tbody>
+              </table>
+            </th>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+        </tbody>
+      </table>
+                  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+        <tbody>
+          <tr>
+            <th valign="top" align="left" scope="row"><h4>पेशी विवरण</h4></th>
+          </tr>
+          <tr>
+            <th valign="top" align="left" scope="row"><table width="100%" cellspacing="0" cellpadding="0" border="1" class="record_display">
+                <tbody>
+                  <tr>
+                    <th valign="top" align="center">पेशी मिति</th>
+                    <th valign="top" align="center">पेशी प्रकार</th>
+                    <th valign="top" align="center">फाटँ</th>
+                    <th valign="top" align="center">मा . न्यायाधीश</th>
+                    <th valign="top" align="center">आदेश/फैसला</th>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०९-११</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">फैसला / अन्तिम आदेश >> अभियोग दावी पुग्ने </td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०९-०२</td>
+                    <td width="16%" valign="top" align="center">साप्ताहिक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">आदेश >> कसुर ठहर सजाय निर्धारणको लागि पेश गर्ने</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०८-०४</td>
+                    <td width="16%" valign="top" align="center">साप्ताहिक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">स्थगित >> प्रतिबादीको कानुन ब्यवसायीबाट</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०६-०९</td>
+                    <td width="16%" valign="top" align="center">साप्ताहिक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">स्थगित >> जिल्ला सरकारी वकिल कार्यालयबाट</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०५-२०</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">आदेश >> बयान/बकपत्र भएको</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०५-१९</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">आदेश >> बयान/बकपत्र नभएको</td>
+                  </tr>
+                                    <tr>
+                    <td width="16%" valign="top" align="center">२०८१-०४-२२</td>
+                    <td width="16%" valign="top" align="center">पूरक</td>
+                    <td width="16%" valign="top" align="center">मुद्दा फाँट</td>
+                    <td width="16%" valign="top" align="center">ग </td>
+                    <td width="10%" valign="top" align="center">आदेश >> पुर्पक्षको लागि थुनामा राख्ने</td>
+                  </tr>
+                                  </tbody>
+              </table></th>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+          </tr>
+        </tbody>
+      </table>
+          </div>
+  </div>
+    <br class="clear"/>
+ </div>
+</div>
+<br class="clear"/>
+
+<!-- End one column box --> 
+
+<!-- End content --> 
+ </div>
+</div>
+<br class="clear">
+<a href="#" class="scrollup" style="display: block;">Scroll</a>
+<div id="footer"> © Copyright 2026  by Supreme Court of Nepal. All Right Reserved. </div>
+
+<!-- End control panel wrapper -->
+
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'ONPOKFEIIDGMGAOGDHMJGOOGMOHGGHDMHBHKJPKADEDGPOCKDDLOIPMCBHKPEABIPBFBHKNKAAHIBAPOGOMAMPCOAAHIMKEPIEDLMKNAIDHHBJGEGCGGPOMJCHIHIJKL',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/district_missing.html
+++ b/courts/tests/fixtures/notfound/district_missing.html
@@ -1,0 +1,551 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<!-- Website Title -->
+<title>दैनिक साप्तहिक पेशी सूची</title>
+<link rel="shortcut icon" type="image/x-icon" href="https://www.supremecourt.gov.np/cp/assets/favicon.ico">
+<!-- Meta data for SEO -->
+<meta name="description" content="">
+<meta name="keywords" content="">
+<link rel="stylesheet" href="https://supremecourt.gov.np/weekly_dainik/assets/main.css" type="text/css" media="all">
+<script type="text/javascript" src="https://supremecourt.gov.np/weekly_dainik/assets/jquery.js"></script>
+<script type="text/javascript" src="https://supremecourt.gov.np/weekly_dainik/assets/jquery_002.js"></script>
+<script type="text/javascript" src="https://supremecourt.gov.np/weekly_dainik/assets/jquery.idTabs.min.js"></script>
+<script type="text/javascript">
+$(document).ready( function() { 
+	// $('ul.idTabs li:first a').addClass('active');
+	
+	$('.tab_button').click( function() {
+		$('.tab_button').removeClass('active');
+		$(this).addClass('active');
+	}); 
+	$(window).scroll(function(){
+		if ($(this).scrollTop() > 100) {
+		$('.scrollup').fadeIn();
+		} else {
+		$('.scrollup').fadeOut();
+		}
+		});
+		$('.scrollup').click(function(){
+		$("html, body").animate({ scrollTop: 0 },1000);
+		return false;
+		}); 	
+ 	});
+ </script>
+<style type="text/css" charset="utf-8">
+/* See license.txt for terms of usage */
+/** reset styling **/
+.firebugResetStyles {
+	z-index: 2147483646 !important;
+	top: 0 !important;
+	left: 0 !important;
+	display: block !important;
+	border: 0 none !important;
+	margin: 0 !important;
+	padding: 0 !important;
+	outline: 0 !important;
+	min-width: 0 !important;
+	max-width: none !important;
+	min-height: 0 !important;
+	max-height: none !important;
+	position: fixed !important;
+	transform: rotate(0deg) !important;
+	transform-origin: 50% 50% !important;
+	border-radius: 0 !important;
+	box-shadow: none !important;
+	background: transparent none !important;
+	pointer-events: none !important;
+	white-space: normal !important;
+}
+.firebugBlockBackgroundColor {
+	background-color: transparent !important;
+}
+.firebugResetStyles:before, .firebugResetStyles:after {
+	content: "" !important;
+}
+/**actual styling to be modified by firebug theme**/
+.firebugCanvas {
+	display: none !important;
+}
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+.firebugLayoutBox {
+	width: auto !important;
+	position: static !important;
+}
+.firebugLayoutBoxOffset {
+	opacity: 0.8 !important;
+	position: fixed !important;
+}
+.firebugLayoutLine {
+	opacity: 0.4 !important;
+	background-color: #000000 !important;
+}
+.firebugLayoutLineLeft, .firebugLayoutLineRight {
+	width: 1px !important;
+	height: 100% !important;
+}
+.firebugLayoutLineTop, .firebugLayoutLineBottom {
+	width: 100% !important;
+	height: 1px !important;
+}
+.firebugLayoutLineTop {
+	margin-top: -1px !important;
+	border-top: 1px solid #999999 !important;
+}
+.firebugLayoutLineRight {
+	border-right: 1px solid #999999 !important;
+}
+.firebugLayoutLineBottom {
+	border-bottom: 1px solid #999999 !important;
+}
+.firebugLayoutLineLeft {
+	margin-left: -1px !important;
+	border-left: 1px solid #999999 !important;
+}
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+.firebugLayoutBoxParent {
+	border-top: 0 none !important;
+	border-right: 1px dashed #E00 !important;
+	border-bottom: 1px dashed #E00 !important;
+	border-left: 0 none !important;
+	position: fixed !important;
+	width: auto !important;
+}
+.firebugRuler {
+	position: absolute !important;
+}
+.firebugRulerH {
+	top: -15px !important;
+	left: 0 !important;
+	width: 100% !important;
+	height: 14px !important;
+	background: url("data:image/png,") repeat-x !important;
+	border-top: 1px solid #BBBBBB !important;
+	border-right: 1px dashed #BBBBBB !important;
+	border-bottom: 1px solid #000000 !important;
+}
+.firebugRulerV {
+	top: 0 !important;
+	left: -15px !important;
+	width: 14px !important;
+	height: 100% !important;
+	background: url("data:image/png,") repeat-y !important;
+	border-left: 1px solid #BBBBBB !important;
+	border-right: 1px solid #000000 !important;
+	border-bottom: 1px dashed #BBBBBB !important;
+}
+.overflowRulerX > .firebugRulerV {
+	left: 0 !important;
+}
+.overflowRulerY > .firebugRulerH {
+	top: 0 !important;
+}
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+.fbProxyElement {
+	position: fixed !important;
+	pointer-events: auto !important;
+}
+</style>
+</head>
+<body>
+
+<!-- Begin control panel wrapper -->
+<div id="wrapper">
+  <div id="top_bar">
+    <div class="logo"> <img src="https://supremecourt.gov.np/weekly_dainik/assets/logo.png"> </div>
+    <div>
+      <h1 style="padding-top:30px; font-family:kalimati">अछाम जिल्ला अदालत</h1>
+      <p  style="padding-top:10px; margin-left:5%; font-size:18px; color:#FFF; display: inline-block;font-family:kalimati">पेशी स्थिती विवरण </p>
+    </div>
+  </div>
+  
+  <!-- Begin content -->
+  <div id="content_wrapper"> <script type="text/javascript">
+
+$(function(){
+
+    $('#weeklytab').click(function(){
+         // $(this).addClass('active');
+         // $('#dailytab').removeClass('active');
+         // $('#dailytab').addClass('selected');
+     
+    });
+
+        $('#supplementarytab').click(function(){
+         // $(this).addClass('active');
+         // $('#dailytab').removeClass('active');
+         // $('#dailytab').addClass('selected');
+     
+    });
+
+    $('#dailytab').click(function(){
+         // $(this).addClass('active');
+         // $('#weeklytab').removeClass('active');
+         // $('#weeklytab').addClass('selected');
+     
+    });
+
+  
+});
+
+function validate_caseprocess(){
+  mudda_no = document.getElementById('mudda_no').value;
+   if(mudda_no==''){
+      alert('कृपया मुद्दा न. हाल्नुहोला');
+      document.getElementById('mudda_no').focus();
+      return false;
+   }
+  return true;
+}
+
+function validate_dainik(){
+   
+   pesi_date = document.getElementById('pesi_date').value;
+   todays_date = document.getElementById('todays_date').value;
+   
+
+
+   if(pesi_date=='____-__-__'){
+     alert('कृपया पेशी मिति हाल्नुहोला');
+      document.getElementById('pesi_date').focus();
+      return false;
+   }
+   
+   if(pesi_date==''){
+      alert('कृपया पेशी मिति हाल्नुहोला');
+      document.getElementById('pesi_date').focus();
+      return false;
+   }
+
+  var partsOfStr = pesi_date.split('-');
+  var todays_date_arr = todays_date.split('-'); 
+
+   // Convert to Roman Digit
+   
+
+   var engDigit = {
+  '०': '0',
+  '१': '1',
+  '२': '2',
+  '३': '3',
+  '४': '4',
+  '५': '5',
+  '६': '6',
+  '७': '7',
+  '८': '8',
+  '९': '9'
+};
+
+var nepDigit = {
+  '0': '०',
+  '1': '१',
+  '2': '२',
+  '3': '३',
+  '4': '४',
+  '5': '५',
+  '6': '६',
+  '7': '७',
+  '8': '८',
+  '9': '९'
+};
+    strMahina = partsOfStr[1].replace(/[०१२३४५६७८९]/g, function(s) {
+        return engDigit[s];
+    });
+
+     strDin = partsOfStr[2].replace(/[०१२३४५६७८९]/g, function(s) {
+        return engDigit[s];
+    });
+
+     strSal = partsOfStr[0].replace(/[०१२३४५६७८९]/g, function(s) {
+        return engDigit[s];
+    });
+
+
+     if(strSal > todays_date_arr[0]){
+      alert('कृपया साल मिलेन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+    
+    if(strMahina>12 ){
+      alert('कृपया पेशी मितिको महिना मिलेन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+
+    if(strMahina > todays_date_arr[1] && strSal > todays_date_arr[0]){
+      alert('कृपया पेशी महिना हालको महिना भन्दा बढि हुनुहुदैन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+
+   if(strDin>32){
+      alert('कृपया पेशी मितिको गते मिलेन');
+      document.getElementById('pesi_date').focus();
+      return false;
+
+   }
+
+
+  //  if(strMahina >= todays_date_arr[1]){
+
+  //    if(strDin > todays_date_arr[2] ){
+  //       alert('कृपया पेशी मिति आजको मिति भन्दा बढि हुनुहुदैन');
+  //       document.getElementById('pesi_date').focus();
+  //       return false;
+
+  //    }
+  // }
+
+    // added on 2020-10-04 db to not allowing accessing data greater than today
+    if(strSal+strMahina+strDin > todays_date_arr[0]+todays_date_arr[1]+todays_date_arr[2]){
+
+        // return true;
+
+     // if(strDin > todays_date_arr[2] ){
+        alert('कृपया पेशी मिति आजको मिति भन्दा बढि हुनुहुदैन');
+        document.getElementById('pesi_date').focus();
+        return false;
+
+     // }
+  }
+
+  
+
+   return true;
+}
+
+$(function(){
+  $('#pesi_date').mask('9999-99-99');
+});
+</script>
+<style type="text/css">
+body {
+	font-family: kalimati;
+}
+dl {
+	margin-bottom:50px;
+	width:50%;
+	float:left;
+}
+dl dt {
+	line-height:30px;
+	background:#FFDCCB;
+	color:#000;
+	float:left;
+	font-weight:bold;
+	margin-right:10px;
+	height:40px;
+	width:200px;
+	font-size:14px;
+	padding-left:10px;
+}
+dl dd {
+	height:30px;
+	padding:5px 0;
+	margin:1px;
+	background:#FAF5DA;
+	font-size:14px;
+}
+</style>
+<ul class="first_level_tab idTabs">
+  <li> <a href="#tab1" class="tab_button " id="dailytab">दैनिक पेशी सूची</a> </li>
+  <li> <a href="#tab2" class="tab_button " id="weeklytab">साप्ताहिक पेशी सूची</a> </li>
+  <li> <a href="#tab4" class="tab_button " id="supplementarytab">पूरक पेशी सूची</a> </li>
+
+  <li> <a href="#tab3" class="tab_button selected active" id="casedetailtab">विस्तृत विवरण</a> </li>
+</ul>
+<br class="clear">
+<div class="onecolumn">
+  <div class="content" id="tab1"> 
+<form  action="https://supremecourt.gov.np/weekly_dainik/pesi/daily/86" method="post" id="form1" onsubmit="return validate_dainik();">
+  <input type="hidden" name="todays_date" id="todays_date" value="2083-04-15">
+  <table width="100%" class="global" style="border:1px solid #CCC;">
+    <tbody>
+      <tr class="">
+        <td width="273">&nbsp;</td>
+        <td width="143"><label for="pesidate"> मिति:</label></td>
+        <td width="535"><img style="display:none;" id="ajaxLoader" src="http://www.supremecourt.gov.np/cp/assets/images/ajax-loader-dark.gif">
+          <input type="text" name="pesi_date" id="pesi_date" class="smallText" value="२०८३-०४-१५" />
+          [yyyy-mm-dd]
+          <!-- added on 2021 jan 17 db to show estagit pesi list -->
+         
+          <a href="https://supremecourt.gov.np/weekly_dainik/pesi/viewStagit/86/20830415" target="_blank">आजको स्थगित</a>
+       
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        &nbsp;
+        <td></td>
+        <td><div class="">
+            <input type="submit" value="खोज्नु होस्" class="button_dark" name="submit">
+          </div></td>
+      </tr>
+    </tbody>
+  </table>
+  
+  <!-- End form elements -->
+  
+</form>
+
+<!-- List of Daily --> 
+<br/>
+<div class="pageTitle">
+   
+  
+</div>
+<center>
+  <span style="font-size:16px; color:#C00;">
+    </span>
+</center>
+<!-- Begin one column box --><!-- Begin two column box --><br/>
+
+<br class="clear"/>
+
+ </div>
+  <div class="content" id="tab2"> 
+    
+    <form id="form2" method="post"  action="https://supremecourt.gov.np/weekly_dainik/pesi/weekly_pesi/86">
+          <table width="100%" class="global" style="border:1px solid #ccc; margin:0 auto;" align="center">
+            <tbody>
+              <tr class="">
+                <td width="273">&nbsp;</td>
+                <td width="142"><label > सुनवाइ मिति:</label></td>
+                <td width="536"><span style="color:#C30">२०८३-०४-१०</span>&nbsp; देखि&nbsp; <span style="color:#C30">२०८३-०४-१५</span>&nbsp;सम्मको साप्‍ताहिक पेशी सूची</td>
+              </tr>
+               <tr class="">
+                 <td width="273">&nbsp;</td>
+                <td width="142"><label for="pesi_bar">बारः</label></td>
+                <td width="536"><select name="pesi_bar" selected>
+                					<option value="all">सबै </option>
+                                    <option value="२०८३-०४-१०" >आईतबार </option>
+                                    <option value="२०८३-०४-११"  >सोमबार </option>
+                                    <option value="२०८३-०४-१२" >मंगलबार </option>
+                                    <option value="२०८३-०४-१३">बुधबार </option>
+                                    <option value="२०८३-०४-१४ " >बिहीबार </option>
+                                    <option value="२०८३-०४-१५" >शुक्रबार </option>
+                				</select>
+                </td>
+                
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              <td>&nbsp;</td>
+              <td>
+              <div class="">
+            <input type="submit" name="submit" class="button_dark" value="खोज्नु होस्">
+          </div>
+              </td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <!-- End form elements -->
+      
+    </form>
+
+       <center><span style="font-size:16px; color:#C00;">  माथिको मितिमा कुनै पनि रेकर्ड भेटिएन </span></center>
+    <!-- Begin one column box --><!-- Begin two column box --><br/>
+        <br class="clear"/>
+    <br/>
+  
+ </div>
+  <div class="content" id="tab4"> 
+    
+    <form id="form4" method="post"  action="https://supremecourt.gov.np/weekly_dainik/pesi/supplementary_pesi/86">
+          <table width="100%" class="global" style="border:1px solid #ccc; margin:0 auto;" align="center">
+            <tbody>
+              <tr class="">
+               <td width="273">&nbsp;</td>
+              <td width="143"><label for="pesidate"> मिति:</label></td>
+              <td width="535"><img style="display:none;" id="ajaxLoader" src="https://www.supremecourt.gov.np/cp/assets/images/ajax-loader-dark.gif">
+                <input type="text" name="pesi_date" id="pesi_date" class="smallText" value="२०८३-०४-१५" />
+                [yyyy-mm-dd]</td>
+                
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              <td>&nbsp;</td>
+              <td>
+              <div class="">
+            <input type="submit" name="submit" class="button_dark" value="खोज्नु होस्">
+          </div>
+              </td>
+              </tr>
+            </tbody>
+          </table>
+          
+          <!-- End form elements -->
+      
+    </form>
+
+       <center><span style="font-size:16px; color:#C00;"> </span></center>
+    <!-- Begin one column box --><!-- Begin two column box --><br/>
+        <br class="clear"/>
+    <br/>
+  
+<!-- added on 2022 jan 7 db  --> </div>
+ 
+  <div class="content" id="tab3"> 
+  <form  action="https://supremecourt.gov.np/weekly_dainik/pesi/case_process_detail/86" method="post" id="form3" onsubmit="return validate_caseprocess(); ">
+    <table width="100%" class="global" style="border:1px solid #CCC;">
+      <tbody>
+        <tr class="">
+          <td width="273">&nbsp;</td>
+          <td width="143"><label for="pesidate"> मुद्दा न:</label></td>
+          <td width="535"><img style="display:none;" id="ajaxLoader" src="https://www.supremecourt.gov.np/cp/assets/images/ajax-loader-dark.gif">
+            <input type="text" name="mudda_no" id="mudda_no" value="" />
+            </td>
+        </tr>
+        <tr>
+          <td></td>
+          &nbsp;
+          <td></td>
+          <td><div class="">
+              <input type="submit" value="खोज्नु होस्" class="button_dark" name="submit">
+            </div></td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <!-- End form elements -->
+    
+  </form>
+  
+  <!-- List of Daily --> 
+  <br/>
+  <center>
+    <span style="font-size:16px; color:#C00;">
+        </span>
+  </center>
+  <!-- Begin one column box --><!-- Begin two column box --><br/>
+    <br class="clear"/>
+ </div>
+</div>
+<br class="clear"/>
+
+<!-- End one column box --> 
+
+<!-- End content --> 
+ </div>
+</div>
+<br class="clear">
+<a href="#" class="scrollup" style="display: block;">Scroll</a>
+<div id="footer"> © Copyright 2026  by Supreme Court of Nepal. All Right Reserved. </div>
+
+<!-- End control panel wrapper -->
+
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'CPMCOADGNOOOPKHMBGIPNGEHMPJEOMMECDOJMMKKFPJGAPAGJMKNPAKOEFIMDKBEKMFBMKDDAACDFCPODJCAPGGCAANFAKJJHFICFFJPBNFCNFNMABPMJHBBIIOLDPDM',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/high_found.html
+++ b/courts/tests/fixtures/notfound/high_found.html
@@ -1,0 +1,1000 @@
+﻿
+<!DOCTYPE html>
+
+<html lang="en">
+<!--<![endif]-->
+
+<!-- Head BEGIN -->
+<head>
+  <meta charset="utf-8">
+  <title>उच्च अदालत विराटनगर</title>
+
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+
+  <link rel="shortcut icon" href="favicon.ico">
+
+  <!-- Fonts START -->
+  <!-- <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|PT+Sans+Narrow|Source+Sans+Pro:200,300,400,600,700,900&amp;subset=all" rel="stylesheet" type="text/css"> -->
+
+  <!-- Fonts END -->
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/jquery.min.js" type="text/javascript"></script>
+
+  <!-- Global styles START -->          
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Global styles END --> 
+   
+  <!-- Page level plugin styles START -->
+  <link href="https://supremecourt.gov.np/court/public/assets/css/animate.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/owl.carousel.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/jquery.fancybox.css" rel="stylesheet">
+
+  <!-- Page level plugin styles END -->
+
+  <!-- Theme styles START -->
+  <link href="https://supremecourt.gov.np/court/public/assets/css/components.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/slider.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/style-responsive.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/style.css" rel="stylesheet">
+  <!-- <link href = "https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css"> -->
+  <!-- added on 8-23-2-18 dd -->
+  <link href="https://supremecourt.gov.np/court/public/assets/css/animate.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/photo-gallery.css" rel="stylesheet">
+
+  
+
+  
+  
+  <!-- Theme styles END -->
+
+<!-- Head END --> 
+
+<link href="https://supremecourt.gov.np/court/public/assets/css/high/style_high.css" rel="stylesheet">
+
+</head>
+
+
+
+<body class="corporate">
+    <!-- BEGIN STYLE CUSTOMIZER -->
+    <div class="color-panel">
+  <div class="color-mode-icons icon-color"></div>
+  <div class="color-mode-icons icon-color-close"></div>
+  <div class="color-mode">
+    <!-- <p><a href="http://supremecourt.gov.np/eportal" target="_blank"><i class="fa fa-desktop"></i> इपोर्टल</a></p></a> -->
+    <div class="form-group">
+      <!-- <label for="sel1" style="font-size: 10px;">अदालत रोज्नुहोस:</label> -->
+         <select name="court_name" id="court_name" class="form-control">
+          <option value="--" selected="">अदालत छान्नुहोस</option>
+          <option value="1" >सर्वोच्च अदालत</option>
+		      <option value="99" >बिशेष अदाल</option>
+        			
+			              
+           			
+						  <option value="6">उच्च अदालत जनकपुर</option>
+			              
+           			
+						  <option value="94">उच्च अदालत जनकपुर, अस्थायी इजलास वीरगन्ज</option>
+			              
+           			
+						  <option value="5">उच्च अदालत जनकपुर, राजविराज इजलास</option>
+			              
+           			
+						  <option value="12">उच्च अदालत तुलसीपुर</option>
+			              
+           			
+						  <option value="13">उच्च अदालत तुलसीपुर, नेपालगंज इजलास</option>
+			              
+           			
+						  <option value="11">उच्च अदालत तुलसीपुर, बुटवल इजलास</option>
+			              
+           			
+						  <option value="16">उच्च अदालत दिपायल</option>
+			              
+           			
+						  <option value="17">उच्च अदालत दिपायल, महेन्द्रनगर इजलास</option>
+			              
+           			
+						  <option value="7">उच्च अदालत पाटन</option>
+			              
+           			
+						  <option value="8">उच्च अदालत पाटन, हेटौंडा इजलास</option>
+			              
+           			
+						  <option value="9">उच्च अदालत पोखरा</option>
+			              
+           			
+						  <option value="10">उच्च अदालत पोखरा, बाग्लुङ्ग इजलास</option>
+			              
+           			
+						  <option value="4">उच्च अदालत विराटनगर</option>
+			              
+           			
+						  <option value="93">उच्च अदालत विराटनगर, अस्थायी इजलास ओखलढुंगा</option>
+			              
+           			
+						  <option value="2">उच्च अदालत विराटनगर, इलाम इजलास</option>
+			              
+           			
+						  <option value="3">उच्च अदालत विराटनगर, धनकुटा इजलास</option>
+			              
+           			
+						  <option value="14">उच्च अदालत सुर्खेत</option>
+			              
+           			
+						  <option value="15">उच्च अदालत सुर्खेत, जुम्ला इजलास</option>
+			              
+           			
+						  <option value="86">अछाम जिल्ला अदालत</option>
+			              
+           			
+						  <option value="64">अर्घाखाँची जिल्ला अदालत</option>
+			              
+           			
+						  <option value="19">इलाम  जिल्ला अदालत</option>
+			              
+           			
+						  <option value="31">उदयपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="29">ओखलढुंगा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="92">कन्चनपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="68">कपिलवस्तु जिल्ला अदालत</option>
+			              
+           			
+						  <option value="39">काठमाडौं जिल्ला अदालत</option>
+			              
+           			
+						  <option value="44">काभ्रेपलान्चोक जिल्ला अदालत</option>
+			              
+           			
+						  <option value="83">कालिकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="57">कास्की जिल्ला अदालत</option>
+			              
+           			
+						  <option value="85">कैलाली जिल्ला अदालत</option>
+			              
+           			
+						  <option value="30">खोटांग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="63">गुल्मी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="54">गोरखा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="49">चितवन जिल्ला अदालत</option>
+			              
+           			
+						  <option value="76">जाजरकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="79">जुम्ला जिल्ला अदालत</option>
+			              
+           			
+						  <option value="18">झापा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="91">डडेलधुरा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="84">डोटी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="81">डोल्पा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="56">तनहूँ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="20">ताप्लेजुङ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="22">तेह्रथुम जिल्ला अदालत</option>
+			              
+           			
+						  <option value="73">दाङ  जिल्ला अदालत</option>
+			              
+           			
+						  <option value="89">दार्चुला जिल्ला अदालत</option>
+			              
+           			
+						  <option value="77">दैलेख जिल्ला अदालत</option>
+			              
+           			
+						  <option value="42">दोलखा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="25">धनकुटा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="36">धनुषा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="46">धादिङ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="66">नवलपरासी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="95">नवलपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="47">नुवाकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="61">पर्वत जिल्ला अदालत</option>
+			              
+           			
+						  <option value="51">पर्सा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="21">पाँचथर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="65">पाल्पा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="72">प्युठान जिल्ला अदालत</option>
+			              
+           			
+						  <option value="88">बझाँग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="75">बर्दिया जिल्ला अदालत</option>
+			              
+           			
+						  <option value="74">बाँके जिल्ला अदालत</option>
+			              
+           			
+						  <option value="62">बागलुङ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="87">बाजुरा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="50">बारा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="90">बैतडी जिल्ला अदालत </option>
+			              
+           			
+						  <option value="41">भक्तपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="24">भोजपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="48">मकवानपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="53">मनांग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="37">महोत्तरी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="82">मुगु जिल्ला अदालत</option>
+			              
+           			
+						  <option value="59">मुस्तांग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="27">मोरंग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="60">म्याग्दी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="45">रसुवा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="34">रामेछाप जिल्ला अदालत</option>
+			              
+           			
+						  <option value="69">रुकुम जिल्ला अदालत</option>
+			              
+           			
+						  <option value="67">रूपन्देही जिल्ला अदालत</option>
+			              
+           			
+						  <option value="70">रोल्पा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="52">रौतहट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="55">लमजुंग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="40">ललितपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="96">श्री रुकुमकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="23">संखुवासभा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="33">सप्तरी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="38">सर्लाही जिल्ला अदालत</option>
+			              
+           			
+						  <option value="71">सल्यान जिल्ला अदालत</option>
+			              
+           			
+						  <option value="43">सिन्धुपाल्चोक जिल्ला अदालत</option>
+			              
+           			
+						  <option value="35">सिन्धुली जिल्ला अदालत</option>
+			              
+           			
+						  <option value="32">सिराहा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="26">सुनसरी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="78">सुर्खेत जिल्ला अदालत</option>
+			              
+           			
+						  <option value="28">सोलुखुम्बु जिल्ला अदालत</option>
+			              
+           			
+						  <option value="58">स्याङ्जा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="80">हुम्ला जिल्ला अदालत</option>
+			              
+           			
+						  <option value="102">ऋृण असुली पुनरावेदन न्यायाधिकरण </option>
+			              
+           			
+						  <option value="103">फैसला कार्यान्वयन निर्देशनालय</option>
+			              
+           			
+			              
+                     </select>
+    </div>
+    <p><a href="http://supremecourt.gov.np/eportal" target="_blank"><i class="fa fa-desktop"></i> इपोर्टल</a></p></a>
+  </div>
+</div>
+
+
+
+
+
+
+
+
+
+<script> 
+ $('#court_name').on('change', function() {
+  var court_id =  this.value;
+  $.post("https://supremecourt.gov.np/court/biratnagarhc/get_slug_from_id",
+   { court_id: court_id},
+    function(slug){
+        window.location.replace("https://supremecourt.gov.np/court/"+slug);
+         });
+})
+</script>
+
+   
+    
+    <!-- BEGIN TOP BAR -->
+    <div class="pre-header">
+        <script src="https://cdn.jsdelivr.net/npm/jquery.marquee@1.6.0/jquery.marquee.js"></script>
+<style>
+   .test > li > a {
+   
+    text-decoration: none;
+    padding: 8px 15px;
+	
+    line-height: 1.7;
+	display: block;
+	clear: both;
+    font-weight: 400;
+	color: #3a5462;
+    white-space: nowrap;
+	
+}  .test > li {
+	padding-left:0px;
+	padding-right:0px;
+}
+
+.marquee {
+    width: 100%;
+    overflow: hidden;
+    background: whit;
+    color: red;
+    position: relative;
+    font-size: 16px;
+  line-height: 2em;
+}
+.marquee:before {
+ 
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: #245dbd;
+  z-index: 1;
+  padding: 0 0.5em;
+}
+.marquee ul {
+  visibility: hidden;
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+  white-space: nowrap;
+  display: inline;
+
+}
+
+.marquee li {
+  padding-left: 1em;
+  text-indent: -1em;
+  display: inline;
+}
+
+.marquee li:before {
+  content: " ";
+  padding-right: 5px;
+  width: 1em;
+  height: 1.4em;
+  display: inline-block;
+  width: 100px;
+  background: url("https://tinypic.host/images/2023/05/14/ModernXP-73-Globe-icon1.png") no-repeat center;
+  background-size: 1em;
+  position: relative;
+  bottom: -0.3em;
+  margin-right: 1em;
+  opacity: 0.6;
+}
+</style>
+<div id="navbar">
+  <nav class="navbar navbar-default navbar-static-top" role="navigation">
+      <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse-1">
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+          </button>
+
+      </div>
+
+      <div class="collapse navbar-collapse" id="navbar-collapse-1">
+        <div class="col-md-6 col-sm-6 additional-shop-info">
+          <ul class="nav navbar-nav list-unstyled list-inline">
+            <!--<li>sfds</li>-->
+            <li class="dropdown-submenu">
+               <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="padding: 0px 15px;">फाराम को ढाँचाहरु <img src="http://supremecourt.gov.np/web/assets/image/New_BlinkIco.gif"><b class="caret"></b>
+              
+               </a>
+                <ul class="dropdown-menu test" role="menu">
+                  					
+                </ul>
+
+  			</li>
+          </ul>
+		    <ul class="list-unstyled list-inline">
+		  <li><a href="https://supremecourt.gov.np/court/biratnagarhc/faq" style="color:#c21825;text-decoration: blink; font-size:14px; text-shadow: 2px 2px white;">
+                  <i class="fa fa-question-circle" style="font-size:15px" aria-hidden="true"></i>
+                  &nbsp;FAQs <img src="https://supremecourt.gov.np/web/assets/image/New_BlinkIco.gif"></a></li>
+				  </ul>
+				  
+        </div>
+        <div class="col-md-6 col-sm-6 additional-nav">
+          <ul class="list-unstyled list-inline pull-right">
+                            <li><a href="#"><i class="fa fa-mobile"></i>Mobile App</a></li>
+                          <!-- <li><a href="#"><i class="fa fa-calendar"></i>2026</a></li> -->
+              <li><a href="#"><i class="fa fa-language"></i>Language</a></li>
+              <!-- <li><a href="page-reg-page.html"><i class="fa fa-envelope-o"></i>मेल</a></li> -->
+          </ul>
+      </div>
+
+    </div><!-- /.navbar-collapse -->
+  </nav>
+<div>
+  <!-- <div class='marquee'>
+  
+  <ul>
+    <li>"समृद्ध नेपालको आधार सूचना प्रविधि र सञ्चार" राष्ट्रिय सूचना तथा सञ्चार प्रविधि दिवस, २०२४ भव्यताका साथ मनाऔ !!! </li>
+   
+  </ul>
+ 
+</div> -->
+<script type="text/javascript">
+  
+
+$(function() {
+  
+  var marquee = $('.marquee');
+  var ul = $('.marquee ul');
+  
+  var cloneContent = function() {
+
+    var doClone = true;
+    var clone_ul = function () {
+       ul.find('li').clone().appendTo( ul );
+    }
+    var check_ul_width = function() {
+      if(marquee.width() > ul.width() ) {
+        clone_ul();
+        return;
+      }
+      doClone = false;
+      ul.css('visibility', 'visible');
+    }
+
+    do {
+      check_ul_width();
+      var mw = marquee.width();
+      var uw = ul.width();
+    } while (doClone);
+
+  }
+
+  cloneContent();
+  
+   
+$('.marquee').marquee({
+  //duration in milliseconds of the marquee
+  duration: 15000,
+  duplicated: true
+});
+
+  
+});
+</script>   
+    </div>
+    <!-- END TOP BAR -->
+    <!-- BEGIN HEADER -->
+    <div class="header">
+      
+        
+
+<!-- <div class="container"> -->
+<div class="navbar navbar-img">
+    <a class="site-logo logo-header responsive" href="https://supremecourt.gov.np/court/biratnagarhc"
+       style="text-decoration: none; font-size: 15px;">
+        <img width="48" src="https://supremecourt.gov.np/court/public/assets/img/supreme_logo_.png" href="index.html">
+        <span><b>उच्च अदालत विराटनगर</b></span>
+        <img class="gov_logo site-log pull-right "
+             src="https://supremecourt.gov.np/court/public/assets/img/link/gov_logo_head.png" width="48" alt="">
+    </a>
+
+    <a href="javascript:void(0);" class="mobi-toggler"><i class="fa fa-bars"></i></a>
+    <!-- Collect the nav links, forms, and other content for toggling -->
+    <div class="header-navigation pull-right font-transform-inherit">
+        <ul class="nav navbar-nav navbar-right">
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#" href="https://supremecourt.gov.np/court/biratnagarhc"><i
+                            class="fa fa-home"></i> गृह</a></li>
+            <!--added by sarita-->
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/about_us">हाम्रो बारेमा</a></li>
+
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/legalmaterials"><i class=""></i>संहिता र
+                    कानूनी सामाग्रीहरु</a></li>
+                    
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/judges">न्यायाधीश</a></li>
+                       <!--                  <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                        href="https://supremecourt.gov.np/court/biratnagarhc/registrar"> रजिस्ट्रार</a></li>
+             -->
+            <!--            -->            <!--                <li class="megamenu"><a class="dropdown-toggle" data-target="#"-->
+            <!--                                        href="-->
+      
+            <!--">श्रेष्तेदार</a></li>-->
+            <!--            -->
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/photo_gallery"><i
+                            class=""></i> ग्यालरी </a></li>
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/pms">कर्मचारी विवरण</a></li>
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/contact_us">सुझाव तथा प्रतिक्रिया</a></li>
+
+            
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://mail.supremecourt.gov.np" target="_blank"><i
+                            class="fa  fa-envelope-o"></i>ईमेल</a></li>
+        </ul>
+    </div>
+</div>
+<!-- </div> -->
+
+    </div>
+
+
+<div class="main">
+    <div class="container" style="width: 100%">
+
+        <div class="row mix-block margin-bottom-20">
+            <!-- officials photos -->
+            <!-- BEGIN SLIDER -->
+          
+            <div class="col-md-12">
+                ﻿ <div class="row">
+	<div class="col-md-12">		
+		<h3>
+			<strong><center>उच्च अदालत विराटनगर</center></strong>
+		</h3>
+		<h3>मुद्दाको बिस्तृत विवरण</h3>
+	</div>
+</div>
+
+<div class = "container-fluid">
+	<div class="row">
+		<div class="col-xs-12">
+			
+			<div class="row">
+				<div class = "col-xs-6 text-right">
+					<p> 
+						<strong>दर्ता नँ. :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>081-AP-0001</p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right">
+					<p>
+						<strong>दर्ता मिती :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>२०८१/०४/०२</p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>रुजु मिती :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>१७-J/UL/-२</p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>मुद्दाको किसिम :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>निवेदन</p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>मुद्दा :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>विविध</p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>फाँटवाला :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>अम्बिका प्रसाद सुवेदी </p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>फाँट :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>नि।प्र।</p>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>मुद्दाको स्थिती :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+				 	<p>
+					फैसला (२०८१/०४/०३)					</p>
+				</div>
+			</div>
+			
+			<div class="row">
+		   		<div class="col-sm-12">
+					<h3 class = "">
+						वादी / प्रतिवादीको विवरण
+					</h3>
+					<hr />
+				</div>
+	    	</div>
+			
+			
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>वादीहरु :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>ख </p>
+				</div>
+			</div>
+			
+			<div class="row">
+				<div class = "col-xs-6 text-right"> 
+					<p>
+						<strong>प्रतिवादीहरु  :</strong>
+					</p>
+				</div>
+				<div class = "col-xs-6 text-left">
+					<p>क   </p>
+				</div>
+			</div>
+
+						
+				
+		</div>
+	</div>
+
+	
+	<div class="row">
+		<div class="col-sm-12">
+			<h3>तारेख विवरण</h3>
+			<hr />
+			<div class="table-responsive">
+				<table class="table table-bordered table-responsive" >
+					<thead>
+						<tr>
+				          	<th valign="top">
+				          		<center>तारेख मिती</center>
+				          	</th>
+				          	<th valign="top">
+				          		<center>तारेखको किसिम</center>
+				          	</th>
+				          	<th valign="top">
+				          		<center>विवरण</center>
+				          	</th>
+				        </tr>
+			    	</thead>
+
+				    <tbody>
+				    						</tbody>
+			    </table>   
+			</div> <!-- / -->
+		</div> <!-- /col-sm-12 -->
+	</div> <!-- /row -->
+
+	<div class="row">
+		<div class="col-sm-12">
+			<h3>मुद्दाको स्थितीको बिस्तृत विवरण</h3>
+			<hr />
+			<div class="table-responsive">
+				<table class="table table-bordered table-responsive" >
+					<thead>
+						<tr>
+				          	<th valign="top">
+				          		<center>मिती</center>
+				          	</th>
+				          	
+				          	<th valign="top">
+				          		<center>विवरण</center>
+				          	</th>
+
+				          	<th valign="top">
+				          		<center>स्थिती</center>
+				          	</th>
+				        </tr>
+				    </thead>
+
+				    <tbody>
+				    						</tbody>
+				</table>   
+			</div> <!-- /col-sm-12 -->
+		</div> <!-- /row -->
+	</div> 
+
+	<div class="row">
+		<div class="col-sm-12">
+			<h3>पेशीको विवरण</h3>
+			<hr />
+			<div class="table-responsive">
+				<table class="table table-bordered table-responsive" >
+					<thead>
+						<tr>
+				          	<th valign="top">
+				          		<center>सुनवाइ मिती</center>
+				          	</th>
+				          	
+				          	<th valign="top">
+				          		<center>न्यायाधिस हरु</center>
+				          	</th>
+
+				          	<th valign="top">
+				          		<center>मुद्दाको स्थिती</center>
+				          	</th>
+
+				          	<th valign="top">
+				          		<center>आदेश /फैसलाको किसिम</center>
+				          	</th>
+				        </tr>
+				    </thead>
+
+				    <tbody>
+				    							<tr>
+							<td valign="top"><center>२०८१/०४/०३</center></td>	
+							<td valign="top">
+																मा.न्या. श्री राजेन्द्र  अधिकारी<br/>
+															</td>
+							<td valign="top"><center>अन्तिम आदेश</center></td>
+							<td valign="top"><center>कैफियत प्रतिवेदन माग्‍ने</center></td>
+						</tr>
+											</tbody>
+				</table>   
+			</div> <!-- /col-sm-12 -->
+		</div> <!-- /row -->
+	</div> 
+</div>            </div>
+
+        </div>
+
+    </div>
+</div>
+
+
+
+
+<!-- BEGIN PRE-FOOTER -->
+    <div class="footer">
+       
+    <!-- <div class="footer"> -->
+        <div class="row">
+          <div class="col-sm-4">
+
+                <div class="contact-us">
+                   <!-- <img src="http://192.168.4.24/website/public/assets/img/supreme_logo_.png" href="index.html" width="70"><span> -->
+                     <h4> सम्पर्क ठेगाना</h4></span>
+                    <h5> उच्च अदालत विराटनगर<br>
+                        विराटनगर</h5>
+                    <h5> फोन नं. :</h5>
+                    <ul>
+                    
+                                                  <li><a href="#">021-512802</a></li>
+                                                  <li><a href="#">021-524056</a></li>
+                                               
+                    </ul>
+                    <h5> इमेल :<a href="mailto:info@supremecourt.gov.np"> info.hcbiratnagar@supremecourt.gov.np</a><br>
+                      <!--   <strong> वेभसाइट : </strong><a href="https://supremecourt.gov.np" target="_blank"> https://supremecourt.gov.np/court/biratnagarhc</a> -->
+                       </h5>
+                </div>
+                <!-- /.contact-us --> 
+              </div>
+            <div class="col-sm-4">
+                <div class="downloads">
+                    <h4> डाउनलोड</h4>
+                    <h5> डाउनलोड नेपाली फन्ट</h5>
+                    <ul class="font-list">
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/PCSNEPA0.TTF">PCS Nepal</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/pcsnepal.TTF">PCS Nepali</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/shann___.TTF">Shangrila Numeric</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/PREETI.TTF">Preeti</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/Kalimati.ttf">Kalimati</a> </li>
+                    </ul>
+                    <h5> डाउनलोड नेपाली युनिकोड</h5>
+                    <ul class="unicode-list">
+                        <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/nepali_romanised.zip"> नेपाली युनिकोड रोमनाइज</a> </li>
+                        <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/nepali_Traditional.zip"> नेपाली युनिकोड ट्रेडिसनल</a> </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="useful-links">
+                    <h4> उपयोगी लिङ्कहरू</h4>
+                    <ul>
+                        <li> <a href="http://judicialcouncil.gov.np" target="_blank"> न्याय परिषद्</a> </li>
+                      <li> <a href="https://mediationcouncil.gov.np/" target="_blank"> मेलमिलाप परिषद्</a> </li>
+                                  <li> <a href="https://moljpa.gov.np" target="_blank"> कानून, न्याय तथा संसदीय मामिला मन्त्रालय</a> </li>
+                                  <li> <a href="https://attorneygeneral.gov.np/" target="_blank"> महान्यायाधिवक्ताको कार्यालय</a> </li>
+                                  <!--<li> <a href="https://lawcommission.gov.np/" target="_blank"> नेपाल कानून आयोग</a> </li>-->
+                                  <li> <a href="https://nepalbar.org.np/" target="_blank"> नेपाल बार एशोसिएशन</a> </li>
+                      <li> <a href="https://dopm.gov.np/" target="_blank">कारागार व्यवस्थापन विभाग</a> </li>
+					  </ul>
+                </div>
+                <!-- /.useful-links --> 
+            </div>
+
+          </div>
+          <!-- /row -->
+    <!-- </div> -->
+
+    </div>
+    <!-- END PRE-FOOTER -->
+
+    <!-- BEGIN FOOTER -->
+    <div class="footer1">
+        
+<div>
+  <div class="row">
+    <!-- BEGIN COPYRIGHT removed social site -->
+    <div class="col-md-12 col-sm-12 padding-top-10">
+     <p class = "pull-right">&copy copyright 2026 SUPREME COURT OF NEPAL. All Rights Reserved.  </p> <a href="javascript:;">Privacy Policy</a> | <a href="javascript:;">Terms of Service</a>
+    </div>
+    <!-- END COPYRIGHT -->
+    <!-- BEGIN PAYMENTS -->
+    
+    <!-- END PAYMENTS -->
+   
+  </div>
+</div>
+    </div>
+    <!-- END FOOTER -->
+
+
+
+
+
+    <!--[endif]-->
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/jquery-migrate.min.js" type="text/javascript"></script>
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>      
+    <script src="https://supremecourt.gov.np/court/public/assets/scripts/back-to-top.js" type="text/javascript"></script>
+    <!-- END CORE PLUGINS -->
+
+    <!-- BEGIN PAGE LEVEL JAVASCRIPTS (REQUIRED ONLY FOR CURRENT PAGE) -->
+  
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/owl.carousel.min.js" type="text/javascript"></script><!-- slider for products -->
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/jquery.maskedinput.js" type="text/javascript"></script>
+
+    <script src="https://supremecourt.gov.np/court/public/assets/scripts/layout.js" type="text/javascript"></script>
+
+    <script src="https://supremecourt.gov.np/court/public/assets/scripts/bs-carousel.js" type="text/javascript"></script>
+     <script src="https://supremecourt.gov.np/court/public/assets/scripts/photo-gallery.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+        jQuery(document).ready(function() {
+            Layout.init();    
+            Layout.initOWL();
+            // Layout.initTwitter();
+            Layout.initFixHeaderWithPreHeader(); /* Switch On Header Fixing (only if you have pre-header) */
+            Layout.initNavScrolling();
+        });
+    </script>
+    <!-- END PAGE LEVEL JAVASCRIPTS -->
+</body>
+<!-- END BODY -->
+</html>
+    <!-- last modified 2018-08-13 -->
+    <!-- Added a side bar  --><script id="f5_cspm">(function(){var f5_cspm={f5_p:'HEGLAKKIIFCOCGDKBGAFHGMENOLBLDODPKIMFEFGAOGKLPEOIEHMNLMFGDGBBOKCAKPBEBMCAABBHFLMHKGABEPNAANFIMIADKIBDEFJMPDHOHKFBPENLMPJNELPDFOI',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/high_missing.html
+++ b/courts/tests/fixtures/notfound/high_missing.html
@@ -1,0 +1,764 @@
+﻿
+<!DOCTYPE html>
+
+<html lang="en">
+<!--<![endif]-->
+
+<!-- Head BEGIN -->
+<head>
+  <meta charset="utf-8">
+  <title>उच्च अदालत विराटनगर</title>
+
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+
+  <link rel="shortcut icon" href="favicon.ico">
+
+  <!-- Fonts START -->
+  <!-- <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|PT+Sans+Narrow|Source+Sans+Pro:200,300,400,600,700,900&amp;subset=all" rel="stylesheet" type="text/css"> -->
+
+  <!-- Fonts END -->
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/jquery.min.js" type="text/javascript"></script>
+
+  <!-- Global styles START -->          
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Global styles END --> 
+   
+  <!-- Page level plugin styles START -->
+  <link href="https://supremecourt.gov.np/court/public/assets/css/animate.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/owl.carousel.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/plugins/jquery.fancybox.css" rel="stylesheet">
+
+  <!-- Page level plugin styles END -->
+
+  <!-- Theme styles START -->
+  <link href="https://supremecourt.gov.np/court/public/assets/css/components.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/slider.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/style-responsive.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/style.css" rel="stylesheet">
+  <!-- <link href = "https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css"> -->
+  <!-- added on 8-23-2-18 dd -->
+  <link href="https://supremecourt.gov.np/court/public/assets/css/animate.css" rel="stylesheet">
+  <link href="https://supremecourt.gov.np/court/public/assets/css/photo-gallery.css" rel="stylesheet">
+
+  
+
+  
+  
+  <!-- Theme styles END -->
+
+<!-- Head END --> 
+
+<link href="https://supremecourt.gov.np/court/public/assets/css/high/style_high.css" rel="stylesheet">
+
+</head>
+
+
+
+<body class="corporate">
+    <!-- BEGIN STYLE CUSTOMIZER -->
+    <div class="color-panel">
+  <div class="color-mode-icons icon-color"></div>
+  <div class="color-mode-icons icon-color-close"></div>
+  <div class="color-mode">
+    <!-- <p><a href="http://supremecourt.gov.np/eportal" target="_blank"><i class="fa fa-desktop"></i> इपोर्टल</a></p></a> -->
+    <div class="form-group">
+      <!-- <label for="sel1" style="font-size: 10px;">अदालत रोज्नुहोस:</label> -->
+         <select name="court_name" id="court_name" class="form-control">
+          <option value="--" selected="">अदालत छान्नुहोस</option>
+          <option value="1" >सर्वोच्च अदालत</option>
+		      <option value="99" >बिशेष अदाल</option>
+        			
+			              
+           			
+						  <option value="6">उच्च अदालत जनकपुर</option>
+			              
+           			
+						  <option value="94">उच्च अदालत जनकपुर, अस्थायी इजलास वीरगन्ज</option>
+			              
+           			
+						  <option value="5">उच्च अदालत जनकपुर, राजविराज इजलास</option>
+			              
+           			
+						  <option value="12">उच्च अदालत तुलसीपुर</option>
+			              
+           			
+						  <option value="13">उच्च अदालत तुलसीपुर, नेपालगंज इजलास</option>
+			              
+           			
+						  <option value="11">उच्च अदालत तुलसीपुर, बुटवल इजलास</option>
+			              
+           			
+						  <option value="16">उच्च अदालत दिपायल</option>
+			              
+           			
+						  <option value="17">उच्च अदालत दिपायल, महेन्द्रनगर इजलास</option>
+			              
+           			
+						  <option value="7">उच्च अदालत पाटन</option>
+			              
+           			
+						  <option value="8">उच्च अदालत पाटन, हेटौंडा इजलास</option>
+			              
+           			
+						  <option value="9">उच्च अदालत पोखरा</option>
+			              
+           			
+						  <option value="10">उच्च अदालत पोखरा, बाग्लुङ्ग इजलास</option>
+			              
+           			
+						  <option value="4">उच्च अदालत विराटनगर</option>
+			              
+           			
+						  <option value="93">उच्च अदालत विराटनगर, अस्थायी इजलास ओखलढुंगा</option>
+			              
+           			
+						  <option value="2">उच्च अदालत विराटनगर, इलाम इजलास</option>
+			              
+           			
+						  <option value="3">उच्च अदालत विराटनगर, धनकुटा इजलास</option>
+			              
+           			
+						  <option value="14">उच्च अदालत सुर्खेत</option>
+			              
+           			
+						  <option value="15">उच्च अदालत सुर्खेत, जुम्ला इजलास</option>
+			              
+           			
+						  <option value="86">अछाम जिल्ला अदालत</option>
+			              
+           			
+						  <option value="64">अर्घाखाँची जिल्ला अदालत</option>
+			              
+           			
+						  <option value="19">इलाम  जिल्ला अदालत</option>
+			              
+           			
+						  <option value="31">उदयपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="29">ओखलढुंगा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="92">कन्चनपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="68">कपिलवस्तु जिल्ला अदालत</option>
+			              
+           			
+						  <option value="39">काठमाडौं जिल्ला अदालत</option>
+			              
+           			
+						  <option value="44">काभ्रेपलान्चोक जिल्ला अदालत</option>
+			              
+           			
+						  <option value="83">कालिकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="57">कास्की जिल्ला अदालत</option>
+			              
+           			
+						  <option value="85">कैलाली जिल्ला अदालत</option>
+			              
+           			
+						  <option value="30">खोटांग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="63">गुल्मी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="54">गोरखा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="49">चितवन जिल्ला अदालत</option>
+			              
+           			
+						  <option value="76">जाजरकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="79">जुम्ला जिल्ला अदालत</option>
+			              
+           			
+						  <option value="18">झापा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="91">डडेलधुरा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="84">डोटी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="81">डोल्पा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="56">तनहूँ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="20">ताप्लेजुङ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="22">तेह्रथुम जिल्ला अदालत</option>
+			              
+           			
+						  <option value="73">दाङ  जिल्ला अदालत</option>
+			              
+           			
+						  <option value="89">दार्चुला जिल्ला अदालत</option>
+			              
+           			
+						  <option value="77">दैलेख जिल्ला अदालत</option>
+			              
+           			
+						  <option value="42">दोलखा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="25">धनकुटा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="36">धनुषा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="46">धादिङ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="66">नवलपरासी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="95">नवलपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="47">नुवाकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="61">पर्वत जिल्ला अदालत</option>
+			              
+           			
+						  <option value="51">पर्सा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="21">पाँचथर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="65">पाल्पा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="72">प्युठान जिल्ला अदालत</option>
+			              
+           			
+						  <option value="88">बझाँग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="75">बर्दिया जिल्ला अदालत</option>
+			              
+           			
+						  <option value="74">बाँके जिल्ला अदालत</option>
+			              
+           			
+						  <option value="62">बागलुङ जिल्ला अदालत</option>
+			              
+           			
+						  <option value="87">बाजुरा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="50">बारा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="90">बैतडी जिल्ला अदालत </option>
+			              
+           			
+						  <option value="41">भक्तपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="24">भोजपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="48">मकवानपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="53">मनांग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="37">महोत्तरी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="82">मुगु जिल्ला अदालत</option>
+			              
+           			
+						  <option value="59">मुस्तांग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="27">मोरंग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="60">म्याग्दी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="45">रसुवा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="34">रामेछाप जिल्ला अदालत</option>
+			              
+           			
+						  <option value="69">रुकुम जिल्ला अदालत</option>
+			              
+           			
+						  <option value="67">रूपन्देही जिल्ला अदालत</option>
+			              
+           			
+						  <option value="70">रोल्पा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="52">रौतहट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="55">लमजुंग जिल्ला अदालत</option>
+			              
+           			
+						  <option value="40">ललितपुर जिल्ला अदालत</option>
+			              
+           			
+						  <option value="96">श्री रुकुमकोट जिल्ला अदालत</option>
+			              
+           			
+						  <option value="23">संखुवासभा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="33">सप्तरी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="38">सर्लाही जिल्ला अदालत</option>
+			              
+           			
+						  <option value="71">सल्यान जिल्ला अदालत</option>
+			              
+           			
+						  <option value="43">सिन्धुपाल्चोक जिल्ला अदालत</option>
+			              
+           			
+						  <option value="35">सिन्धुली जिल्ला अदालत</option>
+			              
+           			
+						  <option value="32">सिराहा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="26">सुनसरी जिल्ला अदालत</option>
+			              
+           			
+						  <option value="78">सुर्खेत जिल्ला अदालत</option>
+			              
+           			
+						  <option value="28">सोलुखुम्बु जिल्ला अदालत</option>
+			              
+           			
+						  <option value="58">स्याङ्जा जिल्ला अदालत</option>
+			              
+           			
+						  <option value="80">हुम्ला जिल्ला अदालत</option>
+			              
+           			
+						  <option value="102">ऋृण असुली पुनरावेदन न्यायाधिकरण </option>
+			              
+           			
+						  <option value="103">फैसला कार्यान्वयन निर्देशनालय</option>
+			              
+           			
+			              
+                     </select>
+    </div>
+    <p><a href="http://supremecourt.gov.np/eportal" target="_blank"><i class="fa fa-desktop"></i> इपोर्टल</a></p></a>
+  </div>
+</div>
+
+
+
+
+
+
+
+
+
+<script> 
+ $('#court_name').on('change', function() {
+  var court_id =  this.value;
+  $.post("https://supremecourt.gov.np/court/biratnagarhc/get_slug_from_id",
+   { court_id: court_id},
+    function(slug){
+        window.location.replace("https://supremecourt.gov.np/court/"+slug);
+         });
+})
+</script>
+
+   
+    
+    <!-- BEGIN TOP BAR -->
+    <div class="pre-header">
+        <script src="https://cdn.jsdelivr.net/npm/jquery.marquee@1.6.0/jquery.marquee.js"></script>
+<style>
+   .test > li > a {
+   
+    text-decoration: none;
+    padding: 8px 15px;
+	
+    line-height: 1.7;
+	display: block;
+	clear: both;
+    font-weight: 400;
+	color: #3a5462;
+    white-space: nowrap;
+	
+}  .test > li {
+	padding-left:0px;
+	padding-right:0px;
+}
+
+.marquee {
+    width: 100%;
+    overflow: hidden;
+    background: whit;
+    color: red;
+    position: relative;
+    font-size: 16px;
+  line-height: 2em;
+}
+.marquee:before {
+ 
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: #245dbd;
+  z-index: 1;
+  padding: 0 0.5em;
+}
+.marquee ul {
+  visibility: hidden;
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+  white-space: nowrap;
+  display: inline;
+
+}
+
+.marquee li {
+  padding-left: 1em;
+  text-indent: -1em;
+  display: inline;
+}
+
+.marquee li:before {
+  content: " ";
+  padding-right: 5px;
+  width: 1em;
+  height: 1.4em;
+  display: inline-block;
+  width: 100px;
+  background: url("https://tinypic.host/images/2023/05/14/ModernXP-73-Globe-icon1.png") no-repeat center;
+  background-size: 1em;
+  position: relative;
+  bottom: -0.3em;
+  margin-right: 1em;
+  opacity: 0.6;
+}
+</style>
+<div id="navbar">
+  <nav class="navbar navbar-default navbar-static-top" role="navigation">
+      <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse-1">
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+          </button>
+
+      </div>
+
+      <div class="collapse navbar-collapse" id="navbar-collapse-1">
+        <div class="col-md-6 col-sm-6 additional-shop-info">
+          <ul class="nav navbar-nav list-unstyled list-inline">
+            <!--<li>sfds</li>-->
+            <li class="dropdown-submenu">
+               <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="padding: 0px 15px;">फाराम को ढाँचाहरु <img src="http://supremecourt.gov.np/web/assets/image/New_BlinkIco.gif"><b class="caret"></b>
+              
+               </a>
+                <ul class="dropdown-menu test" role="menu">
+                  					
+                </ul>
+
+  			</li>
+          </ul>
+		    <ul class="list-unstyled list-inline">
+		  <li><a href="https://supremecourt.gov.np/court/biratnagarhc/faq" style="color:#c21825;text-decoration: blink; font-size:14px; text-shadow: 2px 2px white;">
+                  <i class="fa fa-question-circle" style="font-size:15px" aria-hidden="true"></i>
+                  &nbsp;FAQs <img src="https://supremecourt.gov.np/web/assets/image/New_BlinkIco.gif"></a></li>
+				  </ul>
+				  
+        </div>
+        <div class="col-md-6 col-sm-6 additional-nav">
+          <ul class="list-unstyled list-inline pull-right">
+                            <li><a href="#"><i class="fa fa-mobile"></i>Mobile App</a></li>
+                          <!-- <li><a href="#"><i class="fa fa-calendar"></i>2026</a></li> -->
+              <li><a href="#"><i class="fa fa-language"></i>Language</a></li>
+              <!-- <li><a href="page-reg-page.html"><i class="fa fa-envelope-o"></i>मेल</a></li> -->
+          </ul>
+      </div>
+
+    </div><!-- /.navbar-collapse -->
+  </nav>
+<div>
+  <!-- <div class='marquee'>
+  
+  <ul>
+    <li>"समृद्ध नेपालको आधार सूचना प्रविधि र सञ्चार" राष्ट्रिय सूचना तथा सञ्चार प्रविधि दिवस, २०२४ भव्यताका साथ मनाऔ !!! </li>
+   
+  </ul>
+ 
+</div> -->
+<script type="text/javascript">
+  
+
+$(function() {
+  
+  var marquee = $('.marquee');
+  var ul = $('.marquee ul');
+  
+  var cloneContent = function() {
+
+    var doClone = true;
+    var clone_ul = function () {
+       ul.find('li').clone().appendTo( ul );
+    }
+    var check_ul_width = function() {
+      if(marquee.width() > ul.width() ) {
+        clone_ul();
+        return;
+      }
+      doClone = false;
+      ul.css('visibility', 'visible');
+    }
+
+    do {
+      check_ul_width();
+      var mw = marquee.width();
+      var uw = ul.width();
+    } while (doClone);
+
+  }
+
+  cloneContent();
+  
+   
+$('.marquee').marquee({
+  //duration in milliseconds of the marquee
+  duration: 15000,
+  duplicated: true
+});
+
+  
+});
+</script>   
+    </div>
+    <!-- END TOP BAR -->
+    <!-- BEGIN HEADER -->
+    <div class="header">
+      
+        
+
+<!-- <div class="container"> -->
+<div class="navbar navbar-img">
+    <a class="site-logo logo-header responsive" href="https://supremecourt.gov.np/court/biratnagarhc"
+       style="text-decoration: none; font-size: 15px;">
+        <img width="48" src="https://supremecourt.gov.np/court/public/assets/img/supreme_logo_.png" href="index.html">
+        <span><b>उच्च अदालत विराटनगर</b></span>
+        <img class="gov_logo site-log pull-right "
+             src="https://supremecourt.gov.np/court/public/assets/img/link/gov_logo_head.png" width="48" alt="">
+    </a>
+
+    <a href="javascript:void(0);" class="mobi-toggler"><i class="fa fa-bars"></i></a>
+    <!-- Collect the nav links, forms, and other content for toggling -->
+    <div class="header-navigation pull-right font-transform-inherit">
+        <ul class="nav navbar-nav navbar-right">
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#" href="https://supremecourt.gov.np/court/biratnagarhc"><i
+                            class="fa fa-home"></i> गृह</a></li>
+            <!--added by sarita-->
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/about_us">हाम्रो बारेमा</a></li>
+
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/legalmaterials"><i class=""></i>संहिता र
+                    कानूनी सामाग्रीहरु</a></li>
+                    
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/judges">न्यायाधीश</a></li>
+                       <!--                  <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                        href="https://supremecourt.gov.np/court/biratnagarhc/registrar"> रजिस्ट्रार</a></li>
+             -->
+            <!--            -->            <!--                <li class="megamenu"><a class="dropdown-toggle" data-target="#"-->
+            <!--                                        href="-->
+      
+            <!--">श्रेष्तेदार</a></li>-->
+            <!--            -->
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/photo_gallery"><i
+                            class=""></i> ग्यालरी </a></li>
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/pms">कर्मचारी विवरण</a></li>
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://supremecourt.gov.np/court/biratnagarhc/contact_us">सुझाव तथा प्रतिक्रिया</a></li>
+
+            
+            <li class="megamenu"><a class="dropdown-toggle" data-target="#"
+                                    href="https://mail.supremecourt.gov.np" target="_blank"><i
+                            class="fa  fa-envelope-o"></i>ईमेल</a></li>
+        </ul>
+    </div>
+</div>
+<!-- </div> -->
+
+    </div>
+
+
+<div class="main">
+    <div class="container" style="width: 100%">
+
+        <div class="row mix-block margin-bottom-20">
+            <!-- officials photos -->
+            <!-- BEGIN SLIDER -->
+          
+            <div class="col-md-12">
+                ﻿मुद्दा भेटिएन, कृपया मुद्दा नं. रुजु गर्नुहोस्।            </div>
+
+        </div>
+
+    </div>
+</div>
+
+
+
+
+<!-- BEGIN PRE-FOOTER -->
+    <div class="footer">
+       
+    <!-- <div class="footer"> -->
+        <div class="row">
+          <div class="col-sm-4">
+
+                <div class="contact-us">
+                   <!-- <img src="http://192.168.4.24/website/public/assets/img/supreme_logo_.png" href="index.html" width="70"><span> -->
+                     <h4> सम्पर्क ठेगाना</h4></span>
+                    <h5> उच्च अदालत विराटनगर<br>
+                        विराटनगर</h5>
+                    <h5> फोन नं. :</h5>
+                    <ul>
+                    
+                                                  <li><a href="#">021-512802</a></li>
+                                                  <li><a href="#">021-524056</a></li>
+                                               
+                    </ul>
+                    <h5> इमेल :<a href="mailto:info@supremecourt.gov.np"> info.hcbiratnagar@supremecourt.gov.np</a><br>
+                      <!--   <strong> वेभसाइट : </strong><a href="https://supremecourt.gov.np" target="_blank"> https://supremecourt.gov.np/court/biratnagarhc</a> -->
+                       </h5>
+                </div>
+                <!-- /.contact-us --> 
+              </div>
+            <div class="col-sm-4">
+                <div class="downloads">
+                    <h4> डाउनलोड</h4>
+                    <h5> डाउनलोड नेपाली फन्ट</h5>
+                    <ul class="font-list">
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/PCSNEPA0.TTF">PCS Nepal</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/pcsnepal.TTF">PCS Nepali</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/shann___.TTF">Shangrila Numeric</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/PREETI.TTF">Preeti</a> </li>
+                    <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/Kalimati.ttf">Kalimati</a> </li>
+                    </ul>
+                    <h5> डाउनलोड नेपाली युनिकोड</h5>
+                    <ul class="unicode-list">
+                        <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/nepali_romanised.zip"> नेपाली युनिकोड रोमनाइज</a> </li>
+                        <li> <a href="https://supremecourt.gov.np/web/assets/downloads/fonts/nepali_Traditional.zip"> नेपाली युनिकोड ट्रेडिसनल</a> </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="useful-links">
+                    <h4> उपयोगी लिङ्कहरू</h4>
+                    <ul>
+                        <li> <a href="http://judicialcouncil.gov.np" target="_blank"> न्याय परिषद्</a> </li>
+                      <li> <a href="https://mediationcouncil.gov.np/" target="_blank"> मेलमिलाप परिषद्</a> </li>
+                                  <li> <a href="https://moljpa.gov.np" target="_blank"> कानून, न्याय तथा संसदीय मामिला मन्त्रालय</a> </li>
+                                  <li> <a href="https://attorneygeneral.gov.np/" target="_blank"> महान्यायाधिवक्ताको कार्यालय</a> </li>
+                                  <!--<li> <a href="https://lawcommission.gov.np/" target="_blank"> नेपाल कानून आयोग</a> </li>-->
+                                  <li> <a href="https://nepalbar.org.np/" target="_blank"> नेपाल बार एशोसिएशन</a> </li>
+                      <li> <a href="https://dopm.gov.np/" target="_blank">कारागार व्यवस्थापन विभाग</a> </li>
+					  </ul>
+                </div>
+                <!-- /.useful-links --> 
+            </div>
+
+          </div>
+          <!-- /row -->
+    <!-- </div> -->
+
+    </div>
+    <!-- END PRE-FOOTER -->
+
+    <!-- BEGIN FOOTER -->
+    <div class="footer1">
+        
+<div>
+  <div class="row">
+    <!-- BEGIN COPYRIGHT removed social site -->
+    <div class="col-md-12 col-sm-12 padding-top-10">
+     <p class = "pull-right">&copy copyright 2026 SUPREME COURT OF NEPAL. All Rights Reserved.  </p> <a href="javascript:;">Privacy Policy</a> | <a href="javascript:;">Terms of Service</a>
+    </div>
+    <!-- END COPYRIGHT -->
+    <!-- BEGIN PAYMENTS -->
+    
+    <!-- END PAYMENTS -->
+   
+  </div>
+</div>
+    </div>
+    <!-- END FOOTER -->
+
+
+
+
+
+    <!--[endif]-->
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/jquery-migrate.min.js" type="text/javascript"></script>
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>      
+    <script src="https://supremecourt.gov.np/court/public/assets/scripts/back-to-top.js" type="text/javascript"></script>
+    <!-- END CORE PLUGINS -->
+
+    <!-- BEGIN PAGE LEVEL JAVASCRIPTS (REQUIRED ONLY FOR CURRENT PAGE) -->
+  
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/owl.carousel.min.js" type="text/javascript"></script><!-- slider for products -->
+    <script src="https://supremecourt.gov.np/court/public/assets/plugins/jquery.maskedinput.js" type="text/javascript"></script>
+
+    <script src="https://supremecourt.gov.np/court/public/assets/scripts/layout.js" type="text/javascript"></script>
+
+    <script src="https://supremecourt.gov.np/court/public/assets/scripts/bs-carousel.js" type="text/javascript"></script>
+     <script src="https://supremecourt.gov.np/court/public/assets/scripts/photo-gallery.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+        jQuery(document).ready(function() {
+            Layout.init();    
+            Layout.initOWL();
+            // Layout.initTwitter();
+            Layout.initFixHeaderWithPreHeader(); /* Switch On Header Fixing (only if you have pre-header) */
+            Layout.initNavScrolling();
+        });
+    </script>
+    <!-- END PAGE LEVEL JAVASCRIPTS -->
+</body>
+<!-- END BODY -->
+</html>
+    <!-- last modified 2018-08-13 -->
+    <!-- Added a side bar  --><script id="f5_cspm">(function(){var f5_cspm={f5_p:'NOOEKGEIHPELDMLPHHHEMNFFMMGFBJFHIEAGFFGKGDGOMAIFGPBIIGMAMHGIONFGKHLBNPAAAAKKHGJJCNMAKAEFAAAKDFCJFJMCPBMGJHEFINJBHICMELCOFJHEGMEG',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/special_found.html
+++ b/courts/tests/fixtures/notfound/special_found.html
@@ -1,0 +1,337 @@
+<html>
+<head>
+<title>.::CASE MANAGEMENT SYSTEM::.</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link href="styles/default.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+<style type="text/css">
+.smallnepali {
+	font-family: "Shangrila Numeric";
+	font-size: 16px;
+	color: #990000;
+
+}
+
+body {
+	margin-left: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-bottom: 0px;
+	
+}
+td
+{color:#006666;}
+.style1 {
+	font-size: 12px;
+	font-weight: bold;
+	color: #FF3300;
+}
+.home
+{color:#FFF;
+font-size:12px;
+ border-bottom:1px solid #000000;
+ }
+
+.boldate
+{color:#ffffff; border-bottom:1px solid #000000;}
+
+input,textarea,select
+{border:1px solid #000000;}
+.tab {
+	font-family: Arial, Helvetica, sans-serif;
+	font-weight: bold;
+	color: #999900;
+	text-decoration:underline;
+}
+th
+{
+font-size:11px; background-color:#CCCCCC;
+}
+.nepali{font-family:PCS Nepali, "Shangrila Numeric";font-size:13px;}
+.bignepali{font-family:PCS Nepali, "Shangrila Numeric";font-size:19px;}
+
+.noborder{border:0px;}
+.style1 {color: #FF6600}
+.style2 {
+	color: #FFFFFF;
+	font-weight: bold;
+	font-size: 14px;
+	font-family: Geneva, Arial, Helvetica, sans-serif;
+	background-color:#FF6600;
+	width:320px;
+	padding-bottom:10px;
+	padding-top:10px;
+	text-align:center;
+	
+}
+
+.TOPLINX {
+	color: #FFFFFF;
+	font-weight: bold;
+	font-size: 12px;
+	font-family: Geneva, Arial, Helvetica, sans-serif;
+	background-color:#FF6600;
+	padding-bottom:10px;
+	padding-top:10px;
+	text-align:center;
+	
+}
+
+.rblock {
+	color: #FFFFFF;
+	font-weight: bold;
+	font-size: 14px;
+	font-family: Geneva, Arial, Helvetica, sans-serif;
+	background-color:#FF6600;
+	
+	padding-bottom:10px;
+	padding-top:10px;
+	text-align:center;
+	
+}
+.whbrd{border-bottom:1px solid #ffffff;}
+h2
+{
+font-family:Verdana, Arial, Helvetica, sans-serif; font-size:14px;}
+
+</style>
+<table width="100%" border="0">
+       <tr>
+         <td><img src="images/speciall.jpg" width="412" height="81"></td>
+         <td><img src="images/nepaflag.gif" width="71" height="77"></td>
+       </tr>
+       <tr bordercolor="#CCCCCC" bgcolor="#0099CC">
+         <td height="24" colspan="2"><a href="#" class="boldate" onClick="window.close();"> <strong>CLOSE THIS WINDOW</strong></a>&nbsp; &nbsp; &nbsp; &nbsp;<a href="../index.php" class="home" ><strong> BACK TO SUPREME COURT HOME PAGE</strong></a></td>
+  </tr>
+  
+       <tr>
+         <td colspan="2" class="heading"><div  class="TOPLINX"> <a href="./syspublic.php?d=reports&f=weekly_public">WEEKLY CAUSELISTS </a> || <a href="./syspublic.php?d=reports&f=suplementary_public">DAILY CAUSELISTS(SUPPLEMENTARY)</a> || <a href="./syspublic.php?d=reports&f=daily_public">DAILY CAUSELISTS</a> || <a href="./syspublic.php?d=reports&f=case_details">CASE PROCESS STATUS</a>
+  || <a href="./syspublic.php?d=reports&f=decided_cases">DECIDED CASES</a></div></td></tr>
+   
+             <br>
+ <tr>
+         <td colspan="2">          
+         <style type="text/css">
+   <!--
+      .npix{font-family: "PCS NEPAL, PCS NEPALI" , "PCS NEPALI"; font-size:12px; color:#333333;}
+      .headings{background-color:#E1F0FF; font-size:12px; color:#000066;
+      
+      }
+      .caption {
+        color:#006699;
+        font-weight: bold;
+        font-size: 11px;
+        padding-right:8px;
+      }
+      .message
+      {
+      text-align:center;
+      font-size:14px;
+      color:#FF0000;
+      font-weight:bold;
+      }
+      -->
+</style>
+<div class="rblock">मुद्दाको बिस्तृत विवरण</div>
+<br />
+<br />
+<table width="100%" border="0" cellspacing="0" cellpadding="1">
+   <tr>
+      <td height="27" colspan="4" class="headings" >मुद्दाको विवरण</td>
+   </tr>
+   <tr>
+      <td width="19%" align="right" class="caption">दर्ता नँ . :</td>
+      <td width="28%" ><font size="2" color="#000000">076-CR-0294         &nbsp;</font>
+      </td>
+      <td width="24%" align="right" class="caption">दर्ता मिती :</td>
+      <td width="29%"><font   size="2" color="#000000">२०७६/११/१३</font></td>
+   </tr>
+   <tr>
+      <td align="right" class="caption">मुद्दाको किसिम :</td>
+      <td ><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000">भ्रष्टाचार</font>
+         &nbsp;
+      </td>
+      <td align="right" class="caption">मुद्दा :</td>
+      <td><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000">नक्कली प्रमाण पत्र         &nbsp;</font>
+      </td>
+   </tr>
+   <tr>
+      <td align="right" class="caption">फाँट :</td>
+      <td colspan="3"><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000">
+         फाँट ख         </font>
+      </td>
+   </tr>
+   <tr>
+      <td align="right" valign="top" class="caption">मुद्दाको स्थिती : <br /></td>
+      <td valign="top"><font   size="2" color="#000000">फैसला (मिती: २०७६/१०/०३)</font></td>
+      <td colspan="2"  class="caption">
+      </td>
+   </tr>
+   <tr>
+      <td height="28" colspan="4" class="headings">वादी प्रतिवादीको विवरण</td>
+   </tr>
+   <tr>
+      <td height="22" align="right" class="caption">वादीहरु : </td>
+      <td colspan="3"><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000">
+          ख         </font>
+      </td>
+   </tr>
+   <tr>
+      <td align="right" class="caption">प्रतिवादीहरु :</td>
+      <td colspan="3"><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000">
+          क         </font>
+      </td>
+   </tr>
+   <tr>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+      <td>&nbsp;</td>
+   </tr>
+   <tr>
+      <td height="26" colspan="4" class="headings">हेर्न नमिल्ने मा. न्या. को विवरण</td>
+   </tr>
+   <!--  -->
+   <tr>
+      <td>&nbsp;</td>
+      <td colspan="3">&nbsp;</td>
+   </tr>
+    <!-- start of pesi tarekh -->
+        <tr>
+                <td colspan="4" align="left"  class="headings">पेशी तारेख: </td>
+        </tr>
+   
+       
+        <tr>
+            <td colspan="4" align="left">
+         
+            <table width="100%" border="0" cellspacing="1" cellpadding="0" class="utivtbl">
+            <tr>
+               
+               <td width bgcolor="#F4F4F4" class="caption">पेशी  मिती</td>
+               <td width bgcolor="#F4F4F4" class="caption">पेशी प्रकार</td>
+              
+            </tr>
+                      </table>
+      </td>
+   </tr>             
+            
+   <!-- eof pesi tarekh -->
+    <tr>
+      <td>&nbsp;</td>
+      <td colspan="3">&nbsp;</td>
+   </tr>
+
+   <!-- start of Sadharan tarekh -->
+        <tr>
+                <td colspan="4" align="left"  class="headings">साधारण तारेख: </td>
+        </tr>
+   
+       
+        <tr>
+            <td colspan="4" align="left">
+         
+            <table width="100%" border="0" cellspacing="1" cellpadding="0" class="utivtbl">
+            <tr>
+               
+               <td width bgcolor="#F4F4F4" class="caption">तारेख  मिती</td>
+               <td width bgcolor="#F4F4F4" class="caption">तारेख प्रकार</td>
+              
+            </tr>
+                      </table>
+      </td>
+   </tr>             
+            
+   <!-- eof Sadharan tarekh -->
+
+   <tr>
+      <td>&nbsp;</td>
+      <td colspan="3">&nbsp;</td>
+   </tr>
+
+   <tr>
+      <td height="27" colspan="4"  class="headings">अधिवक्ताको विवरण</td>
+   </tr>
+  
+   <tr>
+      <td align="right" class="caption">वादी अधिवक्ता(हरु): </td>
+      <td colspan="3"></td>
+   </tr>
+   <tr>
+      <td align="right" class="caption">प्रतिवादी अधिवक्ता(हरु): </td>
+      <td colspan="3"></td>
+   </tr>
+   <tr>
+      <td align="right">&nbsp;</td>
+      <td colspan="3">&nbsp;</td>
+   </tr>
+   <tr>
+      <td colspan="4" align="left"  class="headings">लगाब मुद्दाहरुको विवरण </td>
+   </tr>
+   <tr>
+      <td colspan="4" align="left">
+                  <table width="100%" border="0" cellspacing="1" cellpadding="0" class="utivtbl">
+            <tr>
+               <td width="9%" height="24" bgcolor="#F4F4F4" class="caption">दर्ता नँ .</td>
+               <td width="10%" bgcolor="#F4F4F4" class="caption">दर्ता मिती</td>
+               <td width="11%" bgcolor="#F4F4F4" class="caption">मुद्दा</td>
+               <td width="22%" bgcolor="#F4F4F4" class="caption">वादीहरु</td>
+               <td width="24%" bgcolor="#F4F4F4" class="caption">प्रतिवादीहरु</td>
+               <td width="24%" bgcolor="#F4F4F4" class="caption">हालको स्थिती</td>
+            </tr>
+                     </table>
+      </td>
+   </tr>
+   <tr>
+      <td colspan="4" align="left">&nbsp;</td>
+   </tr>
+   <tr>
+      <td colspan="4" align="left"  class="headings">पेशी को विवरण </td>
+   </tr>
+   <tr>
+      <td colspan="4">
+                  <table width="100%" border="0" cellspacing="1" cellpadding="0" class="utivtbl">
+            <tr>
+               <td width="17%" height="26" bgcolor="#F4F4F4" class="caption"><strong>सुनवाइ मिती</strong></td>
+               <td width="40%" bgcolor="#F4F4F4" class="caption"><strong>न्यायधिसहरु</strong></td>
+               <td width="22%" bgcolor="#F4F4F4" class="caption">मुद्दाको स्थिती</td>
+               <td width="21%" bgcolor="#F4F4F4" class="caption">आदेश / फैसलाको किसिम </td>
+            </tr>
+                        <tr>
+               <td valign="top" bgcolor="#F8F8F8"><font   size="2" color="#000000">२०७६/१०/०३                  &nbsp;</font>
+               </td>
+               <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000"></font></td>
+               <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2" color="#000000" >
+                  फैसला                  </font>
+               </td>
+               <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI"  size="2" color="#000000" >
+                                    </font>
+               </td>
+            </tr>
+                     </table>
+      </td>
+   </tr>
+   <tr>
+      <td align="right">&nbsp;</td>
+      <td colspan="3">&nbsp;</td>
+   </tr>
+   <tr>
+      <td colspan="4" align="right">&nbsp;</td>
+   </tr>
+</table>
+	<br> </td>
+  </tr>
+       <tr>
+         <td>&nbsp;</td>
+         <td>&nbsp;</td>
+       </tr>
+</table> 
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'DMJBJHIEPFPJCPKIDALOCKBLJIIHGMJDDGHDCBDBBKJKNNDEGDNKOGOIGJHEBDBFOMFBDAIOAAHIHEBAEMAAHGFBAALKAEOHCLHDAPPPALJNIMEFEDICOKNPJDEKHFCD',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/special_missing.html
+++ b/courts/tests/fixtures/notfound/special_missing.html
@@ -1,0 +1,153 @@
+<html>
+<head>
+<title>.::CASE MANAGEMENT SYSTEM::.</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<link href="styles/default.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+<style type="text/css">
+.smallnepali {
+	font-family: "Shangrila Numeric";
+	font-size: 16px;
+	color: #990000;
+
+}
+
+body {
+	margin-left: 0px;
+	margin-top: 0px;
+	margin-right: 0px;
+	margin-bottom: 0px;
+	
+}
+td
+{color:#006666;}
+.style1 {
+	font-size: 12px;
+	font-weight: bold;
+	color: #FF3300;
+}
+.home
+{color:#FFF;
+font-size:12px;
+ border-bottom:1px solid #000000;
+ }
+
+.boldate
+{color:#ffffff; border-bottom:1px solid #000000;}
+
+input,textarea,select
+{border:1px solid #000000;}
+.tab {
+	font-family: Arial, Helvetica, sans-serif;
+	font-weight: bold;
+	color: #999900;
+	text-decoration:underline;
+}
+th
+{
+font-size:11px; background-color:#CCCCCC;
+}
+.nepali{font-family:PCS Nepali, "Shangrila Numeric";font-size:13px;}
+.bignepali{font-family:PCS Nepali, "Shangrila Numeric";font-size:19px;}
+
+.noborder{border:0px;}
+.style1 {color: #FF6600}
+.style2 {
+	color: #FFFFFF;
+	font-weight: bold;
+	font-size: 14px;
+	font-family: Geneva, Arial, Helvetica, sans-serif;
+	background-color:#FF6600;
+	width:320px;
+	padding-bottom:10px;
+	padding-top:10px;
+	text-align:center;
+	
+}
+
+.TOPLINX {
+	color: #FFFFFF;
+	font-weight: bold;
+	font-size: 12px;
+	font-family: Geneva, Arial, Helvetica, sans-serif;
+	background-color:#FF6600;
+	padding-bottom:10px;
+	padding-top:10px;
+	text-align:center;
+	
+}
+
+.rblock {
+	color: #FFFFFF;
+	font-weight: bold;
+	font-size: 14px;
+	font-family: Geneva, Arial, Helvetica, sans-serif;
+	background-color:#FF6600;
+	
+	padding-bottom:10px;
+	padding-top:10px;
+	text-align:center;
+	
+}
+.whbrd{border-bottom:1px solid #ffffff;}
+h2
+{
+font-family:Verdana, Arial, Helvetica, sans-serif; font-size:14px;}
+
+</style>
+<table width="100%" border="0">
+       <tr>
+         <td><img src="images/speciall.jpg" width="412" height="81"></td>
+         <td><img src="images/nepaflag.gif" width="71" height="77"></td>
+       </tr>
+       <tr bordercolor="#CCCCCC" bgcolor="#0099CC">
+         <td height="24" colspan="2"><a href="#" class="boldate" onClick="window.close();"> <strong>CLOSE THIS WINDOW</strong></a>&nbsp; &nbsp; &nbsp; &nbsp;<a href="../index.php" class="home" ><strong> BACK TO SUPREME COURT HOME PAGE</strong></a></td>
+  </tr>
+  
+       <tr>
+         <td colspan="2" class="heading"><div  class="TOPLINX"> <a href="./syspublic.php?d=reports&f=weekly_public">WEEKLY CAUSELISTS </a> || <a href="./syspublic.php?d=reports&f=suplementary_public">DAILY CAUSELISTS(SUPPLEMENTARY)</a> || <a href="./syspublic.php?d=reports&f=daily_public">DAILY CAUSELISTS</a> || <a href="./syspublic.php?d=reports&f=case_details">CASE PROCESS STATUS</a>
+  || <a href="./syspublic.php?d=reports&f=decided_cases">DECIDED CASES</a></div></td></tr>
+   
+             <br>
+ <tr>
+         <td colspan="2">          
+         <style type="text/css">
+   <!--
+      .npix{font-family: "PCS NEPAL, PCS NEPALI" , "PCS NEPALI"; font-size:12px; color:#333333;}
+      .headings{background-color:#E1F0FF; font-size:12px; color:#000066;
+      
+      }
+      .caption {
+        color:#006699;
+        font-weight: bold;
+        font-size: 11px;
+        padding-right:8px;
+      }
+      .message
+      {
+      text-align:center;
+      font-size:14px;
+      color:#FF0000;
+      font-weight:bold;
+      }
+      -->
+</style>
+<div class="rblock">मुद्दाको बिस्तृत विवरण</div>
+<br />
+<br />
+<div class='message'>कृपया तपाईंको दर्ता मिती राम्रोसँग टाइप गर्नुहोस्</div>	<br> </td>
+  </tr>
+       <tr>
+         <td>&nbsp;</td>
+         <td>&nbsp;</td>
+       </tr>
+</table> 
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'EOHLDBPDJMCGHEODHMCIOMCDFOCHJBFIBMOBMEBNPJIMMBFNLPLHHODKAIKABIAILNBBOGFLAACMALPLECOAOFJFAAPKNDCIKIHGKKFBGAOCBDBGAHDABHBGLLGNDHAB',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/supreme_detail_found.html
+++ b/courts/tests/fixtures/notfound/supreme_detail_found.html
@@ -1,0 +1,870 @@
+
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js">
+<!--<![endif]-->
+<head>
+<!-- <meta charset="utf-8"> -->
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" >
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title>सर्वोच्च अदालत  :: Supreme Court of Nepal</title>
+<meta name="description" content="">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="css/bootstrap.min.css">
+<style>
+
+a:link:after, a:visited:after {  
+  content: normal !important;  
+}
+</style>
+<link rel="stylesheet" href="css/bootstrap-theme.min.css">
+<link rel="stylesheet" href="css/style.css">
+<script src="scripts/jquery-1.9.1.js"></script> 
+
+<style>
+td a, th a, option , td {
+    font-size: 15px;
+    font-family: kalimati;
+
+}
+</style>
+<!--[if lt IE 9]>
+            <script src="js/vendor/html5-3.6-respond-1.1.0.min.js"></script>
+        <![endif]-->
+</head>
+
+<body>
+<div class="clearfix">
+  <div class="logo-disc">
+    <div class="logo"><img src="img/logo.png" alt=""/></div>
+    <h1>Supreme Court of Nepal<br>
+      सर्वोच्च अदालत</h1>
+  </div>
+</div>
+<div class="section-breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb">
+      <li><a href="https://supremecourt.gov.np">Home</a></li>
+      <li class="active">Case Process Details</li>
+    </ol>
+    <!-- /.breadcrumb--> 
+  </div>
+  <!-- /.container --> 
+</div>
+<!--/.section-breadcrumb-->
+
+<div class="container-fluid">
+  <div class="row">
+		 ﻿<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        <form name="form1" method="post" action="">
+            <div class="panel panel-custom">
+                <div class="panel-heading">
+                    <h2 class="panel-title">मुद्दाको बिस्तृत विवरण</h2>
+                    <p align="center">कृपया मुद्दाको दर्ता मिति,फैसला मिति,मुद्दा नं मध्ये कुनै एक टाइप गर्नुहोस् ।
+                </div>
+                <div class="panel-body">
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-3">
+                                <label>दर्ता मितिः</label>
+                            </div>
+                            <div class="col-md-8">
+                                <div class="row">
+                                    <div class="col-md-3">
+                                        <input name="syy" type="text" class="form-control" id="syy"
+                                               value=""></div>
+                                    <div class="col-md-2">
+                                        <input name="smm" type="text" class="form-control" id="smm"
+                                               value="">
+                                    </div>
+                                    <div class="col-md-2">
+                                        <input name="sdd" type="text" class="form-control" id="sdd"
+                                               value=""><input name="mode" type="hidden" id="mode"
+                                                                                  value="show">
+                                        <input name="list" type="hidden" id="list" value="list">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-3">
+                                <label>मुद्दा नं:</label>
+                            </div>
+                            <div class="col-md-3">
+                                <input name="regno" type="text" id="regno" class="form-control"/>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-3">
+                                <label>फैसला मितिः</label>
+                            </div>
+                            <div class="col-md-8">
+                                <div class="row">
+                                    <div class="col-md-3">
+                                        <input name="tyy" type="text" id="tyy" class="form-control"
+                                               value=""></div>
+                                    <div class="col-md-2">
+                                        <input name="tmm" type="text" id="tmm" class="form-control"
+                                               value="">
+                                    </div>
+                                    <div class="col-md-2">
+                                        <input name="tdd" type="text" id="tdd" class="form-control"
+                                               value="">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="row">
+                            <div class="col-md-8 col-md-offset-3">
+                                <input type="submit" class="btn btn-primary" value="    खोज्ने     "/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+
+            </div>
+        </form>
+    </div>
+</div>
+
+
+    <div class="rblock">&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;&#2325;&#2379; &#2348;&#2367;&#2360;&#2381;&#2340;&#2371;&#2340;
+        &#2357;&#2367;&#2357;&#2352;&#2339;
+    </div><br/>
+    <br/>
+            <table class="table table-hover" width="98%" border="0" cellspacing="0" cellpadding="0" align="center">
+            <tr>
+                <th height="27" colspan="4">&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;&#2325;&#2379; &#2357;&#2367;&#2357;&#2352;&#2339;</th>
+            </tr>
+            <tr>
+                <td width="19%" align="right" class="caption">&#2342;&#2352;&#2381;&#2340;&#2366; &#2344;&#2305; . :
+                </td>
+                <td width="28%"><font size="2" color="#000000">081-WO-0001                        &nbsp;</font></td>
+                <td width="24%" align="right" class="caption">&#2342;&#2352;&#2381;&#2340;&#2366; &#2350;&#2367;&#2340;&#2368;:</td>
+                <td width="29%"><font size="2" color="#000000">२०८१।०४।०३</font>
+                </td>
+            </tr>
+            <tr>
+                <td align="right" class="caption">&#2352;&#2369;&#2332;&#2369; &#2350;&#2367;&#2340;&#2368;:</td>
+                <td><font size="2" color="#000000">
+                        २०८१।०४।०३                        &nbsp;</font></td>
+                <td align="right">र.नंः</td>
+
+                                <!-- UNIQUE_CASENO -->
+
+                <td align="npix"> 01-081-00022</td>
+            </tr>
+            <tr>
+                <td align="right" class="caption">मुद्दाको किसिम:</td>
+                <td><font size="2" color="#000000">रिट निवेदन</font>
+                    &nbsp;
+                </td>
+                <td align="right" class="caption">&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;:</td>
+                <td><font size="2" color="#000000">उत्प्रेषण                        &nbsp;</font></td>
+            </tr>
+            <tr>
+                <td align="right" class="caption">&#2347;&#2366;&#2305;&#2335;&#2357;&#2366;&#2354;&#2366;: <font
+                            size="2" color="#000000"><br/>
+                    </font></td>
+                <td><font size="2" color="#000000">
+                        दिपेन्द्र वाग्ले                          &nbsp; &nbsp;
+                        <!--<a href="http://supremecourt.it/download/phone_number_20710220.pdf" target="_blank">फोन नं. हेर्नुहोस् </a> --></font>
+                </td>
+                <td align="right" class="caption">&#2347;&#2366;&#2305;&#2335;:</td>
+                <td><font size="2" color="#000000">
+                    <!-- start of misil jaleko najale -->
+                                        <!-- eof misil jaleko najaleko -->
+                        रिट १                    </font></td>
+            </tr>
+            <tr>
+                <td align="right" valign="top" class="caption">&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;&#2325;&#2379;
+                    &#2360;&#2381;&#2341;&#2367;&#2340;&#2368;: <br/></td>
+                <td valign="top"><font size="2" color="#000000">&#2347;&#2376;&#2360;&#2354;&#2366; <br>&#2350;&#2367;&#2340;&#2368;:<font size="2" color="#000000">२०८३।०१।२५</font></font></td>
+                <td colspan="2" class="caption">
+                                        <span><a href="" target="_blank"><i class="glyphicon glyphicon-save-file"></i></a></span>
+                                    </td>
+            </tr>
+            <tr>
+                <td height="28" colspan="4" class="headings">&#2357;&#2366;&#2342;&#2368; &#2346;&#2381;&#2352;&#2340;&#2367;&#2357;&#2366;&#2342;&#2368;
+                    &#2325;&#2379; &#2357;&#2367;&#2357;&#2352;&#2339;
+                </td>
+            </tr>
+            <tr>
+                <td height="22" align="right" class="caption">&#2357;&#2366;&#2342;&#2368;&#2361;&#2352;&#2369; :</td>
+                <td colspan="3"><font size="2" color="#000000">
+                        आत्रेय-शिवाको-बस्नेत जे.भी. तर्फबाट अख्तियार प्राप्त भई आफ्नो हकमा समेत आत्रेय निर्माण सेवा प्रा.लि को अध्यक्ष ङ                      </font></td>
+            </tr>
+            <tr>
+                <td align="right" class="caption"> &#2346;&#2381;&#2352;&#2340;&#2367;&#2357;&#2366;&#2342;&#2368;&#2361;&#2352;&#2369;
+                    :
+                </td>
+                <td colspan="3"><font face="Arial" size="2" color="#000000">
+                        ग   , घ   / ख                      </font></td>
+            </tr>
+            <tr>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+                <td>&nbsp;</td>
+            </tr>
+             <!-- herna namilne judges -->
+            <!-- <tr>
+                <td height="26" colspan="4" class="headings">&#2361;&#2375;&#2352;&#2381;&#2344; &#2344;&#2350;&#2367;&#2354;&#2381;&#2344;&#2375;
+                    &#2350;&#2366;. &#2344;&#2381;&#2351;&#2366;.
+                </td>
+            </tr> -->
+
+
+           
+            <!-- <tr>
+                <td>&nbsp;</td>
+                <td colspan="3"><font size="2" color="#000000">
+                                            </font></td>
+            </tr> -->
+            <!-- eof herna namilne judges -->
+
+            <tr>
+                <td>&nbsp;</td>
+                <td colspan="3">&nbsp;</td>
+            </tr>
+
+            <tr>
+                <td height="27" colspan="4" class="headings">&#2309;&#2343;&#2367;&#2357;&#2325;&#2381;&#2340;&#2366;
+                    &#2325;&#2379; &#2357;&#2367;&#2357;&#2352;&#2339;
+                </td>
+            </tr>
+            <tr>
+                <td align="right" class="caption">&#2357;&#2366;&#2342;&#2368; &#2309;&#2343;&#2367;&#2357;&#2325;&#2381;&#2340;&#2366;(&#2361;&#2352;&#2369;):</td>
+                <td colspan="3"><font size="2" color="#000000"> </font></td>
+            </tr>
+            <tr>
+                <td align="right" class="caption">&#2346;&#2381;&#2352;&#2340;&#2367;&#2357;&#2366;&#2342;&#2368;
+                    &#2309;&#2343;&#2367;&#2357;&#2325;&#2381;&#2340;&#2366;(&#2361;&#2352;&#2369;):
+                </td>
+                <td colspan="3"><font size="2" color="#000000"></font></td>
+            </tr>
+            <tr>
+                <td align="right">&nbsp;</td>
+                <td colspan="3">&nbsp;</td>
+            </tr>
+            <tr>
+                <th colspan="4">&#2354;&#2327;&#2366;&#2348; &#2350;&#2369;&#2342;&#2381;&#2342;&#2366;&#2361;&#2352;&#2369;&#2325;&#2379;
+                    &#2357;&#2367;&#2357;&#2352;&#2339;
+                </th>
+            </tr>
+            <tr>
+                <td colspan="4" align="left">                    <table class="table-bordered table-striped table-hover" width="100%" border="0" cellspacing="0"
+                           cellpadding="0" align="center">
+                        <tr>
+                            <td>&#2342;&#2352;&#2381;&#2340;&#2366; &#2344;&#2305; .</td>
+                            <td>&#2342;&#2352;&#2381;&#2340;&#2366; &#2350;&#2367;&#2340;&#2368;</td>
+                            <td>&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;</td>
+                            <td>&#2357;&#2366;&#2342;&#2368;&#2361;&#2352;&#2369;</td>
+                            <td>&#2346;&#2381;&#2352;&#2340;&#2367;&#2357;&#2366;&#2342;&#2368;&#2361;&#2352;&#2369;
+                            </td>
+                            <td>&#2361;&#2366;&#2354;&#2325;&#2379; &#2360;&#2381;&#2341;&#2367;&#2340;&#2368;</td>
+                        </tr>
+                                                    <tr>
+                                <td bgcolor="#F8F8F8">
+                                    081-WO-0001                                </td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        २०८१।०४।०३                                    </font></td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        उत्प्रेषण                                    </font></td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        आत्रेय-शिवाको-बस्नेत जे.भी. तर्फबाट अख्तियार प्राप्त भई आफ्नो हकमा समेत आत्रेय निर्माण सेवा प्रा.लि को अध्यक्ष ङ                                      </font></td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        ग   , घ   / ख                                      </font></td>
+                                <td bgcolor="#F8F8F8">
+                                    <font size="2" color="#000000">फैसला                                        ।।
+                                                                            </font>
+
+                                    &nbsp;
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td bgcolor="#F8F8F8">
+                                    081-WO-0081                                </td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        २०८१।०४।२२                                    </font></td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        उत्प्रेषण                                    </font></td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        आत्रेय-शिवाको-बस्नेत जे.भीको तर्फबाट अख्तियार प्राप्त भई आफ्नो हकमा समेत आत्रेय निर्माण सेवा प्रा.लिको अध्यक्ष ङ                                      </font></td>
+                                <td bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                        घ   / ख                                      </font></td>
+                                <td bgcolor="#F8F8F8">
+                                    <font size="2" color="#000000">फैसला                                        ।।
+                                                                            </font>
+
+                                    &nbsp;
+                                </td>
+                            </tr>
+                                                </table>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="4" align="left">&nbsp;</td>
+            </tr>
+
+            <tr>
+                <th colspan="4">&#2340;&#2366;&#2352;&#2375;&#2326; &#2357;&#2367;&#2357;&#2352;&#2339;</th>
+            </tr>
+            <tr>
+                <td colspan="4">                    <table class="table-bordered table-striped table-hover" width="100%" border="0" cellspacing="0"
+                           cellpadding="0" align="center">
+                        <tr>
+                            <td>&#2340;&#2366;&#2352;&#2375;&#2326; &#2350;&#2367;&#2340;&#2368;</td>
+                            <td>&#2357;&#2367;&#2357;&#2352;&#2339;</td>
+                            <td>&#2340;&#2366;&#2352;&#2375;&#2326;&#2325;&#2379; &#2325;&#2367;&#2360;&#2367;&#2350;
+                            </td>
+                            <td>&nbsp;</td>
+                        </tr>
+                        
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०४।०६</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०४।१५</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०४।२२</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०४।२५</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०४।२८</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०४।२९</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०५।०२</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०५।०७</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०५।११</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।०९।१६</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८१।१२।२४</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८२।०१।२८</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८२।०३।२४</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८२।०५।२४</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८२।१२।२९</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                
+                            
+
+                                    <tr>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2"
+                                                                                 color="#000000">२०८३।०१।२५</font>
+                                            &nbsp;
+                                        </td>
+                                        <td valign="top" bgcolor="#F8F8F8"></td>
+                                        <td valign="top" bgcolor="#F8F8F8"><font size="2" color="#000000">
+                                                                                                पेशी तारेख                                            </font></td>
+                                        <td valign="top" bgcolor="#F8F8F8" class="npix"><font size="2" color="#000000">
+                                                &nbsp;
+                                            </font></td>
+                                    </tr>
+                                                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="4">&nbsp;</td>
+            </tr>
+            <tr>
+                <th colspan="4">&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;&#2325;&#2379; &#2360;&#2381;&#2341;&#2367;&#2340;&#2368;&#2325;&#2379;
+                    &#2348;&#2367;&#2360;&#2381;&#2340;&#2371;&#2340; &#2357;&#2367;&#2357;&#2352;&#2339;
+                </th>
+            </tr>
+            <tr>
+                <td colspan="4">                    <table class="table-bordered table-striped table-hover" width="100%" border="0" cellspacing="0"
+                           cellpadding="0" align="center">
+                        <tr>
+                            <td>&#2350;&#2367;&#2340;&#2368;</td>
+                            <td>&#2357;&#2367;&#2357;&#2352;&#2339;</td>
+                            <td>&#2360;&#2381;&#2341;&#2367;&#2340;&#2368;</td>
+                        </tr>
+                                            </table>
+                </td>
+            </tr>
+            <tr>
+                <th colspan="4">&#2346;&#2375;&#2358;&#2368; &#2325;&#2379; &#2357;&#2367;&#2357;&#2352;&#2339;</th>
+            </tr>
+            <tr>
+                <td colspan="4">                    <table class="table-bordered table-striped table-hover" width="100%" border="0" cellspacing="0"
+                           cellpadding="0" align="center">
+                        <tr>
+                            <td>&#2360;&#2369;&#2344;&#2357;&#2366;&#2311; &#2350;&#2367;&#2340;&#2368;</td>
+                            <td>न्यायाधीशहरू</td>
+                            <td>&#2350;&#2369;&#2342;&#2381;&#2342;&#2366;&#2325;&#2379; &#2360;&#2381;&#2341;&#2367;&#2340;&#2368;</td>
+                            <td>&#2310;&#2342;&#2375;&#2358; /&#2347;&#2376;&#2360;&#2354;&#2366;&#2325;&#2379; &#2325;&#2367;&#2360;&#2367;&#2350;</td>
+                        </tr>
+                                                    <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०४।०६                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री प्रकाशमान सिंह राउत<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        आदेश                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        कारण देखाउ, अल्पकालीन अन्तरिम आदेश, अ।आ। छलफल
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०४।१५                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री हरिप्रसाद  फुयाल<br>मा.न्या. श्री तिल प्रसाद  श्रेष्ठ<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०४।२२                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री डा। मनोजकुमार  शर्मा<br>मा.न्या. श्री विनोद   शर्मा<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०४।२५                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री हरिप्रसाद  फुयाल<br>मा.न्या. श्री महेश शर्मा  पौडेल<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०४।२८                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री डा। मनोजकुमार  शर्मा<br>मा.न्या. श्री टेकप्रसाद  ढुङ्गाना<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०४।२९                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री कुमार  रेग्मी<br>मा.न्या. श्री शारङ्गा  सुवेदी<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०५।०२                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री सपना प्रधान मल्ल<br>मा.न्या. श्री बालकृष्ण  ढकाल<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०५।०७                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री प्रकाशमान सिंह राउत<br>मा.न्या. श्री टेकप्रसाद  ढुङ्गाना<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०५।११                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री हरिप्रसाद  फुयाल<br>मा.न्या. श्री तिल प्रसाद  श्रेष्ठ<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        आदेश                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        अ।आ। निरन्तरता हुने
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८१।०९।१६                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री डा। नहकुल  सुवेदी<br>मा.न्या. श्री नित्यानन्द  पाण्डेय<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८२।०३।२४                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री विनोद   शर्मा<br>मा.न्या. श्री मेघराज पोखरेल <br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        हेर्न नभ्याइने                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                        <tr>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">२०८३।०१।२५                                        &nbsp;</font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">मा.न्या. श्री अव्दुल अजीज  मुसलमान<br>मा.न्या. श्री टेकप्रसाद  ढुङ्गाना<br></font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+                                        फैसला                                    </font></td>
+                                <td valign="top" bgcolor="#F8F8F8"><font face="PCS NEPAL, PCS NEPALI" size="2"
+                                                                         color="#000000">
+
+                                        रिट खारेज
+
+
+
+                                    </font>
+
+                                                                       
+                                </td>
+                            </tr>
+                                                </table>
+                </td>
+            </tr>
+            <tr>
+                <td align="right">&nbsp;</td>
+                <td colspan="3">&nbsp;</td>
+            </tr>
+            <tr>
+                <td colspan="4" align="right">&nbsp;</td>
+            </tr>
+        </table>
+
+        	</div>
+   </div>
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'DGDBHLACBFMLIDFIIOOBEMDHLJFNIHEACPMELPDLDPECOAEFJDIONCIOFKMLOBGHCHBBCIAMAAGOKIGCNEHABKKMAAAHAFIKHIKKLACNIDPGDDGCGKFMDFOALMLKNCJP',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/supreme_search_found.html
+++ b/courts/tests/fixtures/notfound/supreme_search_found.html
@@ -1,0 +1,165 @@
+
+<!DOCTYPE html>
+
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js">
+<!--<![endif]-->
+<head>
+<!-- <meta charset="utf-8"> -->
+<meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+<meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/>
+<title>सर्वोच्च अदालत  :: Supreme Court of Nepal</title>
+<meta content="" name="description"/>
+<meta content="width=device-width, initial-scale=1" name="viewport"/>
+<link href="css/bootstrap.min.css" rel="stylesheet"/>
+<style>
+
+a:link:after, a:visited:after {  
+  content: normal !important;  
+}
+</style>
+<link href="css/bootstrap-theme.min.css" rel="stylesheet"/>
+<link href="css/style.css" rel="stylesheet"/>
+<script src="scripts/jquery-1.9.1.js"></script>
+<style>
+td a, th a, option , td {
+    font-size: 15px;
+    font-family: kalimati;
+
+}
+</style>
+<!--[if lt IE 9]>
+            <script src="js/vendor/html5-3.6-respond-1.1.0.min.js"></script>
+        <![endif]-->
+</head>
+<body>
+<div class="clearfix">
+<div class="logo-disc">
+<div class="logo"><img alt="" src="img/logo.png"/></div>
+<h1>Supreme Court of Nepal<br/>
+      सर्वोच्च अदालत</h1>
+</div>
+</div>
+<div class="section-breadcrumb">
+<div class="container">
+<ol class="breadcrumb">
+<li><a href="https://supremecourt.gov.np">Home</a></li>
+<li class="active">Case Process Details</li>
+</ol>
+<!-- /.breadcrumb-->
+</div>
+<!-- /.container -->
+</div>
+<!--/.section-breadcrumb-->
+<div class="container-fluid">
+<div class="row">
+		 ﻿<div class="row">
+<div class="col-md-6 col-md-offset-3">
+<form action="" method="post" name="form1">
+<div class="panel panel-custom">
+<div class="panel-heading">
+<h2 class="panel-title">मुद्दाको बिस्तृत विवरण</h2>
+<p align="center">कृपया मुद्दाको दर्ता मिति,फैसला मिति,मुद्दा नं मध्ये कुनै एक टाइप गर्नुहोस् ।
+                </p></div>
+<div class="panel-body">
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>दर्ता मितिः</label>
+</div>
+<div class="col-md-8">
+<div class="row">
+<div class="col-md-3">
+<input class="form-control" id="syy" name="syy" type="text" value=""/></div>
+<div class="col-md-2">
+<input class="form-control" id="smm" name="smm" type="text" value=""/>
+</div>
+<div class="col-md-2">
+<input class="form-control" id="sdd" name="sdd" type="text" value=""/><input id="mode" name="mode" type="hidden" value="show"/>
+<input id="list" name="list" type="hidden" value="list"/>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>मुद्दा नं:</label>
+</div>
+<div class="col-md-3">
+<input class="form-control" id="regno" name="regno" type="text"/>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>फैसला मितिः</label>
+</div>
+<div class="col-md-8">
+<div class="row">
+<div class="col-md-3">
+<input class="form-control" id="tyy" name="tyy" type="text" value=""/></div>
+<div class="col-md-2">
+<input class="form-control" id="tmm" name="tmm" type="text" value=""/>
+</div>
+<div class="col-md-2">
+<input class="form-control" id="tdd" name="tdd" type="text" value=""/>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-8 col-md-offset-3">
+<input class="btn btn-primary" type="submit" value="    खोज्ने     "/>
+</div>
+</div>
+</div>
+</div>
+</div>
+</form>
+</div>
+</div>
+<strong>Total 1 Records Found</strong>
+<div class="table-wrap">
+<table align="center" border="0" cellpadding="0" cellspacing="0" class="table-bordered table-striped table-hover" width="99%">
+<tr>
+<th>सि नं</th>
+<th>दर्ता नं</th>
+<th>मुद्दाको किसिम</th>
+<th>मुद्दाको नाम</th>
+<th>मुद्दाको
+                    स्थिती
+                </th>
+<th>बादीहरु</th>
+<th>प्रतिबादिहरु</th>
+<th> </th>
+</tr>
+<tr bgcolor="#EBEBEB">
+<td class="nepali whbrd">1</td>
+<td class="english whbrd">081-WO-0001</td>
+<td class="nepali whbrd">रिट निवेदन</td>
+<td class="nepali whbrd">उत्प्रेषण</td>
+<td class="nepali whbrd">फैसला <br/>मितीM<font color="#000000" size="2">2083.01.25</font></td>
+<td class="nepali whbrd"> ख </td>
+<td class="nepali whbrd"> क </td>
+<td class="nepali whbrd"><a href="sys.php?d=reports&amp;f=case_details&amp;num=1&amp;mode=view&amp;caseno=305697"><i class="glyphicon glyphicon-new-window"></i>  मुद्दाको बिस्तृत विवरण</a></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'FAOCDDDGEDOFFDABIPHMEDLDJOLBOICAOHPKFGCJDFAKDGAEDMHHAFELDDDIBLJJCODBBHAOAACHLJIPEAEAEBPNAANCDACGJCKABKLACGLFMLJFMPKKOHPLGBDHMMCG',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/supreme_search_missing.html
+++ b/courts/tests/fixtures/notfound/supreme_search_missing.html
@@ -1,0 +1,155 @@
+
+<!DOCTYPE html>
+
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js">
+<!--<![endif]-->
+<head>
+<!-- <meta charset="utf-8"> -->
+<meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+<meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/>
+<title>सर्वोच्च अदालत  :: Supreme Court of Nepal</title>
+<meta content="" name="description"/>
+<meta content="width=device-width, initial-scale=1" name="viewport"/>
+<link href="css/bootstrap.min.css" rel="stylesheet"/>
+<style>
+
+a:link:after, a:visited:after {  
+  content: normal !important;  
+}
+</style>
+<link href="css/bootstrap-theme.min.css" rel="stylesheet"/>
+<link href="css/style.css" rel="stylesheet"/>
+<script src="scripts/jquery-1.9.1.js"></script>
+<style>
+td a, th a, option , td {
+    font-size: 15px;
+    font-family: kalimati;
+
+}
+</style>
+<!--[if lt IE 9]>
+            <script src="js/vendor/html5-3.6-respond-1.1.0.min.js"></script>
+        <![endif]-->
+</head>
+<body>
+<div class="clearfix">
+<div class="logo-disc">
+<div class="logo"><img alt="" src="img/logo.png"/></div>
+<h1>Supreme Court of Nepal<br/>
+      सर्वोच्च अदालत</h1>
+</div>
+</div>
+<div class="section-breadcrumb">
+<div class="container">
+<ol class="breadcrumb">
+<li><a href="https://supremecourt.gov.np">Home</a></li>
+<li class="active">Case Process Details</li>
+</ol>
+<!-- /.breadcrumb-->
+</div>
+<!-- /.container -->
+</div>
+<!--/.section-breadcrumb-->
+<div class="container-fluid">
+<div class="row">
+		 ﻿<div class="row">
+<div class="col-md-6 col-md-offset-3">
+<form action="" method="post" name="form1">
+<div class="panel panel-custom">
+<div class="panel-heading">
+<h2 class="panel-title">मुद्दाको बिस्तृत विवरण</h2>
+<p align="center">कृपया मुद्दाको दर्ता मिति,फैसला मिति,मुद्दा नं मध्ये कुनै एक टाइप गर्नुहोस् ।
+                </p></div>
+<div class="panel-body">
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>दर्ता मितिः</label>
+</div>
+<div class="col-md-8">
+<div class="row">
+<div class="col-md-3">
+<input class="form-control" id="syy" name="syy" type="text" value=""/></div>
+<div class="col-md-2">
+<input class="form-control" id="smm" name="smm" type="text" value=""/>
+</div>
+<div class="col-md-2">
+<input class="form-control" id="sdd" name="sdd" type="text" value=""/><input id="mode" name="mode" type="hidden" value="show"/>
+<input id="list" name="list" type="hidden" value="list"/>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>मुद्दा नं:</label>
+</div>
+<div class="col-md-3">
+<input class="form-control" id="regno" name="regno" type="text"/>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>फैसला मितिः</label>
+</div>
+<div class="col-md-8">
+<div class="row">
+<div class="col-md-3">
+<input class="form-control" id="tyy" name="tyy" type="text" value=""/></div>
+<div class="col-md-2">
+<input class="form-control" id="tmm" name="tmm" type="text" value=""/>
+</div>
+<div class="col-md-2">
+<input class="form-control" id="tdd" name="tdd" type="text" value=""/>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-8 col-md-offset-3">
+<input class="btn btn-primary" type="submit" value="    खोज्ने     "/>
+</div>
+</div>
+</div>
+</div>
+</div>
+</form>
+</div>
+</div>
+<strong>Total 0 Records Found</strong>
+<div class="table-wrap">
+<table align="center" border="0" cellpadding="0" cellspacing="0" class="table-bordered table-striped table-hover" width="99%">
+<tr>
+<th>सि नं</th>
+<th>दर्ता नं</th>
+<th>मुद्दाको किसिम</th>
+<th>मुद्दाको नाम</th>
+<th>मुद्दाको
+                    स्थिती
+                </th>
+<th>बादीहरु</th>
+<th>प्रतिबादिहरु</th>
+<th> </th>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'JDDICNGIMJHFLCHDBLFICICGOOGCMBLEOIPFGGGLGNBOOIBLEIPMNAMLGCLIIFNKPEHBBLGGAAKIKKLOOCOALGGJAAFFOPJCKIDLBNBIHNGFFIMGHDFOIOKIOGBHMOJM',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/fixtures/notfound/supreme_search_multi.html
+++ b/courts/tests/fixtures/notfound/supreme_search_multi.html
@@ -1,0 +1,180 @@
+<!-- COMPOSED FIXTURE: two REAL captured search rows (081-WO-0081, 081-WO-0001)
+     spliced into one real result page. The portal's regno search is exact-match
+     today, so a genuine multi-row response cannot be captured by case number —
+     but the list is N-row capable (note the per-row num= in each href), and row
+     selection must key on the docket cell rather than document order. Party names
+     replaced with the ख / क placeholders used across these fixtures. -->
+
+<!DOCTYPE html>
+
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js">
+<!--<![endif]-->
+<head>
+<!-- <meta charset="utf-8"> -->
+<meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+<meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/>
+<title>सर्वोच्च अदालत  :: Supreme Court of Nepal</title>
+<meta content="" name="description"/>
+<meta content="width=device-width, initial-scale=1" name="viewport"/>
+<link href="css/bootstrap.min.css" rel="stylesheet"/>
+<style>
+
+a:link:after, a:visited:after {  
+  content: normal !important;  
+}
+</style>
+<link href="css/bootstrap-theme.min.css" rel="stylesheet"/>
+<link href="css/style.css" rel="stylesheet"/>
+<script src="scripts/jquery-1.9.1.js"></script>
+<style>
+td a, th a, option , td {
+    font-size: 15px;
+    font-family: kalimati;
+
+}
+</style>
+<!--[if lt IE 9]>
+            <script src="js/vendor/html5-3.6-respond-1.1.0.min.js"></script>
+        <![endif]-->
+</head>
+<body>
+<div class="clearfix">
+<div class="logo-disc">
+<div class="logo"><img alt="" src="img/logo.png"/></div>
+<h1>Supreme Court of Nepal<br/>
+      सर्वोच्च अदालत</h1>
+</div>
+</div>
+<div class="section-breadcrumb">
+<div class="container">
+<ol class="breadcrumb">
+<li><a href="https://supremecourt.gov.np">Home</a></li>
+<li class="active">Case Process Details</li>
+</ol>
+<!-- /.breadcrumb-->
+</div>
+<!-- /.container -->
+</div>
+<!--/.section-breadcrumb-->
+<div class="container-fluid">
+<div class="row">
+		 ﻿<div class="row">
+<div class="col-md-6 col-md-offset-3">
+<form action="" method="post" name="form1">
+<div class="panel panel-custom">
+<div class="panel-heading">
+<h2 class="panel-title">मुद्दाको बिस्तृत विवरण</h2>
+<p align="center">कृपया मुद्दाको दर्ता मिति,फैसला मिति,मुद्दा नं मध्ये कुनै एक टाइप गर्नुहोस् ।
+                </p></div>
+<div class="panel-body">
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>दर्ता मितिः</label>
+</div>
+<div class="col-md-8">
+<div class="row">
+<div class="col-md-3">
+<input class="form-control" id="syy" name="syy" type="text" value=""/></div>
+<div class="col-md-2">
+<input class="form-control" id="smm" name="smm" type="text" value=""/>
+</div>
+<div class="col-md-2">
+<input class="form-control" id="sdd" name="sdd" type="text" value=""/><input id="mode" name="mode" type="hidden" value="show"/>
+<input id="list" name="list" type="hidden" value="list"/>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>मुद्दा नं:</label>
+</div>
+<div class="col-md-3">
+<input class="form-control" id="regno" name="regno" type="text"/>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-3">
+<label>फैसला मितिः</label>
+</div>
+<div class="col-md-8">
+<div class="row">
+<div class="col-md-3">
+<input class="form-control" id="tyy" name="tyy" type="text" value=""/></div>
+<div class="col-md-2">
+<input class="form-control" id="tmm" name="tmm" type="text" value=""/>
+</div>
+<div class="col-md-2">
+<input class="form-control" id="tdd" name="tdd" type="text" value=""/>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="form-group">
+<div class="row">
+<div class="col-md-8 col-md-offset-3">
+<input class="btn btn-primary" type="submit" value="    खोज्ने     "/>
+</div>
+</div>
+</div>
+</div>
+</div>
+</form>
+</div>
+</div>
+<strong>Total 2 Records Found</strong>
+<div class="table-wrap">
+<table align="center" border="0" cellpadding="0" cellspacing="0" class="table-bordered table-striped table-hover" width="99%">
+<tr>
+<th>सि नं</th>
+<th>दर्ता नं</th>
+<th>मुद्दाको किसिम</th>
+<th>मुद्दाको नाम</th>
+<th>मुद्दाको
+                    स्थिती
+                </th>
+<th>बादीहरु</th>
+<th>प्रतिबादिहरु</th>
+<th> </th>
+</tr>
+<tr bgcolor="#EBEBEB">
+<td class="nepali whbrd">1</td>
+<td class="english whbrd">081-WO-0081</td>
+<td class="nepali whbrd">रिट निवेदन</td>
+<td class="nepali whbrd">उत्प्रेषण</td>
+<td class="nepali whbrd">फैसला <br/>मितीM<font color="#000000" size="2">2083.01.25</font></td>
+<td class="nepali whbrd"> ख </td>
+<td class="nepali whbrd"> क </td>
+<td class="nepali whbrd"><a href="sys.php?d=reports&amp;f=case_details&amp;num=1&amp;mode=view&amp;caseno=307125"><i class="glyphicon glyphicon-new-window"></i>  मुद्दाको बिस्तृत विवरण</a></td>
+</tr><tr bgcolor="#EBEBEB">
+<td class="nepali whbrd">2</td>
+<td class="english whbrd">081-WO-0001</td>
+<td class="nepali whbrd">रिट निवेदन</td>
+<td class="nepali whbrd">उत्प्रेषण</td>
+<td class="nepali whbrd">फैसला <br/>मितीM<font color="#000000" size="2">2083.01.25</font></td>
+<td class="nepali whbrd"> ख </td>
+<td class="nepali whbrd"> क </td>
+<td class="nepali whbrd"><a href="sys.php?d=reports&amp;f=case_details&amp;num=1&amp;mode=view&amp;caseno=305697"><i class="glyphicon glyphicon-new-window"></i>  मुद्दाको बिस्तृत विवरण</a></td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</body>
+</html>
+<script id="f5_cspm">(function(){var f5_cspm={f5_p:'FAOCDDDGEDOFFDABIPHMEDLDJOLBOICAOHPKFGCJDFAKDGAEDMHHAFELDDDIBLJJCODBBHAOAACHLJIPEAEAEBPNAANCDACGJCKABKLACGLFMLJFMPKKOHPLGBDHMMCG',setCharAt:function(str,index,chr){if(index>str.length-1)return str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1347770202aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}
+return;}}
+catch(err){return;}
+setTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var chunk=window.document.cookie.split(/\s*;\s*/);for(var i=0;i<chunk.length;++i){var pair=chunk[i].split(/\s*=\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')
+{var d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}
+f5_cspm.go();}());</script>

--- a/courts/tests/test_repair_enrichment.py
+++ b/courts/tests/test_repair_enrichment.py
@@ -1,0 +1,121 @@
+"""The repair pass for cases falsely marked ``enriched``.
+
+The empty-parse bug set ``status="enriched"`` on cases it wrote nothing to, and
+``_enrich_pending`` excludes that status — so fixing the parser does not reach
+them. These tests pin the selection (only rows with no enrichment evidence) and
+the safety property that matters: a case the portal still can't enrich is left
+exactly as it was.
+"""
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from courts.models import CaseEntity, Court, CourtCase
+from courts.scraper.registry import REGISTRY
+from courts.scraper.rows import ParsedEnrichment
+
+
+def _enrichment():
+    return ParsedEnrichment(
+        core_fields={"registration_number": "0294", "hearing_count": 2},
+        extra_data={"enrichment_hearings": [{"hearing_date": "2080-01-15"}]},
+        entities=[{"side": "defendant", "name": "क", "address": None}],
+    )
+
+
+class RepairEnrichmentTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        Court.objects.using("ngm").get_or_create(
+            identifier="special", defaults={"court_type": "", "full_name_nepali": ""}
+        )
+
+    def _case(self, case_number, **over):
+        fields = dict(status="enriched", extra_data={"enrichment_hearings": []})
+        fields.update(over)
+        return CourtCase.objects.using("ngm").create(
+            court_id="special", case_number=case_number, **fields
+        )
+
+    def _run(self, *args):
+        out = StringIO()
+        call_command("repair_enrichment", "--court", "special", *args, stdout=out, stderr=out)
+        return out.getvalue()
+
+    def test_finds_only_cases_with_no_enrichment_evidence(self):
+        self._case("076-CR-0001")                                  # damaged
+        self._case("076-CR-0002", extra_data={})                   # damaged: key absent
+        self._case("076-CR-0003", registration_number="0003")      # real enrichment
+        self._case("076-CR-0004", hearing_count=5)                 # real enrichment
+        self._case("076-CR-0005", extra_data={"enrichment_hearings": [{"a": 1}]})
+        self._case("076-CR-0006", status=None)                     # _enrich_pending still reaches it
+
+        out = self._run()
+        assert "2 case(s)" in out
+        assert "076-CR-0001" in out and "076-CR-0002" in out
+        assert "076-CR-0003" not in out
+
+    def test_dry_run_is_the_default_and_writes_nothing(self):
+        self._case("076-CR-0001")
+        with mock.patch.object(REGISTRY["special"], "crawl_detail") as detail:
+            out = self._run()
+        detail.assert_not_called()
+        assert "dry run" in out
+        assert CourtCase.objects.using("ngm").get(case_number="076-CR-0001").registration_number is None
+
+    def test_apply_re_enriches_the_damaged_case(self):
+        self._case("076-CR-0001")
+        with mock.patch("courts.management.commands.repair_enrichment.Fetcher"), \
+             mock.patch.object(REGISTRY["special"], "crawl_detail", return_value=_enrichment()):
+            out = self._run("--apply", "--delay", "0")
+        assert "repaired 1" in out
+        case = CourtCase.objects.using("ngm").get(case_number="076-CR-0001")
+        assert case.registration_number == "0294"
+        assert case.extra_data["enrichment_hearings"]
+        assert CaseEntity.objects.using("ngm").filter(case_number="076-CR-0001").count() == 1
+
+    def test_a_case_the_portal_still_cannot_enrich_is_left_untouched(self):
+        # The whole point of the guard being fixed: an empty parse must not
+        # rewrite the row. It stays selectable for a later run.
+        self._case("076-CR-0001", extra_data={"enrichment_hearings": [], "keep": "me"})
+        empty = ParsedEnrichment(
+            core_fields={}, extra_data={"enrichment_hearings": []}, entities=[]
+        )
+        with mock.patch("courts.management.commands.repair_enrichment.Fetcher"), \
+             mock.patch.object(REGISTRY["special"], "crawl_detail", return_value=empty):
+            out = self._run("--apply", "--delay", "0")
+        assert "repaired 0" in out
+        case = CourtCase.objects.using("ngm").get(case_number="076-CR-0001")
+        assert case.extra_data["keep"] == "me"
+        assert case.status == "enriched"
+
+    def test_a_portal_error_does_not_abandon_the_remaining_cases(self):
+        self._case("076-CR-0001")
+        self._case("076-CR-0002")
+        calls = []
+
+        def flaky(fetch, court_id, case_number):
+            calls.append(case_number)
+            if len(calls) == 1:
+                raise RuntimeError("portal blew up")
+            return _enrichment()
+
+        with mock.patch("courts.management.commands.repair_enrichment.Fetcher"), \
+             mock.patch.object(REGISTRY["special"], "crawl_detail", side_effect=flaky):
+            out = self._run("--apply", "--delay", "0")
+        assert len(calls) == 2
+        assert "repaired 1" in out
+
+    def test_limit_caps_the_run(self):
+        for seq in range(1, 6):
+            self._case(f"076-CR-{seq:04d}")
+        assert "2 case(s)" in self._run("--limit", "2")
+
+    def test_all_is_rejected(self):
+        with self.assertRaises(CommandError):
+            call_command("repair_enrichment", "--court", "all", stdout=StringIO())

--- a/courts/tests/test_scraper_notfound.py
+++ b/courts/tests/test_scraper_notfound.py
@@ -1,0 +1,139 @@
+"""Not-found detection across all four court portals.
+
+The register sweep asks a portal "does docket N exist?" thousands of times, so
+mistaking a not-found page for a hit is the single most damaging failure mode
+available: it does not error, it mass-creates empty cases and (via
+``_replace_entities``) deletes real parties.
+
+Every fixture here is a real response captured from the live portal — one found
+and one not-found per tier — so the predicate is tested against what the courts
+actually serve rather than a guess at it.
+"""
+
+import pathlib
+
+import pytest
+
+from courts.scraper import district, high, special, supreme
+from courts.scraper.errors import UnexpectedPage
+from courts.scraper.registry import REGISTRY
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "notfound"
+
+
+def _html(name):
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# tier -> (parser, found fixture, not-found fixture)
+_TIERS = {
+    "special": (special.parse_detail, "special_found.html", "special_missing.html"),
+    "district": (district.parse_district_detail, "district_found.html", "district_missing.html"),
+    "high": (high.parse_high_detail, "high_found.html", "high_missing.html"),
+    # Supreme's not-found is the search LIST with "Total 0 Records Found"; its
+    # found page is only reachable via the stage-2 link (see TestSupremeTwoStage).
+    "supreme": (supreme.parse_supreme_detail, "supreme_detail_found.html", "supreme_search_missing.html"),
+}
+
+
+@pytest.mark.parametrize("tier", sorted(_TIERS))
+def test_found_page_identifies_a_case(tier):
+    parser, found, _ = _TIERS[tier]
+    assert parser(_html(found)).identifies_a_case() is True
+
+
+@pytest.mark.parametrize("tier", sorted(_TIERS))
+def test_not_found_page_does_not_identify_a_case(tier):
+    parser, _, missing = _TIERS[tier]
+    assert parser(_html(missing)).identifies_a_case() is False
+
+
+@pytest.mark.parametrize("tier", sorted(_TIERS))
+def test_extra_data_alone_would_have_passed_a_not_found_page(tier):
+    """Why ``identifies_a_case`` ignores extra_data.
+
+    supreme/district/high always emit ``enrichment_hearings`` /
+    ``enrichment_timeline`` keys, so an empty parse still has a TRUTHY
+    ``extra_data``. The old ``core or extra or entities`` guard therefore passed
+    a not-found page on three of the four courts — marking the case enriched and
+    dropping its parties. This test pins that distinction so the weaker guard
+    cannot come back.
+    """
+    parser, _, missing = _TIERS[tier]
+    parsed = parser(_html(missing))
+    old_guard_would_apply = bool(parsed.core_fields or parsed.extra_data or parsed.entities)
+    assert parsed.identifies_a_case() is False
+    if tier != "special":
+        assert old_guard_would_apply is True, "fixture no longer exercises the regression"
+
+
+class TestSupremeTwoStage:
+    """Searching Supreme by case number returns a result LIST, not the detail page."""
+
+    def test_search_result_yields_a_detail_link(self):
+        href = supreme.parse_search_result_link(_html("supreme_search_found.html"))
+        assert href and "caseno=" in href and "mode=view" in href
+
+    def test_no_records_found_yields_no_link(self):
+        assert supreme.parse_search_result_link(_html("supreme_search_missing.html")) is None
+
+    def test_follows_the_row_that_matches_the_docket_not_the_first(self):
+        """Row selection keys on the docket cell, not document order.
+
+        The result list is N-row capable — each href carries its own ``num=``
+        ordinal. Taking row 1 blind would enrich the requested case with a
+        DIFFERENT docket's parties and verdict, which no error would surface.
+        """
+        html = _html("supreme_search_multi.html")
+        first = supreme.parse_search_result_link(html, "081-WO-0081")
+        second = supreme.parse_search_result_link(html, "081-WO-0001")
+        assert "caseno=307125" in first
+        assert "caseno=305697" in second
+
+    def test_a_list_without_our_docket_is_a_miss(self):
+        # The portal answering with rows that are all other cases means it does
+        # not have ours — not "take whatever is on top".
+        assert supreme.parse_search_result_link(
+            _html("supreme_search_multi.html"), "081-WO-9999"
+        ) is None
+
+    def test_a_page_that_is_not_a_result_list_raises(self):
+        """A WAF challenge / maintenance page must not read as "no such docket".
+
+        Both arrive as HTTP 200. If they were conflated, one soft block would
+        write a whole sweep budget's worth of false absences into RegisterProbe
+        and report a clean run. The detail page stands in for any non-list 200:
+        it carries no record count.
+        """
+        with pytest.raises(UnexpectedPage):
+            supreme.parse_search_result_link(_html("supreme_detail_found.html"))
+        with pytest.raises(UnexpectedPage):
+            supreme.parse_search_result_link("<html><body>blocked</body></html>")
+
+    def test_parsing_the_search_list_as_a_detail_page_finds_nothing(self):
+        # The pre-fix behaviour: stage 1's output is not a detail page, so the
+        # enrichment came back empty for every Supreme case.
+        parsed = supreme.parse_supreme_detail(_html("supreme_search_found.html"))
+        assert parsed.identifies_a_case() is False
+
+    def test_crawl_detail_follows_the_link_and_parses(self):
+        calls = []
+
+        def fake_fetch(url, data=None):
+            calls.append(url)
+            return _html("supreme_search_found.html") if data else _html("supreme_detail_found.html")
+
+        parsed = REGISTRY["supreme"].crawl_detail(fake_fetch, "supreme", "081-WO-0001")
+        assert len(calls) == 2, "must search, then follow the result link"
+        assert parsed is not None and parsed.identifies_a_case()
+        assert parsed.core_fields.get("registration_date_bs") == "2081-04-03"
+
+    def test_crawl_detail_stops_at_stage_one_when_nothing_matches(self):
+        calls = []
+
+        def fake_fetch(url, data=None):
+            calls.append(url)
+            return _html("supreme_search_missing.html")
+
+        assert REGISTRY["supreme"].crawl_detail(fake_fetch, "supreme", "081-WO-99999") is None
+        assert len(calls) == 1, "a 0-record search must not fetch a detail page"


### PR DESCRIPTION
Two bugs in the enrichment path, each hiding the other. Both are live in prod today on the `ngm-court-scrape` cron.

## 1. Supreme enrichment has never worked

`_Supreme.crawl_detail` posted a `regno` search and handed the **result list** to `parse_supreme_detail`, which finds nothing in it. The tell is unambiguous — `hearing_count` is written only by enrichment, and Supreme has **0 of 103,839** populated.

Stage 2 now follows the result row's `…&mode=view&caseno=<id>` link. The row is **matched to the docket we asked for** rather than taken in document order: the list is N-row capable (each href carries its own `num=` ordinal), and following the wrong row would write another case's parties and verdict onto ours.

## 2. Not-found pages passed the empty-parse guard

`apply_enrichment` guarded on `core_fields or extra_data or entities`. The supreme/district/high parsers **always** emit their `enrichment_hearings`/`enrichment_timeline` keys, so `extra_data` is truthy even for a page that identified nothing — the guard passed on three of the four courts. The write then went ahead: `status` flipped to `"enriched"` and `_replace_entities` deleted every party row.

The test is now `core_fields`/`entities` only (`ParsedEnrichment.identifies_a_case`), pinned by captured found **and** not-found fixtures from all four portals. `test_extra_data_alone_would_have_passed_a_not_found_page` asserts the old guard *would* have passed, so the weaker form cannot come back.

## The rows already stranded

`crawl._enrich_pending` excludes `status="enriched"`, so fixing the parser cannot reach what the bug already marked. Verified read-only against prod:

| | |
|---|---|
| supreme cases, all `status='enriched'` | 103,839 |
| …holding an empty `enrichment_hearings` | 714 |
| …with no enrichment columns at all | **626** |

That last set grows every cron tick. `manage.py repair_enrichment --court supreme` re-runs the now-correct enrichment over exactly those rows. Dry-run by default; nothing is reset first, so a case the portal still can't enrich is left as it was rather than downgraded.

**This PR does not run it.** It needs an explicit go-ahead and should run as a Job, not `kubectl exec` — a keel rollout SIGKILLs exec'd processes mid-run.

## Also

- A response with no `Total N Records Found` marker now raises `UnexpectedPage` instead of posing as "no such docket". Both arrive as HTTP 200 (the portal sits behind an F5 front end that serves challenges that way), and conflating them makes a soft block indistinguishable from a court that genuinely has no such case.
- `apply_enrichment`'s `@transaction.atomic(using=NGM_DB)` decorator bound to that one alias at import time, leaving the save and `_replace_entities`' delete-then-recreate untransacted on any other alias. Now opened on `using`.

## Testing

27 new tests. Fixtures are real captured responses (found + not-found for all four tiers); `supreme_search_multi.html` splices two real rows into one real page, since the portal's `regno` search is exact-match today and a genuine multi-row response can't be captured by case number — the header comment says so. Party names are replaced with the same placeholders the other courts tests use.

`courts`: 344 passed. Full suite green except the pre-existing `integration-tests/` errors (need a live service). `ruff check` clean.