### PR TITLE
feat(events): the four producers, stateless by design

### DIFF
--- a/case_events/apps.py
+++ b/case_events/apps.py
@@ -12,3 +12,19 @@ class EventsConfig(AppConfig):
 
     default_auto_field = "django.db.models.BigAutoField"
     name = "case_events"
+
+    def ready(self):
+        # Connects the Material post_save producer. Imported for its side effect,
+        # and guarded: a producer that fails to register must not take down the
+        # app that also owns the consumers and the bootstrap command, since those
+        # are what you would use to diagnose it.
+        #
+        # This opens no connection. With NATS_URL unset every emit is a logged
+        # no-op and no thread is started, so registering it costs nothing until
+        # the broker exists.
+        try:
+            from case_events.producers import materials  # noqa: F401
+        except Exception:  # noqa: BLE001
+            import structlog
+
+            structlog.get_logger(__name__).exception("case_events.producer_registration_failed")

--- a/case_events/management/commands/emit_docket_signals.py
+++ b/case_events/management/commands/emit_docket_signals.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Publish docket signals from the NGM lake.
+
+    manage.py emit_docket_signals                    # READ-ONLY: count what would go
+    manage.py emit_docket_signals --apply            # publish the window
+    manage.py emit_docket_signals --window-hours 6   # narrow it
+    manage.py emit_docket_signals --show 5           # print sample envelopes
+
+Read-only by default, like ``scrape_worker`` and ``review_poller``. The bare
+command reads the lake and reports; it needs no broker, which makes it the way to
+size the window before a cron ever runs.
+
+Runs as a CronJob in the platform image (it needs the ngm database). The window
+must comfortably exceed the schedule — see ``case_events.producers.dockets``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from case_events.producers import dockets
+
+
+class Command(BaseCommand):
+    help = "Emit jaw.signal.docket.* for recent lake activity (read-only without --apply)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually publish. Without it the command only counts and reports.",
+        )
+        parser.add_argument(
+            "--window-hours",
+            type=int,
+            default=dockets.DEFAULT_WINDOW_HOURS,
+            help=(
+                "How far back to rescan. Overlap is intentional and free (the dedup "
+                f"spine drops repeats); a gap is a permanently missed fact. Default {dockets.DEFAULT_WINDOW_HOURS}."
+            ),
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=dockets.DEFAULT_LIMIT,
+            help=f"Cap on rows examined per kind (default {dockets.DEFAULT_LIMIT}).",
+        )
+        parser.add_argument(
+            "--show",
+            type=int,
+            default=0,
+            metavar="N",
+            help="Print the first N signals as JSON. Works without --apply.",
+        )
+
+    def handle(self, *args, **options):
+        window = options["window_hours"]
+        limit = options["limit"]
+
+        if window <= 0:
+            raise CommandError("--window-hours must be positive; a zero window emits nothing.")
+
+        if not options["apply"]:
+            self._report(window, limit, options["show"])
+            return
+
+        if not getattr(settings, "NATS_URL", ""):
+            # Publishing already no-ops without a broker, but silently: the
+            # command would report zero sent and look like an empty window.
+            raise CommandError(
+                "NATS_URL is not set, so --apply would publish nothing and report it "
+                "as an empty window. Run without --apply to inspect the window."
+            )
+
+        counts = dockets.publish_window(window, limit)
+        total = sum(counts.values())
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(f"emit_docket_signals: {total} signal(s) over {window}h")
+        )
+        for subject, n in sorted(counts.items()):
+            self.stdout.write(f"  {subject}: {n}")
+
+        dropped = sum(n for s, n in counts.items() if "not sent" in s)
+        if dropped:
+            # Never silent. A run that published nothing looks identical to a
+            # quiet window unless it says so.
+            self.stderr.write(
+                self.style.WARNING(f"  {dropped} signal(s) were NOT accepted by the bus")
+            )
+
+        self._warn_if_saturated(counts, limit)
+
+    def _report(self, window, limit, show):
+        signals = list(dockets.scan(window, limit))
+        counts: dict[str, int] = {}
+        for subject, *_ in signals:
+            counts[subject] = counts.get(subject, 0) + 1
+
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                f"emit_docket_signals (read-only): {len(signals)} signal(s) over {window}h"
+            )
+        )
+        for subject, n in sorted(counts.items()):
+            self.stdout.write(f"  {subject}: {n}")
+        if not signals:
+            self.stdout.write("  (nothing in the window)")
+
+        for subject, payload, refs, dedup_key, occurred_at in signals[:show]:
+            self.stdout.write("")
+            self.stdout.write(
+                json.dumps(
+                    {
+                        "subject": subject,
+                        "subject_refs": refs,
+                        "dedup_key": dedup_key,
+                        "occurred_at": str(occurred_at),
+                        "payload": payload,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+
+        self.stdout.write("")
+        self.stdout.write("Use --apply to publish. Streams must exist first (manage.py nats_bootstrap).")
+        self._warn_if_saturated(counts, limit)
+
+    def _warn_if_saturated(self, counts, limit):
+        """Say so when the limit truncated a kind.
+
+        A capped run looks exactly like a complete one in the output, and the
+        difference is whether facts were dropped this cycle.
+        """
+        for subject, n in sorted(counts.items()):
+            if n >= limit:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"  {subject} hit the --limit of {limit}; the window is truncated and "
+                        "the remainder waits for the next run. Raise --limit or shorten the window."
+                    )
+                )

--- a/case_events/producers/__init__.py
+++ b/case_events/producers/__init__.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Producers: the things that put observed facts on ``jaw.signal.>``.
+
+A producer's whole job is to notice that something happened in the world and say
+so. It does not decide which case the fact belongs to (that is the matcher), it
+does not draft a change (that is the intent job), and it never writes a Case.
+
+**Signals are emitted where the record LANDS, not where the scraper runs.** The
+CIAA press-release and court-order scrapers are deliberately thin REST clients —
+``scrape_ciaa_press_releases`` says outright that it "never touches the ORM" —
+and hooking the bus into them would give every scraper a broker dependency, a
+``NATS_URL``, and a second way to be half-configured. Both write Materials
+through the ingestion plane, so one ``post_save`` producer at the Material seam
+covers both, and covers anything else that later writes the same kinds of
+document. This mirrors what :mod:`case_proposals.publish` does for proposals.
+
+**Producers are stateless and re-emit freely.** There is no watermark table and
+no checkpoint file. The docket producer rescans an overlapping window every run
+and republishes facts it has already published; the deduplication that makes
+that safe is the same spine every other layer relies on, ending at
+``CaseUpdateProposal.dedup_key``, which is unique and permanent.
+
+That is a deliberate trade and it has one sharp edge worth naming. The queue's
+own dedup does NOT hold across a completed job — ``jobs.queue.enqueue`` frees a
+``dedup_key`` once its job is terminal — so re-emission would have bought a fresh
+premium model call every time, had ``case_events.consumers.handlers`` not checked
+the proposal table before enqueueing. The stateless design and that check are one
+decision, not two; do not remove either without the other.
+
+What we get for it: no migration, no state to corrupt, and a dedup path that is
+exercised continuously in production rather than only in tests. A watermark that
+silently skips a range is a failure nobody notices for months.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from case_events import bus
+from case_events.envelope import build_envelope
+
+logger = structlog.get_logger(__name__)
+
+
+def emit(
+    subject: str,
+    *,
+    producer: str,
+    payload: dict[str, Any],
+    subject_refs: list[str],
+    dedup_key: str,
+    source: str = "",
+    raw_ref: str = "",
+    occurred_at=None,
+) -> bool:
+    """Publish one signal. Never raises; returns False if nothing was sent.
+
+    Best-effort in exactly the same sense as :mod:`case_proposals.publish`: a
+    producer runs alongside work that matters more than the signal does — a
+    scrape that populated the lake, a material that is now in the archive — and
+    a broker outage must not cost that work.
+
+    ``dedup_key`` is mandatory here rather than optional as it is on
+    ``build_envelope``. A signal with no deterministic key defeats every dedup
+    layer downstream, and since producers re-emit by design that is not a
+    degraded message but a duplicate-proposal generator.
+    """
+    if not dedup_key:
+        logger.warning("case_events.signal_without_dedup_key", subject=subject, producer=producer)
+        return False
+
+    envelope = build_envelope(
+        subject=subject,
+        producer=producer,
+        payload=payload,
+        subject_refs=subject_refs,
+        dedup_key=dedup_key,
+        source=source,
+        raw_ref=raw_ref,
+        occurred_at=occurred_at,
+    )
+    try:
+        return bus.publish(subject, envelope)
+    except Exception:  # noqa: BLE001 - a signal is never worth failing real work
+        logger.warning("case_events.signal_publish_failed", subject=subject, dedup_key=dedup_key)
+        return False

--- a/case_events/producers/dockets.py
+++ b/case_events/producers/dockets.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Docket signals, read out of the NGM lake the scrapers already write.
+
+No scraper changes. ``scrape_courtcases`` and ``scrape_worker`` keep filling the
+lake exactly as they do now, and this reads what they wrote. That separation is
+worth keeping: the scrapers are the fragile part (CAPTCHAs, portal HTML, session
+cookies) and they should not also carry a broker dependency.
+
+**Stateless, by an overlapping window.** Every run rescans the last N hours of
+lake rows and re-emits whatever it finds. There is no watermark, no checkpoint,
+and no new table. :mod:`case_events.producers` has the full reasoning; the short
+version is that the deduplication making this safe already exists and has to work
+anyway, and a watermark that silently skips a range is a failure nobody notices
+for months.
+
+The window must comfortably exceed the cron interval. Twice the period is the
+rule of thumb — enough that a skipped run, a slow drain or a clock nudge cannot
+open a gap, since a gap here is a permanently missed fact while a duplicate is
+free.
+
+**Two of the three docket subjects are implemented.**
+``jaw.signal.docket.status.changed`` is not, and cannot be from this vantage: the
+lake stores a case's *current* status with no history, so "changed" is
+unanswerable without the prior value. Detecting it needs either a history table
+or a snapshot, both of which are the stateful design this producer exists to
+avoid. A status change that matters almost always arrives as a hearing row or a
+verdict anyway, so the gap is narrower than it looks — but it is a gap, not an
+oversight.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import structlog
+from django.utils import timezone
+
+from case_events import subjects
+from case_events.producers import emit
+
+logger = structlog.get_logger(__name__)
+
+PRODUCER = "producer:dockets"
+
+#: Default lookback. The docket cron is expected to run every 6h, so 48h is
+#: eight times the period — deliberately generous, because the only cost of
+#: overlap is duplicate messages the dedup spine drops, and the cost of a gap is
+#: a fact that is never proposed.
+DEFAULT_WINDOW_HOURS = 48
+
+#: Hard ceiling on rows examined per kind per run. A backfill that suddenly
+#: inserts a million hearings must not turn into a million messages; it is
+#: better to emit a bounded batch, say so, and let the next run continue.
+DEFAULT_LIMIT = 5000
+
+
+def _courtcase_iri(court_id: str, case_number: str) -> str:
+    """The canonical court-case ``@id``.
+
+    Built with the shared helper, never by hand: ``build_courtcase_iri``
+    lowercases both segments, so a hand-formatted
+    ``.../courtcase/special/082-CR-0154`` matches nothing the matcher holds.
+    """
+    from jawafdehi_shared.entities.ids import build_courtcase_iri
+
+    return build_courtcase_iri(court_id, case_number)
+
+
+def hearing_signals(since, limit: int = DEFAULT_LIMIT):
+    """Yield ``(subject, payload, refs, dedup_key, occurred_at)`` for new hearings.
+
+    Keyed on ``created_at`` rather than ``hearing_date_ad``: a hearing scheduled
+    for next month is news the day we scrape it, not the day it happens, and a
+    hearing backfilled from an old cause list is news now.
+    """
+    from courts.models import CourtCaseHearing
+
+    rows = (
+        CourtCaseHearing.objects.filter(created_at__gte=since)
+        .select_related("court")
+        .order_by("created_at")[:limit]
+    )
+    for row in rows:
+        iri = _courtcase_iri(row.court_id, row.case_number)
+        payload = {
+            "court": row.court_id,
+            "case_number": row.case_number,
+            "hearing_date_bs": row.hearing_date_bs,
+            "hearing_date_ad": row.hearing_date_ad.isoformat() if row.hearing_date_ad else "",
+            "bench": row.bench or "",
+            "judge_names": row.judge_names or "",
+            "case_status": row.case_status or "",
+            "decision_type": row.decision_type or "",
+            "remarks": row.remarks or "",
+        }
+        # The BS date, not the row's pk. The pk is ours and changes on re-import;
+        # the docket date is the fact's own identity, so a re-scraped hearing
+        # dedups against the proposal already staged for it.
+        yield (
+            subjects.SIGNAL_DOCKET_HEARING_ADDED,
+            payload,
+            [iri],
+            f"docket:{iri}:hearing:{row.hearing_date_bs}",
+            row.hearing_date_ad,
+        )
+
+
+def verdict_signals(since, limit: int = DEFAULT_LIMIT):
+    """Yield signals for cases that have gained a verdict.
+
+    Filtered on ``updated_at`` because a verdict lands as an UPDATE to an
+    existing case row, not an insert — which is also why this cannot use
+    ``created_at`` the way hearings do.
+
+    Over-emits by construction: any touch of a case that already has a verdict
+    re-yields it. That is the overlapping-window trade working as intended, and
+    the dedup key is stable across those touches so nothing downstream doubles.
+    """
+    from courts.models import CourtCase
+
+    rows = (
+        CourtCase.objects.filter(
+            updated_at__gte=since,
+            verdict_date_ad__isnull=False,
+            is_deleted=False,
+        )
+        .exclude(verdict_type__isnull=True)
+        .exclude(verdict_type="")
+        .order_by("updated_at")[:limit]
+    )
+    for row in rows:
+        iri = _courtcase_iri(row.court_id, row.case_number)
+        payload = {
+            "court": row.court_id,
+            "case_number": row.case_number,
+            "verdict_type": row.verdict_type or "",
+            "verdict_date_bs": row.verdict_date_bs or "",
+            "verdict_date_ad": row.verdict_date_ad.isoformat() if row.verdict_date_ad else "",
+            "verdict_judge": row.verdict_judge or "",
+            "case_status": row.case_status or "",
+            "case_subject": row.case_subject or "",
+        }
+        # Keyed on the verdict DATE, so a correction to the judge or the type
+        # re-proposes rather than being swallowed — those are exactly the edits a
+        # caseworker would want to see a second time. A verdict date changing is
+        # a different fact and should re-propose.
+        stamp = row.verdict_date_bs or (row.verdict_date_ad.isoformat() if row.verdict_date_ad else "")
+        yield (
+            subjects.SIGNAL_DOCKET_VERDICT_ENTERED,
+            payload,
+            [iri],
+            f"docket:{iri}:verdict:{stamp}",
+            row.verdict_date_ad,
+        )
+
+
+def scan(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAULT_LIMIT):
+    """Every docket signal in the window, as an iterator. Reads only."""
+    since = timezone.now() - timedelta(hours=window_hours)
+    yield from hearing_signals(since, limit)
+    yield from verdict_signals(since, limit)
+
+
+def publish_window(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAULT_LIMIT) -> dict[str, int]:
+    """Emit every signal in the window. Returns per-subject counts sent."""
+    counts: dict[str, int] = {}
+    for subject, payload, refs, dedup_key, occurred_at in scan(window_hours, limit):
+        sent = emit(
+            subject,
+            producer=PRODUCER,
+            payload=payload,
+            subject_refs=refs,
+            dedup_key=dedup_key,
+            source=refs[0] if refs else "",
+            occurred_at=_as_datetime(occurred_at),
+        )
+        key = subject if sent else f"{subject} (not sent)"
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _as_datetime(value):
+    """A ``date`` from the lake as an aware datetime, or None.
+
+    The envelope's ``occurred_at`` is when the FACT happened, and for a docket
+    that is a court date rather than the moment we scraped it — which is the
+    number an audit of enrichment lag actually needs.
+    """
+    if value is None:
+        return None
+    from datetime import date, datetime, timezone as dt_timezone
+
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=dt_timezone.utc)
+    return None

