### PR TITLE
feat(courts): replace coarse case_type with the real charge, from the detail page

### DIFF
--- a/courts/management/commands/backfill_case_type.py
+++ b/courts/management/commands/backfill_case_type.py
@@ -1,0 +1,116 @@
+"""Replace a coarse ``case_type`` with the real charge, from the court's detail page.
+
+Supreme's pages carry two labels — ``मुद्दाको किसिम`` (the class: फौजदारी / देवानी)
+and ``मुद्दा`` (the charge: घुस, सरकारी सम्पत्ति हिनामिना, लिखत वदर …). The legacy
+import stored the class, so **46,373 of 103,934 supreme rows say only "criminal" or
+"civil"**. The parser bug that did the same thing on the live path is fixed, but the
+fix cannot reach rows already written: ``case_type`` is deliberately outside
+``_ENRICH_COLUMNS`` (the cause list owns it), so re-enrichment leaves them alone.
+
+Why it matters beyond tidiness: ``courts.search_visibility`` maps ``case_type`` to a
+canonical code to decide public-index membership, and a class can only ever map to
+OTHER_CRIMINAL. A Supreme bribery case labelled फौजदारी is indistinguishable from a
+homicide and is evicted from ``ngm-courtcases`` with it. Measured yield on a
+stratified sample of 12: **12 improved, 0 unchanged**, three of them corruption.
+
+Deliberately narrow. It rewrites ``case_type``/``case_subject`` and records the class
+in ``extra_data.case_class`` — nothing else. It does NOT call ``apply_enrichment``,
+so parties are never passed through ``_replace_entities`` and no ``nes_id`` link is
+put at risk, and ``status`` is untouched.
+
+Resumable by construction: a repaired row no longer matches the filter.
+
+    manage.py backfill_case_type --court supreme --series CR
+    manage.py backfill_case_type --court supreme --series CR --apply
+"""
+
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+
+from courts.models import CourtCase
+from courts.scraper import base, registry
+
+#: Class labels that are not charges. A row holding one of these tells you only
+#: which half of the court's docket it is on.
+COARSE_TYPES = ["फौजदारी", "देवानी"]
+
+
+class Command(BaseCommand):
+    help = "Re-fetch detail pages to replace a coarse case_type with the real charge."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--court", required=True, help="registry key, e.g. supreme")
+        parser.add_argument("--court-id", default=None, help="restrict to one leaf court")
+        parser.add_argument("--series", default=None,
+                            help="restrict to a register series (e.g. CR). Worth doing: "
+                                 "CR is the criminal register and carries the corruption "
+                                 "cases, RI is 32k writ/revision rows")
+        parser.add_argument("--apply", action="store_true", help="write (default: dry run)")
+        parser.add_argument("--limit", type=int, default=None, help="cap rows this run")
+        parser.add_argument("--delay", type=float, default=3.0, help="seconds between fetches")
+
+    def handle(self, *args, **o):
+        try:
+            keys = registry.resolve(o["court"])
+        except KeyError as exc:
+            raise CommandError(str(exc)) from exc
+        if len(keys) != 1:
+            raise CommandError("--court must name a single tier.")
+        module = registry.REGISTRY[keys[0]]
+        if not hasattr(module, "crawl_detail"):
+            raise CommandError(f"{keys[0]} has no crawl_detail.")
+
+        qs = CourtCase.objects.using(base.NGM_DB).filter(case_type__in=COARSE_TYPES)
+        qs = qs.filter(court_id=o["court_id"]) if o["court_id"] else qs.filter(
+            court_id__in=module.court_ids(None)
+        )
+        if o["series"]:
+            qs = qs.filter(case_number__contains=f"-{o['series'].upper()}-")
+        targets = list(qs.values_list("court_id", "case_number")[: o["limit"]])
+
+        self.stdout.write(f"{len(targets)} row(s) holding only a class, not a charge.")
+        if not o["apply"]:
+            for court_id, case_number in targets[:10]:
+                self.stdout.write(f"  {court_id}/{case_number}")
+            self.stdout.write(self.style.WARNING("dry run — pass --apply to rewrite."))
+            return
+
+        from courts.scraper.fetch import Fetcher
+
+        fetch = Fetcher()
+        fixed = unchanged = failed = 0
+        for court_id, case_number in targets:
+            try:
+                enrichment = module.crawl_detail(fetch, court_id, case_number)
+            except Exception as exc:  # a flake must not abandon the rest of the run
+                failed += 1
+                self.stderr.write(f"  {court_id}/{case_number}: {exc}")
+                time.sleep(o["delay"])
+                continue
+            charge = (enrichment.core_fields or {}).get("case_type") if enrichment else None
+            if not charge or charge in COARSE_TYPES:
+                # The page has no finer label either — leave the row exactly as it
+                # is rather than rewriting it with the value it already holds.
+                unchanged += 1
+                time.sleep(o["delay"])
+                continue
+
+            case = CourtCase.objects.using(base.NGM_DB).filter(
+                court_id=court_id, case_number=case_number
+            ).first()
+            if case is None:
+                unchanged += 1
+                time.sleep(o["delay"])
+                continue
+            case.case_type = charge[:200]
+            case.case_subject = charge
+            klass = (enrichment.extra_data or {}).get("case_class")
+            if klass:
+                case.extra_data = {**(case.extra_data or {}), "case_class": klass}
+            # Narrow save: never touch status, parties or hearings from here.
+            case.save(using=base.NGM_DB,
+                      update_fields=["case_type", "case_subject", "extra_data"])
+            fixed += 1
+            time.sleep(o["delay"])
+        self.stdout.write(f"rewrote {fixed}, left alone {unchanged}, failed {failed}.")

