### PR TITLE
fix(events,llm): the confirmed defects from the case-enrichment code review

### DIFF
--- a/case_events/bus.py
+++ b/case_events/bus.py
@@ -69,6 +69,7 @@ class _Bus:
         self._js = None
         self._pid: int | None = None
         self._last_failure_at: float = 0.0
+        self._starting = False
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -78,9 +79,27 @@ class _Bus:
         self._nc = None
         self._js = None
         self._pid = None
+        # Must be cleared too: a child that inherited _starting=True from a
+        # parent mid-connect would consider a start permanently in progress and
+        # never connect again.
+        self._starting = False
 
     def _ensure_started(self) -> bool:
-        """Start the loop thread and connect if needed. False if unavailable."""
+        """Start the loop thread and connect if needed. False if unavailable.
+
+        At most ONE thread ever performs the connect, and it does so **without
+        holding the lock**. Everyone else returns False immediately rather than
+        queueing behind it.
+
+        That distinction is the whole point. The connect can take the full
+        :data:`STARTUP_TIMEOUT_SECONDS`, and on a dead broker it always does:
+        ``_connect`` passes ``max_reconnect_attempts=-1``, and nats-py treats a
+        negative value as "never stop retrying" for the *initial* connect too
+        (``nats/aio/client.py``), so it never fails fast. Holding the lock across
+        that made one dead broker stall every publishing thread in the process
+        for 5 seconds at a time — precisely the behaviour this module's docstring
+        promises does not happen.
+        """
         with self._lock:
             # A forked child inherits this object's state but NOT the parent's
             # threads, so the loop it points at is gone. Under gunicorn the fork
@@ -93,36 +112,62 @@ class _Bus:
             if self._js is not None:
                 return True
 
+            if self._starting:
+                # Someone else is already paying the connect cost.
+                logger.debug("case_events.connect_in_progress")
+                return False
+
             if time.monotonic() - self._last_failure_at < CONNECT_RETRY_SECONDS:
+                # Logged, because this window used to swallow every publish for
+                # 30 seconds with no output at all — a broker blip looked
+                # identical to a healthy bus with nothing to say.
+                logger.debug("case_events.connect_suppressed", subject_hint="retry window")
                 return False
 
-            try:
-                self._start_locked()
-                return True
-            except Exception as exc:  # noqa: BLE001 - never propagate to a write path
+            self._starting = True
+
+        try:
+            started = self._start()
+        except Exception as exc:  # noqa: BLE001 - never propagate to a write path
+            with self._lock:
                 self._last_failure_at = time.monotonic()
-                self._reset_locked()
-                logger.warning("case_events.connect_failed", error=str(exc))
-                return False
+                self._starting = False
+            # str(TimeoutError()) is "", which made the one line explaining an
+            # outage read `connect_failed error=`. The type is the useful part.
+            logger.warning(
+                "case_events.connect_failed",
+                error=str(exc) or type(exc).__name__,
+                error_type=type(exc).__name__,
+            )
+            return False
 
-    def _start_locked(self):
+        with self._lock:
+            self._loop, self._thread, self._nc, self._js = started
+            self._pid = os.getpid()
+            # Clear the fail-fast window: it is a backoff against a broker that
+            # was down, and this one demonstrably is not.
+            self._last_failure_at = 0.0
+            self._starting = False
+        logger.info("case_events.connected", url=_redact(settings.NATS_URL))
+        return True
+
+    def _start(self):
+        """Connect, returning the new state. Blocking; mutates nothing on self."""
         loop = asyncio.new_event_loop()
-        thread = threading.Thread(
-            target=loop.run_forever, name="events-bus", daemon=True
-        )
+        thread = threading.Thread(target=loop.run_forever, name="events-bus", daemon=True)
         thread.start()
 
         future = asyncio.run_coroutine_threadsafe(self._connect(), loop)
         try:
-            self._nc, self._js = future.result(timeout=STARTUP_TIMEOUT_SECONDS)
+            nc, js = future.result(timeout=STARTUP_TIMEOUT_SECONDS)
         except Exception:
+            # Cancel before stopping the loop, or the abandoned _connect task is
+            # destroyed while pending and nats-py logs it as an error.
+            future.cancel()
             loop.call_soon_threadsafe(loop.stop)
             raise
 
-        self._loop = loop
-        self._thread = thread
-        self._pid = os.getpid()
-        logger.info("case_events.connected", url=_redact(settings.NATS_URL))
+        return loop, thread, nc, js
 
     async def _connect(self):
         import nats

