### PR TITLE
fix(courts): stop discarding the charge on every Supreme case

### DIFF
--- a/courts/scraper/supreme.py
+++ b/courts/scraper/supreme.py
@@ -262,11 +262,22 @@ def _map_field(data: dict, label: str, value: str) -> None:
         if value:
             data["registration_date_ad"] = bs_to_ad(normalize_date(value))
 
-    elif label in ["मुद्दाको किसिम", "मुद्दा", "मुद्दाको बिषय"]:
-        if "case_type" not in data:
-            data["case_type"] = value[:200]
-        if "case_subject" not in data:
-            data["case_subject"] = value
+    # Two DIFFERENT labels, and the page carries both: `मुद्दाको किसिम` is the
+    # coarse class (फौजदारी / देवानी — two values across ~104k rows) and `मुद्दा`
+    # is the actual charge (कर्तव्य ज्यान, भ्रष्टाचार, …). They shared one branch
+    # with first-wins, and किसिम appears first on the page, so the charge was
+    # discarded on every Supreme case — leaving case_type='फौजदारी' corpus-wide.
+    # That is not cosmetic: courts.search_visibility maps case_type to a canonical
+    # code, and a coarse label can only ever map to OTHER_CRIMINAL, so a Supreme
+    # corruption case is indistinguishable from a homicide and stays out of the
+    # public index. The charge wins; the class is kept alongside it.
+    elif label == "मुद्दाको किसिम":
+        data["case_class"] = value[:200]
+        data.setdefault("case_type", value[:200])   # fallback: some pages omit मुद्दा
+        data.setdefault("case_subject", value)
+    elif label in ["मुद्दा", "मुद्दाको बिषय"]:
+        data["case_type"] = value[:200]
+        data["case_subject"] = value
 
     elif label in ["मुद्दाको स्थिती", "मुद्दाको स्थिति"]:
         data["case_status"] = value[:100]
@@ -495,6 +506,10 @@ def parse_supreme_detail(html: str) -> ParsedEnrichment:
     # ``division`` is a legacy Supreme field, NOT a v2 court_cases column.
     if basic.get("division"):
         extra_data["division"] = basic["division"]
+    # The coarse फौजदारी/देवानी class. It has no v2 column and must not be mistaken
+    # for the charge again (see _map_field), but it is worth keeping.
+    if basic.get("case_class"):
+        extra_data["case_class"] = basic["case_class"]
 
     core_fields: dict = {}
     for key in (

--- a/courts/tests/test_scraper_notfound.py
+++ b/courts/tests/test_scraper_notfound.py
@@ -137,3 +137,41 @@ class TestSupremeTwoStage:
 
         assert REGISTRY["supreme"].crawl_detail(fake_fetch, "supreme", "081-WO-99999") is None
         assert len(calls) == 1, "a 0-record search must not fetch a detail page"
+
+
+class TestSupremeChargeVsClass:
+    """Supreme publishes BOTH a coarse class and the actual charge.
+
+    ``मुद्दाको किसिम`` is फौजदारी/देवानी — two values across ~104k rows. ``मुद्दा``
+    is the charge (कर्तव्य ज्यान, भ्रष्टाचार, …). They shared one first-wins branch
+    and किसिम appears first on the page, so the charge was dropped on every Supreme
+    case. That left case_type='फौजदारी' corpus-wide, which courts.search_visibility
+    can only map to OTHER_CRIMINAL — so a Supreme corruption case looked exactly
+    like a homicide and could never reach the public index.
+    """
+
+    _PAGE = """
+    <table class="table-hover"><tr><td>
+      <table class="table-hover">
+        <tr><td>दर्ता नँ . :</td><td>081-CR-1641</td></tr>
+        <tr><td>मुद्दाको किसिम:</td><td>फौजदारी</td></tr>
+        <tr><td>मुद्दा:</td><td>कर्तव्य ज्यान</td></tr>
+      </table>
+    </td></tr></table>"""
+
+    def test_the_charge_wins_over_the_coarse_class(self):
+        core = supreme.parse_supreme_detail(self._PAGE).core_fields
+        assert core["case_type"] == "कर्तव्य ज्यान"
+        assert core["case_subject"] == "कर्तव्य ज्यान"
+
+    def test_the_coarse_class_is_kept_not_discarded(self):
+        assert supreme.parse_supreme_detail(self._PAGE).extra_data["case_class"] == "फौजदारी"
+
+    def test_a_page_without_a_charge_falls_back_to_the_class(self):
+        page = self._PAGE.replace("<tr><td>मुद्दा:</td><td>कर्तव्य ज्यान</td></tr>", "")
+        assert supreme.parse_supreme_detail(page).core_fields["case_type"] == "फौजदारी"
+
+    def test_a_corruption_charge_survives_to_case_type(self):
+        # The whole point: this is what the visibility gate needs to see.
+        page = self._PAGE.replace("कर्तव्य ज्यान", "भ्रष्टाचार")
+        assert supreme.parse_supreme_detail(page).core_fields["case_type"] == "भ्रष्टाचार"


### PR DESCRIPTION
Found while starting the Supreme register sweep. **I aborted that sweep after 91 rows because of this** — it was writing dockets with the charge already thrown away.

## The bug

Supreme's detail page publishes two different labels, and `_map_field` collapsed them into one first-wins branch:

| label | meaning | example |
|---|---|---|
| `मुद्दाको किसिम` | coarse class — effectively 2 values across ~104k rows | फौजदारी |
| `मुद्दा` | **the actual charge** | कर्तव्य ज्यान |

`किसिम` appears first on the page, so under `if "case_type" not in data` the coarse class always won and **the charge was never stored at all**.

Verified against the live portal — `081-CR-1641` serves both, and we stored `case_type = case_subject = 'फौजदारी'`.

## Blast radius

```
supreme -CR- rows reading 'फौजदारी':        3,443 / 3,563
supreme rows with ANY case_subject:            740 / 103,918
supreme rows with a corruption subject:          0
```

This is not cosmetic. `courts.search_visibility` maps `case_type` to a canonical code to decide public-index membership, and a coarse class can only ever map to `OTHER_CRIMINAL` — so **a Supreme corruption case is indistinguishable from a homicide** and gets evicted from `ngm-courtcases` alongside it. I watched that happen live: 0 of the first 65 swept Supreme cases passed the visibility gate, every one a `DELETE`.

It also made the sweep counterproductive for Supreme specifically. `upsert_from_detail` sets `case_type` at creation, so each of the 29,521 dockets it was about to create would have been permanently stamped `फौजदारी`, recoverable only by re-fetching all of them.

## The fix

The charge wins; the class is preserved in `extra_data.case_class` (no v2 column — same treatment as `division`). A page that omits `मुद्दा` still falls back to the class, so a sparser page is no worse off than before.

## Testing

460 courts tests (was 429), `ruff` clean.

## Follow-up, not in this PR

- The 91 rows the aborted sweep created carry the bad `case_type`; they're tagged `extra_data.source='register_sweep'` so they're trivially findable for a re-fetch.
- `case_type` is not in `_ENRICH_COLUMNS`, so re-enrichment alone will **not** correct the ~103k pre-existing Supreme rows — the cause-list owns that column. Fixing those is a separate decision (and a big one).