### PR TITLE
fix(courts): scope the CR-series corruption-forum rule to the court it was written for

### DIFF
--- a/courts/search_visibility.py
+++ b/courts/search_visibility.py
@@ -101,11 +101,36 @@ def is_cr_series(case_number: str | None) -> bool:
     return bool(case_number and _CR_RE.search(case_number))
 
 
+#: Courts where a ``NNN-CR-NNNN`` number means a CIAA prosecution. The CIAA files
+#: at the Special Court; every other court's ``CR`` register is its own general
+#: criminal docket and has nothing to do with corruption.
+CR_SERIES_COURTS = frozenset({"special"})
+
+
 def in_corruption_forum(case: Any) -> bool:
-    """True if the case is in the corruption forum: Special Court or CR-series."""
-    if (getattr(case, "court_id", None) or "") == "special":
+    """True if the case is in the corruption forum: the Special Court's registers.
+
+    The ``NNN-CR-NNNN`` shape is NOT court-specific — the Supreme Court's general
+    criminal register uses it too (7,133 rows: homicide, forgery, cheque dishonour).
+    Matching on the number alone therefore swept an entire general criminal docket
+    into a public index whose stated scope is "a curated corruption /
+    public-accountability slice, NOT a docket mirror".
+
+    That stayed hidden only by accident: Supreme's case_type was the coarse
+    'फौजदारी' for every row, which maps to OTHER_CRIMINAL and is excluded as
+    procedural. Once those rows were backfilled with their real charges they mapped
+    to real codes and passed this rule — an estimated 5,093 of them, ~1,200 homicide.
+
+    Restricting the series rule to the courts where CR means CIAA costs nothing: a
+    genuine Supreme corruption appeal has case_type भ्रष्टाचार, which is in
+    SHOW_CODES and is shown on the code axis regardless of forum.
+    """
+    court_id = getattr(case, "court_id", None) or ""
+    if court_id == "special":
         return True
-    return is_cr_series(getattr(case, "case_number", None))
+    return court_id in CR_SERIES_COURTS and is_cr_series(
+        getattr(case, "case_number", None)
+    )
 
 
 def published_referenced_iris(*, refresh: bool = False) -> frozenset[str]:

--- a/courts/tests/test_search_visibility.py
+++ b/courts/tests/test_search_visibility.py
@@ -79,10 +79,25 @@ def test_forum_hides_procedural():
 
 
 def test_cr_series_forum_shows():
+    """The CR-series forum rule, now scoped to the court it was written for.
+
+    It originally matched ``NNN-CR-NNNN`` on ANY court, on the premise that a CR
+    series means a CIAA prosecution. The corpus says otherwise: no high or district
+    court has a CR series at all, and the Supreme Court's is a general criminal
+    docket (SEXUAL_OFFENSE 869, HOMICIDE 762, CORRUPTION 665 in a 4k sample). The
+    patanhc case this test used was synthetic.
+    """
     c = _case(
-        case_type="____ novel ____", court_id="patanhc", case_number="081-CR-0009"
+        case_type="____ novel ____", court_id="special", case_number="081-CR-0009"
     )
     assert sv.court_case_public_visible(c) is True
+
+    # Same shape, wrong court: an unmapped Supreme criminal case is NOT admitted
+    # to a "curated corruption slice" on the strength of its number alone.
+    other = _case(
+        case_type="____ novel ____", court_id="supreme", case_number="081-CR-0009"
+    )
+    assert sv.court_case_public_visible(other) is False
 
 
 def test_is_deleted_is_hidden():
@@ -103,3 +118,44 @@ def test_published_link_does_not_override_sensitive(monkeypatch):
     c = _case(case_type="सम्बन्ध विच्छेद", case_number="081-CI-0888", iri=iri)
     monkeypatch.setattr(sv, "_published_iris", frozenset({iri}))
     assert sv.court_case_public_visible(c) is False