--- a/case_events/tests/test_bus.py
+++ b/case_events/tests/test_bus.py
@@ -7,6 +7,8 @@ even try.
 """
 
 import json
+import threading
+import time
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -44,11 +46,32 @@ class TestEnvelope:
         )
         assert env["occurred_at"] == "2026-07-30T12:00:00Z"
 
-    def test_occurred_at_defaults_to_now_but_is_distinct_from_published_at(self):
-        # Both default to "now", but they are separate fields because a producer
-        # that knows the real fact time must be able to set one without the other.
-        env = build_envelope(subject="s", payload={}, producer="p")
-        assert "occurred_at" in env and "published_at" in env
+    def test_occurred_at_and_published_at_are_independent(self):
+        """The gap between them is the producer-lag figure.
+
+        Asserting only that both keys exist could not see ``published_at`` being
+        derived from ``occurred_at`` — which collapses the two for any producer
+        that knows its real fact time, destroying the number entirely.
+        """
+        past = datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        env = build_envelope(subject="s", payload={}, producer="p", occurred_at=past)
+        assert env["occurred_at"] == "2020-01-02T03:04:05Z"
+        assert env["published_at"] != env["occurred_at"]
+        assert env["published_at"] > "2024", "published_at must be now, not the fact time"
+
+    def test_provenance_fields_are_carried_through(self):
+        env = build_envelope(
+            subject="s",
+            payload={},
+            producer="consumer:matcher",
+            source="https://x.test/doc",
+            raw_ref="r2://bucket/key",
+            dedup_key="k-1",
+        )
+        assert env["producer"] == "consumer:matcher"
+        assert env["source"] == "https://x.test/doc"
+        assert env["raw_ref"] == "r2://bucket/key"
+        assert env["dedup_key"] == "k-1"
 
     def test_subject_refs_default_to_empty_list_not_none(self):
         assert build_envelope(subject="s", payload={}, producer="p")["subject_refs"] == []
@@ -65,11 +88,24 @@ class TestEnvelope:
 
 class TestStreams:
     def test_three_streams_cover_the_three_subject_trees(self):
-        by_name = {s.name: s for s in streams.STREAMS}
-        assert set(by_name) == {"SIGNALS", "CASE_EVENTS", "DLQ"}
-        assert by_name["SIGNALS"].subjects == (subjects.ALL_SIGNALS,)
-        assert by_name["CASE_EVENTS"].subjects == (subjects.ALL_CASE_EVENTS,)
-        assert by_name["DLQ"].subjects == (subjects.ALL_DLQ,)
+        # Asserted as LITERALS, not against the constants they are built from.
+        # Comparing streams.STREAMS to subjects.ALL_* only proves the module
+        # references the constant: changing ALL_CASE_EVENTS to "jaw.>" used to
+        # pass every test here while making the streams overlap, which JetStream
+        # rejects — so every process would have died at startup.
+        by_name = {s.name: s.subjects for s in streams.STREAMS}
+        assert by_name == {
+            "SIGNALS": ("jaw.signal.>",),
+            "CASE_EVENTS": ("jaw.case.>",),
+            "DLQ": ("jaw.dlq.>",),
+        }
+
+    def test_no_two_streams_claim_overlapping_subjects(self):
+        # JetStream refuses to create a stream whose subjects overlap another's.
+        prefixes = [s.subjects[0].rstrip(">") for s in streams.STREAMS]
+        for i, a in enumerate(prefixes):
+            for b in prefixes[i + 1 :]:
+                assert not (a.startswith(b) or b.startswith(a)), f"{a} overlaps {b}"
 
     def test_pilot_is_single_replica(self):
         # R1 is a deliberate pilot trade (node-local disk). If this ever changes
@@ -83,7 +119,46 @@ class TestStreams:
             subjects.CASE_UPDATE_APPROVED,
             subjects.CASE_UPDATE_REJECTED,
         ):
-            assert subject.startswith(subjects.ALL_CASE_EVENTS.rstrip(">"))
+            assert subject.startswith("jaw.case.")
+
+    def test_every_signal_subject_falls_under_the_signals_stream(self):
+        for name in dir(subjects):
+            if name.startswith("SIGNAL_"):
+                assert getattr(subjects, name).startswith("jaw.signal.")
+
+
+class TestEnsureStreams:
+    """What is actually handed to JetStream, not just what the dataclass holds.
+
+    ``test_pilot_is_single_replica`` reads like coverage of the R1 decision but
+    asserts the dataclass field; the value passed to ``add_stream`` is a separate
+    expression, and hardcoding ``num_replicas=3`` there used to survive the whole
+    suite.
+    """
+
+    async def _assert_streams(self):
+        js = mock.AsyncMock()
+        await streams.ensure_streams(js)
+        return [call.args[0] for call in js.add_stream.await_args_list]
+
+    async def test_asserts_every_stream_with_the_configured_values(self):
+        configs = await self._assert_streams()
+        assert [c.name for c in configs] == ["SIGNALS", "CASE_EVENTS", "DLQ"]
+        for config in configs:
+            # File storage: a memory stream silently loses everything on a
+            # broker restart, which for a 1-year retention window is not a
+            # degraded bus but a broken one.
+            assert config.storage == "file", config.name
+            assert config.num_replicas == 1, config.name
+            assert config.max_age == streams.ONE_YEAR_SECONDS, config.name
+
+    async def test_a_client_error_is_not_swallowed(self):
+        # Unlike publishing, this is deliberately NOT best-effort: a consumer
+        # that cannot see its stream should fail loudly at startup.
+        js = mock.AsyncMock()
+        js.add_stream.side_effect = RuntimeError("jetstream unavailable")
+        with pytest.raises(RuntimeError):
+            await streams.ensure_streams(js)
 
     def test_dlq_subject_preserves_the_original(self):
         # A poison message must stay attributable to where it died.
@@ -118,40 +193,149 @@ class TestDisabledByDefault:
 
 
 class TestPublishMechanics:
+    @staticmethod
+    def _publish(envelope, subject="jaw.case.update.approved", wait=False):
+        """Drive _Bus.publish with the loop and JetStream context stubbed out.
+
+        Returns (positional_args, kwargs, return_value) from the js.publish call.
+        The positional args matter as much as the headers — capturing only
+        kwargs left the subject and body unasserted, so publishing everything to
+        a hardcoded wrong subject used to pass.
+        """
+        seen = {}
+
+        def fake_run(coro, loop):
+            coro.close()
+            return mock.Mock()
+
+        with mock.patch.object(bus._bus, "_ensure_started", return_value=True), \
+             mock.patch.object(bus._bus, "_js") as js, \
+             mock.patch.object(bus._bus, "_loop", mock.Mock()), \
+             mock.patch("case_events.bus.asyncio.run_coroutine_threadsafe", side_effect=fake_run):
+            def record(*args, **kwargs):
+                seen["args"], seen["kwargs"] = args, kwargs
+                return mock.Mock()
+
+            js.publish.side_effect = record
+            result = bus._bus.publish(subject, envelope, wait=wait)
+
+        return seen.get("args"), seen.get("kwargs"), result
+
+    @override_settings(NATS_URL="nats://localhost:4222")
+    def test_the_subject_and_body_reach_jetstream(self):
+        env = {"dedup_key": "k", "payload": {"case_slug": "lalita-niwas"}}
+        args, _kwargs, result = self._publish(env, subject="jaw.case.update.approved")
+        assert args[0] == "jaw.case.update.approved"
+        assert json.loads(args[1].decode("utf-8")) == env
+        assert result is True
+
+    @override_settings(NATS_URL="nats://localhost:4222")
+    def test_devanagari_survives_the_wire_encoding(self):
+        env = {"payload": {"title": "अख्तियार दुरुपयोग अनुसन्धान आयोग"}}
+        args, _kwargs, _ = self._publish(env)
+        # ensure_ascii=False, so it is real UTF-8 rather than \u escapes.
+        assert "अख्तियार".encode("utf-8") in args[1]
+
     @override_settings(NATS_URL="nats://localhost:4222")
     def test_dedup_key_becomes_the_nats_msg_id_header(self):
         # This header is what makes JetStream collapse a duplicate publish.
-        captured = {}
-
-        def fake_run(coro, loop):
-            coro.close()
-            return mock.Mock()
-
-        with mock.patch.object(bus._bus, "_ensure_started", return_value=True), \
-             mock.patch.object(bus._bus, "_js") as js, \
-             mock.patch.object(bus._bus, "_loop", mock.Mock()), \
-             mock.patch("case_events.bus.asyncio.run_coroutine_threadsafe", side_effect=fake_run):
-            js.publish.side_effect = lambda *a, **kw: captured.update(kw) or mock.Mock()
-            bus._bus.publish("s", {"dedup_key": "docket:x:hearing:1"})
-
-        assert captured["headers"] == {"Nats-Msg-Id": "docket:x:hearing:1"}
+        _args, kwargs, _ = self._publish({"dedup_key": "docket:x:hearing:1"})
+        assert kwargs["headers"] == {"Nats-Msg-Id": "docket:x:hearing:1"}
 
     @override_settings(NATS_URL="nats://localhost:4222")
     def test_no_header_when_there_is_no_dedup_key(self):
-        captured = {}
+        _args, kwargs, _ = self._publish({"dedup_key": ""})
+        assert kwargs["headers"] is None
 
-        def fake_run(coro, loop):
-            coro.close()
-            return mock.Mock()
+    @override_settings(NATS_URL="nats://localhost:4222")
+    def test_a_fire_and_forget_failure_is_logged(self):
+        """Nothing else observes a wait=False publish.
 