--- a/case_events/producers/materials.py
+++ b/case_events/producers/materials.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Signals for newly-archived documents: court orders and CIAA press releases.
+
+One ``post_save`` receiver covers both, because both land the same way — a
+Material written through the ingestion plane — and neither scraper should have
+to know a bus exists. See :mod:`case_events.producers` for why the seam is here
+rather than in ``scrape_court_orders`` / ``scrape_ciaa_press_releases``.
+
+An earlier version of ``DESIGN.md`` §8 described the CIAA producer as blocked on
+re-porting a suspended Scrapy spider. That is stale: the spider was replaced by
+``manage.py scrape_ciaa_press_releases``, a REST client that has been minting
+these Materials for some time. The producer was never the hard part.
+"""
+
+from __future__ import annotations
+
+import structlog
+from django.db import router, transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from case_events import subjects
+from case_events.producers import emit
+
+logger = structlog.get_logger(__name__)
+
+#: Material ``source`` -> the signal it raises. Sources not listed here are
+#: archived silently, which is the intended default: a Material appearing is not
+#: by itself news about a case. Only these two carry a fact worth proposing on.
+SOURCE_SUBJECTS = {
+    "court_order": subjects.SIGNAL_COURTORDER_PUBLISHED,
+    "ciaa_press_release": subjects.SIGNAL_CIAA_PRESSRELEASE,
+}
+
+
+def _material_db(instance) -> str:
+    """The alias the row was written on — the one whose commit we must wait for.
+
+    Lifted from ``materials.signals`` because the trap is identical and worth
+    repeating rather than importing: ``Material`` lives on ``ngm``, and an
+    unqualified ``transaction.on_commit`` resolves against ``default``. Inside
+    ``atomic(using="ngm")`` the ``default`` connection is still in autocommit, so
+    Django would run the callback IMMEDIATELY — announcing a document before (or
+    instead of) its row becoming durable.
+    """
+    from materials.models import Material
+
+    return instance._state.db or router.db_for_write(Material, instance=instance)
+
+
+def _part_of_iri(data) -> str:
+    """The ``isPartOf`` IRI a court-order Material carries, or "".
+
+    This is the load-bearing field. A court order's ``isPartOf`` is the canonical
+    ``/courtcase/<court>/<number>`` IRI, which is exactly what the matcher joins
+    on — without it the signal names a document and nothing else, and no case
+    will ever be found for it.
+    """
+    if not isinstance(data, dict):
+        return ""
+    part_of = data.get("isPartOf")
+    if isinstance(part_of, dict):
+        return part_of.get("@id") or ""
+    if isinstance(part_of, str):
+        return part_of
+    return ""
+
+
+def signal_for(instance) -> tuple[str, dict, list[str], str] | None:
+    """``(subject, payload, subject_refs, dedup_key)`` for ``instance``, or None.
+
+    Split out from the receiver so the decision is testable without saving a row
+    through two databases.
+    """
+    subject = SOURCE_SUBJECTS.get(instance.source)
+    if subject is None:
+        return None
+    # A material created already soft-deleted is not an archival event. Rare, but
+    # it happens on re-ingest of a withdrawn document.
+    if getattr(instance, "is_deleted", False):
+        return None
+
+    data = instance.data if isinstance(instance.data, dict) else {}
+    part_of = _part_of_iri(data)
+
+    payload = {
+        "material_iri": instance.iri,
+        "material_type": instance.material_type,
+        "source": instance.source,
+        "ident": instance.ident,
+        "title": data.get("name") or data.get("headline") or "",
+        # The court case the document belongs to, when it names one. CIAA press
+        # releases generally do not — they are matched on their own IRI once a
+        # caseworker has linked one to a case, which is why this may be empty
+        # without the signal being useless.
+        "part_of": part_of,
+    }
+    # The material first: it is the reference most likely to be new. `part_of` is
+    # what actually resolves a case today.
+    refs = [ref for ref in (instance.iri, part_of) if ref]
+    return subject, payload, list(dict.fromkeys(refs)), f"material:{instance.iri}"
+
+
+@receiver(post_save, dispatch_uid="case_events_material_signal")
+def emit_material_signal(sender, instance, created, **kwargs):
+    """Announce a newly-archived court order or CIAA press release.
+
+    Only on CREATE. A Material is re-saved for conversion results, visibility
+    recomputation and index churn; announcing those would republish the same fact
+    every time a background job touched the row.
+    """
+    from materials.models import Material
+
+    # Connected without a `sender=` so it can be registered before the models are
+    # importable at app-load; filter here instead.
+    if sender is not Material or not created:
+        return
+
+    signal = signal_for(instance)
+    if signal is None:
+        return
+    subject, payload, refs, dedup_key = signal
+
+    def _run():
+        emit(
+            subject,
+            producer="producer:materials",
+            payload=payload,
+            subject_refs=refs,
+            dedup_key=dedup_key,
+            source=instance.iri,
+            raw_ref=instance.iri,
+        )
+
+    transaction.on_commit(_run, using=_material_db(instance))

--- a/case_events/tests/test_manual_note.py
+++ b/case_events/tests/test_manual_note.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The manual-note endpoint.
+
+The property worth guarding is honesty about what happened. This endpoint's
+whole job is to hand a fact to an asynchronous pipeline, so the failure that
+matters is telling a caseworker "filed" when the note went nowhere — they would
+have no reason to look again, and the fact would be lost with no trace anywhere.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+from case_events import subjects
+from cases.models import Case, CaseType
+
+pytestmark = pytest.mark.django_db
+
+URL = "/api/signals/manual-note/"
+
+
+@pytest.fixture(autouse=True)
+def _broker(settings):
+    """A broker is configured for every test here unless one says otherwise.
+
+    Set through the ``settings`` fixture rather than a class-level
+    ``@override_settings``, which silently does nothing on a plain pytest class
+    and raises outright on some Django versions.
+    """
+    settings.NATS_URL = "nats://localhost:4222"
+
+
+def make_case(slug="lalita-niwas-land-scam"):
+    return Case.objects.create(title="Lalita Niwas", case_type=CaseType.CORRUPTION, slug=slug)
+
+
+_seq = iter(range(1, 10_000))
+
+
+def client_as(group_name):
+    """An authenticated client in ``group_name``.
+
+    Usernames are sequenced because several tests call this twice; a fixed one
+    collides on the unique constraint.
+    """
+    User = get_user_model()
+    user = User.objects.create_user(username=f"u-{group_name or 'none'}-{next(_seq)}", password="x")
+    if group_name:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def body(**over):
+    return {"case_slug": "lalita-niwas-land-scam", "note": "SC admitted the appeal.", **over}
+
+
+class TestFiling:
+    def test_a_note_reaches_the_bus_as_a_manual_signal(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            r = client_as("Caseworker").post(URL, body(source="https://ekantipur.com/x"), format="json")
+
+        assert r.status_code == 202, r.data
+        subject, envelope = pub.call_args.args[0], pub.call_args.args[1]
+        assert subject == subjects.SIGNAL_MANUAL_NOTE
+        assert envelope["payload"]["note"] == "SC admitted the appeal."
+        assert envelope["source"] == "https://ekantipur.com/x"
+
+    def test_the_case_is_named_outright_so_the_matcher_does_not_have_to_guess(self):
+        """A caseworker has told us which case it is; that is an assertion."""
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+
+        refs = pub.call_args.args[1]["subject_refs"]
+        assert refs == ["https://jawafdehi.org/case/lalita-niwas-land-scam"]
+
+    def test_the_response_says_nothing_has_been_written_to_the_case(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True):
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert "until you approve" in r.data["detail"]
+
+    def test_the_same_note_twice_carries_the_same_dedup_key(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+            client_as("Caseworker").post(URL, body(), format="json")
+
+        keys = [call.args[1]["dedup_key"] for call in pub.call_args_list]
+        assert keys[0] == keys[1]
+
+    def test_a_different_note_on_the_same_case_is_a_different_fact(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+            client_as("Caseworker").post(URL, body(note="Something else entirely."), format="json")
+
+        keys = [call.args[1]["dedup_key"] for call in pub.call_args_list]
+        assert keys[0] != keys[1]
+
+    def test_the_filer_is_recorded(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+        assert pub.call_args.args[1]["payload"]["filed_by"].startswith("caseworker:")
+
+    def test_a_known_fact_date_is_carried_rather_than_the_typing_time(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(
+                URL, body(occurred_at="2026-03-04T00:00:00Z"), format="json"
+            )
+        assert pub.call_args.args[1]["occurred_at"].startswith("2026-03-04")
+
+    def test_nothing_is_written_to_the_case(self):
+        case = make_case()
+        before = case.updated_at
+        with mock.patch("case_events.bus.publish", return_value=True):
+            client_as("Caseworker").post(URL, body(), format="json")
+        case.refresh_from_db()
+        assert case.updated_at == before
+
+
+class TestItNeverClaimsSuccessItDidNotHave:
+    def test_a_refused_publish_is_a_502_not_a_202(self):
+        """Telling a caseworker "filed" when it went nowhere loses the fact."""
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=False):
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 502
+
+    def test_a_raising_bus_is_also_not_a_202(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", side_effect=RuntimeError("broker gone")):
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 502
+
+
+class TestNoBrokerConfigured:
+    def test_it_refuses_rather_than_silently_dropping_the_note(self, settings):
+        settings.NATS_URL = ""
+        make_case()
+        r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 503
+        assert "would go nowhere" in r.data["detail"]
+
+
+class TestValidation:
+    def test_an_unknown_case_is_rejected_up_front(self):
+        """Otherwise it publishes, matches nothing, and is dropped in silence."""
+        r = client_as("Caseworker").post(URL, body(case_slug="no-such-case"), format="json")
+        assert r.status_code == 400
+        assert "case_slug" in r.data
+
+    def test_a_slug_the_iri_grammar_rejects_is_refused(self):
+        make_case()
+        r = client_as("Caseworker").post(URL, body(case_slug="Not_A_Slug"), format="json")
+        assert r.status_code == 400
+
+    @pytest.mark.parametrize("note", ["", "   "])
+    def test_a_blank_note_is_rejected(self, note):
+        make_case()
+        r = client_as("Caseworker").post(URL, body(note=note), format="json")
+        assert r.status_code == 400
+
+    def test_the_note_is_trimmed(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(note="  padded  "), format="json")
+        assert pub.call_args.args[1]["payload"]["note"] == "padded"
+
+
+class TestPermissions:
+    def test_an_anonymous_caller_cannot_file(self):
+        make_case()
+        assert APIClient().post(URL, body(), format="json").status_code in (401, 403)
+
+    def test_a_reader_cannot_file(self):
+        make_case()
+        assert client_as("ReadOnly").post(URL, body(), format="json").status_code == 403
+
+    def test_the_automation_role_cannot_generate_its_own_work(self):
+        """A note becomes a model call and then a human's queue item.
+
+        JobPoller may create proposals — automation is the primary producer —
+        but it must not be able to commission them.
+        """
+        make_case()
+        assert client_as("JobPoller").post(URL, body(), format="json").status_code == 403
+
+    def test_a_caseworker_can(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True):
+            assert client_as("Caseworker").post(URL, body(), format="json").status_code == 202

--- a/case_events/tests/test_producers.py
+++ b/case_events/tests/test_producers.py
@@ -1,0 +1,487 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The producers: docket change-detect, and the Material post_save signal.
+
+Two properties are load-bearing and everything else is detail.
+
+**Dedup keys are deterministic and derived from the FACT.** Producers re-emit an
+overlapping window by design, so a key built from a row pk, a timestamp or
+anything else that moves would turn every rescan into a fresh proposal. Several
+tests here re-run a scan and assert the keys are identical.
+
+**Subject refs carry a join key the matcher can actually use.** A signal with no
+court-case IRI is a message about nothing — it will match no case, and the
+failure is silent because "no match" is a normal outcome.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone as dt_timezone
+from unittest import mock
+
+import pytest
+from django.utils import timezone
+
+from case_events import subjects
+from case_events.producers import dockets, materials as material_producer
+from jawafdehi_shared.entities.ids import build_courtcase_iri
+
+pytestmark = [pytest.mark.django_db(databases="__all__")]
+
+
+def make_court(identifier="special"):
+    from courts.models import Court
+
+    return Court.objects.create(
+        identifier=identifier,
+        court_type="special",
+        full_name_nepali="विशेष अदालत",
+        full_name_english="Special Court",
+    )
+
+
+def make_case(court, case_number="082-CR-0154", **kwargs):
+    from courts.models import CourtCase
+
+    return CourtCase.objects.create(case_number=case_number, court=court, **kwargs)
+
+
+def make_hearing(court, case_number="082-CR-0154", **kwargs):
+    from courts.models import CourtCaseHearing
+
+    defaults = {
+        "hearing_date_bs": "2082-12-01",
+        "hearing_date_ad": date(2026, 3, 14),
+        "scraped_at": datetime(2026, 3, 14, tzinfo=dt_timezone.utc),
+    }
+    return CourtCaseHearing.objects.create(
+        case_number=case_number, court=court, **{**defaults, **kwargs}
+    )
+
+
+class TestHearingSignals:
+    def test_a_new_hearing_becomes_a_signal_joined_to_its_court_case(self):
+        court = make_court()
+        make_hearing(court)
+
+        (subject, payload, refs, dedup_key, occurred_at), = list(
+            dockets.hearing_signals(timezone.now() - timedelta(hours=1))
+        )
+
+        assert subject == subjects.SIGNAL_DOCKET_HEARING_ADDED
+        assert refs == [build_courtcase_iri("special", "082-CR-0154")]
+        assert payload["hearing_date_bs"] == "2082-12-01"
+        assert occurred_at == date(2026, 3, 14)
+
+    def test_the_join_key_is_built_by_the_shared_helper_not_by_hand(self):
+        """``build_courtcase_iri`` LOWERCASES both segments.
+
+        A hand-formatted `.../courtcase/special/082-CR-0154` matches nothing the
+        matcher holds, and the failure is a silent no-match.
+        """
+        court = make_court(identifier="Special")
+        make_hearing(court, case_number="082-CR-0154")
+
+        (_, _, refs, _, _), = list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))
+        # Both segments lowercased, despite the court id and case number being
+        # mixed case on the row.
+        assert refs[0].endswith("/courtcase/special/082-cr-0154")
+        assert refs[0] == build_courtcase_iri("Special", "082-CR-0154")
+
+    def test_the_dedup_key_is_the_docket_date_not_our_row_id(self):
+        """A re-imported hearing gets a new pk; the fact is the same fact."""
+        court = make_court()
+        hearing = make_hearing(court)
+        first = list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))[0][3]
+
+        hearing.delete()
+        make_hearing(court)
+        second = list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))[0][3]
+
+        assert first == second
+        assert "2082-12-01" in first
+
+    def test_rescanning_the_same_window_produces_identical_keys(self):
+        """The whole basis of the stateless design."""
+        court = make_court()
+        make_hearing(court)
+        since = timezone.now() - timedelta(hours=1)
+
+        assert [s[3] for s in dockets.hearing_signals(since)] == [
+            s[3] for s in dockets.hearing_signals(since)
+        ]
+
+    def test_a_hearing_outside_the_window_is_not_emitted(self):
+        court = make_court()
+        make_hearing(court)
+        from courts.models import CourtCaseHearing
+
+        CourtCaseHearing.objects.update(created_at=timezone.now() - timedelta(days=10))
+
+        assert list(dockets.hearing_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_future_hearing_is_news_now_not_on_the_day(self):
+        """Keyed on created_at, so a hearing scheduled for next month emits today."""
+        court = make_court()
+        make_hearing(court, hearing_date_ad=date(2027, 1, 1), hearing_date_bs="2083-09-17")
+
+        assert len(list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))) == 1
+
+    def test_the_limit_is_respected(self):
+        court = make_court()
+        for i in range(5):
+            make_hearing(court, hearing_date_bs=f"2082-12-{i:02d}")
+
+        assert len(list(dockets.hearing_signals(timezone.now() - timedelta(hours=1), limit=2))) == 2
+
+
+class TestVerdictSignals:
+    def test_a_decided_case_becomes_a_verdict_signal(self):
+        court = make_court()
+        make_case(
+            court,
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+        )
+
+        (subject, payload, refs, dedup_key, occurred_at), = list(
+            dockets.verdict_signals(timezone.now() - timedelta(hours=1))
+        )
+
+        assert subject == subjects.SIGNAL_DOCKET_VERDICT_ENTERED
+        assert payload["verdict_type"] == "सफाई"
+        assert refs == [build_courtcase_iri("special", "082-CR-0154")]
+        assert "2082-11-20" in dedup_key
+        assert occurred_at == date(2026, 3, 4)
+
+    def test_a_case_with_no_verdict_is_not_emitted(self):
+        make_case(make_court(), case_status="चालु")
+        assert list(dockets.verdict_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_verdict_date_with_no_verdict_type_is_not_emitted(self):
+        """Half a verdict is a scrape artefact, not a decision."""
+        make_case(make_court(), verdict_date_ad=date(2026, 3, 4), verdict_type="")
+        assert list(dockets.verdict_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_soft_deleted_case_is_not_emitted(self):
+        make_case(
+            make_court(),
+            verdict_type="सफाई",
+            verdict_date_ad=date(2026, 3, 4),
+            is_deleted=True,
+        )
+        assert list(dockets.verdict_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_corrected_judge_re_emits_under_the_same_key(self):
+        """Keyed on the verdict DATE, so a correction reaches a caseworker again."""
+        court = make_court()
+        case = make_case(
+            court,
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+            verdict_judge="A",
+        )
+        since = timezone.now() - timedelta(hours=1)
+        first = list(dockets.verdict_signals(since))[0]
+
+        case.verdict_judge = "A, B"
+        case.save()
+        second = list(dockets.verdict_signals(since))[0]
+
+        assert first[3] == second[3]
+        assert second[1]["verdict_judge"] == "A, B"
+
+    def test_a_different_verdict_date_is_a_different_fact(self):
+        court = make_court()
+        case = make_case(
+            court, verdict_type="सफाई", verdict_date_bs="2082-11-20", verdict_date_ad=date(2026, 3, 4)
+        )
+        since = timezone.now() - timedelta(hours=1)
+        first = list(dockets.verdict_signals(since))[0][3]
+
+        case.verdict_date_bs = "2082-11-25"
+        case.save()
+        assert list(dockets.verdict_signals(since))[0][3] != first
+
+
+class TestPublishWindow:
+    def test_it_emits_everything_in_the_window_and_counts_it(self):
+        court = make_court()
+        make_hearing(court)
+        make_case(
+            court,
+            case_number="082-CR-0999",
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+        )
+
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            counts = dockets.publish_window(window_hours=24)
+
+        assert counts[subjects.SIGNAL_DOCKET_HEARING_ADDED] == 1
+        assert counts[subjects.SIGNAL_DOCKET_VERDICT_ENTERED] == 1
+        assert pub.call_count == 2
+
+    def test_a_signal_the_bus_refused_is_counted_separately(self):
+        """A run that published nothing must not read as an empty window."""
+        court = make_court()
+        make_hearing(court)
+
+        with mock.patch("case_events.bus.publish", return_value=False):
+            counts = dockets.publish_window(window_hours=24)
+
+        assert any("not sent" in key for key in counts)
+
+    def test_a_broker_failure_does_not_stop_the_scan(self):
+        court = make_court()
+        make_hearing(court)
+        make_hearing(court, hearing_date_bs="2082-12-02")
+
+        with mock.patch("case_events.bus.publish", side_effect=RuntimeError("broker gone")):
+            counts = dockets.publish_window(window_hours=24)
+
+        assert sum(counts.values()) == 2
+
+    def test_occurred_at_is_the_court_date_not_the_scrape_time(self):
+        """The number an audit of enrichment lag needs."""
+        court = make_court()
+        make_hearing(court)
+
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            dockets.publish_window(window_hours=24)
+
+        assert pub.call_args.args[1]["occurred_at"].startswith("2026-03-14")
+
+    def test_a_signal_with_no_dedup_key_is_refused_rather_than_published(self):
+        from case_events import producers
+
+        with mock.patch("case_events.bus.publish") as pub:
+            assert producers.emit("jaw.signal.x", producer="p", payload={}, subject_refs=[], dedup_key="") is False
+        pub.assert_not_called()
+
+
+class TestMaterialProducer:
+    """One post_save covers court orders and CIAA press releases."""
+
+    def material(self, source, iri="https://jawafdehi.org/material/court_order/abc", data=None):
+        from materials.models import Material
+
+        return Material(
+            iri=iri,
+            material_type="CourtOrder",
+            source=source,
+            ident="abc",
+            data=data if data is not None else {"@id": iri, "name": "An order"},
+        )
+
+    def test_a_court_order_raises_the_court_order_signal(self):
+        signal = material_producer.signal_for(self.material("court_order"))
+        assert signal is not None
+        assert signal[0] == subjects.SIGNAL_COURTORDER_PUBLISHED
+
+    def test_a_ciaa_press_release_raises_its_own_signal(self):
+        signal = material_producer.signal_for(self.material("ciaa_press_release"))
+        assert signal[0] == subjects.SIGNAL_CIAA_PRESSRELEASE
+
+    def test_the_two_sources_match_the_constants_the_shapers_actually_use(self):
+        """A drifted string here means the producer silently never fires."""
+        from materials.jsonld import COURT_ORDER_SOURCE
+        from materials.sourcing.ciaa.shaper import CIAA_PRESS_SOURCE
+
+        assert COURT_ORDER_SOURCE in material_producer.SOURCE_SUBJECTS
+        assert CIAA_PRESS_SOURCE in material_producer.SOURCE_SUBJECTS
+
+    def test_an_unremarkable_material_raises_nothing(self):
+        """A Material appearing is not by itself news about a case."""
+        assert material_producer.signal_for(self.material("nkp")) is None
+
+    def test_a_court_orders_case_iri_is_carried_as_the_join_key(self):
+        """Without isPartOf the signal names a document and nothing else."""
+        case_iri = build_courtcase_iri("special", "082-CR-0154")
+        m = self.material(
+            "court_order",
+            data={"@id": "https://jawafdehi.org/material/court_order/abc", "isPartOf": {"@id": case_iri}},
+        )
+        _, payload, refs, _ = material_producer.signal_for(m)
+
+        assert payload["part_of"] == case_iri
+        assert case_iri in refs
+
+    def test_a_string_ispartof_is_accepted_too(self):
+        case_iri = build_courtcase_iri("special", "082-CR-0154")
+        m = self.material("court_order", data={"isPartOf": case_iri})
+        assert material_producer.signal_for(m)[1]["part_of"] == case_iri
+
+    def test_a_press_release_with_no_case_still_emits(self):
+        """CIAA releases generally name no docket; that is not a broken signal."""
+        _, payload, refs, _ = material_producer.signal_for(self.material("ciaa_press_release"))
+        assert payload["part_of"] == ""
+        assert refs  # its own IRI is still a ref
+
+    def test_the_dedup_key_is_the_material_iri(self):
+        m = self.material("court_order")
+        assert material_producer.signal_for(m)[3] == f"material:{m.iri}"
+
+    def test_a_material_created_soft_deleted_is_not_an_archival_event(self):
+        m = self.material("court_order")
+        m.is_deleted = True
+        assert material_producer.signal_for(m) is None
+
+    def test_malformed_data_does_not_raise(self):
+        for bad in (None, [], "a string", 7):
+            m = self.material("court_order", data=bad)
+            assert material_producer.signal_for(m) is not None
+
+
+class TestTheMaterialReceiverFiresOnlyOnCreate:
+    """A Material is re-saved for conversion, visibility and index churn.
+
+    These use a REAL Material, not a Mock. An earlier version passed a
+    ``mock.Mock``, and a mutation removing the ``created`` check survived it —
+    because ``getattr(mock, "is_deleted", False)`` returns a truthy Mock, so
+    ``signal_for`` bailed out for the wrong reason and the test proved nothing.
+    """
+
+    def unsaved_order(self):
+        from materials.models import Material
+
+        return Material(
+            iri="https://jawafdehi.org/material/court_order/receiver-1",
+            material_type="CourtOrder",
+            source="court_order",
+            ident="receiver-1",
+            data={},
+        )
+
+    def _callbacks(self, sender, created):
+        """The on_commit callbacks the receiver registers for one call."""
+        with django_capture_on_commit_callbacks_noexec(using="ngm") as callbacks:
+            material_producer.emit_material_signal(
+                sender, instance=self.unsaved_order(), created=created
+            )
+        return callbacks
+
+    def test_an_update_registers_nothing(self):
+        from materials.models import Material
+
+        assert self._callbacks(Material, created=False) == []
+
+    def test_a_create_registers_the_announcement(self):
+        """Paired with the test above so neither can pass for the wrong reason."""
+        from materials.models import Material
+
+        assert len(self._callbacks(Material, created=True)) == 1
+
+    def test_a_save_of_another_model_registers_nothing(self):
+        from cases.models import Case
+
+        assert self._callbacks(Case, created=True) == []
+
+
+class TestTheMaterialProducerIsActuallyConnected:
+    """Everything above tests the logic. This tests that it RUNS.
+
+    A ``post_save`` receiver that is never connected — an app whose ``ready``
+    does not import it, a ``dispatch_uid`` collision, an import error swallowed
+    by the guard — is invisible: every unit test passes and no signal is ever
+    emitted in production. So this saves a real Material through the real ORM.
+    """
+
+    def test_the_app_config_is_what_connects_it(self):
+        """A source-level guard, because the runtime check below cannot catch this.
+
+        The obvious test — save a Material, assert a signal — passes even with
+        ``EventsConfig.ready`` gutted, because THIS TEST MODULE imports
+        ``case_events.producers.materials`` at the top and the ``@receiver``
+        decorator connects on import. The test file wires up the thing it is
+        checking. A mutation removing the import from ``ready()`` survived the
+        whole suite.
+
+        In production nothing imports that module, so ``ready()`` is the only
+        thing that connects the receiver and its absence means no signal is ever
+        emitted, silently. Same shape as the ``ensure_streams`` guard in
+        test_nats_bootstrap.
+        """
+        import inspect
+
+        from case_events.apps import EventsConfig
+
+        source = inspect.getsource(EventsConfig.ready)
+        assert "case_events.producers" in source and "materials" in source, (
+            "EventsConfig.ready must import case_events.producers.materials — it is "
+            "the only thing that connects the post_save producer in production."
+        )
+
+    def test_the_receiver_is_connected_to_post_save(self):
+        from django.db.models.signals import post_save
+
+        # Django's receivers entries are (lookup_key, receiver[, is_async]) and
+        # the arity has changed across versions, so index rather than unpack.
+        uids = [entry[0][0] for entry in post_save.receivers]
+        assert "case_events_material_signal" in uids
+
+    def test_saving_a_real_court_order_material_emits(self, django_capture_on_commit_callbacks):
+        from materials.models import Material
+
+        case_iri = build_courtcase_iri("special", "082-CR-0154")
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            with django_capture_on_commit_callbacks(execute=True, using="ngm"):
+                Material.objects.create(
+                    iri="https://jawafdehi.org/material/court_order/wired-1",
+                    material_type="CourtOrder",
+                    source="court_order",
+                    ident="wired-1",
+                    data={"isPartOf": {"@id": case_iri}, "name": "An order"},
+                )
+
+        subjects_sent = [call.args[0] for call in pub.call_args_list]
+        assert subjects.SIGNAL_COURTORDER_PUBLISHED in subjects_sent
+
+    def test_the_emit_is_deferred_until_the_row_commits(self):
+        """Announcing a document before its row is durable is the trap here.
+
+        ``Material`` lives on ``ngm``, so an unqualified ``on_commit`` would
+        resolve against ``default`` — still in autocommit inside
+        ``atomic(using="ngm")`` — and fire the callback immediately.
+        """
+        from materials.models import Material
+
+        with mock.patch("case_events.bus.publish") as pub:
+            with django_capture_on_commit_callbacks_noexec(using="ngm") as callbacks:
+                Material.objects.create(
+                    iri="https://jawafdehi.org/material/court_order/wired-2",
+                    material_type="CourtOrder",
+                    source="court_order",
+                    ident="wired-2",
+                    data={},
+                )
+            # Captured, NOT run: nothing reached the bus inside the transaction.
+            pub.assert_not_called()
+        assert callbacks, "the producer did not register an on_commit callback at all"
+
+    def test_an_unremarkable_material_save_stays_silent_end_to_end(self):
+        from materials.models import Material
+
+        with mock.patch("case_events.bus.publish") as pub:
+            with django_capture_on_commit_callbacks_noexec(using="ngm"):
+                Material.objects.create(
+                    iri="https://jawafdehi.org/material/nkp/wired-3",
+                    material_type="Judgment",
+                    source="nkp",
+                    ident="wired-3",
+                    data={},
+                )
+        pub.assert_not_called()
+
+
+def django_capture_on_commit_callbacks_noexec(*, using):
+    """``django_capture_on_commit_callbacks`` without executing, as a plain CM.
+
+    The pytest-django fixture cannot be nested inside another `with` in the same
+    test and also inspected afterwards, so use Django's own helper directly.
+    """
+    from django.test import TestCase
+
+    return TestCase.captureOnCommitCallbacks(execute=False, using=using)

--- a/case_events/urls.py
+++ b/case_events/urls.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Signal-filing endpoints.
+
+Only one, and only one is expected: every other producer watches something
+rather than being called. See :mod:`case_events.views`.
+"""
+
+from django.urls import path
+
+from case_events.views import ManualNoteView
+
+urlpatterns = [
+    path("signals/manual-note/", ManualNoteView.as_view(), name="manual-note"),
+]

