### PR TITLE
fix(courts): retry an exhausted verdict extraction at a larger token budget

### DIFF
--- a/courts/management/commands/extract_verdicts.py
+++ b/courts/management/commands/extract_verdicts.py
@@ -19,6 +19,11 @@ Dry-run by default -- ``--write`` persists.
 
 Every row written is model-derived and marked as such under
 ``extra_data['verdict_extraction']``.
+
+A case whose first attempt runs out of output tokens is retried once at
+``ESCALATED_MAX_TOKENS``; nothing else is retried, and a case that exhausts the
+escalated budget too stays a loud failure. The run reports ``escalated=N`` so
+the hard tail is visible rather than blended into the success count.
 """
 
 from __future__ import annotations
@@ -53,6 +58,28 @@ DEFAULT_DELAY = 1.0
 #: output tokens). Those failures are safe -- the case is skipped, never guessed
 #: at -- but they are lost coverage, so give reasoning real headroom.
 MAX_TOKENS = 8000
+#: Second-attempt budget, used ONLY after a first attempt died of exhaustion.
+#: The 2026-07-31 production run lost 3 of 84 cases this way, all of them long
+#: multi-defendant judgments where the reasoning alone outran 8000 tokens.
+ESCALATED_MAX_TOKENS = 32000
+#: How exhaustion presents. ``claude -p`` does not report "out of output tokens":
+#: the assistant turn simply ends unfinished, the CLI wants another turn to
+#: continue, ``--max-turns 1`` denies it, and the run aborts as
+#: ``error_max_turns`` -- "Reached maximum number of turns (1)". So the turn
+#: limit is the messenger and the token budget is the cause, which is why
+#: escalation raises the budget rather than the turn count.
+_EXHAUSTED = ("error_max_turns", "maximum number of turns", "max_tokens")
+
+
+def _is_exhaustion(exc):
+    """True if this failure looks like the model ran out of room, not out of luck.
+
+    Deliberately narrow. A convert failure, a missing document, an auth 403 or a
+    malformed response must NOT be retried at 4x the budget -- that would just
+    spend four times as much to fail the same way.
+    """
+    msg = str(exc).lower()
+    return any(s.lower() in msg for s in _EXHAUSTED)
 
 
 class Command(BaseCommand):
@@ -84,7 +111,30 @@ class Command(BaseCommand):
             time.sleep(delay)
         self._downloads += 1
 
-    def _extract_one(self, case, *, tier):
+    def _extract(self, case, *, tier):
+        """:meth:`_extract_one`, retried once at a larger budget if it ran out.
+
+        Escalation happens ONLY after a failure, and only an exhaustion-shaped
+        one. That ordering is load-bearing: every case that succeeds does so on
+        exactly the parameters the ``--eval`` run scored, so the measured
+        accuracy still describes the rows being written. A first attempt at the
+        bigger budget would be cheaper to write and would quietly invalidate
+        that -- it can only turn a failure into an answer, never change an
+        answer already given.
+
+        Returns ``(extraction, url, model, chars, escalated)``.
+        """
+        try:
+            return (*self._extract_one(case, tier=tier, max_tokens=MAX_TOKENS), False)
+        except Exception as exc:  # noqa: BLE001
+            if not _is_exhaustion(exc):
+                raise
+            self.stdout.write(
+                f"        budget exhausted at {MAX_TOKENS} tokens; retrying at {ESCALATED_MAX_TOKENS}"
+            )
+            return (*self._extract_one(case, tier=tier, max_tokens=ESCALATED_MAX_TOKENS), True)
+
+    def _extract_one(self, case, *, tier, max_tokens=MAX_TOKENS):
         """Download the order, read it, return (extraction, url, model, chars).
 
         Raises RuntimeError with a short reason on any unusable case, so the
@@ -118,7 +168,7 @@ class Command(BaseCommand):
             raise RuntimeError("no order document yielded text")
 
         model = routing.provider_for_tier(tier).model_for_tier(tier)
-        raw = invoke.invoke_text(SYSTEM_PROMPT, build_prompt(text, case.case_number), MAX_TOKENS, tier=tier)
+        raw = invoke.invoke_text(SYSTEM_PROMPT, build_prompt(text, case.case_number), max_tokens, tier=tier)
         return parse_response(raw), used, model, len(text)
 
     # --------------------------------------------------------------------- eval
@@ -144,13 +194,17 @@ class Command(BaseCommand):
         sample = cases[::step][:n]
 
         self.stdout.write(f"eval: {len(sample)} cases sampled from {len(cases)} with both an order and a known verdict\n")
-        hits = miss = abst = err = 0
+        hits = miss = abst = err = esc = 0
         confusion = {}
         for i, case in enumerate(sample, 1):
             want = truth[case.case_number]
             self._gap(delay)
             try:
-                ex, url, _model, chars = self._extract_one(case, tier=tier)
+                # Escalate here too, or the score stops describing the write
+                # path: eval would report as errors the very cases --write now
+                # recovers, understating coverage on exactly the hard tail.
+                ex, url, _model, chars, escalated = self._extract(case, tier=tier)
+                esc += escalated
             except Exception as exc:  # noqa: BLE001
                 err += 1
                 self.stdout.write(f"  {i:>3}/{len(sample)} {case.case_number}  ERROR {exc}")
@@ -178,6 +232,7 @@ class Command(BaseCommand):
         self.stdout.write(f"  wrong      {miss}")
         self.stdout.write(f"  abstained  {abst}")
         self.stdout.write(f"  errored    {err}")
+        self.stdout.write(f"  escalated  {esc}  (recovered at {ESCALATED_MAX_TOKENS} tokens)")
         if answered:
             self.stdout.write(f"  accuracy on answered: {hits / answered * 100:.1f}%  (n={answered})")
         if confusion:
@@ -199,7 +254,7 @@ class Command(BaseCommand):
         mode = "WRITE" if opts["write"] else "dry-run"
         self.stdout.write(f"{mode}: {len(cases)} case(s) from the {court} backlog\n")
 
-        written = skipped = abstained = failed = 0
+        written = skipped = abstained = failed = escalated_n = 0
         for i, case in enumerate(cases, 1):
             if not is_decided(case):
                 skipped += 1
@@ -207,7 +262,8 @@ class Command(BaseCommand):
                 continue
             self._gap(delay)
             try:
-                ex, url, model, chars = self._extract_one(case, tier=tier)
+                ex, url, model, chars, escalated = self._extract(case, tier=tier)
+                escalated_n += escalated
             except Exception as exc:  # noqa: BLE001
                 failed += 1
                 self.stdout.write(f"  {i:>3} {case.case_number}  FAILED {exc}")
@@ -269,6 +325,7 @@ class Command(BaseCommand):
 
         self.stdout.write(
             f"\n{mode} done: written={written} abstained={abstained} skipped={skipped} failed={failed}"
+            f" escalated={escalated_n}"
         )
         if not opts["write"] and written == 0:
             self.stdout.write(f"(dry-run — nothing persisted; rows would carry extra_data['{PROVENANCE_KEY}'])")

--- a/courts/tests/test_scraper_verdicts.py
+++ b/courts/tests/test_scraper_verdicts.py
@@ -293,3 +293,116 @@ class PolitenessGapTests(TestCase):
             cmd._gap(2.5)
             cmd._gap(2.5)
         self.assertEqual([c.args for c in clock.sleep.call_args_list], [(2.5,), (2.5,)])