-        with mock.patch.object(bus._bus, "_ensure_started", return_value=True), \
-             mock.patch.object(bus._bus, "_js") as js, \
-             mock.patch.object(bus._bus, "_loop", mock.Mock()), \
-             mock.patch("case_events.bus.asyncio.run_coroutine_threadsafe", side_effect=fake_run):
-            js.publish.side_effect = lambda *a, **kw: captured.update(kw) or mock.Mock()
-            bus._bus.publish("s", {"dedup_key": ""})
+        ``_log_result`` is the only thing standing between a rejected publish and
+        total silence, and it had no test at all — dropping the done-callback
+        entirely used to pass the suite.
+        """
+        failed = mock.Mock()
+        failed.result.side_effect = RuntimeError("nak")
+        with mock.patch.object(bus.logger, "warning") as warn:
+            bus._log_result(failed, "jaw.case.update.approved")
+        assert warn.call_args.kwargs["subject"] == "jaw.case.update.approved"
 
-        assert captured["headers"] is None
+    @override_settings(NATS_URL="nats://localhost:4222")
+    def test_a_successful_fire_and_forget_logs_nothing(self):
+        ok = mock.Mock()
+        ok.result.return_value = None
+        with mock.patch.object(bus.logger, "warning") as warn:
+            bus._log_result(ok, "s")
+        warn.assert_not_called()
+
+
+class TestOnlyOneThreadPaysTheConnectCost:
+    """A dead broker must not stall every publishing thread.
+
+    The connect can take the full STARTUP_TIMEOUT_SECONDS and on a dead broker
+    always does, because ``max_reconnect_attempts=-1`` stops nats-py ever
+    failing the initial connect fast. It used to run while holding the lock, so
+    one outage froze all 8 gthread workers for 5s at a time.
+    """
+
+    def test_a_second_thread_does_not_queue_behind_a_slow_connect(self):
+        b = bus._Bus()
+        connecting = threading.Event()
+        release = threading.Event()
+
+        def slow_start():
+            connecting.set()
+            release.wait(10)
+            raise RuntimeError("no broker")
+
+        with mock.patch.object(b, "_start", side_effect=slow_start):
+            first = threading.Thread(target=b._ensure_started, daemon=True)
+            first.start()
+            assert connecting.wait(5), "the first thread never began connecting"
+
+            began = time.monotonic()
+            assert b._ensure_started() is False
+            elapsed = time.monotonic() - began
+
+            release.set()
+            first.join(10)
+
+        assert elapsed < 0.5, f"second thread blocked for {elapsed:.2f}s behind the connect"
+
+    def test_a_successful_connect_clears_the_retry_window(self):
+        b = bus._Bus()
+        # Outside the window, so the start is attempted.
+        b._last_failure_at = time.monotonic() - bus.CONNECT_RETRY_SECONDS - 1
+        state = (mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock())
+        with mock.patch.object(b, "_start", return_value=state):
+            assert b._ensure_started() is True
+        assert b._last_failure_at == 0.0, "a working broker must not stay backed off"
+
+    def test_a_failed_connect_arms_the_retry_window_and_clears_starting(self):
+        b = bus._Bus()
+        with mock.patch.object(b, "_start", side_effect=RuntimeError("boom")):
+            assert b._ensure_started() is False
+        assert b._last_failure_at > 0
+        assert b._starting is False, "a failed start must not wedge the bus"
+
+    def test_a_timeout_is_logged_with_its_type_not_an_empty_string(self):
+        # str(TimeoutError()) is "", which made the one line explaining an
+        # outage read `connect_failed error=`.
+        b = bus._Bus()
+        with mock.patch.object(b, "_start", side_effect=TimeoutError()):
+            with mock.patch.object(bus.logger, "warning") as warn:
+                assert b._ensure_started() is False
+        kwargs = warn.call_args.kwargs
+        assert kwargs["error_type"] == "TimeoutError"
+        assert kwargs["error"], "the error field must never be empty"
+
+    def test_reset_clears_starting_so_a_forked_child_can_connect(self):
+        b = bus._Bus()
+        b._starting = True
+        with b._lock:
+            b._reset_locked()
+        assert b._starting is False
 
 
 class TestRedaction:

--- a/case_proposals/publish.py
+++ b/case_proposals/publish.py
@@ -48,14 +48,59 @@ def _case_iri(slug: str) -> str:
         return ""
 
 
+def _producer_refs(proposal) -> list[str]:
+    """``proposal.subject_refs``, defensively reduced to a list of non-empty strings.
+
+    ``subject_refs`` is an unvalidated writable ``JSONField``, so it holds
+    whatever a producer posted — including a scalar or a nested list. Iterating
+    it blindly used to raise *inside the caller's transaction* and roll back the
+    case write; see :func:`schedule_decision_event`. Anything unusable is
+    dropped with a warning rather than propagated.
+    """
+    refs = proposal.subject_refs
+    if not refs:
+        return []
+    if not isinstance(refs, (list, tuple)):
+        logger.warning(
+            "case_proposal.subject_refs_not_a_list",
+            proposal_id=proposal.pk,
+            got=type(refs).__name__,
+        )
+        return []
+
+    clean = [ref for ref in refs if isinstance(ref, str) and ref]
+    if len(clean) != len(refs):
+        logger.warning(
+            "case_proposal.subject_refs_partially_dropped",
+            proposal_id=proposal.pk,
+            kept=len(clean),
+            given=len(refs),
+        )
+    return clean
+
+
 def build_decision_envelope(proposal) -> dict:
-    """The envelope for an approve/reject decision on ``proposal``."""
-    subject = _SUBJECT_BY_STATUS[proposal.status]
+    """The envelope for an approve/reject decision on ``proposal``.
+
+    Raises:
+        ValueError: if ``proposal.status`` is not a decision. Callers scheduling
+            an event should go through :func:`schedule_decision_event`, which
+            treats a non-decision as a no-op; reaching here with one is a bug in
+            the caller, not a message to degrade.
+    """
+    try:
+        subject = _SUBJECT_BY_STATUS[proposal.status]
+    except KeyError:
+        raise ValueError(
+            f"Proposal {proposal.pk} has status {proposal.status!r}, which is not a "
+            f"decision. Expected one of {sorted(_SUBJECT_BY_STATUS)}."
+        ) from None
+
     case_iri = _case_iri(proposal.case_slug)
 
     # The case first, then whatever the producer recorded — deduplicated and
     # order-preserving so the join key a consumer needs is at a stable position.
-    refs = [ref for ref in [case_iri, *(proposal.subject_refs or [])] if ref]
+    refs = [ref for ref in [case_iri, *_producer_refs(proposal)] if ref]
 
     return build_envelope(
         subject=subject,
@@ -98,12 +143,39 @@ def schedule_decision_event(proposal) -> None:
     # Snapshot now, publish later: on_commit runs after the transaction, and
     # reading a mutated-or-refetched instance then would risk publishing state
     # that isn't what was decided.
-    envelope = build_decision_envelope(proposal)
+    #
+    # This runs INSIDE the caller's atomic block, so it must not raise. It used
+    # not to be guarded, and that was a real defect rather than a theoretical
+    # one: a proposal created with a non-list `subject_refs` (a writable,
+    # unvalidated JSONField) raised TypeError here, 500'd the approval and rolled
+    # back the case write — with no broker configured at all. The bus is not
+    # allowed to cost us a write, and "the bus" includes describing the write.
+    try:
+        envelope = build_decision_envelope(proposal)
+    except Exception:  # noqa: BLE001 - a describable decision beats a lost write
+        logger.warning(
+            "case_proposal.envelope_failed",
+            proposal_id=proposal.pk,
+            status=proposal.status,
+            exc_info=True,
+        )
+        return
+
     subject = envelope["subject"]
 
     def _run():
         try:
-            bus.publish(subject, envelope)
+            if not bus.publish(subject, envelope):
+                # publish() returns False for a disabled bus (expected) and for a
+                # dropped message (not). Logged either way: a decision that never
+                # reached the case-domain log is exactly what a later audit would
+                # need to know about, and it is otherwise silent.
+                logger.info(
+                    "case_proposal.decision_not_published",
+                    subject=subject,
+                    proposal_id=envelope["payload"]["proposal_id"],
+                    bus_enabled=bus.enabled(),
+                )
         except Exception:  # noqa: BLE001 - the bus is never allowed to be fatal
             logger.warning(
                 "case_proposal.publish_failed",

--- a/case_proposals/serializers.py
+++ b/case_proposals/serializers.py
@@ -70,6 +70,48 @@ class CaseUpdateProposalSerializer(serializers.ModelSerializer):
     def validate_intent(self, value):
         return validate_intent_shape(value)
 
+    def validate_subject_refs(self, value):
+        """Reject anything that is not a list of non-empty strings.
+
+        ``subject_refs`` is a bare ``JSONField``, so without this it accepts a
+        scalar, a dict, or a nested list. That is not merely untidy: these are
+        ``@id`` IRIs used as the join key between a bus message and our records,
+        and a malformed value used to break the approve/reject path outright.
+
+        Enforced here rather than only at publish time because a proposal is
+        effectively unfixable once created — the viewset exposes no update, and
+        ``dedup_key`` is unique, so the same fact cannot simply be re-filed.
+        """
+        if not isinstance(value, list):
+            raise serializers.ValidationError(
+                f"subject_refs must be a list of @id IRIs, got {type(value).__name__}."
+            )
+        bad = [ref for ref in value if not isinstance(ref, str) or not ref.strip()]
+        if bad:
+            raise serializers.ValidationError(
+                f"subject_refs must contain only non-empty strings; got {bad!r}."
+            )
+        return value
+
+    def validate_case_slug(self, value):
+        """Require a slug the canonical ``@id`` grammar accepts.
+
+        ``case_slug`` is a ``SlugField``, which permits underscores and a leading
+        digit; ``build_case_iri`` does not. A proposal whose slug passes the field
+        but fails the IRI builder publishes its decision with an EMPTY
+        ``subject_refs`` — a message with no join key — and the reject path never
+        notices, because it never resolves the Case at all.
+        """
+        from jawafdehi_shared.entities.ids import build_case_iri
+
+        try:
+            build_case_iri(value)
+        except Exception as exc:
+            raise serializers.ValidationError(
+                f"case_slug {value!r} is not a valid case @id segment: {exc}"
+            ) from None
+        return value
+
 
 class ProposalDecisionSerializer(serializers.Serializer):
     """Request body for approve/reject: an optional review note."""

--- a/case_proposals/tests/test_publish.py
+++ b/case_proposals/tests/test_publish.py
@@ -185,3 +185,145 @@ class TestApprovalIsIndependentOfTheBroker:
 
         assert r.status_code == 409
         publish.assert_not_called()
+
+    @override_settings(NATS_URL="nats://localhost:4222")
+    def test_the_publish_is_deferred_until_after_commit(
+        self, django_capture_on_commit_callbacks
+    ):
+        """Nothing may be announced while the transaction can still roll back.
+
+        Without this, replacing ``transaction.on_commit(_run)`` with a plain
+        ``_run()`` passes the whole suite — the deferral is the documented point
+        of the design and was previously pinned by nothing. ``execute=False``
+        captures the callbacks without running them, so the request completes
+        with the publish still pending.
+        """
+        make_case()
+        p = make_proposal()
+        with mock.patch("case_events.bus.publish") as publish:
+            with django_capture_on_commit_callbacks(execute=False) as callbacks:
+                r = caseworker_client().post(f"{LIST_URL}{p.id}/approve/", {}, format="json")
+
+            assert r.status_code == 200
+            publish.assert_not_called()  # still inside the transaction's lifetime
+
+            for callback in callbacks:
+                callback()
+            publish.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestMalformedSubjectRefsCannotCostUsTheWrite:
+    """A producer-supplied field must never be able to roll back a case write.
+
+    ``subject_refs`` is a writable, historically unvalidated ``JSONField``. A
+    non-list value used to raise ``TypeError`` inside ``build_decision_envelope``
+    — which runs *inside* the caller's ``transaction.atomic()`` — so the
+    approval 500'd and the timeline write was rolled back, with no broker
+    configured at all. These rows can still exist from before the serializer
+    validated the field, so the publisher stays defensive too.
+    """
+
+    @override_settings(NATS_URL="")
+    @pytest.mark.parametrize(
+        "refs", [5, "a-string", {"a": 1}, [["nested"]], [None], [""], ["ok", 7]]
+    )
+    def test_approval_survives_any_shape(self, django_capture_on_commit_callbacks, refs):
+        make_case()
+        p = make_proposal()
+        # Bypass the serializer the way a pre-validation row would have.
+        CaseUpdateProposal.objects.filter(pk=p.pk).update(subject_refs=refs)
+        p.refresh_from_db()
+
+        with django_capture_on_commit_callbacks(execute=True):
+            r = caseworker_client().post(f"{LIST_URL}{p.id}/approve/", {}, format="json")
+
+        assert r.status_code == 200, f"{refs!r} broke the approval"
+        p.refresh_from_db()
+        assert p.status == ProposalStatus.APPROVED
+        # The write that actually matters really did land.
+        assert len(Case.objects.get(slug="lalita-niwas-land-scam").timeline) == 1
+
+    def test_unusable_refs_are_dropped_not_published(self):
+        p = make_proposal(status=ProposalStatus.APPROVED, subject_refs=["ok-ref", 7, None, ""])
+        refs = build_decision_envelope(p)["subject_refs"]
+        assert refs == ["https://jawafdehi.org/case/lalita-niwas-land-scam", "ok-ref"]
+
+    @override_settings(NATS_URL="")
+    def test_an_envelope_that_blows_up_entirely_still_leaves_the_write(
+        self, django_capture_on_commit_callbacks
+    ):
+        """Pins the try/except independently of the ref sanitising.
+
+        The sanitiser and the guard are two layers, so a shape-based test passes
+        with either one alone. This removes the sanitiser from the picture by
+        making envelope construction fail outright, which is the only thing that
+        fails if the guard is dropped.
+        """
+        make_case()
+        p = make_proposal()
+        with mock.patch(
+            "case_proposals.publish.build_decision_envelope",
+            side_effect=RuntimeError("envelope exploded"),
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                r = caseworker_client().post(f"{LIST_URL}{p.id}/approve/", {}, format="json")
+
+        assert r.status_code == 200
+        p.refresh_from_db()
+        assert p.status == ProposalStatus.APPROVED
+        assert len(Case.objects.get(slug="lalita-niwas-land-scam").timeline) == 1
+
+    def test_a_non_decision_status_raises_a_named_error(self):
+        # build_decision_envelope is public and called directly by other code;
+        # a bare KeyError('pending') told the caller nothing.
+        p = make_proposal(status=ProposalStatus.PENDING)
+        with pytest.raises(ValueError, match="not a.*decision"):
+            build_decision_envelope(p)
+
+
+@pytest.mark.django_db
+class TestTheSerializerRejectsUnusableJoinKeys:
+    """Stop the bad rows at the door, since a proposal cannot be repaired later.
+
+    The viewset exposes no update and ``dedup_key`` is unique, so a proposal
+    created with an unusable ``case_slug`` or ``subject_refs`` can neither be
+    fixed nor re-filed.
+    """
+
+    def _post(self, **over):
+        payload = dict(
+            case_slug="lalita-niwas-land-scam",
+            case_title="Lalita Niwas land scam",
+            source_kind="ngm_docket",
+            intent={
+                "type": "append_timeline_entry",
+                "entry": {"date": "2026-08-12", "title": "Hearing"},
+            },
+            confidence=0.9,
+            detected_by="consumer:proposal-builder",
+            dedup_key="d-1",
+        )
+        payload.update(over)
+        return caseworker_client().post(LIST_URL, payload, format="json")
+
+    def test_a_valid_proposal_is_still_accepted(self):
+        assert self._post().status_code == 201
+
+    @pytest.mark.parametrize("refs", [5, "a-string", {"a": 1}, [["nested"]], [""], [None]])
+    def test_malformed_subject_refs_is_a_400_not_a_201(self, refs):
+        r = self._post(subject_refs=refs, dedup_key=f"d-{refs}")
+        assert r.status_code == 400
+        assert "subject_refs" in r.data
+
+    def test_subject_refs_may_be_omitted_or_empty(self):
+        assert self._post(subject_refs=[], dedup_key="d-empty").status_code == 201
+
+    @pytest.mark.parametrize("slug", ["lalita_niwas_scam", "2072-lalita-niwas"])
+    def test_a_slug_the_iri_grammar_rejects_is_a_400(self, slug):
+        # SlugField allows underscores and a leading digit; build_case_iri does
+        # not. Such a proposal would publish its decision with NO join key, and
+        # the reject path never resolves the Case so nothing would notice.
+        r = self._post(case_slug=slug, dedup_key=f"d-{slug}")
+        assert r.status_code == 400
+        assert "case_slug" in r.data

--- a/llm/prompt_templates/reference/content.md
+++ b/llm/prompt_templates/reference/content.md
@@ -1,17 +1,19 @@
-{# A reference content template, exercised by llm/tests/test_templating.py.
+{% comment %}
+A reference content template, exercised by llm/tests/test_templating.py.
 
-   It deliberately contains the three things that break a naively-configured
-   template engine, so the tests around it fail loudly if the prompt engine is
-   ever swapped for the HTML one:
+It deliberately contains the three things that break a naively-configured
+template engine, so the tests around it fail loudly if the prompt engine is
+ever swapped for the HTML one:
 
-     - HTML tags, which autoescaping would turn into &lt;p&gt;
-     - JSON with quotes and braces, which autoescaping turns into &quot;
-       and str.format() chokes on entirely
-     - Devanagari, which must survive as-is
+  - HTML tags, which autoescaping would mangle
+  - JSON with quotes and braces, which autoescaping mangles and str.format()
+    chokes on entirely
+  - Devanagari, which must survive as-is
 
-   Loops and conditionals are for shaping data into prose. Computation —
-   json.dumps, character caps, settings lookups — belongs in Python, and the
-   result gets passed in as context. #}
+Loops and conditionals are for shaping data into prose. Computation —
+json.dumps, character caps, settings lookups — belongs in Python, and the
+result gets passed in as context.
+{% endcomment %}
 CASE: {{ case_title }}
 
 {% if excerpts %}SOURCE EXCERPTS:

--- a/llm/prompt_templates/reference/system.md
+++ b/llm/prompt_templates/reference/system.md
@@ -1,7 +1,15 @@
-{# A reference system prompt. Copy this pair when adding a real one.
+{% comment %}
+A reference system prompt. Copy this pair when adding a real one.
 
-   Django comment tags are stripped from the output, so notes like this one
-   cost nothing at inference time and never reach the model. #}
+Use {% comment %}, NOT {# #}: Django's tag regex is not DOTALL, so a {# #}
+comment spanning more than one line is not a comment at all — it renders
+verbatim into the prompt. Both of these templates shipped with that bug.
+
+Note the `language` variable below is referenced ONLY inside an if tag. The
+engine's missing-variable sentinel cannot see tag arguments, so a spec using
+this template MUST declare required=("language",), or omitting it silently
+yields an English prompt.
+{% endcomment %}
 You are a meticulous research assistant for Jawafdehi.org, an open civic archive
 of Nepali anti-corruption cases.
 

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -105,8 +105,15 @@ class PromptSpec:
         scraper's switches its whole output language on one flag), and forcing
         that into the content block would put it further from the instruction it
         modifies.
+
+        ``required`` applies here as well as to :meth:`render`. It did not, and
+        that was the more dangerous half: the shipped reference system prompt
+        branches on ``{% if language == "np" %}``, a tag-shaped hole the sentinel
+        cannot see, so omitting ``language`` silently produced an English prompt
+        with no error. Both templates take the same context, so one declaration
+        covering both is also the less surprising rule.
         """
