### PR TITLE
feat(courts): sweep a single register series, and probe further on demand

### DIFF
--- a/courts/job_handlers.py
+++ b/courts/job_handlers.py
@@ -15,6 +15,7 @@ from courts.scraper import registry
 from courts.scraper.base import anchor
 from courts.scraper.crawl import run_crawl
 from courts.scraper.fetch import Fetcher
+from courts.scraper.registers import DEFAULT_TAIL_PROBE
 from courts.scraper.sweep import DEFAULT_BUDGET, DEFAULT_DELAY, run_sweep
 
 
@@ -37,7 +38,7 @@ def handle_court_scrape(payload, on_stage=None, fetch=None) -> dict:
     supreme), ``court_id`` (optional leaf court to restrict to — the enqueuer
     posts one job per leaf court), ``lookback_days``, ``limit_dates``, ``enrich``,
     ``today``, and for the register sweep ``sweep``, ``causelist``, ``sweep_budget``,
-    ``sweep_delay``. Returns aggregate + per-court stats (also stored as
+    ``sweep_delay``, ``sweep_series``, ``sweep_tail``. Returns aggregate + per-court stats (also stored as
     ``job.result``). Raises ``BadCourtScrapePayload`` on a missing/unknown court or
     malformed ``today`` (non-retryable); propagates fetch/parse/DB errors (retryable).
 
@@ -66,11 +67,19 @@ def handle_court_scrape(payload, on_stage=None, fetch=None) -> dict:
     # rides the existing queue/lease/cron rather than adding a parallel pipeline.
     causelist = payload.get("causelist", True)
     sweep = bool(payload.get("sweep"))
-    sweep_budget = int(payload.get("sweep_budget") or DEFAULT_BUDGET)
+    # `or DEFAULT` would swallow an explicit 0 — and 0 is meaningful for both of
+    # these (probe nothing / no tail), so absence has to be tested for directly.
+    sweep_budget = payload.get("sweep_budget")
+    sweep_budget = DEFAULT_BUDGET if sweep_budget is None else int(sweep_budget)
     # Politeness delay between probes. Overridable so a test isn't forced to spend
     # real seconds sleeping, and so a court that tolerates more can be tuned.
     sweep_delay = payload.get("sweep_delay")
     sweep_delay = DEFAULT_DELAY if sweep_delay is None else float(sweep_delay)
+    # Narrow the walk to named registers, and let a one-off backfill probe further
+    # past each high-water mark than the recurring default can afford.
+    sweep_series = payload.get("sweep_series") or None
+    sweep_tail = payload.get("sweep_tail")
+    sweep_tail = DEFAULT_TAIL_PROBE if sweep_tail is None else int(sweep_tail)
 
     # Heartbeat the job lease per crawled date so a long single-court crawl does
     # not outlive its lease and get reaped mid-run.
@@ -132,6 +141,8 @@ def handle_court_scrape(payload, on_stage=None, fetch=None) -> dict:
                     court_id=cid,
                     budget=remaining,
                     delay=sweep_delay,
+                    tail_probe=sweep_tail,
+                    series=sweep_series,
                     write=True,
                     on_progress=(
                         (lambda c, n: on_stage(f"sweep {c} {n}"))

--- a/courts/management/commands/enqueue_scrape.py
+++ b/courts/management/commands/enqueue_scrape.py
@@ -15,6 +15,7 @@ crawls of one court.
     manage.py enqueue_scrape --court special --lookback-days 30 --enrich
     manage.py enqueue_scrape --court special --sweep --sweep-budget 200
     manage.py enqueue_scrape --court all --sweep --sweep-courts 4 --sweep-budget 150
+    manage.py enqueue_scrape --court special --sweep --sweep-series CR --sweep-tail 100
 """
 
 from django.core.management.base import BaseCommand, CommandError
@@ -76,6 +77,16 @@ class Command(BaseCommand):
         parser.add_argument("--sweep-budget", type=int, default=None,
                             help="max probes per court per run "
                                  "(default: courts.scraper.sweep.DEFAULT_BUDGET)")
+        parser.add_argument("--sweep-series", default=None,
+                            help="restrict the sweep to named registers, comma separated "
+                                 "(e.g. CR). Series differ sharply in value and cost — on "
+                                 "the special court CR is 72 holes of corruption cases, OA "
+                                 "is 575 mostly-procedural ones")
+        parser.add_argument("--sweep-tail", type=int, default=None,
+                            help="probe this far past each register's high-water mark "
+                                 "(default: courts.scraper.registers.DEFAULT_TAIL_PROBE). "
+                                 "Raise it for a one-off backfill; the default is sized for "
+                                 "a recurring run across thousands of registers")
         parser.add_argument("--sweep-courts", type=int, default=None,
                             help="sweep only the N least-recently-swept courts, so a "
                                  "recurring run rotates through the fleet on a bounded "
@@ -114,7 +125,16 @@ class Command(BaseCommand):
                 payload.update({"sweep": True, "causelist": False})
                 if o["sweep_budget"] is not None:
                     payload["sweep_budget"] = o["sweep_budget"]
-                suffix = ":sweep"
+                if o["sweep_tail"] is not None:
+                    payload["sweep_tail"] = o["sweep_tail"]
+                if o["sweep_series"]:
+                    series = [x.strip().upper() for x in o["sweep_series"].split(",") if x.strip()]
+                    payload["sweep_series"] = series
+                    # Its own dedup namespace: a CR sweep must not be deduped away
+                    # by an in-flight all-series one, or vice versa.
+                    suffix = ":sweep:" + "+".join(series)
+                else:
+                    suffix = ":sweep"
             job = jobs_queue.enqueue(
                 kind="court_scrape",
                 payload=payload,

--- a/courts/scraper/registers.py
+++ b/courts/scraper/registers.py
@@ -24,18 +24,28 @@ from __future__ import annotations
 
 import re
 from collections import Counter, defaultdict
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 
 NGM_DB = "ngm"
 
 #: How far past the highest held slot to probe for a truncated register tail.
 #: Sequence density only finds *interior* holes — if a register's last N numbers
-#: were never listed, the register simply looks shorter than it is. The bound has
-#: to clear the longest run of genuinely-consecutive missing slots, or the probe
-#: stops inside a real run and declares the register finished early. The longest
-#: run observed in the special court is 9 (``082-CR-0162..0170``), so 25 leaves
-#: real headroom. Raise it, don't lower it.
+#: were never listed, the register simply looks shorter than it is, and no amount
+#: of DB analysis can see that. The bound has to clear the longest run of
+#: genuinely-consecutive missing slots or the probe stops inside a real run and
+#: declares the register finished early.
+#:
+#: 25 does NOT clear the worst run in the live mirror. ``078-OA-0005..0072`` is a
+#: **68-slot** consecutive run and every one of the six probed is a real case, so a
+#: register truncated by a run of that shape stays invisible at this setting. It is
+#: kept as the recurring default because the cost is per-register (``tail_probe`` ×
+#: 8,347 registers fleet-wide) and unbounded tail probing would spend an entire
+#: cron budget on closed registers that cannot grow. One-off backfills should raise
+#: it explicitly — ``--sweep-tail`` exists for exactly that.
+#:
+#: (An earlier note here claimed the longest observed run was 9. That was measured
+#: across ``-CR-`` only; the ``-OA-`` registers are far gappier.)
 DEFAULT_TAIL_PROBE = 25
 
 #: ``<3-digit BS year>-<series>-<sequence>``. The series is ``[A-Z0-9]+`` because
@@ -84,7 +94,10 @@ def format_case_number(key: RegisterKey, seq: int, pad: int) -> str:
 
 
 def compute_gaps(
-    case_numbers: Iterable[str], *, tail_probe: int = DEFAULT_TAIL_PROBE
+    case_numbers: Iterable[str],
+    *,
+    tail_probe: int = DEFAULT_TAIL_PROBE,
+    series: Collection[str] | None = None,
 ) -> list[str]:
     """The docket numbers a set of held case numbers implies but does not contain.
 
@@ -102,15 +115,24 @@ def compute_gaps(
        only part of a register that is never final
     3. sequence ascending, for determinism
 
+    ``series`` restricts the walk to named registers (``{"CR"}``). A court's series
+    are not equal in value or in cost: on the special court the 72 ``-CR-`` holes are
+    corruption prosecutions, while the 575 ``-OA-`` holes are mostly procedural
+    filings (वारेस अनुमति निवेदन and the like) or numbers the court never issued.
+    Sweeping one without the other is what keeps a targeted backfill to minutes.
+
     Unparseable/legacy numbers are ignored rather than raising — a court whose
     whole register predates the modern scheme simply yields no candidates.
     """
+    wanted = {s.upper() for s in series} if series else None
     seqs: dict[RegisterKey, set[int]] = defaultdict(set)
     pads: dict[RegisterKey, Counter] = defaultdict(Counter)
 
     for raw in case_numbers:
         parsed = parse_case_number(raw)
         if parsed is None:
+            continue
+        if wanted is not None and parsed.key.series not in wanted:
             continue
         seqs[parsed.key].add(parsed.seq)
         pads[parsed.key][parsed.pad] += 1
@@ -190,7 +212,13 @@ def held_with_dates(court_id: str, *, using: str = NGM_DB) -> list[tuple[str, st
 
 
 def register_gaps(
-    court_id: str, *, using: str = NGM_DB, tail_probe: int = DEFAULT_TAIL_PROBE
+    court_id: str,
+    *,
+    using: str = NGM_DB,
+    tail_probe: int = DEFAULT_TAIL_PROBE,
+    series: Collection[str] | None = None,
 ) -> list[str]:
     """:func:`compute_gaps` over everything the mirror holds for one court."""
-    return compute_gaps(held_case_numbers(court_id, using=using), tail_probe=tail_probe)
+    return compute_gaps(
+        held_case_numbers(court_id, using=using), tail_probe=tail_probe, series=series
+    )

--- a/courts/scraper/sweep.py
+++ b/courts/scraper/sweep.py
@@ -145,6 +145,7 @@ def run_sweep(
     budget: int = DEFAULT_BUDGET,
     delay: float = DEFAULT_DELAY,
     tail_probe: int = DEFAULT_TAIL_PROBE,
+    series=None,
     write: bool = False,
     using: str = NGM_DB,
     on_progress=None,
@@ -154,7 +155,9 @@ def run_sweep(
 
     ``write=False`` (the default) probes and reports without touching the DB —
     the dry run. ``spec`` is a registry entry; a tier without ``crawl_detail``
-    cannot be swept and returns empty stats.
+    cannot be swept and returns empty stats. ``series`` narrows the walk to named
+    registers, which is how a targeted backfill stays proportionate: sweeping the
+    special court's ``CR`` alone is 72 probes, against 647 for every series.
     """
     stats = SweepStats(court_id=court_id)
     crawl_detail = getattr(spec, "crawl_detail", None)
@@ -164,7 +167,9 @@ def run_sweep(
     if budget <= 0:
         return stats
 
-    candidates = register_gaps(court_id, using=using, tail_probe=tail_probe)
+    candidates = register_gaps(
+        court_id, using=using, tail_probe=tail_probe, series=series
+    )
     if write:
         candidates = _prioritise(candidates, court_id, using=using)
     if not candidates:

--- a/courts/tests/test_job_scrape.py
+++ b/courts/tests/test_job_scrape.py
@@ -274,6 +274,35 @@ class SweepJobWiringTests(_NgmTestCase):
         with self.assertRaises(CommandError):
             call_command("enqueue_scrape", "--court", "high", "--sweep-courts", "3")
 
+    def test_series_filter_reaches_the_sweep(self):
+        """CR-only is the difference between a 4-minute backfill and an hour."""
+        from courts.job_handlers import handle_court_scrape
+
+        for series in ("CR", "OA"):
+            for seq in (1, 5):
+                CourtCase.objects.using("ngm").create(
+                    court_id="special", case_number=f"076-{series}-{seq:04d}"
+                )
+        result = handle_court_scrape(
+            {**self._SWEEP_PAYLOAD, "sweep_series": ["CR"], "sweep_tail": 0,
+             "sweep_budget": 50},
+            fetch=_fake_fetch,
+        )
+        # 3 interior holes in CR; OA's 3 are left alone. sweep_tail=0 must be
+        # honoured as zero rather than read as "unset" and defaulted.
+        self.assertEqual(result["swept"], 3)
+
+    def test_enqueue_sets_series_and_tail_and_dedups_them_apart(self):
+        call_command("enqueue_scrape", "--court", "special", "--sweep",
+                     "--sweep-series", "cr", "--sweep-tail", "100")
+        job = Job.objects.get(dedup_key="court_scrape:special:special:sweep:CR")
+        self.assertEqual(job.payload["sweep_series"], ["CR"])
+        self.assertEqual(job.payload["sweep_tail"], 100)
+
+        # An all-series sweep must not be deduped away by the CR one.
+        call_command("enqueue_scrape", "--court", "special", "--sweep")
+        self.assertTrue(Job.objects.filter(dedup_key="court_scrape:special:special:sweep").exists())
+
     def test_the_budget_is_shared_across_courts_not_granted_to_each(self):
         """A tier payload with no ``court_id`` sweeps every leaf court under ONE
         job. Per-court budgets would multiply by 77 for district and overrun the

--- a/courts/tests/test_scraper_registers.py
+++ b/courts/tests/test_scraper_registers.py
@@ -171,3 +171,42 @@ class TestProbePriority:
     def test_duplicate_held_numbers_are_harmless(self):
         held = _numbers("076", "CR", [1, 1, 1, 3])
         assert compute_gaps(held, tail_probe=0) == ["076-CR-0002"]
+
+
+class TestSeriesFilter:
+    """A court's series are not equal in value or cost.
+
+    On the special court the 72 ``-CR-`` holes are corruption prosecutions; the
+    575 ``-OA-`` holes are mostly procedural filings or numbers never issued.
+    Sweeping one without the other is the difference between 4 minutes and an hour.
+    """
+
+    def test_restricts_the_walk_to_named_registers(self):
+        held = _numbers("076", "CR", [1, 3]) + _numbers("076", "OA", [1, 3])
+        assert compute_gaps(held, tail_probe=0, series={"CR"}) == ["076-CR-0002"]
+
+    def test_accepts_several_series(self):
+        held = _numbers("076", "CR", [1, 3]) + _numbers("076", "OA", [1, 3]) + _numbers("076", "WO", [1, 3])
+        gaps = compute_gaps(held, tail_probe=0, series={"CR", "OA"})
+        assert sorted(gaps) == ["076-CR-0002", "076-OA-0002"]
+
+    def test_is_case_insensitive(self):
+        held = _numbers("076", "CR", [1, 3])
+        assert compute_gaps(held, tail_probe=0, series={"cr"}) == ["076-CR-0002"]
+
+    def test_no_filter_means_every_series(self):
+        held = _numbers("076", "CR", [1, 3]) + _numbers("076", "OA", [1, 3])
+        assert len(compute_gaps(held, tail_probe=0)) == 2
+
+    def test_an_unknown_series_yields_nothing_rather_than_everything(self):
+        # A typo must not silently sweep the whole court.
+        held = _numbers("076", "CR", [1, 3])
+        assert compute_gaps(held, tail_probe=0, series={"NOPE"}) == []
+
+    def test_the_excluded_series_neither_leaks_nor_shifts_the_pad(self):
+        # Each register keeps its own pad width; filtering must not borrow the
+        # other series' width, and must not emit any of its numbers.
+        held = ["076-CR-0001", "076-CR-0003", "076-C1-10001", "076-C1-10003"]
+        gaps = compute_gaps(held, tail_probe=0, series={"C1"})
+        assert "076-C1-10002" in gaps
+        assert not [g for g in gaps if g.startswith("076-CR")]


### PR DESCRIPTION
Needed to close the special-court discrepancy proportionately.

## Why

A court's series are not equal in value or in cost. Probing all **647** of the special court's register holes takes ~70 min; the **72** that are `-CR-` take **4**.

I sampled the holes against the live portal before deciding:

| gaps sampled | on portal | what they are |
|---|---|---|
| `082-CR` × 3 | **3/3** | हिनामिना, सरकारी जग्गा व्यक्तिका नाममा दर्ता — corruption prosecutions |
| `078-OA` × 6 | **6/6** | वारेस अनुमति निवेदन, उपस्थित हुने निवेदन — procedural filings |
| `080-OA` × 3 | 0/3 | never issued |
| `069-OA` × 2 | 1/2 | mixed |

The `082-CR` holes are exactly the FY2082/83 shortfall the published filing counts rest on (we hold 142; the register runs to 179). The `-OA-` holes are procedural or never-issued — an hour of crawling and several hundred new rows to fix a number nobody quotes.

`--sweep-series CR` narrows the walk. `--sweep-tail` raises the per-register tail probe for a one-off backfill without changing the recurring default. Series-scoped sweeps get their own dedup namespace so a CR run isn't deduped away by an in-flight all-series one.

## Two corrections from measuring rather than assuming

**`DEFAULT_TAIL_PROBE`'s rationale was wrong.** I documented it as safe because "the longest consecutive run of missing slots is 9" — that was measured across `-CR-` only. **`078-OA-0005..0072` is a 68-slot run**, and all six I probed are real cases. So 25 does *not* clear the worst observed shape. The default stays (its cost is per-register across 8,347 registers fleet-wide, and unbounded tail probing would spend a whole cron budget on closed registers), but the comment now states what it does and doesn't cover, and `--sweep-tail` exists so a targeted run isn't stuck with it.

**A falsy-zero bug, caught by a test.** `payload.get("sweep_budget") or DEFAULT_BUDGET` swallows an explicit `0`, and the same pattern was about to ship for `sweep_tail`. Zero is meaningful for both — probe nothing, no tail. The test asked for tail 0, got 25, and swept 28 candidates instead of 3.

## Testing

429 courts tests (was 421), `ruff check` clean, local sqlite only.

Migration 0007 is applied in prod; `register_completeness` confirms special at **95.15% dense, 647 holes, seq% 100**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted court register sweeps by case series.
  * Added configurable sweep tail probing, including support for zero values.
  * Added command options for selecting sweep series and tail settings.
  * Improved sweep deduplication so filtered and unfiltered sweeps can coexist.

* **Tests**
  * Added coverage for series filtering, normalization, unknown series, and tail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->