--- a/case_events/views.py
+++ b/case_events/views.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The one producer a human drives: a caseworker's manual note.
+
+Every other producer watches something. This one is typed. A caseworker who
+learns a fact — the court published an order today, an appeal was filed, a name
+in the record is wrong — writes it in a sentence and the pipeline drafts a
+properly-shaped timeline entry for them to approve or discard.
+
+Two reasons it earns its place rather than being a shortcut around the SPA's
+existing case editor:
+
+**It is fast capture.** Writing "SC admitted the appeal on 2082-11-20, per
+kathmandupost.com/…" is a few seconds; opening the case editor, finding the
+timeline, and composing a well-formed dated entry in Nepali is not. The model
+does the shaping and the caseworker judges the result, which is the division of
+labour the whole system is built around.
+
+**It is the only producer that can be fired on demand**, which makes it the
+acceptance test for the bus itself. Post one note and every hop — matcher,
+proposal-builder, the intent job, the proposal, the notifier — either works or
+tells you where it stopped, without waiting for a scrape.
+
+It stays a SIGNAL rather than writing a proposal directly. A caseworker note is
+an observed fact like any other, and routing it down the same path means it gets
+the same duplicate detection, the same audit trail, and the same "check the
+timeline before proposing" pass the model applies to scraped facts.
+"""
+
+from __future__ import annotations
+
+import structlog
+from django.conf import settings
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from case_events import subjects
+from case_events.producers import emit
+from review.permissions import IsContentStaff
+
+logger = structlog.get_logger(__name__)
+
+PRODUCER = "producer:caseworker"
+
+
+class ManualNoteSerializer(serializers.Serializer):
+    """A caseworker's free-text observation about one case."""
+
+    case_slug = serializers.SlugField(max_length=50)
+    note = serializers.CharField(max_length=4000)
+    #: Where the caseworker got it. Not required, but every factual claim in the
+    #: archive is supposed to carry one, and a note without a source produces a
+    #: proposal a reviewer cannot check.
+    source = serializers.CharField(max_length=500, required=False, allow_blank=True, default="")
+    #: When the FACT happened, if known — not when the note was typed.
+    occurred_at = serializers.DateTimeField(required=False, allow_null=True, default=None)
+
+    def validate_case_slug(self, value):
+        """The case must exist, and the slug must build a canonical ``@id``.
+
+        Checked here rather than left to the matcher: a typo'd slug would
+        otherwise be accepted, published, matched to nothing, and silently
+        dropped — with the caseworker told it worked.
+        """
+        from cases.models import Case
+        from jawafdehi_shared.entities.ids import build_case_iri
+
+        try:
+            build_case_iri(value)
+        except Exception as exc:
+            raise serializers.ValidationError(f"{value!r} is not a valid case @id segment: {exc}") from None
+        if not Case.objects.filter(slug=value).exists():
+            raise serializers.ValidationError(f"No case with slug {value!r}.")
+        return value
+
+    def validate_note(self, value):
+        if not value.strip():
+            raise serializers.ValidationError("A note cannot be blank.")
+        return value.strip()
+
+
+class ManualNoteView(APIView):
+    """``POST /api/signals/manual-note/`` — put a caseworker observation on the bus.
+
+    Gated to content staff, NOT to the contributor role that may create
+    proposals. A note here becomes a model call and then a queue item for a
+    human; the automation identity must not be able to generate its own work.
+    """
+
+    permission_classes = [IsContentStaff]
+
+    def post(self, request):
+        serializer = ManualNoteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        if not getattr(settings, "NATS_URL", ""):
+            # 503 rather than a cheerful 202. Publishing no-ops without a broker,
+            # and telling a caseworker their note was accepted when it went
+            # nowhere is the worst available outcome.
+            return Response(
+                {"detail": "The event bus is not configured, so this note would go nowhere."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        from jawafdehi_shared.entities.ids import build_case_iri
+
+        case_iri = build_case_iri(data["case_slug"])
+        actor = self._actor(request)
+        # Deterministic in the fact, not the moment: the same caseworker filing
+        # the same note about the same case twice is a duplicate, not two facts.
+        # Hashed because a note is long and free-form, and dedup_key is bounded.
+        import hashlib
+
+        digest = hashlib.sha256(data["note"].encode("utf-8")).hexdigest()[:32]
+        dedup_key = f"manual:{data['case_slug']}:{digest}"
+
+        sent = emit(
+            subjects.SIGNAL_MANUAL_NOTE,
+            producer=PRODUCER,
+            payload={
+                "case_slug": data["case_slug"],
+                "note": data["note"],
+                "filed_by": actor,
+            },
+            # The case @id, so the matcher treats this as an assertion rather
+            # than an inference — the caseworker has told us which case it is.
+            subject_refs=[case_iri],
+            dedup_key=dedup_key,
+            source=data["source"] or "caseworker",
+            occurred_at=data["occurred_at"],
+        )
+
+        logger.info(
+            "case_events.manual_note_filed",
+            case_slug=data["case_slug"],
+            filed_by=actor,
+            published=sent,
+        )
+
+        if not sent:
+            return Response(
+                {"detail": "The note could not be published to the event bus."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        return Response(
+            {
+                "subject": subjects.SIGNAL_MANUAL_NOTE,
+                "dedup_key": dedup_key,
+                "case_slug": data["case_slug"],
+                # Said plainly, because the useful thing to know is that nothing
+                # has happened to the case yet.
+                "detail": (
+                    "Filed. A proposal will appear in the review queue if the note "
+                    "warrants one; nothing is written to the case until you approve it."
+                ),
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    @staticmethod
+    def _actor(request) -> str:
+        user = request.user
+        handle = getattr(user, "username", "") or getattr(user, "email", "") or str(user.pk)
+        return f"caseworker:{handle}"

--- a/config/urls.py
+++ b/config/urls.py
@@ -81,6 +81,9 @@ urlpatterns = [
     path("api/", include("newsletter.urls")),
     # Case-update proposals — before cases.urls (whose router is broad).
     path("api/", include("case_proposals.urls")),
+    # Filing a signal by hand — the one producer a human drives. Also before
+    # cases.urls, for the same reason.
+    path("api/", include("case_events.urls")),
     path("api/", include("cases.urls")),
     path("oembed/", OEmbedView.as_view(), name="oembed"),
     path("api/caseworker/me", MeView.as_view(), name="cw-me"),


### PR DESCRIPTION
Workstream E (`docs/2026-07-27-case-enrichment-events/PHASE-1-PLAN.md` §6). **Stacked on #403** — review that first; this PR's diff is only the producers.

With this, the pipeline is complete end to end in code. Workstream A (applying the broker) is the only remaining step, and now the only thing between this and a real run.

## The two decisions worth arguing with

**Stateless, by an overlapping window.** No watermark table, no checkpoint. The docket producer rescans the last 48h every run and re-emits freely.

We avoid a migration, a stateful `case_events`, and a watermark that silently skips a range — a failure nobody notices for months. We accept duplicate messages, which are free, *and one sharp edge*: `jobs.queue.enqueue` frees a `dedup_key` once its job is terminal, so without the pre-enqueue guard added in #403, every rescan would have bought a fresh premium model call whose result `on_result` then discarded. **The stateless design and that guard are one decision.** Don't remove either alone — there's a test pinning it.

**Signals are emitted where the record lands, not where the scraper runs.** The court-order and CIAA scrapers are deliberately thin REST clients; `scrape_ciaa_press_releases` says outright it "never touches the ORM". Hooking the bus into each would give every scraper a broker dependency and a second way to be half-configured. Both write Materials, so **one `post_save` producer covers both** — and covers whatever writes those documents next. Same principle as publishing `proposed` where the proposal row is created.

## What's here

| Producer | Trigger | Subject |
|---|---|---|
| dockets | cron, `emit_docket_signals` | `jaw.signal.docket.hearing.added`, `…verdict.entered` |
| materials | `post_save` on Material | `jaw.signal.courtorder.published`, `…ciaa.pressrelease` |
| manual note | `POST /api/signals/manual-note/` | `jaw.signal.manual.note` |

**The manual-note endpoint is worth more than its size.** It's fast capture — a caseworker writes a sentence, the model shapes it into a dated timeline entry they approve or discard — and it's the only producer that can be fired on demand, which makes it the acceptance test for the whole bus once A lands. It returns 503/502 rather than reporting success it didn't have; telling a caseworker "filed" when the note went nowhere loses the fact with no trace.

## A stale claim corrected

`DESIGN.md` §8 said the CIAA producer was blocked on re-porting a suspended Scrapy spider. It isn't — the spider was replaced by `manage.py scrape_ciaa_press_releases` some time ago. The producer was never the hard part.

## Two gaps, stated rather than hidden

- **`jaw.signal.docket.status.changed` is not implemented.** The lake stores a case's *current* status with no history, so "changed" is unanswerable without either a history table or a snapshot — the stateful design this producer exists to avoid. A status change that matters almost always arrives as a hearing row or a verdict anyway, but it is a gap.
- **The per-run row cap logs loudly when it truncates.** A capped run and a quiet window otherwise look identical in the output.

## Verification

- 3026 passed, 4 skipped — full suite; `ruff check` clean
- 13 mutations, **all killed**. Two survived a first pass and both were tests that defeated themselves:
  - the "is the receiver actually connected?" test connected it *via its own module-level import*, so gutting `EventsConfig.ready` passed the entire suite. Replaced with a source-level guard, same shape as the `ensure_streams` one.
  - the "only fires on create" test passed because `getattr(Mock(), "is_deleted", False)` is truthy, so `signal_for` bailed for the wrong reason. Now uses a real `Material`.
- Not verifiable end to end until A. The manual-note endpoint is designed to be exactly that test.

## Deploy notes

- No migrations.
- `emit_docket_signals` needs a CronJob (platform image, needs the ngm DB). Suggested every 6h against the 48h window — 8× the period, deliberately generous. Not written here; it belongs with A's manifests.
- The Material producer needs nothing: it registers at app-ready and no-ops with `NATS_URL` unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)