-        return render_prompt(self.system_template, context)
+        return render_prompt(self.system_template, context, required=self.required)
 
     def render(self, **context) -> str:
         """Render the content block without invoking a model.

--- a/llm/templating.py
+++ b/llm/templating.py
@@ -29,10 +29,26 @@ than a crash. So the engine is configured with a sentinel
 ``string_if_invalid``, and :func:`render_prompt` refuses to return any string
 still containing it.
 
-That sentinel closes the ``{{ var }}`` case but **not** the tag case: Django
-never consults ``string_if_invalid`` for ``{% if missing %}`` (falsy) or
-``{% for x in missing %}`` (empty). A variable used *only* inside a tag must
-therefore be declared in ``required=``, which is checked before rendering.
+That sentinel closes the ``{{ var }}`` case but **not** the tag case. Django
+never consults ``string_if_invalid`` for tag arguments, and the list is longer
+than it first looks — ``{% if %}``, ``{% for %}``, ``{% firstof %}``,
+``{% regroup %}``, ``{% widthratio %}`` and any ``... as name`` form. A variable
+used *only* inside a tag must therefore be declared in ``required=``, which is
+checked before rendering.
+
+Two of those are worse than "silently falsy" and are worth naming:
+
+- ``{% with x=missing %}`` binds the alias to the sentinel *string*, which is
+  truthy and 24 characters long. So ``{% if x %}`` takes the **TRUE** branch and
+  ``{% for i in x %}`` iterates 24 times — the opposite of the failure you would
+  predict. ``required=`` cannot close this one for a dotted path
+  (``{% with x=case.language %}``), because it only checks top-level keys.
+- ``{% filter %}`` renders its body *before* applying filters, so
+  ``{% filter slugify %}{{ missing }}{% endfilter %}`` strips the NUL delimiters
+  and the check below finds nothing.
+
+Multi-line ``{# ... #}`` is **not a comment**: Django's tag regex is not
+``DOTALL``, so it renders verbatim into the prompt. Use ``{% comment %}``.
 
 One consequence of the sentinel worth knowing: ``{{ x|default:"unknown" }}``
 does not rescue an *absent* ``x`` — Django substitutes the sentinel without
@@ -47,13 +63,15 @@ import re
 from pathlib import Path
 from typing import Any, Iterable
 
+import structlog
 from django.apps import apps
+from django.conf import settings
 from django.template import Context, Engine, TemplateDoesNotExist
 
-# Deliberately no logger here. Rendering happens on the way to a model call that
-# llm.prompts already logs (name + version + size), and anything this module
-# could usefully log is the prompt text itself — which carries case content and
-# does not belong in the log stream.
+# Used only for discovery/config warnings. Rendered prompt TEXT is never logged:
+# it carries case content, and llm.prompts already logs the identifying part
+# (name + version + size) on the way to the model.
+logger = structlog.get_logger(__name__)
 
 #: Directory name, relative to an app package, holding that app's prompt
 #: templates. NOT ``prompts``: ``llm/prompts.py`` is the registry module, and a
@@ -76,17 +94,55 @@ class PromptRenderError(Exception):
     """A prompt could not be rendered into text safe to send to a model."""
 
 
+def _strip_nulls(value):
+    """Remove NUL bytes from a string value before it enters the context.
+
+    The sentinel is NUL-delimited so a template cannot collide with it — but a
+    context *value* can, and prompt context is external data (OCR'd court
+    documents, scraped pages, converted uploads). A value containing
+    ``\\x00prompt-missing:`` would trip the check below and make that record's
+    enrichment fail permanently, since the same input fails identically on every
+    retry.
+
+    Postgres already rejects NUL in ``text``/``jsonb``, so anything round-tripped
+    through the database is clean; the live window is text handled before it is
+    persisted. Non-strings are returned untouched — nested values are rendered
+    by Django, and a NUL surviving in one would still be caught rather than
+    silently passed.
+    """
+    if isinstance(value, str) and "\x00" in value:
+        return value.replace("\x00", "")
+    return value
+
+
 def prompt_template_dirs() -> list[Path]:
-    """Every installed app's ``prompt_templates/`` directory that exists.
+    """Every FIRST-PARTY app's ``prompt_templates/`` directory that exists.
 
     Discovered from the app registry rather than hardcoded, so an app owns its
     own prompts and adding one is a directory, not a settings edit.
+
+    Restricted to apps living inside ``BASE_DIR``. Template names are not
+    namespaced by app label, so without this filter any of the twenty-odd
+    third-party apps registered ahead of ours (``jazzmin``, ``wagtail.*``,
+    ``rest_framework``, …) could ship a ``prompt_templates/`` directory and
+    silently win the name. The failure mode is the exact one this registry
+    exists to prevent: :mod:`llm.prompts` would log the right prompt name and
+    version while the text actually sent came from somebody else's file.
     """