+
+
+class TestCorruptionForumIsCourtScoped:
+    """``NNN-CR-NNNN`` is not a CIAA marker on its own.
+
+    The Supreme Court's general criminal register uses the same shape (7,133 rows
+    of homicide, forgery, cheque dishonour). Matching the number alone swept that
+    whole docket into an index whose stated scope is a curated corruption slice.
+    It stayed hidden only by accident — every Supreme row carried the coarse
+    'फौजदारी', which maps to OTHER_CRIMINAL and is excluded as procedural — so the
+    moment those rows were backfilled with their real charges, an estimated 5,093
+    became public, ~1,200 of them homicide.
+    """
+
+    def test_supreme_homicide_is_not_in_the_corruption_forum(self):
+        case = _case(court_id="supreme", case_number="081-CR-1641",
+                     case_type="कर्तव्य ज्यान")
+        assert sv.in_corruption_forum(case) is False
+        assert sv.court_case_public_visible(case) is False
+
+    def test_special_court_cr_still_is(self):
+        case = _case(court_id="special", case_number="076-CR-0294",
+                     case_type="नक्कली प्रमाण पत्र")
+        assert sv.in_corruption_forum(case) is True
+
+    def test_a_supreme_corruption_appeal_is_still_shown(self):
+        """The fix costs nothing: SHOW_CODES carries it on the code axis."""
+        case = _case(court_id="supreme", case_number="071-CR-0306",
+                     case_type="भ्रष्टाचार")
+        assert sv.in_corruption_forum(case) is False
+        assert sv.court_case_public_visible(case) is True
+
+    def test_a_district_criminal_docket_is_not_a_corruption_forum(self):
+        case = _case(court_id="kathmandudc", case_number="080-CR-0012",
+                     case_type="कर्तव्य ज्यान")
+        assert sv.court_case_public_visible(case) is False
+
+    def test_the_sensitive_floor_is_unaffected(self):
+        case = _case(court_id="special", case_number="076-CR-0294",
+                     case_type="जवरजस्ती करणी")
+        assert sv.court_case_public_visible(case) is False


### PR DESCRIPTION
**This overturns a deliberate, tested decision — please read before merging.** I found it by causing it.

## What happened

`in_corruption_forum` admits any case whose number matches `NNN-CR-NNNN`, on the premise that a CR series means a CIAA prosecution. The Supreme Court's **general criminal** register uses the same shape.

That stayed harmless only by accident: every Supreme row carried the coarse `फौजदारी`, which maps to `OTHER_CRIMINAL` and is excluded as procedural. When I backfilled Supreme's real charges (#402 + the one-off repair), those rows mapped to real codes and started passing this rule.

Measured on the live index before I stopped the run: **~5,093 of 7,133 Supreme CR rows are public-visible**, led by `HOMICIDE`, `FORGERY`, `CHEQUE_DISHONOUR`, `LABOR_EMPLOYMENT`. The index's stated scope is *"a curated corruption / public-accountability slice, NOT a docket mirror."*

## Why the premise doesn't survive the corpus

| court | CR rows | composition (4k sample) |
|---|---|---|
| **special** | 2,952 | CORRUPTION 1,166 · FORGERY 756 · COOPERATIVE_FRAUD 350 — the CIAA register |
| **supreme** | 7,133 | SEXUAL_OFFENSE 869 · **HOMICIDE 762** · CORRUPTION 665 · FORGERY 525 |
| high | **0** | no CR series exists |
| district | **0** | no CR series exists |

The any-court rule therefore has exactly one real-world effect: admitting Supreme's general criminal docket. The `patanhc` case in `test_cr_series_forum_shows` was synthetic — no such data exists anywhere in the corpus.

## Why the fix costs nothing

A genuine Supreme corruption appeal has `case_type = भ्रष्टाचार` → `CORRUPTION` → `SHOW_CODES` → shown on the **code** axis regardless of forum. That's pinned by a test. The forum rule was only ever load-bearing for cases whose type is unmapped, and for those, "Supreme + CR" is not evidence of corruption.

The sensitive floor is untouched and separately tested (`जवरजस्ती करणी` stays hidden either way).

## After merge — this needs a reindex

Deploying alone corrects nothing. The ~5,093 docs already in `ngm-courtcases` need evicting via `reindex_courtcases` for supreme.

## Testing

465 courts tests, `ruff` clean. `test_cr_series_forum_shows` is rewritten rather than deleted: it now pins the rule for `special` and the inverse for `supreme`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected corruption-forum classification so CR-series cases are recognized only within the Special Court.
  * Prevented similarly numbered cases from other courts, including the Supreme Court and district courts, from being incorrectly classified.
  * Preserved existing visibility protections for sensitive cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->