+
+
+class BudgetEscalationTests(TestCase):
+    """A first attempt that runs out of room gets one retry at a bigger budget.
+
+    The 2026-07-31 production run lost 3 of 84 cases to `error_max_turns` on long
+    multi-defendant judgments. Escalation buys those back -- but ONLY on failure,
+    because a case answered at the escalated budget was never the case the
+    --eval run scored.
+    """
+
+    def _cmd(self):
+        cmd = Command()
+        cmd._downloads = 0
+        return cmd
+
+    def test_a_clean_first_attempt_never_escalates(self):
+        """The common path must be untouched: one call, at the scored budget."""
+        cmd = self._cmd()
+        seen = []
+        with mock.patch.object(Command, "_extract_one", autospec=True) as one:
+            one.side_effect = lambda _s, _c, tier, max_tokens: (
+                seen.append(max_tokens) or ("EX", "u", "m", 10)
+            )
+            result = cmd._extract(mock.Mock(), tier="premium")
+        self.assertEqual(result, ("EX", "u", "m", 10, False))
+        self.assertEqual(seen, [extract_verdicts.MAX_TOKENS])
+
+    def test_exhaustion_retries_once_at_the_escalated_budget(self):
+        cmd = self._cmd()
+        seen = []
+
+        def fake(_self, _case, *, tier, max_tokens):
+            seen.append(max_tokens)
+            if len(seen) == 1:
+                raise RuntimeError(
+                    "claude_cli error: Reached maximum number of turns (1)"
+                )
+            return ("EX", "u", "m", 99)
+
+        with mock.patch.object(Command, "_extract_one", autospec=True, side_effect=fake):
+            result = cmd._extract(mock.Mock(), tier="premium")
+        self.assertEqual(result, ("EX", "u", "m", 99, True))
+        self.assertEqual(
+            seen, [extract_verdicts.MAX_TOKENS, extract_verdicts.ESCALATED_MAX_TOKENS]
+        )
+
+    def test_a_non_budget_failure_is_not_retried(self):
+        """Retrying a dead document or a 403 at 4x the budget just costs 4x.
+
+        This is the guard that keeps escalation from becoming a blanket retry.
+        """
+        cmd = self._cmd()
+        calls = []
+
+        def fake(_self, _case, *, tier, max_tokens):
+            calls.append(max_tokens)
+            raise RuntimeError("no order document yielded text")
+
+        with mock.patch.object(Command, "_extract_one", autospec=True, side_effect=fake):
+            with self.assertRaises(RuntimeError):
+                cmd._extract(mock.Mock(), tier="premium")
+        self.assertEqual(calls, [extract_verdicts.MAX_TOKENS])
+
+    def test_escalation_can_still_fail_and_is_not_swallowed(self):
+        """A case too long even for the bigger budget stays a loud failure.
+
+        The whole design prefers a gap to a guess; escalation must not turn a
+        second exhaustion into a silent success.
+        """
+        cmd = self._cmd()
+        with mock.patch.object(
+            Command, "_extract_one", autospec=True,
+            side_effect=RuntimeError("error_max_turns"),
+        ) as one:
+            with self.assertRaises(RuntimeError):
+                cmd._extract(mock.Mock(), tier="premium")
+        self.assertEqual(one.call_count, 2)
+
+    def test_the_exhaustion_matcher_reads_the_real_production_message(self):
+        """Guard the guard: the matcher is a substring list, so pin it to the
+        exact string the failing production run emitted."""
+        self.assertTrue(
+            extract_verdicts._is_exhaustion(
+                RuntimeError(
+                    "claude_cli error: Reached maximum number of turns (1)\n"
+                    'Payload: {"subtype":"error_max_turns","is_error":true}'
+                )
+            )
+        )
+        self.assertFalse(
+            extract_verdicts._is_exhaustion(RuntimeError("no order url on case"))
+        )
+        self.assertFalse(
+            extract_verdicts._is_exhaustion(RuntimeError("403 organization disabled"))
+        )
+
+    def test_max_tokens_actually_reaches_the_model_call(self):
+        """Guard the plumbing: _extract_one must PASS its budget, not ignore it.
+
+        Before this change the invoke used the module constant directly, so a
+        per-call budget would have been accepted and silently dropped -- the
+        escalation would look like it worked while changing nothing.
+        """
+        cmd = self._cmd()
+        case = mock.Mock(case_number="070-CR-0001")
+        with mock.patch.object(extract_verdicts, "order_urls", return_value=["http://x/a.pdf"]), \
+             mock.patch("review.converter.convert_all",
+                        return_value=[{"conversion_status": "ok", "markdown": "फैसला"}]), \
+             mock.patch("llm.routing.provider_for_tier"), \
+             mock.patch("llm.invoke.invoke_text", return_value=_resp()) as invoke_text:
+            cmd._extract_one(case, tier="premium", max_tokens=4242)
+        self.assertEqual(invoke_text.call_args.args[2], 4242)


### PR DESCRIPTION
## What

The 2026-07-31 production run of `extract_verdicts --write` lost **3 of 84 cases** to `error_max_turns` — *"Reached maximum number of turns (1)"* — all long multi-defendant judgments. This retries those once at a larger output-token budget.

## Why the turn count is not the fix

`claude -p` never reports "out of output tokens". When reasoning outruns `CLAUDE_CODE_MAX_OUTPUT_TOKENS` the assistant turn simply ends unfinished, the CLI wants a second turn to continue, `--max-turns 1` denies it, and the run aborts as `error_max_turns`. The turn limit is the messenger; the budget is the cause. So escalation raises the budget (8000 → 32000).

## Escalation fires only after a failure — deliberately

| choice | why |
|---|---|
| retry-on-failure, not a bigger first attempt | Every case answered today used exactly the parameters `--eval 24` scored at **100% on answered**. Raising the first-attempt budget would silently detach that calibration from the rows being written. Retrying only after a failure can turn a failure into an answer but can never change an answer already given. |
| `_is_exhaustion` is a narrow match | A dead document, a missing order url or a 403 must not be retried at 4× the budget — that spends 4× as much to fail identically. |
| a second exhaustion still fails loudly | The design prefers a gap to a guess. Escalation must not convert exhaustion into silent success. |

`--eval` escalates on the same terms, or the score stops describing the write path — it would report as errors the very cases `--write` now recovers, understating coverage on exactly the hard tail. Both paths report `escalated=N`, so recovered-by-retry is never blended into plain success.

## Verification

- 33 tests in `test_scraper_verdicts.py`, **471** in `courts/` — all pass.
- Six new tests, each **verified to fail against a targeted mutation**: dropping the exhaustion guard, ignoring the per-call budget, and escalating on the first attempt are each caught by the test that claims to catch them.
- `test_max_tokens_actually_reaches_the_model_call` pins the plumbing: the invoke previously passed the module constant, so a per-call budget would have been accepted and silently dropped — escalation would have looked like it worked while changing nothing.
- Not reformatted: both files are already non-conformant to `ruff format` on `main`, which `ci.yml` documents as deliberate. `ruff check` passes.

## Deploying

Needs `REVIEW_CLI_TIMEOUT` raised in the Job (default 300s; a 32000-token reasoning run on the longest judgments can exceed it). That is env-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)