### PR TITLE
fix(courts): convert order documents with the converter that ships

### DIFF
--- a/courts/management/commands/extract_verdicts.py
+++ b/courts/management/commands/extract_verdicts.py
@@ -90,8 +90,8 @@ class Command(BaseCommand):
         Raises RuntimeError with a short reason on any unusable case, so the
         caller can count failure kinds instead of swallowing them.
         """
-        from casework.convert import extract_markdown
         from llm import invoke, routing
+        from review.converter import convert_all
 
         urls = order_urls(case)
         if not urls:
@@ -100,12 +100,18 @@ class Command(BaseCommand):
         text = ""
         used = None
         for url in urls:
-            try:
-                text = extract_markdown(url, timeout=180)
-            except Exception as exc:  # noqa: BLE001 - one bad artefact != a dead case
-                self.stderr.write(f"    fetch failed {url}: {type(exc).__name__}: {exc}")
+            # review.converter is the in-repo converter the material_convert
+            # worker uses (see materials/job_handlers.py): likhit/MarkItDown,
+            # Devanagari OCR at a safe DPI, on-disk cache, and a hard per-source
+            # wall-clock timeout so one stalled scan can't hang the whole run.
+            # It reports failure in the result dict rather than raising, so one
+            # bad artefact costs a URL, not the case.
+            (res,) = convert_all([{"url": [url]}])
+            if res.get("conversion_status") == "error":
+                self.stderr.write(f"    convert failed {url}: {res.get('conversion_note')}")
                 continue
-            if text and text.strip():
+            text = res.get("markdown") or ""
+            if text.strip():
                 used = url
                 break
         if not used:

--- a/tests/test_app_package_names.py
+++ b/tests/test_app_package_names.py
@@ -111,6 +111,87 @@ def test_every_first_party_app_ships_in_the_wheel():
     )
 
 
+def _copied_packages():
+    """Top-level package names the Dockerfile actually COPYs into the image."""
+    dockerfile = (settings.BASE_DIR / "Dockerfile").read_text()
+    return set(re.findall(r"^COPY\s+([A-Za-z_][A-Za-z0-9_]*)/\s", dockerfile, re.MULTILINE))
+
+
+def _first_party_packages():
+    """Every top-level importable package in the repo, app or not."""
+    base = Path(settings.BASE_DIR).resolve()
+    return {
+        p.name for p in base.iterdir()
+        if p.is_dir() and (p / "__init__.py").exists() and not p.name.startswith(".")
+    }
+
+
+#: `import X` / `from X import ...`, including indented (function-local) ones.
+_IMPORT = re.compile(r"^\s*(?:from|import)\s+([A-Za-z_][A-Za-z0-9_]*)", re.MULTILINE)
+
+
+def test_shipped_code_never_imports_a_package_the_image_lacks():
+    """A COPYed package may only import other COPYed packages.
+
+    The INSTALLED_APPS checks above miss a whole class of this bug: a package
+    that is NOT a Django app (so not in the registry, so invisible to
+    ``_first_party_apps``) but IS imported by shipped code. ``casework`` is one --
+    a local-only helper package, never COPYed. When ``extract_verdicts`` imported
+    ``casework.convert`` for its document conversion, every check in this file
+    passed, CI passed, the image built, and the command failed on all 84 cases in
+    production with ``No module named 'casework'``. It had worked in development
+    for the same reason the docstring at the top of this file gives: a source
+    checkout makes every directory importable.
+
+    Function-local imports are included deliberately -- that is where the real
+    one was, and where they hide best.
+    """
+    copied = _copied_packages()
+    first_party = _first_party_packages()
+    base = Path(settings.BASE_DIR).resolve()
+
+    offenders = {}
+    for pkg in sorted(copied):
+        for py in sorted((base / pkg).rglob("*.py")):
+            if "/migrations/" in str(py) or "/tests/" in str(py):
+                continue
+            for name in set(_IMPORT.findall(py.read_text(encoding="utf-8"))):
+                if name in first_party and name not in copied:
+                    offenders.setdefault(name, []).append(str(py.relative_to(base)))
+
+    assert not offenders, (
+        "Shipped code imports first-party packages that are never COPYed into "
+        f"the image: { {k: v[:3] for k, v in offenders.items()} }. Either add "
+        "`COPY <pkg>/ ./<pkg>/` to the Dockerfile (and the wheel `packages` "
+        "list) or import something that ships."
+    )
+
+
+def test_the_import_check_reads_function_local_imports():
+    """Guard the guard: the regex must see an indented import.
+
+    The real defect was a lazy `from casework.convert import ...` inside a
+    method. A top-level-only regex would pass this file forever while missing
+    exactly the shape that caused the incident.
+    """
+    sample = "def f():\n    from casework.convert import extract_markdown\n    import llm\n"
+    assert set(_IMPORT.findall(sample)) == {"casework", "llm"}
+
+
+def test_the_import_check_has_something_to_check():
+    """Guard the guard: empty inputs would make the scan pass vacuously."""
+    copied, first_party = _copied_packages(), _first_party_packages()
+    assert len(copied) > 10, f"suspiciously few COPYed packages: {sorted(copied)}"
+    assert "courts" in copied and "review" in copied, sorted(copied)
+    # A first-party package that is deliberately NOT shipped must exist, or the
+    # check above can never fire and its passing means nothing.
+    assert first_party - copied, (
+        "Every first-party package is COPYed, so the scan cannot distinguish "
+        "shipped from unshipped. If that is now genuinely true, keep the scan "
+        "but drop this guard."
+    )
+
+
 def test_the_app_list_is_not_empty_and_finds_dotted_appconfigs():
     """Guard the shared input to all three checks above.
 