--- a/courts/tests/test_backfill_case_type.py
+++ b/courts/tests/test_backfill_case_type.py
@@ -1,0 +1,137 @@
+"""Replacing a coarse case_type with the real charge.
+
+The command exists because ``case_type`` is outside ``_ENRICH_COLUMNS`` by design,
+so no amount of re-enrichment reaches the 46k Supreme rows that hold only
+"criminal"/"civil". The tests pin the two properties that make it safe to point at
+a live 1.6M-row corpus: it rewrites nothing but the label, and it never makes a row
+worse than it found it.
+"""
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from courts.models import CaseEntity, Court, CourtCase
+from courts.scraper.registry import REGISTRY
+from courts.scraper.rows import ParsedEnrichment
+
+NES_IRI = "https://jawafdehi.org/entity/person/ram-bahadur"
+
+
+def _page(charge="घुस", klass="फौजदारी"):
+    return ParsedEnrichment(
+        core_fields={"case_type": charge, "case_subject": charge},
+        extra_data={"case_class": klass, "enrichment_hearings": []},
+        entities=[{"side": "defendant", "name": "ख", "address": None}],
+    )
+
+
+class BackfillCaseTypeTests(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        Court.objects.using("ngm").get_or_create(
+            identifier="supreme", defaults={"court_type": "", "full_name_nepali": ""}
+        )
+
+    def _case(self, case_number, case_type="फौजदारी", **over):
+        return CourtCase.objects.using("ngm").create(
+            court_id="supreme", case_number=case_number, case_type=case_type, **over
+        )
+
+    def _run(self, *args, page=None, side_effect=None):
+        out = StringIO()
+        with mock.patch("courts.scraper.fetch.Fetcher"), \
+             mock.patch.object(REGISTRY["supreme"], "crawl_detail",
+                               side_effect=side_effect,
+                               **({} if side_effect else {"return_value": page or _page()})):
+            call_command("backfill_case_type", "--court", "supreme", *args,
+                         stdout=out, stderr=out)
+        return out.getvalue()
+
+    def test_selects_only_rows_holding_a_class(self):
+        self._case("081-CR-0001")                              # फौजदारी  -> selected
+        self._case("081-CR-0002", case_type="देवानी")           # selected
+        self._case("081-CR-0003", case_type="घुस")              # already a charge
+        out = self._run("--delay", "0")
+        assert "2 row(s)" in out
+        assert "081-CR-0003" not in out
+
+    def test_dry_run_is_the_default_and_fetches_nothing(self):
+        self._case("081-CR-0001")
+        with mock.patch.object(REGISTRY["supreme"], "crawl_detail") as detail:
+            out = self._run("--delay", "0")
+        detail.assert_not_called()
+        assert "dry run" in out
+
+    def test_apply_replaces_the_class_with_the_charge(self):
+        self._case("081-CR-0001")
+        out = self._run("--apply", "--delay", "0")
+        case = CourtCase.objects.using("ngm").get(case_number="081-CR-0001")
+        assert case.case_type == "घुस"
+        assert case.case_subject == "घुस"
+        assert case.extra_data["case_class"] == "फौजदारी", "the class is kept, not lost"
+        assert "rewrote 1" in out
+
+    def test_a_page_with_no_finer_label_leaves_the_row_alone(self):
+        # Rewriting फौजदारी with फौजदारी would churn the row and its search doc
+        # for no gain.
+        self._case("081-CR-0001")
+        out = self._run("--apply", "--delay", "0", page=_page(charge="फौजदारी"))
+        assert CourtCase.objects.using("ngm").get(case_number="081-CR-0001").case_type == "फौजदारी"
+        assert "rewrote 0" in out
+
+    def test_it_never_touches_parties(self):
+        """The nes_id guard, again.
+
+        This command deliberately does NOT call apply_enrichment — that would run
+        _replace_entities, which drops every party row and recreates it without
+        nes_id. Only 607 such links exist corpus-wide.
+        """
+        self._case("081-CR-0001")
+        CaseEntity.objects.using("ngm").create(
+            court_id="supreme", case_number="081-CR-0001",
+            side="defendant", name="क", nes_id=NES_IRI,
+        )
+        self._run("--apply", "--delay", "0")
+        rows = CaseEntity.objects.using("ngm").filter(case_number="081-CR-0001")
+        assert rows.count() == 1, "the page's party list must not be applied"
+        assert rows.first().nes_id == NES_IRI
+
+    def test_it_never_touches_status(self):
+        self._case("081-CR-0001", status="enriched")
+        self._run("--apply", "--delay", "0")
+        assert CourtCase.objects.using("ngm").get(case_number="081-CR-0001").status == "enriched"
+
+    def test_series_narrows_the_run(self):
+        self._case("081-CR-0001")
+        self._case("081-RI-0001")
+        assert "1 row(s)" in self._run("--series", "cr", "--delay", "0")
+
+    def test_a_portal_error_does_not_abandon_the_rest(self):
+        self._case("081-CR-0001")
+        self._case("081-CR-0002")
+        calls = []
+
+        def flaky(fetch, court_id, case_number):
+            calls.append(case_number)
+            if len(calls) == 1:
+                raise RuntimeError("portal blew up")
+            return _page()
+
+        out = self._run("--apply", "--delay", "0", side_effect=flaky)
+        assert len(calls) == 2
+        assert "rewrote 1" in out and "failed 1" in out
+
+    def test_a_repaired_row_drops_out_of_the_next_run(self):
+        # Resumability comes from the filter itself, not from bookkeeping.
+        self._case("081-CR-0001")
+        self._run("--apply", "--delay", "0")
+        assert "0 row(s)" in self._run("--delay", "0")
+
+    def test_all_is_rejected(self):
+        with self.assertRaises(CommandError):
+            call_command("backfill_case_type", "--court", "all", stdout=StringIO())


### PR DESCRIPTION
Follow-up to #402. That fixed the parser; this fixes the rows already written.

## Why re-enrichment can't do it

`case_type` sits **outside `_ENRICH_COLUMNS` by design** — the cause list owns that column — so no amount of re-enrichment touches it. Meanwhile:

```
supreme rows holding only a class (फौजदारी / देवानी):  46,373 / 103,934   (44.6%)
  by series:   RI 32,014    CI 4,520    CR 3,466    RV 2,367    RB 1,671
```

`courts.search_visibility` maps `case_type` to a canonical code to decide public-index membership, and a class can only ever map to `OTHER_CRIMINAL`. So a Supreme bribery case labelled फौजदारी is indistinguishable from a homicide and is evicted from `ngm-courtcases` with it.

## Measured before building

Stratified sample of 12 coarse rows across RI/CI/CR — **12 of 12 returned a finer charge**, three of them corruption:

| docket | stored | detail page `मुद्दा` |
|---|---|---|
| `063-CR-0650` | फौजदारी | **सरकारी सम्पत्ति हिनामिना** |
| `064-CR-0466` | फौजदारी | **घुस** |
| `075-RI-1618` | फौजदारी | **सरकारीछाप र दस्तखत कीर्ते** |
| `069-CI-0215` | देवानी | लेनदेन |
| `076-CI-0732` | देवानी | दर्ता वदर |

## Why not just re-crawl cause lists (4h instead of 39h)

I checked — column 4 of the Supreme cause list **is** `मुद्दा`, the charge, so the crawler is already correct for anything it lists. But it can't reach these rows: they're BS 063–078, largely outside Supreme's 15-year lookback, and a decided case never appears on a cause list again. The detail page is the only source that still holds them.

## Safety

Deliberately narrow — rewrites `case_type`/`case_subject`, records the class in `extra_data.case_class`, nothing else.

- **Does not call `apply_enrichment`**, so parties never pass through `_replace_entities` and no `nes_id` link is at risk (pinned by a test).
- **Does not touch `status`.**
- A page with no finer label **leaves the row alone** rather than rewriting a value with itself — no pointless row churn or search-doc rewrite.
- Dry-run by default; `--series` scopes it; resumable by construction since a repaired row stops matching the filter.

## Cost, and suggested order

~39h total at the 3s delay (2 fetches/probe on Supreme). Worth doing by series rather than in one go:

| series | rows | est. |
|---|---|---|
| **CR** | 3,466 | ~2.9h — criminal register, densest in corruption |
| CI | 4,520 | ~3.8h |
| RI | 32,014 | ~27h |

## Testing

470 courts tests (was 460), `ruff` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintenance tool to refine broadly classified Supreme Court cases with more specific charge information.
  * Supports preview mode by default, with optional application of changes.
  * Allows filtering by court, series, and record limit.
  * Preserves the original broad classification alongside updated details.
  * Reports updated, unchanged, and failed records, and can safely resume interrupted processing.

* **Tests**
  * Added coverage for filtering, preview mode, error handling, data preservation, and resumable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->