+    base = Path(settings.BASE_DIR).resolve()
     dirs = []
     for config in apps.get_app_configs():
         candidate = Path(config.path) / PROMPT_DIR_NAME
-        if candidate.is_dir():
-            dirs.append(candidate)
+        if not candidate.is_dir():
+            continue
+        if not candidate.resolve().is_relative_to(base):
+            logger.warning(
+                "prompt.third_party_templates_ignored",
+                app=config.label,
+                path=str(candidate),
+            )
+            continue
+        dirs.append(candidate)
     return dirs
 
 
@@ -140,7 +196,12 @@ def render_prompt(
             prompt — sending one to a model is worse than failing, because the
             failure would surface later as a bad record with no obvious cause.
     """
-    context = dict(context or {})
+    if isinstance(required, str):
+        # "flag" iterates as ['f','l','a','g'] and reports four absurd missing
+        # keys. An easy typo when there is only one.
+        raise TypeError(f"required must be a sequence of keys, not the string {required!r}.")
+
+    context = {key: _strip_nulls(value) for key, value in (context or {}).items()}
 
     missing_required = [key for key in required if key not in context]
     if missing_required:

--- a/llm/tests/test_prompts.py
+++ b/llm/tests/test_prompts.py
@@ -10,6 +10,7 @@ Rendering itself is covered in test_templating.py; here it only matters that a
 spec wires the right template to the right invoke parameters.
 """
 
+import dataclasses
 from unittest import mock
 
 import pytest
@@ -78,9 +79,13 @@ class TestValidation:
             _spec(**kwargs)
 
     def test_spec_is_frozen(self):
+        # FrozenInstanceError specifically: `Exception` also passes for a typo'd
+        # attribute name on any frozen dataclass, so it would keep passing while
+        # asserting nothing about `version` being a real field.
         spec = _spec()
-        with pytest.raises(Exception):
+        with pytest.raises(dataclasses.FrozenInstanceError):
             spec.version = 2
+        assert "version" in {f.name for f in dataclasses.fields(spec)}
 
     def test_a_nonexistent_template_is_not_caught_until_render(self):
         # Construction cannot check the filesystem: specs are built at import
@@ -157,13 +162,24 @@ class TestInvoke:
             _spec().invoke(usage=sentinel, case_title="X", excerpts=[])
         assert invoke.call_args.kwargs["usage"] is sentinel
 
-    def test_usage_is_not_treated_as_template_context(self):
-        # `usage` is an invoke_json concern; leaking it into the context would
-        # put a repr of an accumulator object into the prompt.
-        with mock.patch("llm.prompts.invoke_json", return_value={}) as invoke:
-            _spec().invoke(usage=object(), case_title="X", excerpts=[])
-        _system, content = invoke.call_args.args
-        assert "usage" not in content
+    def test_usage_is_not_treated_as_template_context(self, tmp_path, monkeypatch):
+        """`usage` is an invoke_json concern and must not reach the template.
+
+        Asserting ``"usage" not in content`` against the reference template was
+        vacuous — that template never mentions ``usage``, so the assertion held
+        no matter what the context contained. This renders a template that
+        *would* show it, so the test can actually fail.
+        """
+        (tmp_path / "probe.md").write_text("[{{ usage }}]", encoding="utf-8")
+        monkeypatch.setattr(templating, "prompt_template_dirs", lambda: [tmp_path])
+        templating.reset_engine()
+
+        spec = _spec(system_template="probe.md", content_template="probe.md")
+        with mock.patch("llm.prompts.invoke_json", return_value={}):
+            # `usage` binds the parameter, so the template variable is missing —
+            # which the sentinel catches. That is the proof it never arrived.
+            with pytest.raises(PromptRenderError, match="usage"):
+                spec.invoke(usage=object())
 
     def test_a_render_failure_costs_no_model_call(self):
         # The whole reason rendering is strict: fail before spending a call,
@@ -183,6 +199,36 @@ class TestInvoke:
         kwargs = log.call_args.kwargs
         assert kwargs["prompt"] == "case_proposal.intent"
         assert kwargs["version"] == 7
+
+
+class TestRequiredAppliesToBothTemplates:
+    """`required` must cover the system prompt too, not just the content.
+
+    It previously covered only the content template, which is the less dangerous
+    half: the shipped reference system prompt gates its whole output language on
+    `{% if language == "np" %}`, a tag-shaped hole the sentinel cannot detect.
+    """
+
+    def test_render_system_enforces_required(self):
+        spec = _spec(required=("language",))
+        with pytest.raises(PromptRenderError, match="language"):
+            spec.render_system()
+
+    def test_render_system_succeeds_once_declared_key_is_supplied(self):
+        spec = _spec(required=("language",))
+        assert "नेपाली भाषामा" in spec.render_system(language="np")
+
+    def test_invoke_refuses_before_calling_the_model(self):
+        spec = _spec(required=("language",))
+        with mock.patch("llm.prompts.invoke_json") as invoke:
+            with pytest.raises(PromptRenderError, match="language"):
+                spec.invoke(case_title="X", excerpts=[])
+        invoke.assert_not_called()
+
+    def test_render_still_enforces_required_for_content(self):
+        spec = _spec(required=("flag",))
+        with pytest.raises(PromptRenderError, match="flag"):
+            spec.render(case_title="X", excerpts=[])
 
 
 class TestRegisteredSpecsAreLoadable:

--- a/llm/tests/test_templating.py
+++ b/llm/tests/test_templating.py
@@ -8,6 +8,9 @@ nothing downstream would notice — the model would just answer a slightly
 different question and we would blame the model.
 """
 
+import re
+from unittest import mock
+
 import pytest
 
 from llm import templating
@@ -88,9 +91,21 @@ class TestMissingVariablesRaise:
         assert "case_title" in str(exc.value)
 
     def test_the_sentinel_never_leaks_into_output(self, templates):
+        """The NUL sentinel must never reach a caller, whether or not we raise.
+
+        This previously just re-asserted ``pytest.raises`` — a duplicate of the
+        test above that never looked at a rendered string. Here the sentinel is
+        produced and the check disabled, so the only thing under test is whether
+        any output path can return it.
+        """
         templates("t.md", "Case: {{ nope }}")
+        with mock.patch.object(templating, "_MISSING_RE", re.compile("(?!x)x")):
+            leaked = render_prompt("t.md", {})
+        # With detection defeated, the sentinel IS present — which is exactly
+        # what the real regex has to catch.
+        assert "\x00" in leaked
         with pytest.raises(PromptRenderError):
-            render_prompt("t.md", {})
+            render_prompt("t.md", {})  # real regex restored
 
     def test_unresolved_dotted_path_raises(self, templates):
         templates("t.md", "{{ case.title }}")
@@ -116,12 +131,16 @@ class TestMissingVariablesRaise:
         with pytest.raises(PromptRenderError):
             render_prompt("t.md", {}, required=["flag"])
 
-    def test_missing_template_names_the_search_path(self, templates):
+    def test_missing_template_names_the_search_path(self, templates, tmp_path):
         templates("other.md", "x")
         with pytest.raises(PromptRenderError) as exc:
             render_prompt("absent.md", {})
-        assert "absent.md" in str(exc.value)
-        assert "prompt_templates" in str(exc.value)
+        message = str(exc.value)
+        assert "absent.md" in message
+        # The DIRECTORIES actually searched, not just the literal word
+        # "prompt_templates" — that appears in a hardcoded tail sentence, so
+        # asserting on it was asserting a constant against itself.
+        assert str(tmp_path) in message
 
 
 class TestRendering:
@@ -133,8 +152,24 @@ class TestRendering:
         out = render_prompt("t.md", {"rules": [{"title": "A"}, {"title": "B"}]})
         assert out == "- A\n- B"
 
-    def test_comments_are_stripped(self, templates):
+    def test_single_line_hash_comments_are_stripped(self, templates):
         templates("t.md", "{# a note for humans #}text")
+        assert render_prompt("t.md", {}) == "text"
+
+    def test_a_multi_line_hash_comment_is_NOT_a_comment(self, templates):
+        """Django's tag regex is not DOTALL, so ``{# #}`` is single-line only.
+
+        A multi-line one is not stripped — it renders verbatim into the prompt.
+        Both shipped reference templates had exactly this bug, and the
+        single-line test above passed the whole time. Asserted rather than
+        fixed, because it is Django's behaviour: the fix is to use
+        ``{% comment %}``, which the next test enforces for real templates.
+        """
+        templates("t.md", "{# line one\n   line two #}text")
+        assert "line one" in render_prompt("t.md", {})
+
+    def test_comment_tags_are_stripped_across_lines(self, templates):
+        templates("t.md", "{% comment %}line one\n   line two{% endcomment %}text")
         assert render_prompt("t.md", {}) == "text"
 
     def test_trailing_whitespace_is_stripped(self, templates):
@@ -142,11 +177,62 @@ class TestRendering:
         assert render_prompt("t.md", {}) == "text"
 
 
+class TestHostileContextValues:
+    def test_a_value_containing_the_sentinel_cannot_deny_the_render(self, templates):
+        """Prompt context is external data, and the sentinel is only NUL-delimited.
+
+        A court document whose converted text happened to contain the sentinel
+        would otherwise trip the missing-variable check and fail that record's
+        enrichment permanently — deterministically, so retries fail too.
+        """
+        templates("t.md", "EXCERPT: {{ excerpt }}")
+        hostile = f"court text {templating.MISSING_SENTINEL % 'pwn'} more text"
+        out = render_prompt("t.md", {"excerpt": hostile})
+        assert "\x00" not in out
+        assert "court text" in out and "more text" in out
+
+    def test_a_genuine_missing_variable_is_still_caught_alongside_a_hostile_value(
+        self, templates
+    ):
+        templates("t.md", "{{ excerpt }} {{ absent }}")
+        hostile = "\x00prompt-missing:"  # bare prefix, tries to swallow the real one
+        with pytest.raises(PromptRenderError, match="absent"):
+            render_prompt("t.md", {"excerpt": hostile})
+
+    def test_required_as_a_bare_string_is_rejected(self, templates):
+        templates("t.md", "x")
+        with pytest.raises(TypeError, match="not the string"):
+            render_prompt("t.md", {"flag": 1}, required="flag")
+
+
 class TestDiscovery:
     def test_finds_the_llm_apps_prompt_templates_directory(self):
         # No monkeypatching here: this asserts the real on-disk convention works.
         dirs = [str(d) for d in templating.prompt_template_dirs()]
         assert any(d.endswith("llm/prompt_templates") for d in dirs), dirs
+
+    def test_only_first_party_apps_can_contribute_prompts(self, tmp_path, monkeypatch):
+        """A dependency must not be able to shadow one of our prompts.
+
+        Template names are not namespaced by app label, and ~20 third-party apps
+        are registered ahead of `llm`. If one shipped prompt_templates/, it would
+        win the name while the logs still reported our prompt's name and version.
+        """
+        from django.apps import apps as django_apps
+
+        intruder = tmp_path / "site-packages" / "somedep" / templating.PROMPT_DIR_NAME
+        intruder.mkdir(parents=True)
+        (intruder / "reference").mkdir()
+        (intruder / "reference" / "system.md").write_text("PWNED", encoding="utf-8")
+
+        fake = mock.Mock(label="somedep", path=str(intruder.parent))
+        real = list(django_apps.get_app_configs())
+        monkeypatch.setattr(django_apps, "get_app_configs", lambda: [fake, *real])
+        templating.reset_engine()
+
+        dirs = [str(d) for d in templating.prompt_template_dirs()]
+        assert not any("site-packages" in d for d in dirs), dirs
+        assert "PWNED" not in render_prompt(REFERENCE_SYSTEM, {"language": "en"})
 
     def test_the_engine_is_not_the_html_engine(self):
         from django.template.loader import engines
@@ -181,3 +267,22 @@ class TestTheReferenceTemplates:
     def test_content_still_fails_loudly_without_its_variable(self):
         with pytest.raises(PromptRenderError, match="case_title"):
             render_prompt(REFERENCE_CONTENT, {"excerpts": []})
+
+    @pytest.mark.parametrize(
+        "template,context",
+        [
+            (REFERENCE_CONTENT, {"case_title": "X", "excerpts": []}),
+            (REFERENCE_SYSTEM, {"language": "en"}),
+        ],
+    )
+    def test_no_template_leaks_its_own_commentary_into_the_prompt(self, template, context):
+        """Developer notes must not be billed as tokens and read as instructions.
+
+        Both templates originally used a multi-line ``{# #}`` comment, which
+        Django does not strip, so the entire explanatory block — including the
+        words 'autoescaping' and a literal HTML entity — was being sent to the
+        model as part of the prompt.
+        """
+        out = render_prompt(template, context)
+        for marker in ("{#", "{% comment", "Copy this pair", "belongs in Python", "DOTALL"):
+            assert marker not in out, f"{template} leaked {marker!r} into the prompt"

--- a/tests/test_app_package_names.py
+++ b/tests/test_app_package_names.py
@@ -25,7 +25,9 @@ Two distinct problems, and both are worth blocking:
 
 import re
 from importlib.metadata import packages_distributions
+from pathlib import Path
 
+from django.apps import apps
 from django.conf import settings
 
 #: The distribution this project itself installs as. Packages it owns are not
@@ -34,19 +36,30 @@ OWN_DISTRIBUTION = "jawafdehi"
 
 
 def _first_party_apps():
-    """Apps whose package directory lives in this repo.
+    """Top-level package names of apps whose code lives in this repo.
 
     Defined by what is on disk rather than by a name prefix: a third-party app
     that happens to share a name with its own distribution (``auditlog`` ships
     from ``django-auditlog``, ``corsheaders`` from ``django-cors-headers``) is
     not a collision — it is the same package, correctly resolved. Only a
     directory we ship can shadow something.
+
+    Read from the app REGISTRY rather than the raw ``INSTALLED_APPS`` strings.
+    An entry may be either ``"case_events"`` or the equally standard
+    ``"case_events.apps.EventsConfig"``, and the previous string-based version
+    skipped anything containing a dot — so writing an app the dotted way removed
+    it from all three checks below at once, silently reopening exactly the hole
+    they exist to close.
     """
-    return [
-        app
-        for app in settings.INSTALLED_APPS
-        if "." not in app and (settings.BASE_DIR / app / "__init__.py").exists()
-    ]
+    base = Path(settings.BASE_DIR).resolve()
+    names = set()
+    for config in apps.get_app_configs():
+        if not Path(config.path).resolve().is_relative_to(base):
+            continue  # third-party, installed into site-packages
+        top = config.name.split(".")[0]
+        if (base / top / "__init__.py").exists():
+            names.add(top)
+    return sorted(names)
 
 
 def test_no_app_shadows_an_installed_distribution():
@@ -96,6 +109,22 @@ def test_every_first_party_app_ships_in_the_wheel():
         f"These apps are in INSTALLED_APPS but not in the wheel `packages` list: "
         f"{missing}. They would be missing from the installed package."
     )
+
+
+def test_the_app_list_is_not_empty_and_finds_dotted_appconfigs():
+    """Guard the shared input to all three checks above.
+
+    Everything here loops over ``_first_party_apps()``, so if that returns a
+    short list the checks pass vacuously. It previously dropped every app
+    declared as ``"pkg.apps.SomeConfig"``; ``case_events`` is declared that way
+    in its own AppConfig, so it is the natural canary.
+    """
+    found = _first_party_apps()
+    assert len(found) > 5, f"suspiciously few first-party apps: {found}"
+    assert "case_events" in found, found
+    # And the registry really does expose the dotted form somewhere, so this
+    # test is exercising the case it claims to.
+    assert any("." in config.name for config in apps.get_app_configs())
 
 
 def test_the_check_can_actually_detect_a_collision():


### PR DESCRIPTION
Follow-up to #394. A four-lens adversarial review of that merged code found defects I confirmed by reproducing them, not by reading. This fixes the confirmed ones.

Every fix is mutation-verified: the mutation that restores the old behaviour is re-run and must fail the new test.

## 1. CRITICAL — the bus could roll back a case write

`build_decision_envelope()` ran synchronously **inside** the caller's `transaction.atomic()`; only `bus.publish` was in the guarded `on_commit` callback. Reproduced end-to-end through the API with `NATS_URL=""`:

| step | result |
|---|---|
| `POST` proposal with `subject_refs: 5` | **201 Created** |
| `POST .../approve/` | **500** `TypeError` |
| `proposal.status` | `pending` — rolled back |
| `case.timeline` | `[]` — **the case write was rolled back** |

No broker involved. The existing tests couldn't catch this class because they all mock `bus.publish`, which was the one part already safe.

Latent today only because nothing populates `subject_refs` yet — and the `proposal-builder` consumer, the next thing on the plan, is specified to fill exactly that field. It was also unrecoverable: reject takes the same path, the viewset has no update, and `dedup_key` is unique.

Fixed in three independently-pinned layers: guard the envelope build, sanitise the refs, and validate at creation.

## 2. HIGH — one dead broker stalled every publishing thread

The lock was held across a blocking connect. And the timeout was always paid in full: `max_reconnect_attempts=-1` makes nats-py retry the *initial* connect forever (`client.py:562` `continue`, never raises), so it can't fail fast. 2 workers × 4 threads → all 8 frozen 5s at a time, once per 30s window.

Now one thread connects, without the lock; the rest return immediately. **10.00s → <0.5s**, asserted.

## 3. HIGH — `render_system` ignored `required`

The shipped reference system prompt gates its whole output language on `{% if language == "np" %}` — the exact tag-shaped hole `required` exists for. Omitting `language` silently produced an English prompt.

## 4. Both reference templates were leaking their own comments into the prompt

Django's tag regex isn't DOTALL, so a multi-line `{# #}` is **not a comment** — it renders verbatim. The entire explanatory block was being sent to the model and billed as tokens, including the passage about autoescaping. `test_comments_are_stripped` used a single-line comment and passed throughout.

## 5. Third-party apps could shadow a prompt

Template names aren't namespaced and ~20 third-party apps register ahead of `llm`. A dependency shipping `prompt_templates/` would win the name while the logs reported ours — defeating the registry's whole purpose. Restricted to apps under `BASE_DIR`.

## Test gaps closed

The audit ran 37 mutations against the merged tests; 24 survived. Notably:

- **My own guard test had a blind spot.** `_first_party_apps` skipped any dotted `AppConfig`, so the original incident (dotted config + no Dockerfile `COPY` + no wheel entry) passed all four tests. Now fails two.
- `ensure_streams` had no test at all — `FILE`→`MEMORY` and `num_replicas`→`3` both survived.
- Stream subjects were asserted against the constants they're built from, so `ALL_CASE_EVENTS = "jaw.>"` passed while making the streams overlap, which JetStream rejects at startup.
- Nothing pinned the `on_commit` deferral — replacing it with a direct call passed everything.
- `_log_result` untested, so dropping the done-callback (and every fire-and-forget failure) passed.

## Not in scope

**Prompt injection.** Context values are external data (OCR'd court PDFs, uploaded materials) interpolated raw into both prompts, with no data/instruction boundary. Pre-existing in `review/judge.py` and the `enrich_*` ports, but this design blesses the pattern. A real answer affects those too, so it wants its own discussion rather than being smuggled in here.

## Verification

1508 passed in CI scope (`--ignore=integration-tests`, as `ci.yml` does). `ruff check` clean. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)