### PR DESCRIPTION
`extract_verdicts` (#399) read the judgment through `casework.convert`. That package is not in the Dockerfile's `COPY` allowlist, so it is in **neither published image**. The write Job selected all 84 Special Court cases and failed all 84 with `No module named 'casework'`.

Nothing was written — the per-case failure path held, and prod still has 0 derived rows — but the command could not have run anywhere except a source checkout, which is exactly where it was developed and where its 24-case eval scored 100%.

## The fix

`review.converter.convert_all`, which `materials/job_handlers.py:10` already names as the in-repo path for this exact job:

> Conversion reuses the **in-repo** casework converter (`review.converter`), which wraps `likhit` / MarkItDown (both declared deps) — download, Devanagari OCR at a Bedrock-safe DPI, and on-disk caching are already handled there. We deliberately do NOT depend on any code outside this repo.

It also gives a hard per-source wall-clock timeout (`CONVERT_SOURCE_TIMEOUT`), so one stalled scan can't hang an 84-case run — the old path had no such bound. It reports failure in the result dict rather than raising, so a bad artefact still costs a URL and not the case.

## Why CI didn't catch it

`tests/test_app_package_names.py` exists for this precise bug class, and its own docstring explains why it can't fail at test time: *"the unit suite runs from a source checkout where every directory is importable regardless."* Its three checks walk `INSTALLED_APPS` — and `casework` is not a Django app, so it was invisible to all of them.

Added `test_shipped_code_never_imports_a_package_the_image_lacks`: every `COPY`ed package may only import other `COPY`ed packages, **function-local imports included** — that is where this one was, and where they hide best. Reverting the import fails it with the production error:

```
AssertionError: Shipped code imports first-party packages that are never COPYed
into the image: {'casework': ['courts/management/commands/extract_verdicts.py']}
```

Two guards keep the scan from passing vacuously (one pins the regex against an indented import; one asserts an unshipped first-party package still exists, or the scan could never fire).

## Verification

- 464 tests pass (`courts/` + the contract suite), ruff clean
- Mutation-checked: reverting the import fails the new test; restoring it passes
- The backlog query is confirmed against prod — 84 cases, all with a parseable फैसला date, 0 derived rows currently

Not yet re-run in prod; that waits on this merging and the image rebuilding.