### PR TITLE
feat(courts): recover missing verdicts by reading the court's faisala

### DIFF
--- a/courts/management/commands/extract_verdicts.py
+++ b/courts/management/commands/extract_verdicts.py
@@ -29,7 +29,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
 
-from courts.models import CourtCaseHearing
+from courts.models import CourtCase, CourtCaseHearing
 from courts.scraper.registers import NGM_DB
 from courts.scraper.verdicts import (
     DECISION_TYPES,
@@ -37,6 +37,8 @@ from courts.scraper.verdicts import (
     backlog,
     build_hearing,
     build_prompt,
+    court_coded_verdicts,
+    has_order,
     is_decided,
     order_urls,
     parse_response,
@@ -69,6 +71,19 @@ class Command(BaseCommand):
         parser.add_argument("--delay", type=float, default=DEFAULT_DELAY)
 
     # ------------------------------------------------------------------ helpers
+    def _gap(self, delay):
+        """Wait out the politeness gap, then count this download.
+
+        Called immediately before each download, because the download is the only
+        thing here that touches the court. Putting the wait on the WRITE instead
+        let a dry run -- which fetches every bit as much -- hammer the site at
+        full speed, and putting it at the end of the loop let a run of failures
+        do the same by skipping it on ``continue``.
+        """
+        if self._downloads:
+            time.sleep(delay)
+        self._downloads += 1
+
     def _extract_one(self, case, *, tier):
         """Download the order, read it, return (extraction, url, model, chars).
 
@@ -108,17 +123,13 @@ class Command(BaseCommand):
         it deliberately draws from the SAME population (has an order document,
         Special Court judgment) and just happens to know the answer.
         """
-        from courts.models import CourtCase
-
-        truth = dict(
-            CourtCaseHearing.objects.using(NGM_DB)
-            .filter(court_id=court, decision_type__in=DECISION_TYPES)
-            .values_list("case_number", "decision_type")
-        )
-        # Spread the sample across the register rather than taking one era.
+        truth = dict(court_coded_verdicts(court).using(NGM_DB))
+        # Same order-document predicate the writer uses, so the score describes
+        # the population that would actually be written. Spread across the
+        # register rather than taking one era.
         cases = list(
             CourtCase.objects.using(NGM_DB)
-            .filter(court_id=court, case_number__in=list(truth), extra_data__has_key="court_orders")
+            .filter(has_order(), court_id=court, case_number__in=list(truth))
             .order_by("case_number")
         )
         if not cases:
@@ -131,6 +142,7 @@ class Command(BaseCommand):
         confusion = {}
         for i, case in enumerate(sample, 1):
             want = truth[case.case_number]
+            self._gap(delay)
             try:
                 ex, url, _model, chars = self._extract_one(case, tier=tier)
             except Exception as exc:  # noqa: BLE001
@@ -153,7 +165,6 @@ class Command(BaseCommand):
             )
             if ex.abstained or verdict == "WRONG":
                 self.stdout.write(f"        evidence: {(ex.evidence or '')[:150]}")
-            time.sleep(delay)
 
         answered = hits + miss
         self.stdout.write("\n=== eval ===")
@@ -172,6 +183,7 @@ class Command(BaseCommand):
     # ------------------------------------------------------------------- handle
     def handle(self, *args, **opts):
         court, tier, delay = opts["court"], opts["tier"], opts["delay"]
+        self._downloads = 0
 
         if opts.get("eval"):
             return self._run_eval(court, opts["eval"], tier, delay)
@@ -187,6 +199,7 @@ class Command(BaseCommand):
                 skipped += 1
                 self.stdout.write(f"  {i:>3} {case.case_number}  skip: case_status is not decided")
                 continue
+            self._gap(delay)
             try:
                 ex, url, model, chars = self._extract_one(case, tier=tier)
             except Exception as exc:  # noqa: BLE001
@@ -214,10 +227,24 @@ class Command(BaseCommand):
             if not opts["write"]:
                 continue
 
-            # Re-check inside the transaction: hearings carry no unique
-            # constraint, so a concurrent cause-list scrape (or a second run of
-            # this command) would otherwise duplicate the row.
+            # Lock the CASE row and re-check under it. Hearings carry no unique
+            # constraint -- and can't easily: 500k+ (case, court) pairs already
+            # hold more than one row with a non-null decision_type, legitimately,
+            # from district-court cause lists. Locking the parent gives the one
+            # guarantee that is actually needed here, that two runs of this
+            # command (a retried Job, an overlapping one) cannot both decide the
+            # same case. A concurrent cause-list scrape does not take this lock,
+            # so that window stays open; it is narrow and the duplicate would be
+            # a benign repeat of the same disposition. --write therefore needs
+            # Postgres; sqlite has no SELECT FOR UPDATE and raises here.
             with transaction.atomic(using=NGM_DB):
+                (
+                    CourtCase.objects.using(NGM_DB)
+                    .select_for_update()
+                    .filter(pk=case.pk)
+                    .values_list("pk", flat=True)
+                    .first()
+                )
                 exists = (
                     CourtCaseHearing.objects.using(NGM_DB)
                     .filter(
@@ -233,7 +260,6 @@ class Command(BaseCommand):
                     continue
                 hearing.save(using=NGM_DB)
                 written += 1
-            time.sleep(delay)
 
         self.stdout.write(
             f"\n{mode} done: written={written} abstained={abstained} skipped={skipped} failed={failed}"

--- a/courts/management/commands/extract_verdicts.py
+++ b/courts/management/commands/extract_verdicts.py
@@ -1,0 +1,243 @@
+"""Recover missing verdicts by reading the court's published faisala.
+
+Cases that reached the mirror without ever appearing on a daily cause list can be
+marked decided in ``case_status`` while carrying no hearing with a
+``decision_type``. They count as decided and contribute to no outcome. The court
+publishes the judgment for most of them; this command reads it and writes the
+missing deciding hearing.
+
+Dry-run by default -- ``--write`` persists.
+
+    # score the extractor against verdicts the court already told us
+    manage.py extract_verdicts --court special --eval 60
+
+    # see what would be written
+    manage.py extract_verdicts --court special --limit 10
+
+    # write
+    manage.py extract_verdicts --court special --write
+
+Every row written is model-derived and marked as such under
+``extra_data['verdict_extraction']``.
+"""
+
+from __future__ import annotations
+
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+from courts.models import CourtCaseHearing
+from courts.scraper.registers import NGM_DB
+from courts.scraper.verdicts import (
+    DECISION_TYPES,
+    PROVENANCE_KEY,
+    backlog,
+    build_hearing,
+    build_prompt,
+    is_decided,
+    order_urls,
+    parse_response,
+    SYSTEM_PROMPT,
+)
+
+#: Politeness gap between document downloads, matching the order scraper.
+DEFAULT_DELAY = 1.0
+#: The answer is a small JSON object, but the budget must also cover the model's
+#: reasoning: on the CLI provider this becomes CLAUDE_CODE_MAX_OUTPUT_TOKENS, and
+#: a 1200 budget failed 3 of 24 eval cases outright (rc=1 after spending ~4800
+#: output tokens). Those failures are safe -- the case is skipped, never guessed
+#: at -- but they are lost coverage, so give reasoning real headroom.
+MAX_TOKENS = 8000
+
+
+class Command(BaseCommand):
+    help = "Read court orders to recover missing verdicts (dry-run unless --write)."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--court", default="special", help="court_identifier (default: special)")
+        parser.add_argument("--case", help="a single case number, for smoke-testing")
+        parser.add_argument("--limit", type=int, default=25, help="max cases (default: 25)")
+        parser.add_argument("--write", action="store_true", help="persist; otherwise dry-run")
+        parser.add_argument(
+            "--eval", type=int, metavar="N",
+            help="score against N cases whose verdict the court already gave us; never writes",
+        )
+        parser.add_argument("--tier", default="premium", choices=("premium", "cheap"))
+        parser.add_argument("--delay", type=float, default=DEFAULT_DELAY)
+
+    # ------------------------------------------------------------------ helpers
+    def _extract_one(self, case, *, tier):
+        """Download the order, read it, return (extraction, url, model, chars).
+
+        Raises RuntimeError with a short reason on any unusable case, so the
+        caller can count failure kinds instead of swallowing them.
+        """
+        from casework.convert import extract_markdown
+        from llm import invoke, routing
+
+        urls = order_urls(case)
+        if not urls:
+            raise RuntimeError("no order url on case")
+
+        text = ""
+        used = None
+        for url in urls:
+            try:
+                text = extract_markdown(url, timeout=180)
+            except Exception as exc:  # noqa: BLE001 - one bad artefact != a dead case
+                self.stderr.write(f"    fetch failed {url}: {type(exc).__name__}: {exc}")
+                continue
+            if text and text.strip():
+                used = url
+                break
+        if not used:
+            raise RuntimeError("no order document yielded text")
+
+        model = routing.provider_for_tier(tier).model_for_tier(tier)
+        raw = invoke.invoke_text(SYSTEM_PROMPT, build_prompt(text, case.case_number), MAX_TOKENS, tier=tier)
+        return parse_response(raw), used, model, len(text)
+
+    # --------------------------------------------------------------------- eval
+    def _run_eval(self, court, n, tier, delay):
+        """Score the extractor on cases whose disposition the court already gave.
+
+        This is the only evidence that the written verdicts are trustworthy, so
+        it deliberately draws from the SAME population (has an order document,
+        Special Court judgment) and just happens to know the answer.
+        """
+        from courts.models import CourtCase
+
+        truth = dict(
+            CourtCaseHearing.objects.using(NGM_DB)
+            .filter(court_id=court, decision_type__in=DECISION_TYPES)
+            .values_list("case_number", "decision_type")
+        )
+        # Spread the sample across the register rather than taking one era.
+        cases = list(
+            CourtCase.objects.using(NGM_DB)
+            .filter(court_id=court, case_number__in=list(truth), extra_data__has_key="court_orders")
+            .order_by("case_number")
+        )
+        if not cases:
+            raise CommandError("no evaluable cases (need an order document + a known verdict)")
+        step = max(1, len(cases) // n)
+        sample = cases[::step][:n]
+
+        self.stdout.write(f"eval: {len(sample)} cases sampled from {len(cases)} with both an order and a known verdict\n")
+        hits = miss = abst = err = 0
+        confusion = {}
+        for i, case in enumerate(sample, 1):
+            want = truth[case.case_number]
+            try:
+                ex, url, _model, chars = self._extract_one(case, tier=tier)
+            except Exception as exc:  # noqa: BLE001
+                err += 1
+                self.stdout.write(f"  {i:>3}/{len(sample)} {case.case_number}  ERROR {exc}")
+                continue
+            if ex.abstained:
+                abst += 1
+                verdict = "ABSTAIN"
+            elif ex.decision_type == want:
+                hits += 1
+                verdict = "ok"
+            else:
+                miss += 1
+                verdict = "WRONG"
+                confusion[(want, ex.decision_type)] = confusion.get((want, ex.decision_type), 0) + 1
+            self.stdout.write(
+                f"  {i:>3}/{len(sample)} {case.case_number}  want={want:<10} got={ex.decision_type or 'ABSTAIN':<10}"
+                f" conf={ex.confidence or '-':<6} {chars:>6}c  {verdict}"
+            )
+            if ex.abstained or verdict == "WRONG":
+                self.stdout.write(f"        evidence: {(ex.evidence or '')[:150]}")
+            time.sleep(delay)
+
+        answered = hits + miss
+        self.stdout.write("\n=== eval ===")
+        self.stdout.write(f"  correct    {hits}")
+        self.stdout.write(f"  wrong      {miss}")
+        self.stdout.write(f"  abstained  {abst}")
+        self.stdout.write(f"  errored    {err}")
+        if answered:
+            self.stdout.write(f"  accuracy on answered: {hits / answered * 100:.1f}%  (n={answered})")
+        if confusion:
+            self.stdout.write("  confusion (want -> got):")
+            for (w, g), c in sorted(confusion.items(), key=lambda kv: -kv[1]):
+                self.stdout.write(f"    {w} -> {g}: {c}")
+        return 0
+
+    # ------------------------------------------------------------------- handle
+    def handle(self, *args, **opts):
+        court, tier, delay = opts["court"], opts["tier"], opts["delay"]
+
+        if opts.get("eval"):
+            return self._run_eval(court, opts["eval"], tier, delay)
+
+        qs = backlog(court_identifier=court, case_number=opts.get("case")).using(NGM_DB)
+        cases = list(qs[: opts["limit"]])
+        mode = "WRITE" if opts["write"] else "dry-run"
+        self.stdout.write(f"{mode}: {len(cases)} case(s) from the {court} backlog\n")
+
+        written = skipped = abstained = failed = 0
+        for i, case in enumerate(cases, 1):
+            if not is_decided(case):
+                skipped += 1
+                self.stdout.write(f"  {i:>3} {case.case_number}  skip: case_status is not decided")
+                continue
+            try:
+                ex, url, model, chars = self._extract_one(case, tier=tier)
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                self.stdout.write(f"  {i:>3} {case.case_number}  FAILED {exc}")
+                continue
+
+            if ex.abstained:
+                abstained += 1
+                self.stdout.write(f"  {i:>3} {case.case_number}  ABSTAIN ({chars}c) — left alone")
+                continue
+
+            now = timezone.now()
+            try:
+                hearing = build_hearing(case, ex, order_url=url, model=model, now=now)
+            except ValueError as exc:
+                failed += 1
+                self.stdout.write(f"  {i:>3} {case.case_number}  FAILED {exc}")
+                continue
+
+            self.stdout.write(
+                f"  {i:>3} {case.case_number}  {ex.decision_type:<10} conf={ex.confidence or '-':<6}"
+                f" date={hearing.hearing_date_bs} judges={(ex.judges or '').splitlines()[:1]}"
+            )
+            if not opts["write"]:
+                continue
+
+            # Re-check inside the transaction: hearings carry no unique
+            # constraint, so a concurrent cause-list scrape (or a second run of
+            # this command) would otherwise duplicate the row.
+            with transaction.atomic(using=NGM_DB):
+                exists = (
+                    CourtCaseHearing.objects.using(NGM_DB)
+                    .filter(
+                        case_number=case.case_number,
+                        court_id=case.court_id,
+                        decision_type__in=DECISION_TYPES,
+                    )
+                    .exists()
+                )
+                if exists:
+                    skipped += 1
+                    self.stdout.write("        skip: a deciding hearing appeared since selection")
+                    continue
+                hearing.save(using=NGM_DB)
+                written += 1
+            time.sleep(delay)
+
+        self.stdout.write(
+            f"\n{mode} done: written={written} abstained={abstained} skipped={skipped} failed={failed}"
+        )
+        if not opts["write"] and written == 0:
+            self.stdout.write(f"(dry-run — nothing persisted; rows would carry extra_data['{PROVENANCE_KEY}'])")
+        return 0

--- a/courts/scraper/verdicts.py
+++ b/courts/scraper/verdicts.py
@@ -1,0 +1,327 @@
+"""Recover a missing verdict by reading the court's own faisala (judgment).
+
+Hearings normally arrive from the daily cause list, and the deciding hearing is
+what carries ``decision_type``. Cases that reached NGM by some other route -- the
+register sweep in :mod:`courts.scraper.sweep`, chiefly -- can therefore be marked
+decided in ``case_status`` while carrying no hearing with a ``decision_type`` at
+all. They count as decided and contribute to no outcome.
+
+The court publishes the full judgment for most of them (see
+``scrape_court_orders``), and the judgment states the disposition. This module
+holds the deterministic halves -- backlog selection, prompt construction,
+response validation, and the hearing row to write -- so they are unit-testable
+without a network or a model. The download, the model call and the DB write live
+in the ``extract_verdicts`` management command.
+
+WHY A MODEL AND NOT A REGEX: a faisala recites the charge and then the finding,
+and a mixed bench convicts some accused while acquitting others, so most
+judgments contain BOTH ``ठहर`` and ``सफाई``. Keyword matching picks the wrong one
+often enough to matter -- 4 of 6 sampled documents contained both terms. The
+distinction between full and partial conviction in particular is only available
+from reading the operative section.
+
+EVERY ROW THIS WRITES IS MODEL-DERIVED and is marked as such in
+``extra_data`` (:data:`PROVENANCE_KEY`). Downstream consumers that publish
+conviction rates must be able to tell these apart from court-scraped verdicts --
+see :func:`derived_hearing_filter`.
+
+CALIBRATION (2026-07-31, ``--eval 24`` on Special Court cases whose disposition
+the court had already given us, Opus 4.8[1m]):
+
+    prompt v1   21 correct / 3 WRONG / 0 abstain   87.5%
+    prompt v2   21 correct / 0 wrong / 3 errored   100.0% on answered
+
+Every one of v1's three errors ran the same way -- ``ठहर`` reported as
+``आंशिक ठहर`` -- because v1 defined आंशिक to include "a materially reduced
+claim/amount". It does not. The court reserves आंशिक ठहर for the CHARGE standing
+only in part: an accused acquitted, or a count dismissed. Differing fines between
+convicted accused, a बिगो below what was demanded, or seized money returned as
+private property are all still ``ठहर``. v2 states that as an ordered test and
+requires the model to NAME the acquitted accused before answering आंशिक.
+
+The remaining 3 are the longest, most-multi-defendant judgments; they exhaust the
+output-token budget or time out. That is the intended failure mode -- a skipped
+case costs coverage, a wrong one corrupts a published conviction rate -- so
+expect roughly one case in eight to be left for a human rather than answered.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+from django.db.models import Exists, OuterRef, Q
+
+from courts.case_status import parse_case_status
+from courts.models import CourtCase, CourtCaseHearing
+
+#: The court's three dispositions, exactly as ``decision_type`` stores them.
+#: This is a closed set -- anything else is a parse failure, not a new category.
+FULL = "ठहर"
+PARTIAL = "आंशिक ठहर"
+ACQUITTAL = "सफाई"
+DECISION_TYPES = (FULL, PARTIAL, ACQUITTAL)
+
+#: Marker under ``CourtCaseHearing.extra_data`` identifying a model-derived row.
+PROVENANCE_KEY = "verdict_extraction"
+
+#: Returned by the model when the judgment does not settle the disposition.
+#: Recorded as a skip, never written -- an abstention is a correct answer.
+ABSTAIN = "ABSTAIN"
+
+#: Judgments run 13k-19k characters. The operative finding (``ठहर खण्ड``) and the
+#: directions (``तपसिल``) sit at the END, while the bench sits at the head, so a
+#: naive truncation drops exactly the part that decides the answer. Keep both
+#: ends when a document is too long to send whole.
+MAX_CHARS = 24_000
+HEAD_CHARS = 6_000
+
+SYSTEM_PROMPT = """You read judgments (फैसला) of Nepal's Special Court and report the disposition.
+
+Return ONLY a JSON object, no prose and no code fence:
+
+{"decision_type": "<one of: ठहर | आंशिक ठहर | सफाई | ABSTAIN>",
+ "judges": "<presiding and member judges, newline-separated, as printed>",
+ "verdict_date_bs": "<YYYY-MM-DD in Bikram Sambat, or null>",
+ "evidence": "<the clause you decided from, quoted verbatim, max 300 chars>",
+ "confidence": "<high | medium | low>"}
+
+The three dispositions:
+  ठहर        FULL. Every accused is held guilty. The charge stands in full.
+  आंशिक ठहर  PARTIAL. The charge stands only IN PART.
+  सफाई       ACQUITTAL. Every accused is cleared.
+
+Apply ONE test, in this order:
+  1. Is EVERY accused acquitted?                     -> सफाई
+  2. Is at least one accused ACQUITTED (सफाई पाउने)
+     while at least one other is convicted, OR is a
+     charge/count expressly DISMISSED while another
+     is upheld?                                      -> आंशिक ठहर
+  3. Otherwise (every accused convicted)             -> ठहर
+
+आंशिक ठहर is about WHO and WHICH CHARGE, never about how much. All of the
+following are still ठहर, not आंशिक ठहर, as long as no accused is acquitted and
+no count is dismissed:
+- different fines or sentences for different accused;
+- a fine or बिगो smaller than the amount the prosecution demanded;
+- seized money partly returned as the accused's own private property;
+- conviction under a lesser section than the one charged.
+
+How to read one:
+- Decide from the OPERATIVE section -- the ठहर खण्ड and the तपसिल directions near
+  the end. The earlier sections recite the charge and the defence; they state
+  what was ALLEGED, not what was decided.
+- The operative verbs are ठहर्छ / ठहरेको (held) and सफाई पाउने ठहर्छ (acquitted).
+- Nearly every judgment contains both the words ठहर and सफाई. Their presence
+  proves nothing -- सफाई usually appears only because the defence ASKED for it.
+  Only the operative holding counts.
+- Before answering आंशिक ठहर, name the accused who was acquitted or the count
+  that was dismissed. If you cannot name one, the answer is ठहर.
+
+Answer ABSTAIN if the text is truncated before the operative section, is
+unreadable, or is not a Special Court judgment. Do not guess: a wrong verdict is
+far worse than an abstention."""
+
+
+@dataclass(frozen=True)
+class VerdictExtraction:
+    """A parsed model answer. ``decision_type`` is None when the model abstained."""
+
+    decision_type: str | None
+    judges: str | None
+    verdict_date_bs: str | None
+    evidence: str | None
+    confidence: str | None
+    raw: str
+
+    @property
+    def abstained(self) -> bool:
+        return self.decision_type is None
+
+
+def build_prompt(text: str, case_number: str) -> str:
+    """Shape one judgment into the user message.
+
+    Long documents keep their head (the bench) and their tail (the holding)
+    rather than the first N characters, which would drop the answer.
+    """
+    body = " ".join((text or "").split())
+    if len(body) > MAX_CHARS:
+        keep_tail = MAX_CHARS - HEAD_CHARS
+        body = f"{body[:HEAD_CHARS]}\n\n[... middle omitted ...]\n\n{body[-keep_tail:]}"
+    return f"Case number: {case_number}\n\nJudgment:\n{body}"
+
+
+def parse_response(raw: str) -> VerdictExtraction:
+    """Validate a model answer into a :class:`VerdictExtraction`.
+
+    Raises ValueError on anything that is not a usable answer, so a malformed
+    response is a visible failure rather than a silently skipped case.
+    """
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("empty response")
+
+    # Models occasionally wrap JSON in a fence despite the instruction, or
+    # prepend a sentence. Take the outermost object.
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError(f"no JSON object in response: {text[:120]!r}")
+    try:
+        data = json.loads(text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("response JSON is not an object")
+
+    decision = (data.get("decision_type") or "").strip()
+    if decision == ABSTAIN:
+        decision = None
+    elif decision not in DECISION_TYPES:
+        raise ValueError(f"decision_type not one of {DECISION_TYPES}: {decision!r}")
+
+    date_bs = (data.get("verdict_date_bs") or "").strip() or None
+    if date_bs and not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_bs):
+        # A stray format is not worth failing the whole extraction over; the
+        # authoritative date comes from case_status anyway.
+        date_bs = None
+
+    def _text(key, cap):
+        v = data.get(key)
+        return " ".join(str(v).split())[:cap] if v else None
+
+    return VerdictExtraction(
+        decision_type=decision,
+        judges=_text("judges", 500),
+        verdict_date_bs=date_bs,
+        evidence=_text("evidence", 300),
+        confidence=(data.get("confidence") or "").strip().lower() or None,
+        raw=text,
+    )
+
+
+def has_deciding_hearing() -> Exists:
+    """Subquery: the case already carries a hearing with a real disposition."""
+    return Exists(
+        CourtCaseHearing.objects.filter(
+            case_number=OuterRef("case_number"),
+            court_id=OuterRef("court_id"),
+            decision_type__in=DECISION_TYPES,
+        )
+    )
+
+
+def backlog(court_identifier="special", case_number=None):
+    """Cases marked decided, holding an order document, and carrying no verdict.
+
+    Ordered newest-register-first so a truncated run still makes useful
+    progress on the years most likely to be cited.
+    """
+    qs = CourtCase.objects.filter(court_id=court_identifier)
+    if case_number:
+        return qs.filter(case_number=case_number)
+    return (
+        qs.filter(extra_data__has_key="court_orders")
+        .annotate(decided=has_deciding_hearing())
+        .filter(decided=False)
+        .exclude(Q(case_status__isnull=True) | Q(case_status=""))
+        .order_by("-case_number")
+    )
+
+
+def is_decided(case) -> bool:
+    """True when ``case_status`` says a verdict exists (via the shared parser)."""
+    return parse_case_status(case.case_status).lifecycle_status == "DECIDED"
+
+
+def order_urls(case) -> list[str]:
+    """Fetchable order-document URLs for a case, RAW first.
+
+    Two storage generations have to be read here, and only one of them is
+    self-describing:
+
+    * ``document_sources`` CANONICAL (post-monolith capture) -- ``url`` is a LIST
+      of ``{link, role}``.
+    * ``document_sources`` LEGACY HYBRID (the 2026-07 rehost) -- ``url`` is a
+      SCALAR string and the roled list lives under ``links``.
+      ``materials.jsonld.media_objects_from_document_sources`` drops these,
+      because it requires ``url`` to be a list.
+    * ``extra_data['court_orders']`` holds ABSOLUTE urls on newly captured cases
+      but RELATIVE keys (``court-orders/special/<case>.1.doc``) on historical
+      ones, so it is only a fallback and only when it is already absolute.
+    """
+    out: list[str] = []
+
+    def add(link):
+        if isinstance(link, str) and link.startswith("http") and link not in out:
+            out.append(link)
+
+    raw, other = [], []
+    for src in getattr(case, "document_sources", None) or []:
+        if not isinstance(src, dict) or src.get("source_type") != "COURT_ORDER":
+            continue
+        url = src.get("url")
+        candidates = []
+        if isinstance(url, list):
+            candidates = url
+        elif isinstance(url, str):
+            # Legacy hybrid: the scalar is the primary, `links` carries the roles.
+            candidates = [{"link": url, "role": "RAW"}, *(src.get("links") or [])]
+        for link in candidates:
+            if isinstance(link, dict):
+                (raw if (link.get("role") or "").upper() == "RAW" else other).append(link.get("link"))
+            elif isinstance(link, str):
+                other.append(link)
+    for link in (*raw, *other):
+        add(link)
+
+    for entry in (case.extra_data or {}).get("court_orders") or []:
+        add(entry)
+    return out
+
+
+def derived_hearing_filter() -> Q:
+    """Q matching hearing rows this module wrote.
+
+    Exists so consumers can include or exclude model-derived verdicts
+    deliberately. Publishing a conviction rate over a mix of court-scraped and
+    model-derived rows without saying so would misrepresent the data.
+    """
+    return Q(**{f"extra_data__{PROVENANCE_KEY}__isnull": False})
+
+
+def build_hearing(case, extraction: VerdictExtraction, *, order_url, model, now):
+    """The unsaved :class:`CourtCaseHearing` for one recovered verdict.
+
+    The verdict DATE comes from ``case_status`` -- that is the court's own field
+    and is not in question. Only the disposition is model-derived.
+    """
+    if extraction.abstained:
+        raise ValueError("refusing to build a hearing from an abstention")
+    parsed = parse_case_status(case.case_status)
+    if not parsed.verdict_date_bs or not parsed.verdict_date_ad:
+        raise ValueError(f"no verdict date in case_status: {case.case_status!r}")
+
+    return CourtCaseHearing(
+        case_number=case.case_number,
+        court_id=case.court_id,
+        hearing_date_bs=parsed.verdict_date_bs,
+        hearing_date_ad=parsed.verdict_date_ad,
+        decision_type=extraction.decision_type,
+        judge_names=extraction.judges,
+        case_status=case.case_status,
+        scraped_at=now,
+        extra_data={
+            PROVENANCE_KEY: {
+                "derived": True,
+                "method": "llm_read_of_court_order",
+                "model": model,
+                "order_url": order_url,
+                "confidence": extraction.confidence,
+                "evidence": extraction.evidence,
+                "model_verdict_date_bs": extraction.verdict_date_bs,
+                "extracted_at": now.isoformat(),
+            }
+        },
+    )

--- a/courts/scraper/verdicts.py
+++ b/courts/scraper/verdicts.py
@@ -53,7 +53,7 @@ from dataclasses import dataclass
 
 from django.db.models import Exists, OuterRef, Q
 
-from courts.case_status import parse_case_status
+from courts.case_status import DECIDED, parse_case_status
 from courts.models import CourtCase, CourtCaseHearing
 
 #: The court's three dispositions, exactly as ``decision_type`` stores them.
@@ -212,6 +212,23 @@ def has_deciding_hearing() -> Exists:
     )
 
 
+def has_order() -> Q:
+    """Q for "an order document was captured for this case".
+
+    :func:`order_urls` reads TWO stores -- ``extra_data['court_orders']`` and
+    ``document_sources`` -- so this predicate looks narrower than it is. It is
+    not: ``scrape_court_orders`` writes both together, and the mirror bears that
+    out. Special Court cases that are decided, verdictless, and hold a
+    ``COURT_ORDER`` document source but NO ``court_orders`` key: 0 (measured
+    2026-07-31). Matching on ``document_sources`` instead would mean an
+    unindexed ``jsonb_array_elements`` scan of 1.6M cases to find them.
+
+    Shared with the eval sampler on purpose -- scoring the extractor against a
+    population the writer would never see would prove nothing.
+    """
+    return Q(extra_data__has_key="court_orders")
+
+
 def backlog(court_identifier="special", case_number=None):
     """Cases marked decided, holding an order document, and carrying no verdict.
 
@@ -222,7 +239,7 @@ def backlog(court_identifier="special", case_number=None):
     if case_number:
         return qs.filter(case_number=case_number)
     return (
-        qs.filter(extra_data__has_key="court_orders")
+        qs.filter(has_order())
         .annotate(decided=has_deciding_hearing())
         .filter(decided=False)
         .exclude(Q(case_status__isnull=True) | Q(case_status=""))
@@ -232,7 +249,7 @@ def backlog(court_identifier="special", case_number=None):
 
 def is_decided(case) -> bool:
     """True when ``case_status`` says a verdict exists (via the shared parser)."""
-    return parse_case_status(case.case_status).lifecycle_status == "DECIDED"
+    return parse_case_status(case.case_status).lifecycle_status == DECIDED
 
 
 def order_urls(case) -> list[str]:
@@ -279,6 +296,24 @@ def order_urls(case) -> list[str]:
     for entry in (case.extra_data or {}).get("court_orders") or []:
         add(entry)
     return out
+
+
+def court_coded_verdicts(court_identifier="special"):
+    """``(case_number, decision_type)`` pairs for verdicts THE COURT coded.
+
+    The eval's answer key, so it must exclude the rows this module wrote.
+    Without that, every ``--write`` run would fold the model's own answers into
+    the key and the reported accuracy would drift towards self-agreement.
+
+    Returns a queryset -- the caller picks the database, as with :func:`backlog`.
+    """
+    return (
+        CourtCaseHearing.objects.filter(
+            court_id=court_identifier, decision_type__in=DECISION_TYPES
+        )
+        .exclude(derived_hearing_filter())
+        .values_list("case_number", "decision_type")
+    )
 
 
 def derived_hearing_filter() -> Q:

--- a/courts/tests/test_scraper_verdicts.py
+++ b/courts/tests/test_scraper_verdicts.py
@@ -6,10 +6,13 @@ refuses anything it cannot vouch for, and these tests pin that refusal.
 """
 
 import json
+from unittest import mock
 
 from django.test import TestCase
 from django.utils import timezone
 
+from courts.management.commands import extract_verdicts
+from courts.management.commands.extract_verdicts import Command
 from courts.models import Court, CourtCase, CourtCaseHearing
 from courts.scraper.verdicts import (
     ACQUITTAL,
@@ -19,6 +22,7 @@ from courts.scraper.verdicts import (
     backlog,
     build_hearing,
     build_prompt,
+    court_coded_verdicts,
     derived_hearing_filter,
     is_decided,
     order_urls,
@@ -238,3 +242,54 @@ class CaseHelperTests(TestCase):
             {"source_type": "PRESS_RELEASE", "url": [{"link": "https://a/pr.pdf", "role": "RAW"}]},
         ])
         self.assertEqual(order_urls(c), [])
+
+
+class EvalAnswerKeyTests(TestCase):
+    """The eval is the only evidence the written verdicts are trustworthy, so it
+    must never grade the model against the model."""
+
+    databases = "__all__"
+
+    def setUp(self):
+        self.court = Court.objects.create(identifier="special", court_type="special", full_name_nepali="विशेष अदालत")
+
+    def _hearing(self, num, *, derived, decision=FULL):
+        return CourtCaseHearing.objects.create(
+            case_number=num, court=self.court, hearing_date_bs="2076-01-01",
+            hearing_date_ad="2019-04-14", decision_type=decision, scraped_at=timezone.now(),
+            extra_data={PROVENANCE_KEY: {"derived": True}} if derived else {},
+        )
+
+    def test_the_answer_key_holds_only_what_the_court_coded(self):
+        self._hearing("076-CR-0001", derived=False)
+        self._hearing("076-CR-0002", derived=True)
+        self.assertEqual(dict(court_coded_verdicts("special")), {"076-CR-0001": FULL})
+
+    def test_a_written_verdict_never_becomes_its_own_ground_truth(self):
+        """Left unfiltered, each --write run would enlarge the key with the
+        model's own answers and accuracy would drift towards self-agreement."""
+        case = CourtCase.objects.create(
+            case_number="076-CR-0215", court=self.court, case_status="फैसला (मिती: २०७६/१२/०३)",
+        )
+        build_hearing(case, parse_response(_resp()), order_url="u", model="m", now=timezone.now()).save()
+        self.assertEqual(dict(court_coded_verdicts("special")), {})
+
+    def test_hearings_without_a_disposition_are_not_an_answer(self):
+        self._hearing("076-CR-0003", derived=False, decision=None)
+        self.assertEqual(dict(court_coded_verdicts("special")), {})
+
+
+class PolitenessGapTests(TestCase):
+    """A dry run downloads exactly as much as a write run, and a run of failures
+    downloads more per minute than a run of successes. The gap has to sit on the
+    DOWNLOAD, not on the write and not at the end of the loop."""
+
+    def test_the_gap_precedes_every_download_but_the_first(self):
+        cmd = Command()
+        cmd._downloads = 0
+        with mock.patch.object(extract_verdicts, "time") as clock:
+            cmd._gap(2.5)
+            self.assertFalse(clock.sleep.called)   # nothing to be polite about yet
+            cmd._gap(2.5)
+            cmd._gap(2.5)
+        self.assertEqual([c.args for c in clock.sleep.call_args_list], [(2.5,), (2.5,)])

--- a/courts/tests/test_scraper_verdicts.py
+++ b/courts/tests/test_scraper_verdicts.py
@@ -1,0 +1,240 @@
+"""Verdict recovery from court orders.
+
+The load-bearing risk here is not a crash, it is a WRONG verdict written
+silently into a field that feeds a published conviction rate. So the parse layer
+refuses anything it cannot vouch for, and these tests pin that refusal.
+"""
+
+import json
+
+from django.test import TestCase
+from django.utils import timezone
+
+from courts.models import Court, CourtCase, CourtCaseHearing
+from courts.scraper.verdicts import (
+    ACQUITTAL,
+    FULL,
+    MAX_CHARS,
+    PROVENANCE_KEY,
+    backlog,
+    build_hearing,
+    build_prompt,
+    derived_hearing_filter,
+    is_decided,
+    order_urls,
+    parse_response,
+)
+
+
+def _resp(**over):
+    body = {
+        "decision_type": FULL,
+        "judges": "श्री क\nश्री ख",
+        "verdict_date_bs": "2076-12-03",
+        "evidence": "जरिवाना हुने ठहर्छ",
+        "confidence": "high",
+    }
+    body.update(over)
+    return json.dumps(body, ensure_ascii=False)
+
+
+class ParseResponseTests(TestCase):
+    def test_a_clean_answer_parses(self):
+        ex = parse_response(_resp())
+        self.assertEqual(ex.decision_type, FULL)
+        self.assertFalse(ex.abstained)
+        self.assertEqual(ex.confidence, "high")
+
+    def test_abstain_is_an_answer_not_an_error(self):
+        """Abstention is the correct output for an unreadable judgment."""
+        ex = parse_response(_resp(decision_type="ABSTAIN"))
+        self.assertTrue(ex.abstained)
+        self.assertIsNone(ex.decision_type)
+
+    def test_a_decision_outside_the_closed_set_is_rejected(self):
+        """The court has exactly three dispositions. A fourth is a parse failure,
+        never a new category -- silently storing it would corrupt every rate."""
+        for bogus in ("guilty", "ठहर्छ", "आंशिक", "", "convicted"):
+            with self.assertRaises(ValueError):
+                parse_response(_resp(decision_type=bogus))
+
+    def test_prose_around_the_json_is_tolerated(self):
+        ex = parse_response("Here is the result:\n```json\n" + _resp() + "\n```\nDone.")
+        self.assertEqual(ex.decision_type, FULL)
+
+    def test_malformed_and_empty_responses_raise(self):
+        for bad in ("", "   ", "not json at all", "{oops", "[]"):
+            with self.assertRaises(ValueError):
+                parse_response(bad)
+
+    def test_a_stray_date_format_is_dropped_not_fatal(self):
+        """case_status is the authoritative date, so a bad model date is noise."""
+        ex = parse_response(_resp(verdict_date_bs="03/12/2076"))
+        self.assertIsNone(ex.verdict_date_bs)
+        self.assertEqual(ex.decision_type, FULL)
+
+    def test_long_fields_are_capped(self):
+        ex = parse_response(_resp(evidence="क" * 5000, judges="ख" * 5000))
+        self.assertLessEqual(len(ex.evidence), 300)
+        self.assertLessEqual(len(ex.judges), 500)
+
+
+class BuildPromptTests(TestCase):
+    def test_a_short_judgment_is_sent_whole(self):
+        self.assertIn("ठहर्छ", build_prompt("क ख ठहर्छ", "076-CR-0001"))
+
+    def test_a_long_judgment_keeps_its_TAIL(self):
+        """The holding sits at the END. Plain truncation would cut off exactly
+        the section the answer depends on and invite a confident wrong guess."""
+        text = "HEAD" + ("पदपद " * 40_000) + "OPERATIVE ठहर्छ"
+        out = build_prompt(text, "076-CR-0001")
+        self.assertIn("HEAD", out)
+        self.assertIn("OPERATIVE ठहर्छ", out)
+        self.assertLess(len(out), MAX_CHARS + 500)
+
+
+class BuildHearingTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.court = Court.objects.create(identifier="special", court_type="special", full_name_nepali="विशेष अदालत")
+        self.case = CourtCase.objects.create(
+            case_number="076-CR-0215", court=self.court,
+            case_status="फैसला (मिती: २०७६/१२/०३)",
+            extra_data={"court_orders": ["https://s3.example/x.docx"]},
+        )
+        self.ex = parse_response(_resp())
+
+    def test_the_row_carries_the_courts_date_not_the_models(self):
+        """Only the disposition is model-derived; the date is the court's own."""
+        ex = parse_response(_resp(verdict_date_bs="2000-01-01"))
+        h = build_hearing(self.case, ex, order_url="u", model="m", now=timezone.now())
+        self.assertEqual(h.hearing_date_bs, "2076-12-03")
+        self.assertIsNotNone(h.hearing_date_ad)
+        self.assertEqual(h.extra_data[PROVENANCE_KEY]["model_verdict_date_bs"], "2000-01-01")
+
+    def test_every_written_row_is_marked_model_derived(self):
+        """A published conviction rate mixing scraped and inferred verdicts
+        without saying so would misrepresent the data."""
+        h = build_hearing(self.case, self.ex, order_url="u", model="m", now=timezone.now())
+        prov = h.extra_data[PROVENANCE_KEY]
+        self.assertTrue(prov["derived"])
+        self.assertEqual(prov["model"], "m")
+        self.assertEqual(prov["order_url"], "u")
+        self.assertEqual(prov["evidence"], "जरिवाना हुने ठहर्छ")
+
+        h.save(using="ngm")
+        self.assertTrue(CourtCaseHearing.objects.using("ngm").filter(derived_hearing_filter()).exists())
+        scraped = CourtCaseHearing.objects.using("ngm").create(
+            case_number="076-CR-0999", court=self.court, hearing_date_bs="2076-01-01",
+            hearing_date_ad="2019-04-14", decision_type=FULL, scraped_at=timezone.now(),
+        )
+        found = CourtCaseHearing.objects.using("ngm").filter(derived_hearing_filter())
+        self.assertNotIn(scraped.pk, [h.pk for h in found])
+
+    def test_an_abstention_can_never_become_a_row(self):
+        with self.assertRaises(ValueError):
+            build_hearing(self.case, parse_response(_resp(decision_type="ABSTAIN")),
+                          order_url="u", model="m", now=timezone.now())
+
+    def test_a_case_without_a_verdict_date_is_refused(self):
+        """No date means no defensible hearing_date -- better to skip the case
+        than to invent one or reach for a sentinel."""
+        self.case.case_status = "फैसला"
+        with self.assertRaises(ValueError):
+            build_hearing(self.case, self.ex, order_url="u", model="m", now=timezone.now())
+
+
+class BacklogTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.court = Court.objects.create(identifier="special", court_type="special", full_name_nepali="विशेष अदालत")
+        self.other = Court.objects.create(identifier="supreme", court_type="supreme", full_name_nepali="सर्वोच्च अदालत")
+
+    def _case(self, num, *, orders=True, status="फैसला (मिती: २०७६/१२/०३)", court=None):
+        return CourtCase.objects.create(
+            case_number=num, court=court or self.court, case_status=status,
+            extra_data={"court_orders": ["https://s3.example/x.docx"]} if orders else {},
+        )
+
+    def test_it_selects_only_cases_that_need_and_can_have_a_verdict(self):
+        want = self._case("076-CR-0001")
+        self._case("076-CR-0002", orders=False)          # nothing to read
+        self._case("076-CR-0003", status="")             # no status at all
+        already = self._case("076-CR-0004")
+        CourtCaseHearing.objects.create(
+            case_number=already.case_number, court=self.court, hearing_date_bs="2076-01-01",
+            hearing_date_ad="2019-04-14", decision_type=ACQUITTAL, scraped_at=timezone.now(),
+        )
+        self.assertEqual([c.case_number for c in backlog()], [want.case_number])
+
+    def test_a_hearing_without_a_disposition_does_not_count_as_decided(self):
+        """The backfilled cases have exactly this shape -- hearing rows present,
+        decision_type never populated. Missing them would defeat the point."""
+        c = self._case("076-CR-0005")
+        CourtCaseHearing.objects.create(
+            case_number=c.case_number, court=self.court, hearing_date_bs="2076-01-01",
+            hearing_date_ad="2019-04-14", decision_type=None, scraped_at=timezone.now(),
+        )
+        self.assertIn(c.case_number, [x.case_number for x in backlog()])
+
+    def test_it_stays_within_one_court(self):
+        self._case("076-CR-0007", court=self.other)
+        self.assertEqual(list(backlog(court_identifier="special")), [])
+
+    def test_a_named_case_bypasses_the_filters_for_smoke_testing(self):
+        c = self._case("076-CR-0008", orders=False)
+        self.assertEqual([x.case_number for x in backlog(case_number=c.case_number)], [c.case_number])
+
+
+class CaseHelperTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.court = Court.objects.create(identifier="special", court_type="special", full_name_nepali="विशेष अदालत")
+
+    def test_is_decided_reads_the_shared_parser(self):
+        mk = lambda s: CourtCase(case_number="x", court=self.court, case_status=s)  # noqa: E731
+        self.assertTrue(is_decided(mk("फैसला (मिती: २०७६/१२/०३)")))
+        self.assertFalse(is_decided(mk("चलिरहेको")))
+        self.assertFalse(is_decided(mk("")))
+
+    def test_order_urls_ignores_junk_entries(self):
+        c = CourtCase(case_number="x", court=self.court,
+                      extra_data={"court_orders": ["https://a/x.doc", "", None, 7, "not-a-url"]})
+        self.assertEqual(order_urls(c), ["https://a/x.doc"])
+        self.assertEqual(order_urls(CourtCase(case_number="y", court=self.court, extra_data=None)), [])
+
+    def test_order_urls_reads_the_CANONICAL_document_source_shape(self):
+        c = CourtCase(case_number="x", court=self.court, document_sources=[{
+            "source_type": "COURT_ORDER", "document_id": "d",
+            "url": [{"link": "https://a/alt.pdf", "role": "ALTERNATE"},
+                    {"link": "https://a/raw.doc", "role": "RAW"}],
+        }])
+        # RAW first: it is the judgment; ALTERNATE may be a scan or a summary.
+        self.assertEqual(order_urls(c), ["https://a/raw.doc", "https://a/alt.pdf"])
+
+    def test_order_urls_reads_the_LEGACY_HYBRID_shape(self):
+        """The 2026-07 rehost left historical cases with a SCALAR `url` plus a
+        `links` list. materials.jsonld drops these, so reading document_sources
+        naively would make every historical order invisible."""
+        c = CourtCase(case_number="x", court=self.court, document_sources=[{
+            "source_type": "COURT_ORDER",
+            "url": "https://a/raw.doc",
+            "links": [{"link": "https://a/raw.doc", "role": "RAW"}],
+        }])
+        self.assertEqual(order_urls(c), ["https://a/raw.doc"])
+
+    def test_order_urls_skips_relative_legacy_court_orders_keys(self):
+        """Historical `extra_data['court_orders']` holds STORAGE KEYS, not URLs.
+        Treating one as a URL would fetch nothing and look like a missing order."""
+        c = CourtCase(case_number="x", court=self.court,
+                      extra_data={"court_orders": ["court-orders/special/076-CR-0006.1.doc"]})
+        self.assertEqual(order_urls(c), [])
+
+    def test_order_urls_ignores_non_order_document_sources(self):
+        c = CourtCase(case_number="x", court=self.court, document_sources=[
+            {"source_type": "PRESS_RELEASE", "url": [{"link": "https://a/pr.pdf", "role": "RAW"}]},
+        ])
+        self.assertEqual(order_urls(c), [])


### PR DESCRIPTION
## The gap

A hearing carries the disposition, and hearings come from the daily cause list. Cases that reached the mirror by another route — the register sweep, mostly — can be marked decided in `case_status` while carrying **no hearing with a `decision_type` at all**. They count as decided and contribute to no outcome.

In the Special Court `-CR-` corpus that is **112 cases**. It is the 2,728-vs-2,740 discrepancy the research pack documents.

| | n |
|---|---|
| **order document available** | **77** |
| court publishes no order | 31 |
| too recent to have one | 4 |

## Why not a regex

A faisala recites the charge and *then* the finding, and a mixed bench convicts some accused while acquitting others. **4 of 6 sampled judgments contain both ठहर and सफाई.** Keyword matching picks the wrong one often enough to matter, and full-vs-partial is only available by reading the operative section.

## Calibration

`--eval N` scores against cases whose disposition the court already gave us — same population, known answer. It never writes.

| | correct | wrong | errored | accuracy on answered |
|---|---|---|---|---|
| prompt v1 | 21 | **3** | 0 | 87.5% |
| **prompt v2** | 21 | **0** | 3 | **100.0%** |

All three of v1's errors ran the same way — `ठहर` reported as `आंशिक ठहर` — because v1 defined आंशिक to include "a materially reduced claim/amount". It does not. The court reserves आंशिक ठहर for the **charge** standing only in part: an accused acquitted, or a count dismissed. Differing fines between convicted accused, a बिगो below what was demanded, and seized money returned as private property are all still `ठहर`.

v2 states that as an ordered test and requires the model to **name** the acquitted accused before it may answer आंशिक. Confidence is not a usable filter — 2 of v1's 3 wrong answers were `high`.

The 3 remaining failures are the longest multi-defendant judgments, which exhaust the output-token budget. That is the failure mode we want: **a skipped case costs coverage, a wrong one corrupts a published conviction rate.** Expect roughly one in eight to be left for a human.

## Guardrails

- **The verdict date is never inferred** — it comes from `case_status`, the court's own field. Only the disposition is model-derived.
- **Every row is marked model-derived** under `extra_data['verdict_extraction']`, carrying the model, the source document and the quoted clause. `derived_hearing_filter()` lets a consumer include or exclude them deliberately.
- `decision_type` is a closed set of three; a fourth value is a parse failure, never a new category.
- An abstention can never become a row.
- Hearings carry no unique constraint, so the write re-checks inside the transaction — a concurrent cause-list scrape or a second run cannot duplicate.

## Also fixed

`order_urls` reads **both** `document_sources` generations: the canonical `url`-list and the legacy hybrid the 2026-07 rehost left behind (scalar `url` + `links`). `materials.jsonld.media_objects_from_document_sources` requires `url` to be a list and drops the hybrid, so reading only the canonical shape would have made every historical order invisible.

## Required follow-up before this reaches the published rate

The research pack pulls hearings as `case_number, decision_type, judge_names` — **it cannot tell a model-derived verdict from a court-scraped one.** Its 45.1% conviction rate would silently absorb these. The dataset pull needs the provenance column before any of this is quoted. Separate PR in `corruption-research`.

## Testing

452 courts tests pass, `ruff` clean. Nothing has been run with `--write`; the eval ran against the **read replica**, so a write was physically impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooling to recover missing case verdicts from published judgment documents.
  * Supports preview, evaluation, and write modes, with court, batch size, model tier, and request-delay controls.
  * Recovered verdicts include decision details, authoritative hearing dates, supporting evidence, and source information.
  * Supports multiple court-document formats and identifies cases eligible for recovery.

* **Bug Fixes**
  * Avoids duplicate records and rejects incomplete, malformed, or unverifiable judgment data.
  * Improves handling of unavailable documents and model-processing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->