### PR TITLE
fix(events): the producers, and six silent failures the review found

### DIFF
--- a/case_events/apps.py
+++ b/case_events/apps.py
@@ -12,3 +12,19 @@ class EventsConfig(AppConfig):
 
     default_auto_field = "django.db.models.BigAutoField"
     name = "case_events"
+
+    def ready(self):
+        # Connects the Material post_save producer. Imported for its side effect,
+        # and guarded: a producer that fails to register must not take down the
+        # app that also owns the consumers and the bootstrap command, since those
+        # are what you would use to diagnose it.
+        #
+        # This opens no connection. With NATS_URL unset every emit is a logged
+        # no-op and no thread is started, so registering it costs nothing until
+        # the broker exists.
+        try:
+            from case_events.producers import materials  # noqa: F401
+        except Exception:  # noqa: BLE001
+            import structlog
+
+            structlog.get_logger(__name__).exception("case_events.producer_registration_failed")

--- a/case_events/bus.py
+++ b/case_events/bus.py
@@ -259,7 +259,23 @@ def _shutdown_loop(loop, thread) -> None:
     running raises, and ``stop()`` only asks. A short timeout because this is
     shutdown, and a thread that will not stop is not worth blocking a request
     for — leaking a loop beats hanging.
+
+    **Pending tasks are drained first, and that is not tidiness.** The timeout
+    path in ``_start`` cancels the ``_connect()`` future, but cancellation is
+    only *scheduled* — the task is still mid-flight when we stop the loop, so
+    closing it discards a task that owns a half-open TCP socket. Measured: stop
+    the loop straight after a cancel and the task is still pending, and CPython
+    prints "Task was destroyed but it is pending!" on close. Draining defeats
+    the point of closing if it is skipped, since the socket is the very thing
+    the close is meant to reclaim.
     """
+    if thread is not None and thread.is_alive():
+        try:
+            drained = asyncio.run_coroutine_threadsafe(_drain_tasks(), loop)
+            drained.result(timeout=2)
+        except Exception as exc:  # noqa: BLE001 - shutdown is best-effort throughout
+            logger.warning("case_events.loop_drain_failed", error=str(exc) or type(exc).__name__)
+
     loop.call_soon_threadsafe(loop.stop)
     if thread is not None:
         thread.join(timeout=2)
@@ -270,6 +286,23 @@ def _shutdown_loop(loop, thread) -> None:
         loop.close()
     except Exception as exc:  # noqa: BLE001 - shutdown is best-effort
         logger.warning("case_events.loop_close_failed", error=str(exc))
+
+
+async def _drain_tasks() -> None:
+    """Cancel every other task on this loop and wait for them to finish.
+
+    Runs ON the loop, which is the only place it can see the task set. Excludes
+    itself, or it would cancel the drain mid-drain.
+    """
+    me = asyncio.current_task()
+    others = [t for t in asyncio.all_tasks() if t is not me and not t.done()]
+    if not others:
+        return
+    for task in others:
+        task.cancel()
+    # return_exceptions: a cancelled task raises CancelledError, which is the
+    # expected outcome here rather than a failure to report.
+    await asyncio.gather(*others, return_exceptions=True)
 
 
 def _log_result(future, subject: str):

--- a/case_events/bus.py
+++ b/case_events/bus.py
@@ -164,7 +164,7 @@ class _Bus:
             # Cancel before stopping the loop, or the abandoned _connect task is
             # destroyed while pending and nats-py logs it as an error.
             future.cancel()
-            loop.call_soon_threadsafe(loop.stop)
+            _shutdown_loop(loop, thread)
             raise
 
         return loop, thread, nc, js
@@ -192,7 +192,9 @@ class _Bus:
     def close(self):
         """Drain and disconnect. For tests and orderly shutdown."""
         with self._lock:
-            loop, nc = self._loop, self._nc
+            # Captured before the reset nulls them, thread included — the
+            # shutdown below has to join it before the loop can be closed.
+            loop, nc, thread = self._loop, self._nc, self._thread
             self._reset_locked()
         if loop is None:
             return
@@ -202,7 +204,7 @@ class _Bus:
         except Exception as exc:  # noqa: BLE001 - shutdown is best-effort too
             logger.warning("case_events.close_failed", error=str(exc))
         finally:
-            loop.call_soon_threadsafe(loop.stop)
+            _shutdown_loop(loop, thread)
 
     # ── publishing ───────────────────────────────────────────────────────────
 
@@ -241,6 +243,33 @@ class _Bus:
         else:
             future.add_done_callback(lambda f: _log_result(f, subject))
         return True
+
+
+def _shutdown_loop(loop, thread) -> None:
+    """Stop a loop, join its thread, and CLOSE it.
+
+    The close is the part that was missing. ``loop.stop()`` alone leaves the
+    loop's selector and its self-pipe socketpair open, so every abandoned loop
+    costs a couple of file descriptors permanently. That is invisible for the
+    orderly-shutdown case, which happens once — but ``_start`` takes the same
+    path on every failed connect, and with a 30-second retry window a sustained
+    broker outage leaks steadily in a process that never restarts.
+
+    The join is what makes closing safe: ``loop.close()`` on a loop still
+    running raises, and ``stop()`` only asks. A short timeout because this is
+    shutdown, and a thread that will not stop is not worth blocking a request
+    for — leaking a loop beats hanging.
+    """
+    loop.call_soon_threadsafe(loop.stop)
+    if thread is not None:
+        thread.join(timeout=2)
+        if thread.is_alive():
+            logger.warning("case_events.loop_thread_did_not_stop")
+            return
+    try:
+        loop.close()
+    except Exception as exc:  # noqa: BLE001 - shutdown is best-effort
+        logger.warning("case_events.loop_close_failed", error=str(exc))
 
 
 def _log_result(future, subject: str):

--- a/case_events/consumers/__init__.py
+++ b/case_events/consumers/__init__.py
@@ -77,13 +77,13 @@ class Disposition(str, Enum):
     DEAD_LETTER = "dead_letter"
 
 
-def decide(*, error: BaseException | None, num_delivered: int, max_deliver: int) -> Disposition:
+def decide(*, error: BaseException | None, num_delivered: int | None, max_deliver: int) -> Disposition:
     """Choose a disposition for one delivery.
 
     Args:
         error: What the handler raised, or None if it returned cleanly.
         num_delivered: JetStream's delivery count for this message, 1-based on
-            the first delivery.
+            the first delivery, or None when it could not be read.
         max_deliver: The consumer's configured delivery budget.
 
     Returns:
@@ -94,12 +94,21 @@ def decide(*, error: BaseException | None, num_delivered: int, max_deliver: int)
     advisory nobody here is listening to — so a message NAK'd on its final
     delivery is simply gone. Detecting the last delivery ourselves, and burying
     it deliberately, is the difference between a dead-letter queue and a leak.
+
+    An UNKNOWN count buries too, which reverses what this used to do. Treating
+    an unreadable delivery count as "first delivery" reads like the cautious
+    choice — retry rather than give up — but it can never satisfy the check
+    above, so such a message is NAK'd forever until JetStream drops it silently:
+    precisely the leak this function exists to prevent, reintroduced by the
+    safety default. Burying early costs a few retries we did not have to skip
+    and leaves the body on the DLQ, where a human can requeue it. The two
+    mistakes are not symmetric; only one of them is recoverable.
     """
     if error is None:
         return Disposition.ACK
     if isinstance(error, PoisonMessage):
         return Disposition.DEAD_LETTER
-    if num_delivered >= max_deliver:
+    if num_delivered is None or num_delivered >= max_deliver:
         return Disposition.DEAD_LETTER
     return Disposition.RETRY
 
@@ -141,14 +150,31 @@ class ConsumerSpec:
         return f"jaw-{self.name}"
 
     @property
-    def dlq_hint(self) -> str:
-        """Where this consumer's poison messages land, as a wildcard.
+    def dlq_pattern(self) -> str:
+        """Where this consumer's poison messages land, as a SUBSCRIBE PATTERN.
 
-        Approximate by construction: the real subject appends the message's own
-        subject, so a consumer filtering a wildcard buries to several. Shown by
-        ``run_consumers`` so the DLQ is greppable before anything has failed.
+        Not a subject, and named so it cannot be mistaken for one. The real
+        subject appends the message's own subject, so a consumer filtering a
+        wildcard buries to several — which means for ``matcher`` this evaluates
+        to ``jaw.dlq.jaw.signal.>`` and NATS rejects a publish to it. It exists
+        so ``run_consumers`` can print something greppable before anything has
+        failed; the publish target is built per message by
+        :func:`case_events.subjects.dlq_subject`.
         """
         return f"{subjects.DLQ_PREFIX}{self.filter_subject}"
+
+    @property
+    def backoff(self) -> list[int]:
+        """The redelivery backoff, trimmed to fit ``max_deliver``.
+
+        JetStream requires strictly more deliveries than backoff steps and
+        rejects the consumer at subscribe time otherwise — which means at
+        rollout, in a pod that then crashloops. Deriving the list from
+        ``max_deliver`` rather than asserting the pair makes the two impossible
+        to set inconsistently: lowering ``max_deliver`` shortens the schedule
+        instead of breaking the subscribe.
+        """
+        return list(DEFAULT_BACKOFF_SECONDS)[: max(0, self.max_deliver - 1)]
 
 
 _REGISTRY: dict[str, ConsumerSpec] = {}

--- a/case_events/consumers/handlers.py
+++ b/case_events/consumers/handlers.py
@@ -55,6 +55,22 @@ def _producer(name: str) -> str:
 # ── matcher ──────────────────────────────────────────────────────────────────
 
 
+def _enrichable():
+    """Cases an observed fact may be proposed against.
+
+    Excludes CLOSED, which on this platform is the soft delete: ``Case.delete()``
+    flips the state and keeps the row (accountability archive — nothing is hard
+    deleted). Without this filter a deleted case still joins on its court-case
+    references, so every scrape of that docket buys a premium model call and puts
+    a review item in front of a caseworker for a case somebody deliberately
+    removed. DRAFT and IN_REVIEW are deliberately kept: a case being built is
+    exactly the sort of thing new facts should land on.
+    """
+    from cases.models import Case, CaseState
+
+    return Case.objects.exclude(state=CaseState.CLOSED)
+
+
 def _cases_for_refs(refs: list[str]):
     """Cases joined to any of ``refs`` by an EXACT identifier match.
 
@@ -68,15 +84,14 @@ def _cases_for_refs(refs: list[str]):
     observation into dozens of proposals, none of them evidenced. Entity-based
     matching needs its own scoring, and it is not this consumer's pilot job.
     """
-    from cases.models import Case
-
     if not refs:
         return []
 
     from django.db.models import Q
 
     return list(
-        Case.objects.filter(
+        _enrichable()
+        .filter(
             Q(courtcase_references__courtcase_iri__in=refs)
             | Q(material_references__material_iri__in=refs)
         )
@@ -103,9 +118,7 @@ def _cases_named_directly(refs: list[str]):
     if not slugs:
         return []
 
-    from cases.models import Case
-
-    return list(Case.objects.filter(slug__in=slugs).only("id", "slug", "title"))
+    return list(_enrichable().filter(slug__in=slugs).only("id", "slug", "title"))
 
 
 def handle_matcher(envelope: dict, context) -> None:
@@ -115,6 +128,15 @@ def handle_matcher(envelope: dict, context) -> None:
     rather than one message listing several keeps every downstream consumer's
     unit of work a single case, which is what makes their dedup keys and their
     retries meaningful.
+
+    **A failed publish raises**, which is the one place this file departs from
+    the best-effort publishing rule the rest of the codebase follows. Everywhere
+    else the bus describes work that has already been done, so a dropped message
+    costs a log line. Here the message IS the work: if the ``jaw.case.matched``
+    does not land, the signal has been consumed and nothing downstream will ever
+    hear about it — acked, unretried, and absent from the DLQ. ``bus.publish``
+    returns False without raising for a suppressed connect and logs it at DEBUG,
+    so ignoring the return silently discards facts during any broker blip.
     """
     from case_events import bus
 
@@ -167,7 +189,12 @@ def handle_matcher(envelope: dict, context) -> None:
                 "producer": envelope.get("producer"),
             },
         }
-        bus.publish(
+        matched_key = _matched_dedup_key(envelope, case.slug)
+        # wait=True: without it a True return means "handed to the loop thread",
+        # and the JetStream ack — including the rejection you get when no stream
+        # claims the subject, i.e. when nats_bootstrap has not been run — arrives
+        # later on a callback nothing here can see.
+        sent = bus.publish(
             subjects.CASE_MATCHED,
             build_envelope(
                 subject=subjects.CASE_MATCHED,
@@ -176,13 +203,22 @@ def handle_matcher(envelope: dict, context) -> None:
                 # Derived from the SIGNAL's dedup key, not generated: re-matching
                 # a redelivered signal must collapse rather than fan out. Scoped
                 # by case so a multi-case match still produces distinct messages.
-                dedup_key=_matched_dedup_key(envelope, case.slug),
+                dedup_key=matched_key,
                 source=envelope.get("source") or "",
                 raw_ref=envelope.get("raw_ref") or "",
                 occurred_at=None,
                 payload=payload,
             ),
+            wait=True,
         )
+        if not sent:
+            # Retryable, not poison: the message is fine, the broker is not. The
+            # redelivery re-publishes the cases already done in this loop, and
+            # that is harmless — every one of them carries a deterministic
+            # dedup_key, so JetStream collapses the repeats.
+            raise RuntimeError(
+                f"could not publish {subjects.CASE_MATCHED} for {case.slug!r} ({matched_key})"
+            )
 
     logger.info(
         "case_events.matcher_matched",
@@ -371,11 +407,14 @@ def handle_derive(envelope: dict, context) -> None:
         # will not find it, so bury rather than burn four more attempts.
         raise PoisonMessage(f"no case with slug {case_slug!r} to re-index")
 
-    from cases.search_index import index
+    from cases.search_index import index_now
 
-    # Any failure here propagates: unlike the on_commit hook this backstops, a
-    # failed index write should be retried and then dead-lettered, not swallowed.
-    index(case)
+    # `index_now`, not `index`. They are the same function; `index` is wrapped in
+    # @best_effort, which logs the transport error and returns None. Calling that
+    # one made this handler unable to fail — so the retry budget and the DLQ that
+    # justify doing the re-index from the bus at all were decoration, and this
+    # consumer was the duplicated effort its docstring says it is not.
+    index_now(case)
     logger.info("case_events.derived_reindex", case_slug=case_slug, proposal_id=payload.get("proposal_id"))
 
 

--- a/case_events/consumers/runner.py
+++ b/case_events/consumers/runner.py
@@ -16,11 +16,18 @@ not stream-admin rights. The streams themselves must already exist; assert them
 with ``manage.py nats_bootstrap``. A subscribe against a missing stream fails
 loudly here, which is the intended behaviour: a consumer with nothing to bind to
 should not sit looking healthy.
+
+**"Loudly" means the process exits, and that took a fix to become true.** The
+four consumers share one Deployment, so the only health signal an orchestrator
+can read is whether the process is alive. Any one of them ending — a crash, a
+subscribe against a missing stream, a connection that stops answering — now
+stops the others and exits non-zero. See :func:`run`.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from typing import Any
 
@@ -39,6 +46,17 @@ FETCH_TIMEOUT_SECONDS = 5.0
 
 #: Ceiling on the initial connect.
 CONNECT_TIMEOUT_SECONDS = 10
+
+#: Pause between failing fetches. A named constant rather than a literal so a
+#: test can shorten it — patching ``asyncio.sleep`` itself is not an option, as
+#: pytest-asyncio's own machinery runs on it.
+FETCH_RETRY_SLEEP_SECONDS = 1
+
+#: Consecutive failing fetches before a consumer gives up and exits. Small on
+#: purpose: nats-py reconnects underneath us, so a fetch that keeps failing this
+#: many times in a row means the connection is not coming back, and polling a
+#: broker that is not answering is indistinguishable from working.
+MAX_CONSECUTIVE_FETCH_FAILURES = 10
 
 
 class ConsumerStopped(Exception):
@@ -70,8 +88,6 @@ async def subscribe(js, spec: ConsumerSpec):
     """Create-or-attach the durable pull consumer for ``spec``."""
     from nats.js.api import AckPolicy, ConsumerConfig
 
-    from case_events.consumers import DEFAULT_BACKOFF_SECONDS
-
     return await js.pull_subscribe(
         spec.filter_subject,
         durable=spec.durable,
@@ -83,7 +99,10 @@ async def subscribe(js, spec: ConsumerSpec):
             ack_policy=AckPolicy.EXPLICIT,
             ack_wait=spec.ack_wait_seconds,
             max_deliver=spec.max_deliver,
-            backoff=list(DEFAULT_BACKOFF_SECONDS),
+            # Trimmed to max_deliver by the spec: JetStream rejects a consumer
+            # with as many backoff steps as deliveries, and it does so at
+            # subscribe time — i.e. during a rollout.
+            backoff=spec.backoff,
             filter_subject=spec.filter_subject,
         ),
     )
@@ -105,20 +124,33 @@ def parse_envelope(raw: bytes) -> dict:
     return envelope
 
 
-def _num_delivered(msg) -> int:
-    """This message's delivery count, defaulting to 1 if unavailable.
+def _num_delivered(msg) -> int | None:
+    """This message's delivery count, or None when the metadata cannot be read.
 
-    Defaulting LOW on purpose. If the metadata cannot be read, treating the
-    message as a first delivery means it gets retried rather than buried — the
-    recoverable mistake of the two.
+    None rather than a guess. :func:`case_events.consumers.decide` buries an
+    unknown count, and it can only make that call if it is told the count is
+    unknown — a plausible-looking 1 would have it retry forever instead. See
+    that function for why burying is the recoverable half of the choice.
     """
     try:
         return int(msg.metadata.num_delivered)
     except Exception:  # noqa: BLE001 - metadata is best-effort
-        return 1
+        return None
 
 
-async def dead_letter(js, spec: ConsumerSpec, msg, error: BaseException, num_delivered: int) -> bool:
+def _dlq_dedup_key(spec: ConsumerSpec, original_subject: str, body: str) -> str:
+    """A deterministic key for "this consumer buried this body".
+
+    Derived from the BODY rather than the envelope's own ``dedup_key``, because
+    the commonest reason to be in the DLQ is that the body could not be parsed
+    into an envelope at all — so the field may not exist. Hashing what we
+    actually have keeps the key available in every case, including that one.
+    """
+    digest = hashlib.sha256(body.encode("utf-8", errors="replace")).hexdigest()[:32]
+    return f"dlq:{spec.name}:{original_subject}:{digest}"
+
+
+async def dead_letter(js, spec: ConsumerSpec, msg, error: BaseException, num_delivered: int | None) -> bool:
     """Republish a poison message to the DLQ. True if it was accepted.
 
     The original subject is appended to ``jaw.dlq.`` so the message stays
@@ -135,9 +167,17 @@ async def dead_letter(js, spec: ConsumerSpec, msg, error: BaseException, num_del
     except Exception:  # noqa: BLE001
         body = "<undecodable>"
 
+    dlq_key = _dlq_dedup_key(spec, original_subject, body)
     envelope = build_envelope(
         subject=subjects.dlq_subject(original_subject),
         producer=f"consumer:{spec.name}",
+        # Keyed like every other publish on this bus. A message can reach the DLQ
+        # more than once — it is buried on its final delivery, and a consumer
+        # restart or a re-published copy can bury the same fact again — and
+        # without a key the DLQ's depth reads as a count of failing FACTS when it
+        # is really a count of attempts. The depth is the number an operator acts
+        # on, so it has to mean what it looks like.
+        dedup_key=dlq_key,
         payload={
             "consumer": spec.name,
             "original_subject": original_subject,
@@ -151,6 +191,7 @@ async def dead_letter(js, spec: ConsumerSpec, msg, error: BaseException, num_del
         await js.publish(
             subjects.dlq_subject(original_subject),
             json.dumps(envelope, ensure_ascii=False, default=str).encode("utf-8"),
+            headers={"Nats-Msg-Id": dlq_key} if dlq_key else None,
         )
         return True
     except Exception as exc:  # noqa: BLE001
@@ -162,6 +203,30 @@ async def dead_letter(js, spec: ConsumerSpec, msg, error: BaseException, num_del
             consumer=spec.name,
             original_subject=original_subject,
             error=str(exc),
+        )
+        return False
+
+
+async def _settle(spec: ConsumerSpec, msg, action: str) -> bool:
+    """Ack / nak / term the message. True if the broker took it.
+
+    Settling is the one part of handling a message that talks to the broker, so
+    it is the part that fails when the connection drops — and it used to be the
+    only unguarded await in the loop, which meant a single transient ack error
+    propagated out of the fetch loop and killed that consumer for the life of
+    the pod. Redelivery already covers a lost ack (that is what at-least-once
+    means); losing the consumer does not cover anything.
+    """
+    try:
+        await getattr(msg, action)()
+        return True
+    except Exception as exc:  # noqa: BLE001 - a settle failure is redelivery, not death
+        logger.warning(
+            "case_events.settle_failed",
+            consumer=spec.name,
+            action=action,
+            subject=getattr(msg, "subject", ""),
+            error=str(exc) or type(exc).__name__,
         )
         return False
 
@@ -185,7 +250,7 @@ async def process_message(js, spec: ConsumerSpec, msg) -> Disposition:
     disposition = decide(error=error, num_delivered=num_delivered, max_deliver=spec.max_deliver)
 
     if disposition is Disposition.ACK:
-        await msg.ack()
+        await _settle(spec, msg, "ack")
         return disposition
 
     logger.warning(
@@ -204,20 +269,20 @@ async def process_message(js, spec: ConsumerSpec, msg) -> Disposition:
         # No delay argument: the consumer's own `backoff` schedule governs when
         # it comes back, so passing one here would override the policy the
         # subscription was created with.
-        await msg.nak()
+        await _settle(spec, msg, "nak")
         return disposition
 
     if await dead_letter(js, spec, msg, error, num_delivered):
         # Terminate ONLY once the DLQ has the message. Terminating first and
         # failing to republish would be a silent loss — exactly what the DLQ
         # exists to prevent.
-        await msg.term()
+        await _settle(spec, msg, "term")
         return Disposition.DEAD_LETTER
 
     # The DLQ is unreachable. NAK instead, so the message stays on the stream
     # and someone can deal with it. It may exceed max_deliver and be dropped by
     # JetStream, but an un-acked message with a loud error beats a terminated one.
-    await msg.nak()
+    await _settle(spec, msg, "nak")
     return Disposition.RETRY
 
 
@@ -235,6 +300,7 @@ async def run_one(js, spec: ConsumerSpec, *, stop: asyncio.Event, once: bool, ma
     )
 
     handled = 0
+    consecutive_failures = 0
     while not stop.is_set():
         if max_messages is not None and handled >= max_messages:
             break
@@ -243,17 +309,35 @@ async def run_one(js, spec: ConsumerSpec, *, stop: asyncio.Event, once: bool, ma
             batch = min(batch, max_messages - handled)
         try:
             msgs = await sub.fetch(batch, timeout=FETCH_TIMEOUT_SECONDS)
+            consecutive_failures = 0
         except (NatsTimeoutError, asyncio.TimeoutError):
             # An empty window. In --once mode that is the signal that the
-            # backlog is drained; otherwise just poll again.
+            # backlog is drained; otherwise just poll again. NOT counted as a
+            # failure: on a quiet bus this is the normal case.
+            consecutive_failures = 0
             if once:
                 break
             continue
         except Exception as exc:  # noqa: BLE001
-            logger.warning("case_events.fetch_failed", consumer=spec.name, error=str(exc))
+            consecutive_failures += 1
+            logger.warning(
+                "case_events.fetch_failed",
+                consumer=spec.name,
+                error=str(exc),
+                consecutive=consecutive_failures,
+            )
             if once:
                 break
-            await asyncio.sleep(1)
+            if consecutive_failures >= MAX_CONSECUTIVE_FETCH_FAILURES:
+                # Give up rather than poll a broker that is not answering. The
+                # previous behaviour was to warn and sleep forever, which left
+                # the pod Ready and consuming nothing — the failure mode this
+                # whole file is arranged to avoid. Raising exits the process
+                # (see `run`), and the orchestrator restarts it.
+                raise RuntimeError(
+                    f"{spec.name}: {consecutive_failures} consecutive fetch failures; last: {exc}"
+                ) from exc
+            await asyncio.sleep(FETCH_RETRY_SLEEP_SECONDS)
             continue
 
         for msg in msgs:
@@ -264,22 +348,72 @@ async def run_one(js, spec: ConsumerSpec, *, stop: asyncio.Event, once: bool, ma
     return handled
 
 
+async def _supervise(
+    js,
+    spec: ConsumerSpec,
+    *,
+    stop: asyncio.Event,
+    once: bool,
+    max_messages: int | None,
+    fatal: bool,
+    ended_early: list[str],
+):
+    """Run one consumer, and stop its siblings when it ends unexpectedly.
+
+    ``fatal`` is set in the continuous mode, where a consumer returning at all
+    is already wrong: the loop only exits on ``stop``, so reaching here means it
+    raised or its subscription died. In ``--once`` / ``--max-messages`` mode the
+    consumers are meant to finish at their own pace and one finishing says
+    nothing about the others.
+
+    Recording the name in ``ended_early`` is what keeps a clean-but-premature
+    return distinguishable from a graceful SIGTERM, which also sets ``stop``.
+    """
+    try:
+        return await run_one(js, spec, stop=stop, once=once, max_messages=max_messages)
+    finally:
+        if fatal and not stop.is_set():
+            logger.error("case_events.consumer_ended_early", consumer=spec.name)
+            ended_early.append(spec.name)
+            stop.set()
+
+
 async def run(specs: list[ConsumerSpec], *, once: bool = False, max_messages: int | None = None) -> dict[str, int]:
     """Run every spec concurrently until stopped. Returns per-consumer counts.
 
     One connection is shared by all of them; each gets its own subscription and
-    its own task. A consumer whose loop raises takes only itself down — recorded
-    as an exception in the returned mapping's place, logged, and left for the
-    orchestrator to notice via the process exiting when all of them have.
+    its own task.
+
+    **One consumer ending takes the whole process down**, and that is the point.
+    These four run in a single Deployment, so the only thing an orchestrator can
+    observe is the process. An earlier version gathered the tasks and reported a
+    crash afterwards — but in the continuous mode nothing ever finishes, so
+    "afterwards" never arrived: a matcher that died on a missing stream left the
+    other three polling happily and the pod Ready, consuming nothing, for as
+    long as nobody looked. Stopping the siblings converts that into an exit,
+    which is the one signal a Deployment reacts to.
     """
     nc, js = await connect()
     stop = asyncio.Event()
+    fatal = not (once or max_messages is not None)
+    ended_early: list[str] = []
 
     _install_signal_handlers(stop)
 
     try:
         results = await asyncio.gather(
-            *(run_one(js, spec, stop=stop, once=once, max_messages=max_messages) for spec in specs),
+            *(
+                _supervise(
+                    js,
+                    spec,
+                    stop=stop,
+                    once=once,
+                    max_messages=max_messages,
+                    fatal=fatal,
+                    ended_early=ended_early,
+                )
+                for spec in specs
+            ),
             return_exceptions=True,
         )
     finally:
@@ -293,6 +427,11 @@ async def run(specs: list[ConsumerSpec], *, once: bool = False, max_messages: in
     for spec, result in zip(specs, results):
         if isinstance(result, BaseException):
             logger.error("case_events.consumer_crashed", consumer=spec.name, error=str(result))
+            counts[spec.name] = -1
+        elif spec.name in ended_early:
+            # Returned without raising, but before it was asked to. Same signal
+            # as a crash — a consumer that stopped consuming is a consumer that
+            # stopped consuming, and the caller turns -1 into a non-zero exit.
             counts[spec.name] = -1
         else:
             counts[spec.name] = result

--- a/case_events/consumers/runner.py
+++ b/case_events/consumers/runner.py
@@ -327,7 +327,14 @@ async def run_one(js, spec: ConsumerSpec, *, stop: asyncio.Event, once: bool, ma
                 consecutive=consecutive_failures,
             )
             if once:
-                break
+                # RAISE, not break. A bounded run that could not reach the
+                # broker drained nothing — but breaking returns a count, and
+                # `run` reads any count as a clean finish (`fatal` is False in
+                # bounded mode), so `run_consumers --apply --once` against a
+                # dead broker exited 0 and a scheduled drain looked successful.
+                # Only the timeout branch above means "the backlog is empty"; a
+                # transport error means we do not know what the backlog holds.
+                raise RuntimeError(f"{spec.name}: fetch failed in a bounded run; last: {exc}") from exc
             if consecutive_failures >= MAX_CONSECUTIVE_FETCH_FAILURES:
                 # Give up rather than poll a broker that is not answering. The
                 # previous behaviour was to warn and sleep forever, which left

--- a/case_events/management/commands/emit_docket_signals.py
+++ b/case_events/management/commands/emit_docket_signals.py
@@ -86,12 +86,28 @@ class Command(BaseCommand):
         dropped = sum(n for s, n in counts.items() if "not sent" in s)
         if dropped:
             # Never silent. A run that published nothing looks identical to a
-            # quiet window unless it says so.
+            # quiet window unless it says so. Meaningful only because
+            # publish_window waits for the JetStream ack.
             self.stderr.write(
                 self.style.WARNING(f"  {dropped} signal(s) were NOT accepted by the bus")
             )
 
-        self._warn_if_saturated(counts, limit)
+        missed = self._report_saturation(window, limit)
+
+        # Non-zero exit, deliberately, AFTER the publishing is done. The run did
+        # useful work and the signals it sent are on the bus — but facts inside
+        # the window were never emitted and never will be, so a green CronJob
+        # would be a lie. backoffLimit is 0, so this surfaces as a failed Job
+        # rather than a retry storm.
+        if missed:
+            raise CommandError(
+                f"{missed} fact(s) in the {window}h window were never emitted because --limit "
+                f"({limit}) truncated the scan. They are NOT deferred — the next run rescans "
+                "the same window in the same order and reaches the same rows. Re-run with a "
+                "larger --limit before they age out of the window."
+            )
+        if dropped:
+            raise CommandError(f"{dropped} signal(s) were refused by the bus.")
 
     def _report(self, window, limit, show):
         signals = list(dockets.scan(window, limit))
@@ -127,19 +143,29 @@ class Command(BaseCommand):
 
         self.stdout.write("")
         self.stdout.write("Use --apply to publish. Streams must exist first (manage.py nats_bootstrap).")
-        self._warn_if_saturated(counts, limit)
+        self._report_saturation(window, limit)
 
-    def _warn_if_saturated(self, counts, limit):
-        """Say so when the limit truncated a kind.
+    def _report_saturation(self, window, limit) -> int:
+        """Report any kind the limit truncated. Returns facts never emitted.
 
-        A capped run looks exactly like a complete one in the output, and the
-        difference is whether facts were dropped this cycle.
+        Counted against the real row totals rather than inferred from what came
+        back, so the message can say "5000 of 8231" — and an earlier version of
+        this said the remainder "waits for the next run", which was wrong in the
+        way that matters. There is no watermark: the next run rescans the same
+        window in the same ``created_at`` order and re-selects the same first
+        ``limit`` rows. The tail is never reached, and when the burst ages out of
+        the window it is gone for good.
         """
-        for subject, n in sorted(counts.items()):
-            if n >= limit:
-                self.stderr.write(
-                    self.style.WARNING(
-                        f"  {subject} hit the --limit of {limit}; the window is truncated and "
-                        "the remainder waits for the next run. Raise --limit or shorten the window."
-                    )
+        missed = 0
+        for subject, total in sorted(dockets.window_totals(window).items()):
+            if total <= limit:
+                continue
+            missed += total - limit
+            self.stderr.write(
+                self.style.ERROR(
+                    f"  {subject}: emitted {limit} of {total}. The other {total - limit} are "
+                    "NOT deferred — with no watermark the next run reaches the same rows, so "
+                    "these are lost when they age out of the window. Raise --limit."
                 )
+            )
+        return missed

--- a/case_events/management/commands/emit_docket_signals.py
+++ b/case_events/management/commands/emit_docket_signals.py
@@ -63,6 +63,13 @@ class Command(BaseCommand):
         if window <= 0:
             raise CommandError("--window-hours must be positive; a zero window emits nothing.")
 
+        if limit <= 0:
+            # A negative limit reaches the queryset slice and Django raises
+            # "Negative indexing is not supported" — a traceback where a
+            # CommandError belongs. A zero limit emits nothing and then reports
+            # the whole window as a shortfall, which reads like a catastrophe.
+            raise CommandError("--limit must be positive; a non-positive limit emits nothing.")
+
         if not options["apply"]:
             self._report(window, limit, options["show"])
             return

--- a/case_events/management/commands/emit_docket_signals.py
+++ b/case_events/management/commands/emit_docket_signals.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Publish docket signals from the NGM lake.
+
+    manage.py emit_docket_signals                    # READ-ONLY: count what would go
+    manage.py emit_docket_signals --apply            # publish the window
+    manage.py emit_docket_signals --window-hours 6   # narrow it
+    manage.py emit_docket_signals --show 5           # print sample envelopes
+
+Read-only by default, like ``scrape_worker`` and ``review_poller``. The bare
+command reads the lake and reports; it needs no broker, which makes it the way to
+size the window before a cron ever runs.
+
+Runs as a CronJob in the platform image (it needs the ngm database). The window
+must comfortably exceed the schedule — see ``case_events.producers.dockets``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from case_events.producers import dockets
+
+
+class Command(BaseCommand):
+    help = "Emit jaw.signal.docket.* for recent lake activity (read-only without --apply)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually publish. Without it the command only counts and reports.",
+        )
+        parser.add_argument(
+            "--window-hours",
+            type=int,
+            default=dockets.DEFAULT_WINDOW_HOURS,
+            help=(
+                "How far back to rescan. Overlap is intentional and free (the dedup "
+                f"spine drops repeats); a gap is a permanently missed fact. Default {dockets.DEFAULT_WINDOW_HOURS}."
+            ),
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=dockets.DEFAULT_LIMIT,
+            help=f"Cap on rows examined per kind (default {dockets.DEFAULT_LIMIT}).",
+        )
+        parser.add_argument(
+            "--show",
+            type=int,
+            default=0,
+            metavar="N",
+            help="Print the first N signals as JSON. Works without --apply.",
+        )
+
+    def handle(self, *args, **options):
+        window = options["window_hours"]
+        limit = options["limit"]
+
+        if window <= 0:
+            raise CommandError("--window-hours must be positive; a zero window emits nothing.")
+
+        if not options["apply"]:
+            self._report(window, limit, options["show"])
+            return
+
+        if not getattr(settings, "NATS_URL", ""):
+            # Publishing already no-ops without a broker, but silently: the
+            # command would report zero sent and look like an empty window.
+            raise CommandError(
+                "NATS_URL is not set, so --apply would publish nothing and report it "
+                "as an empty window. Run without --apply to inspect the window."
+            )
+
+        counts = dockets.publish_window(window, limit)
+        total = sum(counts.values())
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(f"emit_docket_signals: {total} signal(s) over {window}h")
+        )
+        for subject, n in sorted(counts.items()):
+            self.stdout.write(f"  {subject}: {n}")
+
+        dropped = sum(n for s, n in counts.items() if "not sent" in s)
+        if dropped:
+            # Never silent. A run that published nothing looks identical to a
+            # quiet window unless it says so.
+            self.stderr.write(
+                self.style.WARNING(f"  {dropped} signal(s) were NOT accepted by the bus")
+            )
+
+        self._warn_if_saturated(counts, limit)
+
+    def _report(self, window, limit, show):
+        signals = list(dockets.scan(window, limit))
+        counts: dict[str, int] = {}
+        for subject, *_ in signals:
+            counts[subject] = counts.get(subject, 0) + 1
+
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                f"emit_docket_signals (read-only): {len(signals)} signal(s) over {window}h"
+            )
+        )
+        for subject, n in sorted(counts.items()):
+            self.stdout.write(f"  {subject}: {n}")
+        if not signals:
+            self.stdout.write("  (nothing in the window)")
+
+        for subject, payload, refs, dedup_key, occurred_at in signals[:show]:
+            self.stdout.write("")
+            self.stdout.write(
+                json.dumps(
+                    {
+                        "subject": subject,
+                        "subject_refs": refs,
+                        "dedup_key": dedup_key,
+                        "occurred_at": str(occurred_at),
+                        "payload": payload,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+
+        self.stdout.write("")
+        self.stdout.write("Use --apply to publish. Streams must exist first (manage.py nats_bootstrap).")
+        self._warn_if_saturated(counts, limit)
+
+    def _warn_if_saturated(self, counts, limit):
+        """Say so when the limit truncated a kind.
+
+        A capped run looks exactly like a complete one in the output, and the
+        difference is whether facts were dropped this cycle.
+        """
+        for subject, n in sorted(counts.items()):
+            if n >= limit:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"  {subject} hit the --limit of {limit}; the window is truncated and "
+                        "the remainder waits for the next run. Raise --limit or shorten the window."
+                    )
+                )

--- a/case_events/management/commands/run_consumers.py
+++ b/case_events/management/commands/run_consumers.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
             self.stdout.write(f"    durable        {spec.durable}")
             self.stdout.write(f"    stream         {spec.stream}")
             self.stdout.write(f"    filter         {spec.filter_subject}")
-            self.stdout.write(f"    max_deliver    {spec.max_deliver} (then -> {spec.dlq_hint})")
+            self.stdout.write(f"    max_deliver    {spec.max_deliver} (then -> {spec.dlq_pattern})")
             self.stdout.write(f"    ack_wait       {spec.ack_wait_seconds}s")
             if spec.description:
                 self.stdout.write(f"    {spec.description}")

--- a/case_events/producers/__init__.py
+++ b/case_events/producers/__init__.py
@@ -54,6 +54,7 @@ def emit(
     source: str = "",
     raw_ref: str = "",
     occurred_at=None,
+    wait: bool = False,
 ) -> bool:
     """Publish one signal. Never raises; returns False if nothing was sent.
 
@@ -66,6 +67,17 @@ def emit(
     ``build_envelope``. A signal with no deterministic key defeats every dedup
     layer downstream, and since producers re-emit by design that is not a
     degraded message but a duplicate-proposal generator.
+
+    Args:
+        wait: Block for the JetStream ack rather than returning as soon as the
+            publish is handed to the bus thread. **A False return only means
+            anything when this is set.** Without it the return value says the
+            coroutine was scheduled, and the broker's answer — including the
+            rejection you get when no stream claims the subject, i.e. when
+            ``nats_bootstrap`` has not been run — arrives later on a callback
+            nobody reads. Any caller that reports a result to a human, or counts
+            what it sent, wants this on. A ``post_save`` receiver does not: it
+            has no one to tell and a request to keep short.
     """
     if not dedup_key:
         logger.warning("case_events.signal_without_dedup_key", subject=subject, producer=producer)
@@ -82,7 +94,7 @@ def emit(
         occurred_at=occurred_at,
     )
     try:
-        return bus.publish(subject, envelope)
+        return bus.publish(subject, envelope, wait=wait)
     except Exception:  # noqa: BLE001 - a signal is never worth failing real work
         logger.warning("case_events.signal_publish_failed", subject=subject, dedup_key=dedup_key)
         return False

--- a/case_events/producers/__init__.py
+++ b/case_events/producers/__init__.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Producers: the things that put observed facts on ``jaw.signal.>``.
+
+A producer's whole job is to notice that something happened in the world and say
+so. It does not decide which case the fact belongs to (that is the matcher), it
+does not draft a change (that is the intent job), and it never writes a Case.
+
+**Signals are emitted where the record LANDS, not where the scraper runs.** The
+CIAA press-release and court-order scrapers are deliberately thin REST clients —
+``scrape_ciaa_press_releases`` says outright that it "never touches the ORM" —
+and hooking the bus into them would give every scraper a broker dependency, a
+``NATS_URL``, and a second way to be half-configured. Both write Materials
+through the ingestion plane, so one ``post_save`` producer at the Material seam
+covers both, and covers anything else that later writes the same kinds of
+document. This mirrors what :mod:`case_proposals.publish` does for proposals.
+
+**Producers are stateless and re-emit freely.** There is no watermark table and
+no checkpoint file. The docket producer rescans an overlapping window every run
+and republishes facts it has already published; the deduplication that makes
+that safe is the same spine every other layer relies on, ending at
+``CaseUpdateProposal.dedup_key``, which is unique and permanent.
+
+That is a deliberate trade and it has one sharp edge worth naming. The queue's
+own dedup does NOT hold across a completed job — ``jobs.queue.enqueue`` frees a
+``dedup_key`` once its job is terminal — so re-emission would have bought a fresh
+premium model call every time, had ``case_events.consumers.handlers`` not checked
+the proposal table before enqueueing. The stateless design and that check are one
+decision, not two; do not remove either without the other.
+
+What we get for it: no migration, no state to corrupt, and a dedup path that is
+exercised continuously in production rather than only in tests. A watermark that
+silently skips a range is a failure nobody notices for months.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from case_events import bus
+from case_events.envelope import build_envelope
+
+logger = structlog.get_logger(__name__)
+
+
+def emit(
+    subject: str,
+    *,
+    producer: str,
+    payload: dict[str, Any],
+    subject_refs: list[str],
+    dedup_key: str,
+    source: str = "",
+    raw_ref: str = "",
+    occurred_at=None,
+) -> bool:
+    """Publish one signal. Never raises; returns False if nothing was sent.
+
+    Best-effort in exactly the same sense as :mod:`case_proposals.publish`: a
+    producer runs alongside work that matters more than the signal does — a
+    scrape that populated the lake, a material that is now in the archive — and
+    a broker outage must not cost that work.
+
+    ``dedup_key`` is mandatory here rather than optional as it is on
+    ``build_envelope``. A signal with no deterministic key defeats every dedup
+    layer downstream, and since producers re-emit by design that is not a
+    degraded message but a duplicate-proposal generator.
+    """
+    if not dedup_key:
+        logger.warning("case_events.signal_without_dedup_key", subject=subject, producer=producer)
+        return False
+
+    envelope = build_envelope(
+        subject=subject,
+        producer=producer,
+        payload=payload,
+        subject_refs=subject_refs,
+        dedup_key=dedup_key,
+        source=source,
+        raw_ref=raw_ref,
+        occurred_at=occurred_at,
+    )
+    try:
+        return bus.publish(subject, envelope)
+    except Exception:  # noqa: BLE001 - a signal is never worth failing real work
+        logger.warning("case_events.signal_publish_failed", subject=subject, dedup_key=dedup_key)
+        return False

--- a/case_events/producers/dockets.py
+++ b/case_events/producers/dockets.py
@@ -49,8 +49,16 @@ PRODUCER = "producer:dockets"
 DEFAULT_WINDOW_HOURS = 48
 
 #: Hard ceiling on rows examined per kind per run. A backfill that suddenly
-#: inserts a million hearings must not turn into a million messages; it is
-#: better to emit a bounded batch, say so, and let the next run continue.
+#: inserts a million hearings must not turn into a million messages.
+#:
+#: **Hitting this loses facts permanently, and an earlier version of this
+#: comment claimed the opposite** — that the remainder "waits for the next run".
+#: It does not, and it cannot: there is no watermark, so the next run rescans the
+#: same window in the same ``created_at`` order and re-selects the same first
+#: ``limit`` rows. The tail is never reached, and once the burst ages out of the
+#: window it is gone. That is inherent to the stateless design and is an
+#: acceptable trade only because saturation is loud — see
+#: :func:`window_totals`, and the non-zero exit in ``emit_docket_signals``.
 DEFAULT_LIMIT = 5000
 
 
@@ -75,11 +83,11 @@ def hearing_signals(since, limit: int = DEFAULT_LIMIT):
     """
     from courts.models import CourtCaseHearing
 
-    rows = (
-        CourtCaseHearing.objects.filter(created_at__gte=since)
-        .select_related("court")
-        .order_by("created_at")[:limit]
-    )
+    # No select_related("court"): `court` is a FK whose db_column IS the court
+    # identifier, so `row.court_id` is already the string the IRI needs. Joining
+    # `courts` would be a wasted join on every row of a 5000-row scan to fetch a
+    # value we hold.
+    rows = CourtCaseHearing.objects.filter(created_at__gte=since).order_by("created_at")[:limit]
     for row in rows:
         iri = _courtcase_iri(row.court_id, row.case_number)
         payload = {
@@ -161,8 +169,47 @@ def scan(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAULT_LIMIT):
     yield from verdict_signals(since, limit)
 
 
-def publish_window(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAULT_LIMIT) -> dict[str, int]:
-    """Emit every signal in the window. Returns per-subject counts sent."""
+def window_totals(window_hours: int = DEFAULT_WINDOW_HOURS) -> dict[str, int]:
+    """How many rows are in the window per kind, ignoring any limit.
+
+    Two COUNT queries, so that saturation can be reported as "5000 of 8231"
+    rather than "5000". The difference matters more than it looks: with no
+    watermark, the 3231 rows this run did not reach are not deferred, they are
+    dropped, and they stay dropped once the window slides past them. An
+    operator seeing only "5000" has no way to tell a capped run from a busy one.
+    """
+    from courts.models import CourtCase, CourtCaseHearing
+
+    since = timezone.now() - timedelta(hours=window_hours)
+    return {
+        subjects.SIGNAL_DOCKET_HEARING_ADDED: CourtCaseHearing.objects.filter(
+            created_at__gte=since
+        ).count(),
+        subjects.SIGNAL_DOCKET_VERDICT_ENTERED: CourtCase.objects.filter(
+            updated_at__gte=since,
+            verdict_date_ad__isnull=False,
+            is_deleted=False,
+        )
+        .exclude(verdict_type__isnull=True)
+        .exclude(verdict_type="")
+        .count(),
+    }
+
+
+def publish_window(
+    window_hours: int = DEFAULT_WINDOW_HOURS,
+    limit: int = DEFAULT_LIMIT,
+    *,
+    wait: bool = True,
+) -> dict[str, int]:
+    """Emit every signal in the window. Returns per-subject counts sent.
+
+    ``wait`` defaults True here, unlike ``emit``: this runs in a CronJob whose
+    entire output is the counts, and a fire-and-forget publish returns True
+    before the broker has said anything — so a run against a broker that
+    rejected every message would report a clean sweep. The round trips cost a
+    scheduled job nothing worth having.
+    """
     counts: dict[str, int] = {}
     for subject, payload, refs, dedup_key, occurred_at in scan(window_hours, limit):
         sent = emit(
@@ -173,6 +220,7 @@ def publish_window(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAUL
             dedup_key=dedup_key,
             source=refs[0] if refs else "",
             occurred_at=_as_datetime(occurred_at),
+            wait=wait,
         )
         key = subject if sent else f"{subject} (not sent)"
         counts[key] = counts.get(key, 0) + 1

--- a/case_events/producers/dockets.py
+++ b/case_events/producers/dockets.py
@@ -62,16 +62,34 @@ DEFAULT_WINDOW_HOURS = 48
 DEFAULT_LIMIT = 5000
 
 
-def _courtcase_iri(court_id: str, case_number: str) -> str:
-    """The canonical court-case ``@id``.
+def _courtcase_iri(court_id: str, case_number: str) -> str | None:
+    """The canonical court-case ``@id``, or None if this row cannot have one.
 
     Built with the shared helper, never by hand: ``build_courtcase_iri``
     lowercases both segments, so a hand-formatted
     ``.../courtcase/special/082-CR-0154`` matches nothing the matcher holds.
+
+    **Returns None rather than propagating.** The helper raises ``ValueError``
+    for an empty or unparseable ``case_number``, and this reads a lake filled by
+    a scraper against portal HTML — ``case_number`` is a plain CharField, so a
+    blank one is a data-quality event, not an impossibility. Letting that escape
+    would abort the generator mid-scan and drop every remaining row in the
+    window; and because the window is stateless and overlapping, the next run
+    would hit the same row at the same point and abort identically. One bad row
+    would stop the producer permanently. Skipping it costs that row only.
     """
     from jawafdehi_shared.entities.ids import build_courtcase_iri
 
-    return build_courtcase_iri(court_id, case_number)
+    try:
+        return build_courtcase_iri(court_id, case_number)
+    except ValueError as exc:
+        logger.warning(
+            "case_events.docket_row_has_no_iri",
+            court=court_id,
+            case_number=case_number,
+            error=str(exc),
+        )
+        return None
 
 
 def hearing_signals(since, limit: int = DEFAULT_LIMIT):
@@ -90,6 +108,9 @@ def hearing_signals(since, limit: int = DEFAULT_LIMIT):
     rows = CourtCaseHearing.objects.filter(created_at__gte=since).order_by("created_at")[:limit]
     for row in rows:
         iri = _courtcase_iri(row.court_id, row.case_number)
+        if iri is None:
+            # Logged in the helper. Skip the row, keep the scan.
+            continue
         payload = {
             "court": row.court_id,
             "case_number": row.case_number,
@@ -138,6 +159,9 @@ def verdict_signals(since, limit: int = DEFAULT_LIMIT):
     )
     for row in rows:
         iri = _courtcase_iri(row.court_id, row.case_number)
+        if iri is None:
+            # Logged in the helper. Skip the row, keep the scan.
+            continue
         payload = {
             "court": row.court_id,
             "case_number": row.case_number,

--- a/case_events/producers/dockets.py
+++ b/case_events/producers/dockets.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Docket signals, read out of the NGM lake the scrapers already write.
+
+No scraper changes. ``scrape_courtcases`` and ``scrape_worker`` keep filling the
+lake exactly as they do now, and this reads what they wrote. That separation is
+worth keeping: the scrapers are the fragile part (CAPTCHAs, portal HTML, session
+cookies) and they should not also carry a broker dependency.
+
+**Stateless, by an overlapping window.** Every run rescans the last N hours of
+lake rows and re-emits whatever it finds. There is no watermark, no checkpoint,
+and no new table. :mod:`case_events.producers` has the full reasoning; the short
+version is that the deduplication making this safe already exists and has to work
+anyway, and a watermark that silently skips a range is a failure nobody notices
+for months.
+
+The window must comfortably exceed the cron interval. Twice the period is the
+rule of thumb — enough that a skipped run, a slow drain or a clock nudge cannot
+open a gap, since a gap here is a permanently missed fact while a duplicate is
+free.
+
+**Two of the three docket subjects are implemented.**
+``jaw.signal.docket.status.changed`` is not, and cannot be from this vantage: the
+lake stores a case's *current* status with no history, so "changed" is
+unanswerable without the prior value. Detecting it needs either a history table
+or a snapshot, both of which are the stateful design this producer exists to
+avoid. A status change that matters almost always arrives as a hearing row or a
+verdict anyway, so the gap is narrower than it looks — but it is a gap, not an
+oversight.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import structlog
+from django.utils import timezone
+
+from case_events import subjects
+from case_events.producers import emit
+
+logger = structlog.get_logger(__name__)
+
+PRODUCER = "producer:dockets"
+
+#: Default lookback. The docket cron is expected to run every 6h, so 48h is
+#: eight times the period — deliberately generous, because the only cost of
+#: overlap is duplicate messages the dedup spine drops, and the cost of a gap is
+#: a fact that is never proposed.
+DEFAULT_WINDOW_HOURS = 48
+
+#: Hard ceiling on rows examined per kind per run. A backfill that suddenly
+#: inserts a million hearings must not turn into a million messages; it is
+#: better to emit a bounded batch, say so, and let the next run continue.
+DEFAULT_LIMIT = 5000
+
+
+def _courtcase_iri(court_id: str, case_number: str) -> str:
+    """The canonical court-case ``@id``.
+
+    Built with the shared helper, never by hand: ``build_courtcase_iri``
+    lowercases both segments, so a hand-formatted
+    ``.../courtcase/special/082-CR-0154`` matches nothing the matcher holds.
+    """
+    from jawafdehi_shared.entities.ids import build_courtcase_iri
+
+    return build_courtcase_iri(court_id, case_number)
+
+
+def hearing_signals(since, limit: int = DEFAULT_LIMIT):
+    """Yield ``(subject, payload, refs, dedup_key, occurred_at)`` for new hearings.
+
+    Keyed on ``created_at`` rather than ``hearing_date_ad``: a hearing scheduled
+    for next month is news the day we scrape it, not the day it happens, and a
+    hearing backfilled from an old cause list is news now.
+    """
+    from courts.models import CourtCaseHearing
+
+    rows = (
+        CourtCaseHearing.objects.filter(created_at__gte=since)
+        .select_related("court")
+        .order_by("created_at")[:limit]
+    )
+    for row in rows:
+        iri = _courtcase_iri(row.court_id, row.case_number)
+        payload = {
+            "court": row.court_id,
+            "case_number": row.case_number,
+            "hearing_date_bs": row.hearing_date_bs,
+            "hearing_date_ad": row.hearing_date_ad.isoformat() if row.hearing_date_ad else "",
+            "bench": row.bench or "",
+            "judge_names": row.judge_names or "",
+            "case_status": row.case_status or "",
+            "decision_type": row.decision_type or "",
+            "remarks": row.remarks or "",
+        }
+        # The BS date, not the row's pk. The pk is ours and changes on re-import;
+        # the docket date is the fact's own identity, so a re-scraped hearing
+        # dedups against the proposal already staged for it.
+        yield (
+            subjects.SIGNAL_DOCKET_HEARING_ADDED,
+            payload,
+            [iri],
+            f"docket:{iri}:hearing:{row.hearing_date_bs}",
+            row.hearing_date_ad,
+        )
+
+
+def verdict_signals(since, limit: int = DEFAULT_LIMIT):
+    """Yield signals for cases that have gained a verdict.
+
+    Filtered on ``updated_at`` because a verdict lands as an UPDATE to an
+    existing case row, not an insert — which is also why this cannot use
+    ``created_at`` the way hearings do.
+
+    Over-emits by construction: any touch of a case that already has a verdict
+    re-yields it. That is the overlapping-window trade working as intended, and
+    the dedup key is stable across those touches so nothing downstream doubles.
+    """
+    from courts.models import CourtCase
+
+    rows = (
+        CourtCase.objects.filter(
+            updated_at__gte=since,
+            verdict_date_ad__isnull=False,
+            is_deleted=False,
+        )
+        .exclude(verdict_type__isnull=True)
+        .exclude(verdict_type="")
+        .order_by("updated_at")[:limit]
+    )
+    for row in rows:
+        iri = _courtcase_iri(row.court_id, row.case_number)
+        payload = {
+            "court": row.court_id,
+            "case_number": row.case_number,
+            "verdict_type": row.verdict_type or "",
+            "verdict_date_bs": row.verdict_date_bs or "",
+            "verdict_date_ad": row.verdict_date_ad.isoformat() if row.verdict_date_ad else "",
+            "verdict_judge": row.verdict_judge or "",
+            "case_status": row.case_status or "",
+            "case_subject": row.case_subject or "",
+        }
+        # Keyed on the verdict DATE, so a correction to the judge or the type
+        # re-proposes rather than being swallowed — those are exactly the edits a
+        # caseworker would want to see a second time. A verdict date changing is
+        # a different fact and should re-propose.
+        stamp = row.verdict_date_bs or (row.verdict_date_ad.isoformat() if row.verdict_date_ad else "")
+        yield (
+            subjects.SIGNAL_DOCKET_VERDICT_ENTERED,
+            payload,
+            [iri],
+            f"docket:{iri}:verdict:{stamp}",
+            row.verdict_date_ad,
+        )
+
+
+def scan(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAULT_LIMIT):
+    """Every docket signal in the window, as an iterator. Reads only."""
+    since = timezone.now() - timedelta(hours=window_hours)
+    yield from hearing_signals(since, limit)
+    yield from verdict_signals(since, limit)
+
+
+def publish_window(window_hours: int = DEFAULT_WINDOW_HOURS, limit: int = DEFAULT_LIMIT) -> dict[str, int]:
+    """Emit every signal in the window. Returns per-subject counts sent."""
+    counts: dict[str, int] = {}
+    for subject, payload, refs, dedup_key, occurred_at in scan(window_hours, limit):
+        sent = emit(
+            subject,
+            producer=PRODUCER,
+            payload=payload,
+            subject_refs=refs,
+            dedup_key=dedup_key,
+            source=refs[0] if refs else "",
+            occurred_at=_as_datetime(occurred_at),
+        )
+        key = subject if sent else f"{subject} (not sent)"
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _as_datetime(value):
+    """A ``date`` from the lake as an aware datetime, or None.
+
+    The envelope's ``occurred_at`` is when the FACT happened, and for a docket
+    that is a court date rather than the moment we scraped it — which is the
+    number an audit of enrichment lag actually needs.
+    """
+    if value is None:
+        return None
+    from datetime import date, datetime, timezone as dt_timezone
+
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=dt_timezone.utc)
+    return None

--- a/case_events/producers/materials.py
+++ b/case_events/producers/materials.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Signals for newly-archived documents: court orders and CIAA press releases.
+
+One ``post_save`` receiver covers both, because both land the same way — a
+Material written through the ingestion plane — and neither scraper should have
+to know a bus exists. See :mod:`case_events.producers` for why the seam is here
+rather than in ``scrape_court_orders`` / ``scrape_ciaa_press_releases``.
+
+An earlier version of ``DESIGN.md`` §8 described the CIAA producer as blocked on
+re-porting a suspended Scrapy spider. That is stale: the spider was replaced by
+``manage.py scrape_ciaa_press_releases``, a REST client that has been minting
+these Materials for some time. The producer was never the hard part.
+"""
+
+from __future__ import annotations
+
+import structlog
+from django.db import router, transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from case_events import subjects
+from case_events.producers import emit
+
+logger = structlog.get_logger(__name__)
+
+#: Material ``source`` -> the signal it raises. Sources not listed here are
+#: archived silently, which is the intended default: a Material appearing is not
+#: by itself news about a case. Only these two carry a fact worth proposing on.
+SOURCE_SUBJECTS = {
+    "court_order": subjects.SIGNAL_COURTORDER_PUBLISHED,
+    "ciaa_press_release": subjects.SIGNAL_CIAA_PRESSRELEASE,
+}
+
+
+def _material_db(instance) -> str:
+    """The alias the row was written on — the one whose commit we must wait for.
+
+    Lifted from ``materials.signals`` because the trap is identical and worth
+    repeating rather than importing: ``Material`` lives on ``ngm``, and an
+    unqualified ``transaction.on_commit`` resolves against ``default``. Inside
+    ``atomic(using="ngm")`` the ``default`` connection is still in autocommit, so
+    Django would run the callback IMMEDIATELY — announcing a document before (or
+    instead of) its row becoming durable.
+    """
+    from materials.models import Material
+
+    return instance._state.db or router.db_for_write(Material, instance=instance)
+
+
+def _part_of_iri(data) -> str:
+    """The ``isPartOf`` IRI a court-order Material carries, or "".
+
+    This is the load-bearing field. A court order's ``isPartOf`` is the canonical
+    ``/courtcase/<court>/<number>`` IRI, which is exactly what the matcher joins
+    on — without it the signal names a document and nothing else, and no case
+    will ever be found for it.
+    """
+    if not isinstance(data, dict):
+        return ""
+    part_of = data.get("isPartOf")
+    if isinstance(part_of, dict):
+        return part_of.get("@id") or ""
+    if isinstance(part_of, str):
+        return part_of
+    return ""
+
+
+def signal_for(instance) -> tuple[str, dict, list[str], str] | None:
+    """``(subject, payload, subject_refs, dedup_key)`` for ``instance``, or None.
+
+    Split out from the receiver so the decision is testable without saving a row
+    through two databases.
+    """
+    subject = SOURCE_SUBJECTS.get(instance.source)
+    if subject is None:
+        return None
+    # A material created already soft-deleted is not an archival event. Rare, but
+    # it happens on re-ingest of a withdrawn document.
+    if getattr(instance, "is_deleted", False):
+        return None
+
+    data = instance.data if isinstance(instance.data, dict) else {}
+    part_of = _part_of_iri(data)
+
+    payload = {
+        "material_iri": instance.iri,
+        "material_type": instance.material_type,
+        "source": instance.source,
+        "ident": instance.ident,
+        "title": data.get("name") or data.get("headline") or "",
+        # The court case the document belongs to, when it names one. CIAA press
+        # releases generally do not — they are matched on their own IRI once a
+        # caseworker has linked one to a case, which is why this may be empty
+        # without the signal being useless.
+        "part_of": part_of,
+    }
+    # The material first: it is the reference most likely to be new. `part_of` is
+    # what actually resolves a case today.
+    refs = [ref for ref in (instance.iri, part_of) if ref]
+    return subject, payload, list(dict.fromkeys(refs)), f"material:{instance.iri}"
+
+
+@receiver(post_save, dispatch_uid="case_events_material_signal")
+def emit_material_signal(sender, instance, created, **kwargs):
+    """Announce a newly-archived court order or CIAA press release.
+
+    Only on CREATE. A Material is re-saved for conversion results, visibility
+    recomputation and index churn; announcing those would republish the same fact
+    every time a background job touched the row.
+    """
+    from materials.models import Material
+
+    # Connected without a `sender=` so it can be registered before the models are
+    # importable at app-load; filter here instead.
+    if sender is not Material or not created:
+        return
+
+    signal = signal_for(instance)
+    if signal is None:
+        return
+    subject, payload, refs, dedup_key = signal
+
+    def _run():
+        emit(
+            subject,
+            producer="producer:materials",
+            payload=payload,
+            subject_refs=refs,
+            dedup_key=dedup_key,
+            source=instance.iri,
+            raw_ref=instance.iri,
+        )
+
+    transaction.on_commit(_run, using=_material_db(instance))

--- a/case_events/tests/test_bus.py
+++ b/case_events/tests/test_bus.py
@@ -6,6 +6,7 @@ which is also the point of the design under test — the disabled path must not
 even try.
 """
 
+import asyncio
 import json
 import threading
 import time
@@ -336,6 +337,55 @@ class TestOnlyOneThreadPaysTheConnectCost:
         with b._lock:
             b._reset_locked()
         assert b._starting is False
+
+
+class TestTheLoopIsClosedNotJustStopped:
+    """``loop.stop()`` leaves the selector and its self-pipe socketpair open.
+
+    Harmless for orderly shutdown, which happens once — but ``_start`` takes the
+    same path on every failed connect, and with a 30-second retry window a
+    sustained broker outage leaks a couple of descriptors per attempt in a
+    process that never restarts.
+    """
+
+    def test_a_failed_connect_closes_the_loop_it_abandoned(self):
+        b = bus._Bus()
+        loops = []
+        real_new_event_loop = asyncio.new_event_loop
+
+        def track():
+            loop = real_new_event_loop()
+            loops.append(loop)
+            return loop
+
+        with mock.patch.object(bus.asyncio, "new_event_loop", track):
+            with mock.patch.object(b, "_connect", side_effect=RuntimeError("no broker")):
+                assert b._ensure_started() is False
+
+        assert loops, "the failure path must still have created a loop to abandon"
+        assert all(loop.is_closed() for loop in loops)
+
+    def test_close_closes_the_loop_too(self):
+        b = bus._Bus()
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+        b._loop, b._thread, b._nc, b._js = loop, thread, None, mock.Mock()
+
+        b.close()
+
+        assert loop.is_closed()
+
+    def test_a_thread_that_will_not_stop_leaks_rather_than_hangs(self):
+        """Shutdown must not block a request on a wedged loop thread."""
+        stuck = mock.Mock()
+        stuck.is_alive.return_value = True
+        loop = mock.Mock()
+
+        bus._shutdown_loop(loop, stuck)
+
+        loop.close.assert_not_called()  # closing a running loop raises
+        stuck.join.assert_called_once()
 
 
 class TestRedaction:

--- a/case_events/tests/test_bus.py
+++ b/case_events/tests/test_bus.py
@@ -376,6 +376,34 @@ class TestTheLoopIsClosedNotJustStopped:
 
         assert loop.is_closed()
 
+    def test_shutdown_finishes_the_tasks_still_running_on_the_loop(self):
+        """A cancelled connect is still mid-flight when the loop is stopped.
+
+        `future.cancel()` only SCHEDULES cancellation. Stop the loop straight
+        after and the task is still pending — holding, in the real case, a
+        half-open TCP socket — so closing discards it ("Task was destroyed but
+        it is pending!") along with the descriptor the close exists to reclaim.
+        """
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
+        async def never_finishes():
+            await asyncio.sleep(30)
+
+        asyncio.run_coroutine_threadsafe(never_finishes(), loop)
+
+        async def grab_others():
+            return [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+
+        pending = asyncio.run_coroutine_threadsafe(grab_others(), loop).result(timeout=2)
+        assert pending and not pending[0].done(), "fixture did not produce a live task"
+
+        bus._shutdown_loop(loop, thread)
+
+        assert loop.is_closed()
+        assert pending[0].done(), "a task was still pending when the loop was closed"
+
     def test_a_thread_that_will_not_stop_leaks_rather_than_hangs(self):
         """Shutdown must not block a request on a wedged loop thread."""
         stuck = mock.Mock()

--- a/case_events/tests/test_consumer_handlers.py
+++ b/case_events/tests/test_consumer_handlers.py
@@ -194,6 +194,78 @@ class TestMatcher:
         assert signal["payload"] == {"hearing_date": "2082-12-01"}
         assert signal["source"] == "https://example.test/docket"
 
+    def test_a_publish_the_bus_refused_raises_instead_of_acking(self):
+        """The one handler whose output IS a publish must not swallow one.
+
+        `bus.publish` is best-effort everywhere else because the message merely
+        describes work already done. Here the message is the only trace of the
+        match; dropping it and returning cleanly acks the signal, and nothing
+        downstream ever hears the fact. No retry, no DLQ, no log above DEBUG.
+        """
+        case = make_case()
+        iri = build_courtcase_iri("special", "082-CR-0154")
+        CaseCourtCaseReference.objects.create(case=case, courtcase_iri=iri, ordinal=1)
+
+        with mock.patch("case_events.bus.publish", return_value=False):
+            with pytest.raises(RuntimeError, match="could not publish"):
+                handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
+
+    def test_it_waits_for_the_jetstream_ack(self):
+        """`wait=False` returns True for a publish the broker later rejects.
+
+        Which is exactly what happens when no stream claims the subject — the
+        "forgot to run nats_bootstrap" case — so without waiting, the check
+        above would pass every message on a broker that accepted none of them.
+        """
+        case = make_case()
+        iri = build_courtcase_iri("special", "082-CR-0154")
+        CaseCourtCaseReference.objects.create(case=case, courtcase_iri=iri, ordinal=1)
+
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
+
+        assert pub.call_args.kwargs.get("wait") is True
+
+    def test_a_soft_deleted_case_is_not_matched(self):
+        """CLOSED is this platform's soft delete — `Case.delete()` keeps the row.
+
+        Without the filter the deleted case still joins on its court-case
+        reference, so every re-scrape of that docket buys a premium model call
+        and puts a review item in front of a caseworker for a case somebody
+        deliberately removed.
+        """
+        case = make_case()
+        iri = build_courtcase_iri("special", "082-CR-0154")
+        CaseCourtCaseReference.objects.create(case=case, courtcase_iri=iri, ordinal=1)
+        case.delete()
+
+        with mock.patch("case_events.bus.publish") as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
+
+        assert published(pub) == []
+
+    def test_a_soft_deleted_case_named_outright_is_not_matched_either(self):
+        """The direct-@id path is a separate query and needs the same filter."""
+        case = make_case()
+        case.delete()
+
+        with mock.patch("case_events.bus.publish") as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[build_case_iri(case.slug)]), None)
+
+        assert published(pub) == []
+
+    def test_a_draft_case_IS_matched(self):
+        """Kept deliberately: a case being built is what new facts should land on."""
+        case = make_case()
+        assert case.state == "DRAFT"
+        iri = build_courtcase_iri("special", "082-CR-0154")
+        CaseCourtCaseReference.objects.create(case=case, courtcase_iri=iri, ordinal=1)
+
+        with mock.patch("case_events.bus.publish") as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
+
+        assert len(published(pub)) == 1
+
 
 def matched_envelope(case, **overrides):
     return {
@@ -325,7 +397,7 @@ class TestNotifier:
 class TestDerive:
     def test_an_approved_change_reindexes_the_case(self):
         case = make_case()
-        with mock.patch("cases.search_index.index") as index:
+        with mock.patch("cases.search_index.index_now") as index:
             handlers.handle_derive(decision_envelope(case), None)
         index.assert_called_once()
         assert index.call_args.args[0].pk == case.pk
@@ -333,7 +405,7 @@ class TestDerive:
     def test_an_index_failure_propagates_so_it_is_retried(self):
         """The on_commit hook this backstops swallows failures; this must not."""
         case = make_case()
-        with mock.patch("cases.search_index.index", side_effect=RuntimeError("opensearch down")):
+        with mock.patch("cases.search_index.index_now", side_effect=RuntimeError("opensearch down")):
             with pytest.raises(RuntimeError):
                 handlers.handle_derive(decision_envelope(case), None)
 
@@ -357,7 +429,7 @@ class TestDerive:
         CaseSlugHistory.objects.create(slug="old-slug", case=case)
         envelope = {"payload": {"case_slug": "old-slug"}}
 
-        with mock.patch("cases.search_index.index") as index:
+        with mock.patch("cases.search_index.index_now") as index:
             handlers.handle_derive(envelope, None)
 
         assert index.call_args.args[0].pk == case.pk
@@ -369,7 +441,7 @@ class TestDerive:
         other = make_case(slug="some-other-case")
         CaseSlugHistory.objects.create(slug="contested-slug", case=other)
 
-        with mock.patch("cases.search_index.index") as index:
+        with mock.patch("cases.search_index.index_now") as index:
             handlers.handle_derive({"payload": {"case_slug": "contested-slug"}}, None)
 
         assert index.call_args.args[0].pk == live.pk
@@ -378,7 +450,7 @@ class TestDerive:
         """Closing a case is a visibility change; the index needs to hear about it."""
         case = make_case()
         case.delete()  # soft: state -> CLOSED
-        with mock.patch("cases.search_index.index") as index:
+        with mock.patch("cases.search_index.index_now") as index:
             handlers.handle_derive(decision_envelope(case), None)
         assert index.call_args.args[0].pk == case.pk
 
@@ -390,7 +462,7 @@ class TestDerive:
         """15-19s on prod; it would eat the ack window and pile up under a burst."""
         case = make_case()
         with mock.patch("cases.services.statistics.refresh_statistics") as refresh:
-            with mock.patch("cases.search_index.index"):
+            with mock.patch("cases.search_index.index_now"):
                 handlers.handle_derive(decision_envelope(case), None)
         refresh.assert_not_called()
 
@@ -405,7 +477,15 @@ class TestNoHandlerWritesACase:
         before = (case.title, list(case.timeline or []), case.state, case.updated_at)
 
         published_msgs = []
-        with mock.patch("case_events.bus.publish", side_effect=lambda s, e, **k: published_msgs.append(e)):
+
+        def record(subject, envelope, **kwargs):
+            published_msgs.append(envelope)
+            # Returns True: `bus.publish` returning False now means "this did
+            # not go", and the matcher raises on it. The old fake returned
+            # `list.append(...)` — i.e. None — which claimed a failed publish.
+            return True
+
+        with mock.patch("case_events.bus.publish", side_effect=record):
             handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
         for envelope in published_msgs:
             handlers.handle_proposal_builder(envelope, None)

--- a/case_events/tests/test_consumer_runner.py
+++ b/case_events/tests/test_consumer_runner.py
@@ -202,8 +202,16 @@ class TestProcessMessage:
         assert await runner.process_message(js, spec_for(lambda e, c: None), msg) is Disposition.DEAD_LETTER
         assert js.published
 
-    async def test_unreadable_metadata_retries_rather_than_burying(self):
-        """Defaulting the delivery count LOW is the recoverable mistake."""
+    async def test_unreadable_metadata_buries_rather_than_retrying_forever(self):
+        """The reverse of what this asserted before, and the reversal is the point.
+
+        Defaulting the delivery count LOW *looks* like the recoverable choice —
+        retry rather than give up. It is not: an unknown count can never satisfy
+        ``num_delivered >= max_deliver``, so the message is NAK'd until
+        JetStream silently drops it at MaxDeliver. That is the exact leak the
+        DLQ exists to prevent, arrived at by the safety default. Burying puts
+        the body somewhere a human can find it.
+        """
         js = FakeJS()
         msg = FakeMsg({"a": 1})
         del msg.metadata
@@ -211,7 +219,25 @@ class TestProcessMessage:
         def boom(envelope, ctx):
             raise RuntimeError("x")
 
-        assert await runner.process_message(js, spec_for(boom), msg) is Disposition.RETRY
+        result = await runner.process_message(js, spec_for(boom), msg)
+
+        assert result is Disposition.DEAD_LETTER
+        assert msg.settled == ["term"]
+        # And the body reached the DLQ before the terminate, as always.
+        assert js.published and js.published[0][0].startswith(subjects.DLQ_PREFIX)
+
+    async def test_an_unknown_delivery_count_is_reported_as_unknown(self):
+        """`decide` can only bury an unknown count if it is told the count is unknown.
+
+        Pinning the None rather than a plausible-looking 1: a guess here reads
+        as a real first delivery at every call site downstream, including the
+        `handler_failed` log line an operator would use to work out why a
+        message kept coming back.
+        """
+        msg = FakeMsg({"a": 1})
+        del msg.metadata
+
+        assert runner._num_delivered(msg) is None
 
     async def test_a_handler_that_blocks_does_not_run_on_the_event_loop(self):
         """Handlers use the Django ORM, which refuses to run inside a loop."""
@@ -240,6 +266,322 @@ def _loop_is_running() -> bool:
         return True
     except RuntimeError:
         return False
+
+
+class TestSettling:
+    """Talking to the broker is the part of handling a message that can fail."""
+
+    async def test_a_failed_ack_does_not_kill_the_consumer(self):
+        """Redelivery already covers a lost ack. Losing the consumer covers nothing.
+
+        The settle calls used to be the only unguarded awaits in the fetch loop,
+        so one transient ack error propagated all the way out of `run_one` and
+        that consumer was gone for the life of the pod.
+        """
+        js = FakeJS()
+        msg = FakeMsg({"a": 1})
+
+        async def boom_ack():
+            raise RuntimeError("connection reset")
+
+        msg.ack = boom_ack
+
+        result = await runner.process_message(js, spec_for(lambda e, c: None), msg)
+
+        assert result is Disposition.ACK  # the decision stands; only delivery failed
+
+    async def test_a_failed_nak_does_not_kill_the_consumer_either(self):
+        js = FakeJS()
+        msg = FakeMsg({"a": 1}, num_delivered=1)
+
+        async def boom_nak(delay=None):
+            raise RuntimeError("connection reset")
+
+        msg.nak = boom_nak
+
+        def handler(envelope, ctx):
+            raise RuntimeError("transient")
+
+        result = await runner.process_message(js, spec_for(handler, max_deliver=5), msg)
+
+        assert result is Disposition.RETRY
+
+
+class TestFetchFailures:
+    async def test_a_broker_that_never_answers_makes_the_consumer_give_up(self, monkeypatch):
+        """Warn-and-sleep-forever leaves the pod Ready and consuming nothing.
+
+        Which is the same failure the supervision below exists to convert into
+        an exit — a consumer polling a broker that stopped answering is
+        indistinguishable, from outside, from one with no work to do.
+        """
+        import asyncio
+
+        class DeadSub:
+            async def fetch(self, batch, timeout=None):
+                raise RuntimeError("nats: connection closed")
+
+        monkeypatch.setattr(runner, "subscribe", lambda js, spec: _resolved(DeadSub()))
+        # The constant, not `asyncio.sleep` — pytest-asyncio's own machinery
+        # runs on that, and replacing it process-wide wedges the loop.
+        monkeypatch.setattr(runner, "FETCH_RETRY_SLEEP_SECONDS", 0)
+
+        # wait_for, because the thing being asserted is that this TERMINATES.
+        # Without the bound, a regression that removes the ceiling does not fail
+        # the test — it hangs it, and a wedged CI job is a much worse way to
+        # learn about a bug than a red one.
+        with pytest.raises(RuntimeError, match="consecutive fetch failures"):
+            await asyncio.wait_for(
+                runner.run_one(
+                    FakeJS(),
+                    spec_for(lambda e, c: None, max_deliver=5),
+                    stop=asyncio.Event(),
+                    once=False,
+                    max_messages=None,
+                ),
+                timeout=5,
+            )
+
+    async def test_an_empty_window_is_not_a_failure(self, monkeypatch):
+        """A quiet bus is the normal case and must never count toward the ceiling."""
+        import asyncio
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        calls = {"n": 0}
+        stop = asyncio.Event()
+
+        class QuietSub:
+            async def fetch(self, batch, timeout=None):
+                calls["n"] += 1
+                if calls["n"] > runner.MAX_CONSECUTIVE_FETCH_FAILURES * 2:
+                    stop.set()
+                raise NatsTimeoutError()
+
+        monkeypatch.setattr(runner, "subscribe", lambda js, spec: _resolved(QuietSub()))
+
+        handled = await asyncio.wait_for(
+            runner.run_one(
+                FakeJS(),
+                spec_for(lambda e, c: None, max_deliver=5),
+                stop=stop,
+                once=False,
+                max_messages=None,
+            ),
+            timeout=5,
+        )
+
+        assert handled == 0  # it polled well past the ceiling and never gave up
+
+    async def test_a_recovered_fetch_resets_the_count(self, monkeypatch):
+        """The ceiling is CONSECUTIVE failures, not cumulative ones.
+
+        A bus that fails a fetch now and then over weeks is a working bus, and
+        it must never accumulate its way to an exit. Without the reset the
+        counter only ever climbs, so a long-lived consumer eventually kills
+        itself on a broker that is fine — and the two dedicated tests above
+        cannot tell the difference, because neither ever interleaves.
+        """
+        import asyncio
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        # Alternate: fail, then a quiet window, over and over. Far more rounds
+        # than the ceiling allows if the count were cumulative.
+        rounds = runner.MAX_CONSECUTIVE_FETCH_FAILURES * 3
+        calls = {"n": 0}
+        stop = asyncio.Event()
+
+        class FlakySub:
+            async def fetch(self, batch, timeout=None):
+                calls["n"] += 1
+                if calls["n"] >= rounds * 2:
+                    stop.set()
+                if calls["n"] % 2:
+                    raise RuntimeError("transient blip")
+                raise NatsTimeoutError()
+
+        monkeypatch.setattr(runner, "subscribe", lambda js, spec: _resolved(FlakySub()))
+        monkeypatch.setattr(runner, "FETCH_RETRY_SLEEP_SECONDS", 0)
+
+        handled = await asyncio.wait_for(
+            runner.run_one(
+                FakeJS(),
+                spec_for(lambda e, c: None, max_deliver=5),
+                stop=stop,
+                once=False,
+                max_messages=None,
+            ),
+            timeout=5,
+        )
+
+        assert handled == 0
+        assert calls["n"] >= rounds, "it gave up despite recovering between failures"
+
+
+async def _resolved(value):
+    return value
+
+
+class TestRun:
+    """One dead consumer must take the process down with it.
+
+    These four share a Deployment, so the process is the only thing an
+    orchestrator can observe. An earlier version gathered the tasks and reported
+    a crash afterwards — but nothing ever finishes in the continuous mode, so
+    "afterwards" never came: a matcher that died on a missing stream left the
+    other three polling and the pod Ready, consuming nothing.
+    """
+
+    async def _run(self, monkeypatch, specs, run_one, **kwargs):
+        import contextlib
+
+        class FakeNC:
+            async def drain(self):
+                return None
+
+        async def fake_connect():
+            return FakeNC(), FakeJS()
+
+        monkeypatch.setattr(runner, "connect", fake_connect)
+        monkeypatch.setattr(runner, "run_one", run_one)
+        monkeypatch.setattr(runner, "_install_signal_handlers", lambda stop: None)
+        with contextlib.suppress(Exception):
+            return await runner.run(specs, **kwargs)
+
+    async def test_a_crashed_consumer_stops_the_others_and_is_reported(self, monkeypatch):
+        import asyncio
+
+        specs = [
+            spec_for(lambda e, c: None, name="crasher", max_deliver=5),
+            spec_for(lambda e, c: None, name="survivor", max_deliver=5),
+        ]
+
+        async def run_one(js, spec, *, stop, once, max_messages):
+            if spec.name == "crasher":
+                raise RuntimeError("stream not found")
+            # The sibling: loops until told to stop, exactly like the real one.
+            while not stop.is_set():
+                await asyncio.sleep(0.01)
+            return 7
+
+        counts = await asyncio.wait_for(self._run(monkeypatch, specs, run_one), timeout=5)
+
+        assert counts["crasher"] == -1, "a crash must be reported"
+        # And the sibling actually returned, i.e. it was told to stop. Without
+        # that, this test would hang rather than fail — hence the wait_for.
+        assert counts["survivor"] == 7
+
+    async def test_a_consumer_that_returns_early_counts_as_a_crash(self, monkeypatch):
+        """A clean return in continuous mode is still a consumer that stopped.
+
+        Distinguished from a graceful SIGTERM, which also sets `stop` — that one
+        must stay a zero exit.
+        """
+        import asyncio
+
+        specs = [
+            spec_for(lambda e, c: None, name="quitter", max_deliver=5),
+            spec_for(lambda e, c: None, name="survivor", max_deliver=5),
+        ]
+
+        async def run_one(js, spec, *, stop, once, max_messages):
+            if spec.name == "quitter":
+                return 0
+            while not stop.is_set():
+                await asyncio.sleep(0.01)
+            return 3
+
+        counts = await asyncio.wait_for(self._run(monkeypatch, specs, run_one), timeout=5)
+
+        assert counts["quitter"] == -1
+
+    async def test_once_mode_lets_consumers_finish_independently(self, monkeypatch):
+        """A drain is meant to end. One finishing says nothing about the others."""
+        import asyncio
+
+        specs = [
+            spec_for(lambda e, c: None, name="a", max_deliver=5),
+            spec_for(lambda e, c: None, name="b", max_deliver=5),
+        ]
+
+        async def run_one(js, spec, *, stop, once, max_messages):
+            if spec.name == "a":
+                return 1
+            await asyncio.sleep(0.05)
+            return 2
+
+        counts = await asyncio.wait_for(
+            self._run(monkeypatch, specs, run_one, once=True), timeout=5
+        )
+
+        assert counts == {"a": 1, "b": 2}, "neither should be marked crashed"
+
+
+class TestBackoffFitsTheDeliveryBudget:
+    """JetStream rejects a consumer with as many backoff steps as deliveries.
+
+    It does so at subscribe time — during a rollout, in a pod that then
+    crashloops — so the schedule is derived from ``max_deliver`` rather than
+    asserted against it. Setting the two inconsistently is not possible.
+    """
+
+    def test_the_default_pair_leaves_room(self):
+        from case_events.consumers import DEFAULT_BACKOFF_SECONDS
+
+        spec = spec_for(lambda e, c: None, max_deliver=5)
+        assert spec.backoff == list(DEFAULT_BACKOFF_SECONDS)
+        assert len(spec.backoff) < spec.max_deliver
+
+    def test_a_small_budget_shortens_the_schedule_instead_of_breaking_it(self):
+        for max_deliver in range(1, 8):
+            spec = spec_for(lambda e, c: None, max_deliver=max_deliver)
+            assert len(spec.backoff) < max_deliver or max_deliver == 0
+
+
+class TestDeadLetterKey:
+    async def test_burying_the_same_body_twice_collapses(self):
+        """Otherwise the DLQ's depth counts delivery attempts, not failing facts.
+
+        The depth is the number an operator reacts to, so it has to mean what it
+        looks like — and a message reaches here on its final delivery, which a
+        consumer restart or a re-published copy can repeat.
+        """
+        js = FakeJS()
+        spec = spec_for(_boom, max_deliver=5)
+
+        keys = []
+        for _ in range(2):
+            msg = FakeMsg({"a": 1}, num_delivered=5)
+            await runner.process_message(js, spec, msg)
+            keys.append(js.published[-1][1]["dedup_key"])
+
+        assert keys[0] == keys[1] and keys[0]
+
+    async def test_an_unparseable_body_still_gets_a_key(self):
+        """The commonest reason to be in the DLQ is that there was no envelope to read."""
+        js = FakeJS()
+        msg = FakeMsg(raw=b"\xff\xfe not json", num_delivered=1)
+
+        await runner.process_message(js, spec_for(lambda e, c: None, max_deliver=5), msg)
+
+        assert js.published[-1][1]["dedup_key"]
+
+    async def test_two_different_bodies_do_not_collapse(self):
+        js = FakeJS()
+        spec = spec_for(_boom, max_deliver=5)
+
+        keys = []
+        for payload in ({"a": 1}, {"a": 2}):
+            msg = FakeMsg(payload, num_delivered=5)
+            await runner.process_message(js, spec, msg)
+            keys.append(js.published[-1][1]["dedup_key"])
+
+        assert keys[0] != keys[1]
+
+
+def _boom(envelope, ctx):
+    raise RuntimeError("nope")
 
 
 class TestSelect:

--- a/case_events/tests/test_consumer_runner.py
+++ b/case_events/tests/test_consumer_runner.py
@@ -16,6 +16,7 @@ assertions on a Mock.
 from __future__ import annotations
 
 import json
+from unittest import mock
 
 import pytest
 
@@ -372,6 +373,58 @@ class TestFetchFailures:
         )
 
         assert handled == 0  # it polled well past the ceiling and never gave up
+
+    async def test_a_bounded_run_that_cannot_reach_the_broker_fails(self, monkeypatch):
+        """`--once` against a dead broker must not exit zero.
+
+        Breaking out of the loop returns a count, and `run` reads any count as
+        a clean finish because `fatal` is False in bounded mode — so a
+        scheduled `run_consumers --apply --once` drain reported success having
+        drained nothing. Only the timeout branch means "the backlog is empty".
+        """
+        import asyncio
+
+        class DeadSub:
+            async def fetch(self, batch, timeout=None):
+                raise RuntimeError("nats: connection closed")
+
+        monkeypatch.setattr(runner, "subscribe", lambda js, spec: _resolved(DeadSub()))
+
+        with pytest.raises(RuntimeError, match="bounded run"):
+            await asyncio.wait_for(
+                runner.run_one(
+                    FakeJS(),
+                    spec_for(lambda e, c: None, max_deliver=5),
+                    stop=asyncio.Event(),
+                    once=True,
+                    max_messages=None,
+                ),
+                timeout=5,
+            )
+
+    async def test_a_bounded_run_on_a_quiet_bus_still_succeeds(self):
+        """The timeout branch keeps meaning "drained", which is the whole point."""
+        import asyncio
+
+        from nats.errors import TimeoutError as NatsTimeoutError
+
+        class QuietSub:
+            async def fetch(self, batch, timeout=None):
+                raise NatsTimeoutError()
+
+        with mock.patch.object(runner, "subscribe", lambda js, spec: _resolved(QuietSub())):
+            handled = await asyncio.wait_for(
+                runner.run_one(
+                    FakeJS(),
+                    spec_for(lambda e, c: None, max_deliver=5),
+                    stop=asyncio.Event(),
+                    once=True,
+                    max_messages=None,
+                ),
+                timeout=5,
+            )
+
+        assert handled == 0
 
     async def test_a_recovered_fetch_resets_the_count(self, monkeypatch):
         """The ceiling is CONSECUTIVE failures, not cumulative ones.

--- a/case_events/tests/test_manual_note.py
+++ b/case_events/tests/test_manual_note.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The manual-note endpoint.
+
+The property worth guarding is honesty about what happened. This endpoint's
+whole job is to hand a fact to an asynchronous pipeline, so the failure that
+matters is telling a caseworker "filed" when the note went nowhere — they would
+have no reason to look again, and the fact would be lost with no trace anywhere.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+from case_events import subjects
+from cases.models import Case, CaseType
+
+pytestmark = pytest.mark.django_db
+
+URL = "/api/signals/manual-note/"
+
+
+@pytest.fixture(autouse=True)
+def _broker(settings):
+    """A broker is configured for every test here unless one says otherwise.
+
+    Set through the ``settings`` fixture rather than a class-level
+    ``@override_settings``, which silently does nothing on a plain pytest class
+    and raises outright on some Django versions.
+    """
+    settings.NATS_URL = "nats://localhost:4222"
+
+
+def make_case(slug="lalita-niwas-land-scam"):
+    return Case.objects.create(title="Lalita Niwas", case_type=CaseType.CORRUPTION, slug=slug)
+
+
+_seq = iter(range(1, 10_000))
+
+
+def client_as(group_name):
+    """An authenticated client in ``group_name``.
+
+    Usernames are sequenced because several tests call this twice; a fixed one
+    collides on the unique constraint.
+    """
+    User = get_user_model()
+    user = User.objects.create_user(username=f"u-{group_name or 'none'}-{next(_seq)}", password="x")
+    if group_name:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def body(**over):
+    return {"case_slug": "lalita-niwas-land-scam", "note": "SC admitted the appeal.", **over}
+
+
+class TestFiling:
+    def test_a_note_reaches_the_bus_as_a_manual_signal(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            r = client_as("Caseworker").post(URL, body(source="https://ekantipur.com/x"), format="json")
+
+        assert r.status_code == 202, r.data
+        subject, envelope = pub.call_args.args[0], pub.call_args.args[1]
+        assert subject == subjects.SIGNAL_MANUAL_NOTE
+        assert envelope["payload"]["note"] == "SC admitted the appeal."
+        assert envelope["source"] == "https://ekantipur.com/x"
+
+    def test_the_case_is_named_outright_so_the_matcher_does_not_have_to_guess(self):
+        """A caseworker has told us which case it is; that is an assertion."""
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+
+        refs = pub.call_args.args[1]["subject_refs"]
+        assert refs == ["https://jawafdehi.org/case/lalita-niwas-land-scam"]
+
+    def test_the_response_says_nothing_has_been_written_to_the_case(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True):
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert "until you approve" in r.data["detail"]
+
+    def test_the_same_note_twice_carries_the_same_dedup_key(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+            client_as("Caseworker").post(URL, body(), format="json")
+
+        keys = [call.args[1]["dedup_key"] for call in pub.call_args_list]
+        assert keys[0] == keys[1]
+
+    def test_a_different_note_on_the_same_case_is_a_different_fact(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+            client_as("Caseworker").post(URL, body(note="Something else entirely."), format="json")
+
+        keys = [call.args[1]["dedup_key"] for call in pub.call_args_list]
+        assert keys[0] != keys[1]
+
+    def test_the_filer_is_recorded(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(), format="json")
+        assert pub.call_args.args[1]["payload"]["filed_by"].startswith("caseworker:")
+
+    def test_a_known_fact_date_is_carried_rather_than_the_typing_time(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(
+                URL, body(occurred_at="2026-03-04T00:00:00Z"), format="json"
+            )
+        assert pub.call_args.args[1]["occurred_at"].startswith("2026-03-04")
+
+    def test_nothing_is_written_to_the_case(self):
+        case = make_case()
+        before = case.updated_at
+        with mock.patch("case_events.bus.publish", return_value=True):
+            client_as("Caseworker").post(URL, body(), format="json")
+        case.refresh_from_db()
+        assert case.updated_at == before
+
+
+class TestItNeverClaimsSuccessItDidNotHave:
+    def test_a_refused_publish_is_a_502_not_a_202(self):
+        """Telling a caseworker "filed" when it went nowhere loses the fact."""
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=False):
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 502
+
+    def test_a_raising_bus_is_also_not_a_202(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", side_effect=RuntimeError("broker gone")):
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 502
+
+
+class TestNoBrokerConfigured:
+    def test_it_refuses_rather_than_silently_dropping_the_note(self, settings):
+        settings.NATS_URL = ""
+        make_case()
+        r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 503
+        assert "would go nowhere" in r.data["detail"]
+
+
+class TestValidation:
+    def test_an_unknown_case_is_rejected_up_front(self):
+        """Otherwise it publishes, matches nothing, and is dropped in silence."""
+        r = client_as("Caseworker").post(URL, body(case_slug="no-such-case"), format="json")
+        assert r.status_code == 400
+        assert "case_slug" in r.data
+
+    def test_a_slug_the_iri_grammar_rejects_is_refused(self):
+        make_case()
+        r = client_as("Caseworker").post(URL, body(case_slug="Not_A_Slug"), format="json")
+        assert r.status_code == 400
+
+    @pytest.mark.parametrize("note", ["", "   "])
+    def test_a_blank_note_is_rejected(self, note):
+        make_case()
+        r = client_as("Caseworker").post(URL, body(note=note), format="json")
+        assert r.status_code == 400
+
+    def test_the_note_is_trimmed(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            client_as("Caseworker").post(URL, body(note="  padded  "), format="json")
+        assert pub.call_args.args[1]["payload"]["note"] == "padded"
+
+
+class TestPermissions:
+    def test_an_anonymous_caller_cannot_file(self):
+        make_case()
+        assert APIClient().post(URL, body(), format="json").status_code in (401, 403)
+
+    def test_a_reader_cannot_file(self):
+        make_case()
+        assert client_as("ReadOnly").post(URL, body(), format="json").status_code == 403
+
+    def test_the_automation_role_cannot_generate_its_own_work(self):
+        """A note becomes a model call and then a human's queue item.
+
+        JobPoller may create proposals — automation is the primary producer —
+        but it must not be able to commission them.
+        """
+        make_case()
+        assert client_as("JobPoller").post(URL, body(), format="json").status_code == 403
+
+    def test_a_caseworker_can(self):
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True):
+            assert client_as("Caseworker").post(URL, body(), format="json").status_code == 202

--- a/case_events/tests/test_manual_note.py
+++ b/case_events/tests/test_manual_note.py
@@ -144,6 +144,21 @@ class TestItNeverClaimsSuccessItDidNotHave:
             r = client_as("Caseworker").post(URL, body(), format="json")
         assert r.status_code == 502
 
+    def test_it_waits_for_the_broker_before_returning_202(self):
+        """Without this the two checks above cannot fire on the case that matters.
+
+        Fire-and-forget returns True the moment the publish is scheduled, so a
+        broker that rejects the message — which is what a fresh one does for
+        every subject until `nats_bootstrap` has run — still produces a 202.
+        This endpoint is the documented acceptance test for the whole bus; a
+        green light it cannot back up is worse than no endpoint.
+        """
+        make_case()
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            r = client_as("Caseworker").post(URL, body(), format="json")
+        assert r.status_code == 202
+        assert pub.call_args.kwargs.get("wait") is True
+
 
 class TestNoBrokerConfigured:
     def test_it_refuses_rather_than_silently_dropping_the_note(self, settings):

--- a/case_events/tests/test_producers.py
+++ b/case_events/tests/test_producers.py
@@ -19,6 +19,7 @@ from datetime import date, datetime, timedelta, timezone as dt_timezone
 from unittest import mock
 
 import pytest
+from django.test import override_settings
 from django.utils import timezone
 
 from case_events import subjects
@@ -260,6 +261,78 @@ class TestPublishWindow:
         with mock.patch("case_events.bus.publish") as pub:
             assert producers.emit("jaw.signal.x", producer="p", payload={}, subject_refs=[], dedup_key="") is False
         pub.assert_not_called()
+
+    def test_it_waits_for_the_jetstream_ack(self):
+        """Otherwise the "not sent" count above is decorative.
+
+        Fire-and-forget returns True as soon as the publish is scheduled, so a
+        run against a broker rejecting every message — which is what a fresh one
+        does until nats_bootstrap has run — would report a clean sweep.
+        """
+        court = make_court()
+        make_hearing(court)
+
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            dockets.publish_window(window_hours=24)
+
+        assert pub.call_args.kwargs.get("wait") is True
+
+
+class TestSaturationIsNotSilent:
+    """Hitting --limit drops facts permanently. It must be impossible to miss.
+
+    There is no watermark, so the next run rescans the same window in the same
+    `created_at` order and re-selects the same first `limit` rows: the tail is
+    never reached, and it is gone once the burst ages out. The command used to
+    say the remainder "waits for the next run", which is the opposite.
+    """
+
+    def test_window_totals_counts_past_the_limit(self):
+        court = make_court()
+        for i in range(4):
+            make_hearing(court, case_number=f"082-CR-{i:04d}")
+
+        totals = dockets.window_totals(window_hours=24)
+
+        assert totals[subjects.SIGNAL_DOCKET_HEARING_ADDED] == 4
+
+    def test_a_truncated_run_exits_non_zero_and_names_the_shortfall(self):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        court = make_court()
+        for i in range(4):
+            make_hearing(court, case_number=f"082-CR-{i:04d}")
+
+        with mock.patch("case_events.bus.publish", return_value=True):
+            with override_settings(NATS_URL="nats://x:4222"):
+                with pytest.raises(CommandError, match="never emitted"):
+                    call_command("emit_docket_signals", "--apply", "--window-hours", "24", "--limit", "2")
+
+    def test_an_untruncated_run_is_quiet(self):
+        court = make_court()
+        make_hearing(court)
+
+        from django.core.management import call_command
+
+        with mock.patch("case_events.bus.publish", return_value=True):
+            with override_settings(NATS_URL="nats://x:4222"):
+                call_command("emit_docket_signals", "--apply", "--window-hours", "24", "--limit", "50")
+
+    def test_the_read_only_report_says_so_too(self):
+        """Sizing the window before the cron runs is the whole point of --apply-less."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        court = make_court()
+        for i in range(4):
+            make_hearing(court, case_number=f"082-CR-{i:04d}")
+
+        err = StringIO()
+        call_command("emit_docket_signals", "--window-hours", "24", "--limit", "2", stderr=err)
+
+        assert "emitted 2 of 4" in err.getvalue()
 
 
 class TestMaterialProducer:

--- a/case_events/tests/test_producers.py
+++ b/case_events/tests/test_producers.py
@@ -1,0 +1,487 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The producers: docket change-detect, and the Material post_save signal.
+
+Two properties are load-bearing and everything else is detail.
+
+**Dedup keys are deterministic and derived from the FACT.** Producers re-emit an
+overlapping window by design, so a key built from a row pk, a timestamp or
+anything else that moves would turn every rescan into a fresh proposal. Several
+tests here re-run a scan and assert the keys are identical.
+
+**Subject refs carry a join key the matcher can actually use.** A signal with no
+court-case IRI is a message about nothing — it will match no case, and the
+failure is silent because "no match" is a normal outcome.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone as dt_timezone
+from unittest import mock
+
+import pytest
+from django.utils import timezone
+
+from case_events import subjects
+from case_events.producers import dockets, materials as material_producer
+from jawafdehi_shared.entities.ids import build_courtcase_iri
+
+pytestmark = [pytest.mark.django_db(databases="__all__")]
+
+
+def make_court(identifier="special"):
+    from courts.models import Court
+
+    return Court.objects.create(
+        identifier=identifier,
+        court_type="special",
+        full_name_nepali="विशेष अदालत",
+        full_name_english="Special Court",
+    )
+
+
+def make_case(court, case_number="082-CR-0154", **kwargs):
+    from courts.models import CourtCase
+
+    return CourtCase.objects.create(case_number=case_number, court=court, **kwargs)
+
+
+def make_hearing(court, case_number="082-CR-0154", **kwargs):
+    from courts.models import CourtCaseHearing
+
+    defaults = {
+        "hearing_date_bs": "2082-12-01",
+        "hearing_date_ad": date(2026, 3, 14),
+        "scraped_at": datetime(2026, 3, 14, tzinfo=dt_timezone.utc),
+    }
+    return CourtCaseHearing.objects.create(
+        case_number=case_number, court=court, **{**defaults, **kwargs}
+    )
+
+
+class TestHearingSignals:
+    def test_a_new_hearing_becomes_a_signal_joined_to_its_court_case(self):
+        court = make_court()
+        make_hearing(court)
+
+        (subject, payload, refs, dedup_key, occurred_at), = list(
+            dockets.hearing_signals(timezone.now() - timedelta(hours=1))
+        )
+
+        assert subject == subjects.SIGNAL_DOCKET_HEARING_ADDED
+        assert refs == [build_courtcase_iri("special", "082-CR-0154")]
+        assert payload["hearing_date_bs"] == "2082-12-01"
+        assert occurred_at == date(2026, 3, 14)
+
+    def test_the_join_key_is_built_by_the_shared_helper_not_by_hand(self):
+        """``build_courtcase_iri`` LOWERCASES both segments.
+
+        A hand-formatted `.../courtcase/special/082-CR-0154` matches nothing the
+        matcher holds, and the failure is a silent no-match.
+        """
+        court = make_court(identifier="Special")
+        make_hearing(court, case_number="082-CR-0154")
+
+        (_, _, refs, _, _), = list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))
+        # Both segments lowercased, despite the court id and case number being
+        # mixed case on the row.
+        assert refs[0].endswith("/courtcase/special/082-cr-0154")
+        assert refs[0] == build_courtcase_iri("Special", "082-CR-0154")
+
+    def test_the_dedup_key_is_the_docket_date_not_our_row_id(self):
+        """A re-imported hearing gets a new pk; the fact is the same fact."""
+        court = make_court()
+        hearing = make_hearing(court)
+        first = list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))[0][3]
+
+        hearing.delete()
+        make_hearing(court)
+        second = list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))[0][3]
+
+        assert first == second
+        assert "2082-12-01" in first
+
+    def test_rescanning_the_same_window_produces_identical_keys(self):
+        """The whole basis of the stateless design."""
+        court = make_court()
+        make_hearing(court)
+        since = timezone.now() - timedelta(hours=1)
+
+        assert [s[3] for s in dockets.hearing_signals(since)] == [
+            s[3] for s in dockets.hearing_signals(since)
+        ]
+
+    def test_a_hearing_outside_the_window_is_not_emitted(self):
+        court = make_court()
+        make_hearing(court)
+        from courts.models import CourtCaseHearing
+
+        CourtCaseHearing.objects.update(created_at=timezone.now() - timedelta(days=10))
+
+        assert list(dockets.hearing_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_future_hearing_is_news_now_not_on_the_day(self):
+        """Keyed on created_at, so a hearing scheduled for next month emits today."""
+        court = make_court()
+        make_hearing(court, hearing_date_ad=date(2027, 1, 1), hearing_date_bs="2083-09-17")
+
+        assert len(list(dockets.hearing_signals(timezone.now() - timedelta(hours=1)))) == 1
+
+    def test_the_limit_is_respected(self):
+        court = make_court()
+        for i in range(5):
+            make_hearing(court, hearing_date_bs=f"2082-12-{i:02d}")
+
+        assert len(list(dockets.hearing_signals(timezone.now() - timedelta(hours=1), limit=2))) == 2
+
+
+class TestVerdictSignals:
+    def test_a_decided_case_becomes_a_verdict_signal(self):
+        court = make_court()
+        make_case(
+            court,
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+        )
+
+        (subject, payload, refs, dedup_key, occurred_at), = list(
+            dockets.verdict_signals(timezone.now() - timedelta(hours=1))
+        )
+
+        assert subject == subjects.SIGNAL_DOCKET_VERDICT_ENTERED
+        assert payload["verdict_type"] == "सफाई"
+        assert refs == [build_courtcase_iri("special", "082-CR-0154")]
+        assert "2082-11-20" in dedup_key
+        assert occurred_at == date(2026, 3, 4)
+
+    def test_a_case_with_no_verdict_is_not_emitted(self):
+        make_case(make_court(), case_status="चालु")
+        assert list(dockets.verdict_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_verdict_date_with_no_verdict_type_is_not_emitted(self):
+        """Half a verdict is a scrape artefact, not a decision."""
+        make_case(make_court(), verdict_date_ad=date(2026, 3, 4), verdict_type="")
+        assert list(dockets.verdict_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_soft_deleted_case_is_not_emitted(self):
+        make_case(
+            make_court(),
+            verdict_type="सफाई",
+            verdict_date_ad=date(2026, 3, 4),
+            is_deleted=True,
+        )
+        assert list(dockets.verdict_signals(timezone.now() - timedelta(hours=1))) == []
+
+    def test_a_corrected_judge_re_emits_under_the_same_key(self):
+        """Keyed on the verdict DATE, so a correction reaches a caseworker again."""
+        court = make_court()
+        case = make_case(
+            court,
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+            verdict_judge="A",
+        )
+        since = timezone.now() - timedelta(hours=1)
+        first = list(dockets.verdict_signals(since))[0]
+
+        case.verdict_judge = "A, B"
+        case.save()
+        second = list(dockets.verdict_signals(since))[0]
+
+        assert first[3] == second[3]
+        assert second[1]["verdict_judge"] == "A, B"
+
+    def test_a_different_verdict_date_is_a_different_fact(self):
+        court = make_court()
+        case = make_case(
+            court, verdict_type="सफाई", verdict_date_bs="2082-11-20", verdict_date_ad=date(2026, 3, 4)
+        )
+        since = timezone.now() - timedelta(hours=1)
+        first = list(dockets.verdict_signals(since))[0][3]
+
+        case.verdict_date_bs = "2082-11-25"
+        case.save()
+        assert list(dockets.verdict_signals(since))[0][3] != first
+
+
+class TestPublishWindow:
+    def test_it_emits_everything_in_the_window_and_counts_it(self):
+        court = make_court()
+        make_hearing(court)
+        make_case(
+            court,
+            case_number="082-CR-0999",
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+        )
+
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            counts = dockets.publish_window(window_hours=24)
+
+        assert counts[subjects.SIGNAL_DOCKET_HEARING_ADDED] == 1
+        assert counts[subjects.SIGNAL_DOCKET_VERDICT_ENTERED] == 1
+        assert pub.call_count == 2
+
+    def test_a_signal_the_bus_refused_is_counted_separately(self):
+        """A run that published nothing must not read as an empty window."""
+        court = make_court()
+        make_hearing(court)
+
+        with mock.patch("case_events.bus.publish", return_value=False):
+            counts = dockets.publish_window(window_hours=24)
+
+        assert any("not sent" in key for key in counts)
+
+    def test_a_broker_failure_does_not_stop_the_scan(self):
+        court = make_court()
+        make_hearing(court)
+        make_hearing(court, hearing_date_bs="2082-12-02")
+
+        with mock.patch("case_events.bus.publish", side_effect=RuntimeError("broker gone")):
+            counts = dockets.publish_window(window_hours=24)
+
+        assert sum(counts.values()) == 2
+
+    def test_occurred_at_is_the_court_date_not_the_scrape_time(self):
+        """The number an audit of enrichment lag needs."""
+        court = make_court()
+        make_hearing(court)
+
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            dockets.publish_window(window_hours=24)
+
+        assert pub.call_args.args[1]["occurred_at"].startswith("2026-03-14")
+
+    def test_a_signal_with_no_dedup_key_is_refused_rather_than_published(self):
+        from case_events import producers
+
+        with mock.patch("case_events.bus.publish") as pub:
+            assert producers.emit("jaw.signal.x", producer="p", payload={}, subject_refs=[], dedup_key="") is False
+        pub.assert_not_called()
+
+
+class TestMaterialProducer:
+    """One post_save covers court orders and CIAA press releases."""
+
+    def material(self, source, iri="https://jawafdehi.org/material/court_order/abc", data=None):
+        from materials.models import Material
+
+        return Material(
+            iri=iri,
+            material_type="CourtOrder",
+            source=source,
+            ident="abc",
+            data=data if data is not None else {"@id": iri, "name": "An order"},
+        )
+
+    def test_a_court_order_raises_the_court_order_signal(self):
+        signal = material_producer.signal_for(self.material("court_order"))
+        assert signal is not None
+        assert signal[0] == subjects.SIGNAL_COURTORDER_PUBLISHED
+
+    def test_a_ciaa_press_release_raises_its_own_signal(self):
+        signal = material_producer.signal_for(self.material("ciaa_press_release"))
+        assert signal[0] == subjects.SIGNAL_CIAA_PRESSRELEASE
+
+    def test_the_two_sources_match_the_constants_the_shapers_actually_use(self):
+        """A drifted string here means the producer silently never fires."""
+        from materials.jsonld import COURT_ORDER_SOURCE
+        from materials.sourcing.ciaa.shaper import CIAA_PRESS_SOURCE
+
+        assert COURT_ORDER_SOURCE in material_producer.SOURCE_SUBJECTS
+        assert CIAA_PRESS_SOURCE in material_producer.SOURCE_SUBJECTS
+
+    def test_an_unremarkable_material_raises_nothing(self):
+        """A Material appearing is not by itself news about a case."""
+        assert material_producer.signal_for(self.material("nkp")) is None
+
+    def test_a_court_orders_case_iri_is_carried_as_the_join_key(self):
+        """Without isPartOf the signal names a document and nothing else."""
+        case_iri = build_courtcase_iri("special", "082-CR-0154")
+        m = self.material(
+            "court_order",
+            data={"@id": "https://jawafdehi.org/material/court_order/abc", "isPartOf": {"@id": case_iri}},
+        )
+        _, payload, refs, _ = material_producer.signal_for(m)
+
+        assert payload["part_of"] == case_iri
+        assert case_iri in refs
+
+    def test_a_string_ispartof_is_accepted_too(self):
+        case_iri = build_courtcase_iri("special", "082-CR-0154")
+        m = self.material("court_order", data={"isPartOf": case_iri})
+        assert material_producer.signal_for(m)[1]["part_of"] == case_iri
+
+    def test_a_press_release_with_no_case_still_emits(self):
+        """CIAA releases generally name no docket; that is not a broken signal."""
+        _, payload, refs, _ = material_producer.signal_for(self.material("ciaa_press_release"))
+        assert payload["part_of"] == ""
+        assert refs  # its own IRI is still a ref
+
+    def test_the_dedup_key_is_the_material_iri(self):
+        m = self.material("court_order")
+        assert material_producer.signal_for(m)[3] == f"material:{m.iri}"
+
+    def test_a_material_created_soft_deleted_is_not_an_archival_event(self):
+        m = self.material("court_order")
+        m.is_deleted = True
+        assert material_producer.signal_for(m) is None
+
+    def test_malformed_data_does_not_raise(self):
+        for bad in (None, [], "a string", 7):
+            m = self.material("court_order", data=bad)
+            assert material_producer.signal_for(m) is not None
+
+
+class TestTheMaterialReceiverFiresOnlyOnCreate:
+    """A Material is re-saved for conversion, visibility and index churn.
+
+    These use a REAL Material, not a Mock. An earlier version passed a
+    ``mock.Mock``, and a mutation removing the ``created`` check survived it —
+    because ``getattr(mock, "is_deleted", False)`` returns a truthy Mock, so
+    ``signal_for`` bailed out for the wrong reason and the test proved nothing.
+    """
+
+    def unsaved_order(self):
+        from materials.models import Material
+
+        return Material(
+            iri="https://jawafdehi.org/material/court_order/receiver-1",
+            material_type="CourtOrder",
+            source="court_order",
+            ident="receiver-1",
+            data={},
+        )
+
+    def _callbacks(self, sender, created):
+        """The on_commit callbacks the receiver registers for one call."""
+        with django_capture_on_commit_callbacks_noexec(using="ngm") as callbacks:
+            material_producer.emit_material_signal(
+                sender, instance=self.unsaved_order(), created=created
+            )
+        return callbacks
+
+    def test_an_update_registers_nothing(self):
+        from materials.models import Material
+
+        assert self._callbacks(Material, created=False) == []
+
+    def test_a_create_registers_the_announcement(self):
+        """Paired with the test above so neither can pass for the wrong reason."""
+        from materials.models import Material
+
+        assert len(self._callbacks(Material, created=True)) == 1
+
+    def test_a_save_of_another_model_registers_nothing(self):
+        from cases.models import Case
+
+        assert self._callbacks(Case, created=True) == []
+
+
+class TestTheMaterialProducerIsActuallyConnected:
+    """Everything above tests the logic. This tests that it RUNS.
+
+    A ``post_save`` receiver that is never connected — an app whose ``ready``
+    does not import it, a ``dispatch_uid`` collision, an import error swallowed
+    by the guard — is invisible: every unit test passes and no signal is ever
+    emitted in production. So this saves a real Material through the real ORM.
+    """
+
+    def test_the_app_config_is_what_connects_it(self):
+        """A source-level guard, because the runtime check below cannot catch this.
+
+        The obvious test — save a Material, assert a signal — passes even with
+        ``EventsConfig.ready`` gutted, because THIS TEST MODULE imports
+        ``case_events.producers.materials`` at the top and the ``@receiver``
+        decorator connects on import. The test file wires up the thing it is
+        checking. A mutation removing the import from ``ready()`` survived the
+        whole suite.
+
+        In production nothing imports that module, so ``ready()`` is the only
+        thing that connects the receiver and its absence means no signal is ever
+        emitted, silently. Same shape as the ``ensure_streams`` guard in
+        test_nats_bootstrap.
+        """
+        import inspect
+
+        from case_events.apps import EventsConfig
+
+        source = inspect.getsource(EventsConfig.ready)
+        assert "case_events.producers" in source and "materials" in source, (
+            "EventsConfig.ready must import case_events.producers.materials — it is "
+            "the only thing that connects the post_save producer in production."
+        )
+
+    def test_the_receiver_is_connected_to_post_save(self):
+        from django.db.models.signals import post_save
+
+        # Django's receivers entries are (lookup_key, receiver[, is_async]) and
+        # the arity has changed across versions, so index rather than unpack.
+        uids = [entry[0][0] for entry in post_save.receivers]
+        assert "case_events_material_signal" in uids
+
+    def test_saving_a_real_court_order_material_emits(self, django_capture_on_commit_callbacks):
+        from materials.models import Material
+
+        case_iri = build_courtcase_iri("special", "082-CR-0154")
+        with mock.patch("case_events.bus.publish", return_value=True) as pub:
+            with django_capture_on_commit_callbacks(execute=True, using="ngm"):
+                Material.objects.create(
+                    iri="https://jawafdehi.org/material/court_order/wired-1",
+                    material_type="CourtOrder",
+                    source="court_order",
+                    ident="wired-1",
+                    data={"isPartOf": {"@id": case_iri}, "name": "An order"},
+                )
+
+        subjects_sent = [call.args[0] for call in pub.call_args_list]
+        assert subjects.SIGNAL_COURTORDER_PUBLISHED in subjects_sent
+
+    def test_the_emit_is_deferred_until_the_row_commits(self):
+        """Announcing a document before its row is durable is the trap here.
+
+        ``Material`` lives on ``ngm``, so an unqualified ``on_commit`` would
+        resolve against ``default`` — still in autocommit inside
+        ``atomic(using="ngm")`` — and fire the callback immediately.
+        """
+        from materials.models import Material
+
+        with mock.patch("case_events.bus.publish") as pub:
+            with django_capture_on_commit_callbacks_noexec(using="ngm") as callbacks:
+                Material.objects.create(
+                    iri="https://jawafdehi.org/material/court_order/wired-2",
+                    material_type="CourtOrder",
+                    source="court_order",
+                    ident="wired-2",
+                    data={},
+                )
+            # Captured, NOT run: nothing reached the bus inside the transaction.
+            pub.assert_not_called()
+        assert callbacks, "the producer did not register an on_commit callback at all"
+
+    def test_an_unremarkable_material_save_stays_silent_end_to_end(self):
+        from materials.models import Material
+
+        with mock.patch("case_events.bus.publish") as pub:
+            with django_capture_on_commit_callbacks_noexec(using="ngm"):
+                Material.objects.create(
+                    iri="https://jawafdehi.org/material/nkp/wired-3",
+                    material_type="Judgment",
+                    source="nkp",
+                    ident="wired-3",
+                    data={},
+                )
+        pub.assert_not_called()
+
+
+def django_capture_on_commit_callbacks_noexec(*, using):
+    """``django_capture_on_commit_callbacks`` without executing, as a plain CM.
+
+    The pytest-django fixture cannot be nested inside another `with` in the same
+    test and also inspected afterwards, so use Django's own helper directly.
+    """
+    from django.test import TestCase
+
+    return TestCase.captureOnCommitCallbacks(execute=False, using=using)

--- a/case_events/tests/test_producers.py
+++ b/case_events/tests/test_producers.py
@@ -278,6 +278,74 @@ class TestPublishWindow:
         assert pub.call_args.kwargs.get("wait") is True
 
 
+class TestABadLakeRowDoesNotStopTheScan:
+    """`build_courtcase_iri` raises on an empty case_number, and the lake is scraped.
+
+    Letting that escape aborted the generator mid-window and dropped every
+    remaining row — and because the window is stateless and overlapping, the
+    next run would reach the same row and abort at the same point. One
+    malformed row would have stopped the producer permanently.
+    """
+
+    def test_a_hearing_with_no_case_number_is_skipped_not_fatal(self):
+        court = make_court()
+        make_hearing(court, case_number="")
+        make_hearing(court, case_number="082-CR-0154")
+
+        signals = list(dockets.hearing_signals(timezone.now() - timedelta(hours=24)))
+
+        assert len(signals) == 1, "the good row must still be emitted"
+        assert "082-cr-0154" in signals[0][2][0]
+
+    def test_a_verdict_row_with_no_case_number_is_skipped_too(self):
+        court = make_court()
+        make_case(
+            court,
+            case_number="",
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+        )
+        make_case(
+            court,
+            case_number="082-CR-0999",
+            verdict_type="सफाई",
+            verdict_date_bs="2082-11-20",
+            verdict_date_ad=date(2026, 3, 4),
+        )
+
+        signals = list(dockets.verdict_signals(timezone.now() - timedelta(hours=24)))
+
+        assert len(signals) == 1
+
+    def test_the_bad_row_is_logged_rather_than_swallowed(self):
+        court = make_court()
+        make_hearing(court, case_number="")
+
+        with mock.patch.object(dockets.logger, "warning") as warn:
+            list(dockets.hearing_signals(timezone.now() - timedelta(hours=24)))
+
+        assert warn.called
+        assert warn.call_args.args[0] == "case_events.docket_row_has_no_iri"
+
+
+class TestLimitIsValidated:
+    def test_a_negative_limit_is_a_command_error_not_a_traceback(self):
+        """Django raises "Negative indexing is not supported" from the slice."""
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        with pytest.raises(CommandError, match="--limit must be positive"):
+            call_command("emit_docket_signals", "--limit", "-1")
+
+    def test_a_zero_limit_is_refused_rather_than_reporting_the_window_lost(self):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        with pytest.raises(CommandError, match="--limit must be positive"):
+            call_command("emit_docket_signals", "--limit", "0")
+
+
 class TestSaturationIsNotSilent:
     """Hitting --limit drops facts permanently. It must be impossible to miss.
 
@@ -532,13 +600,27 @@ class TestTheMaterialProducerIsActuallyConnected:
                 )
             # Captured, NOT run: nothing reached the bus inside the transaction.
             pub.assert_not_called()
-        assert callbacks, "the producer did not register an on_commit callback at all"
+        assert ours(callbacks), "the producer did not register an on_commit callback at all"
 
     def test_an_unremarkable_material_save_stays_silent_end_to_end(self):
+        """No callback is REGISTERED by us, not merely none executed.
+
+        `pub.assert_not_called()` alone proved nothing: the context manager
+        captures on_commit callbacks without running them, so the publish mock
+        could not have been called whatever the producer did. If `signal_for`
+        started returning a signal for source "nkp", the callback would be
+        registered, never executed, and this would have stayed green.
+
+        Filtered to OUR callbacks rather than asserting the list is empty:
+        `materials` registers its own search-index on_commit for every save, so
+        `callbacks == []` fails on an unrelated app's work and `assert
+        callbacks` passes on it — which is what made the sibling test above
+        vacuous in the same way until this was fixed.
+        """
         from materials.models import Material
 
         with mock.patch("case_events.bus.publish") as pub:
-            with django_capture_on_commit_callbacks_noexec(using="ngm"):
+            with django_capture_on_commit_callbacks_noexec(using="ngm") as callbacks:
                 Material.objects.create(
                     iri="https://jawafdehi.org/material/nkp/wired-3",
                     material_type="Judgment",
@@ -546,7 +628,19 @@ class TestTheMaterialProducerIsActuallyConnected:
                     ident="wired-3",
                     data={},
                 )
+
+        assert ours(callbacks) == [], "an unremarkable source must not even register an emit"
         pub.assert_not_called()
+
+
+def ours(callbacks):
+    """The captured on_commit callbacks this app registered.
+
+    `materials` schedules its own search-index callback on every Material save,
+    so an unfiltered capture list says nothing about our producer: it is never
+    empty, and it is truthy whether or not we registered anything.
+    """
+    return [cb for cb in callbacks if getattr(cb, "__module__", "").startswith("case_events.")]
 
 
 def django_capture_on_commit_callbacks_noexec(*, using):

--- a/case_events/urls.py
+++ b/case_events/urls.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Signal-filing endpoints.
+
+Only one, and only one is expected: every other producer watches something
+rather than being called. See :mod:`case_events.views`.
+"""
+
+from django.urls import path
+
+from case_events.views import ManualNoteView
+
+urlpatterns = [
+    path("signals/manual-note/", ManualNoteView.as_view(), name="manual-note"),
+]

--- a/case_events/views.py
+++ b/case_events/views.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The one producer a human drives: a caseworker's manual note.
+
+Every other producer watches something. This one is typed. A caseworker who
+learns a fact — the court published an order today, an appeal was filed, a name
+in the record is wrong — writes it in a sentence and the pipeline drafts a
+properly-shaped timeline entry for them to approve or discard.
+
+Two reasons it earns its place rather than being a shortcut around the SPA's
+existing case editor:
+
+**It is fast capture.** Writing "SC admitted the appeal on 2082-11-20, per
+kathmandupost.com/…" is a few seconds; opening the case editor, finding the
+timeline, and composing a well-formed dated entry in Nepali is not. The model
+does the shaping and the caseworker judges the result, which is the division of
+labour the whole system is built around.
+
+**It is the only producer that can be fired on demand**, which makes it the
+acceptance test for the bus itself. Post one note and every hop — matcher,
+proposal-builder, the intent job, the proposal, the notifier — either works or
+tells you where it stopped, without waiting for a scrape.
+
+It stays a SIGNAL rather than writing a proposal directly. A caseworker note is
+an observed fact like any other, and routing it down the same path means it gets
+the same duplicate detection, the same audit trail, and the same "check the
+timeline before proposing" pass the model applies to scraped facts.
+"""
+
+from __future__ import annotations
+
+import structlog
+from django.conf import settings
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from case_events import subjects
+from case_events.producers import emit
+from review.permissions import IsContentStaff
+
+logger = structlog.get_logger(__name__)
+
+PRODUCER = "producer:caseworker"
+
+
+class ManualNoteSerializer(serializers.Serializer):
+    """A caseworker's free-text observation about one case."""
+
+    case_slug = serializers.SlugField(max_length=50)
+    note = serializers.CharField(max_length=4000)
+    #: Where the caseworker got it. Not required, but every factual claim in the
+    #: archive is supposed to carry one, and a note without a source produces a
+    #: proposal a reviewer cannot check.
+    source = serializers.CharField(max_length=500, required=False, allow_blank=True, default="")
+    #: When the FACT happened, if known — not when the note was typed.
+    occurred_at = serializers.DateTimeField(required=False, allow_null=True, default=None)
+
+    def validate_case_slug(self, value):
+        """The case must exist, and the slug must build a canonical ``@id``.
+
+        Checked here rather than left to the matcher: a typo'd slug would
+        otherwise be accepted, published, matched to nothing, and silently
+        dropped — with the caseworker told it worked.
+        """
+        from cases.models import Case
+        from jawafdehi_shared.entities.ids import build_case_iri
+
+        try:
+            build_case_iri(value)
+        except Exception as exc:
+            raise serializers.ValidationError(f"{value!r} is not a valid case @id segment: {exc}") from None
+        if not Case.objects.filter(slug=value).exists():
+            raise serializers.ValidationError(f"No case with slug {value!r}.")
+        return value
+
+    def validate_note(self, value):
+        if not value.strip():
+            raise serializers.ValidationError("A note cannot be blank.")
+        return value.strip()
+
+
+class ManualNoteView(APIView):
+    """``POST /api/signals/manual-note/`` — put a caseworker observation on the bus.
+
+    Gated to content staff, NOT to the contributor role that may create
+    proposals. A note here becomes a model call and then a queue item for a
+    human; the automation identity must not be able to generate its own work.
+    """
+
+    permission_classes = [IsContentStaff]
+
+    def post(self, request):
+        serializer = ManualNoteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        if not getattr(settings, "NATS_URL", ""):
+            # 503 rather than a cheerful 202. Publishing no-ops without a broker,
+            # and telling a caseworker their note was accepted when it went
+            # nowhere is the worst available outcome.
+            return Response(
+                {"detail": "The event bus is not configured, so this note would go nowhere."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        from jawafdehi_shared.entities.ids import build_case_iri
+
+        case_iri = build_case_iri(data["case_slug"])
+        actor = self._actor(request)
+        # Deterministic in the fact, not the moment: the same caseworker filing
+        # the same note about the same case twice is a duplicate, not two facts.
+        # Hashed because a note is long and free-form, and dedup_key is bounded.
+        import hashlib
+
+        digest = hashlib.sha256(data["note"].encode("utf-8")).hexdigest()[:32]
+        dedup_key = f"manual:{data['case_slug']}:{digest}"
+
+        sent = emit(
+            subjects.SIGNAL_MANUAL_NOTE,
+            producer=PRODUCER,
+            payload={
+                "case_slug": data["case_slug"],
+                "note": data["note"],
+                "filed_by": actor,
+            },
+            # The case @id, so the matcher treats this as an assertion rather
+            # than an inference — the caseworker has told us which case it is.
+            subject_refs=[case_iri],
+            dedup_key=dedup_key,
+            source=data["source"] or "caseworker",
+            occurred_at=data["occurred_at"],
+        )
+
+        logger.info(
+            "case_events.manual_note_filed",
+            case_slug=data["case_slug"],
+            filed_by=actor,
+            published=sent,
+        )
+
+        if not sent:
+            return Response(
+                {"detail": "The note could not be published to the event bus."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        return Response(
+            {
+                "subject": subjects.SIGNAL_MANUAL_NOTE,
+                "dedup_key": dedup_key,
+                "case_slug": data["case_slug"],
+                # Said plainly, because the useful thing to know is that nothing
+                # has happened to the case yet.
+                "detail": (
+                    "Filed. A proposal will appear in the review queue if the note "
+                    "warrants one; nothing is written to the case until you approve it."
+                ),
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    @staticmethod
+    def _actor(request) -> str:
+        user = request.user
+        handle = getattr(user, "username", "") or getattr(user, "email", "") or str(user.pk)
+        return f"caseworker:{handle}"

--- a/case_events/views.py
+++ b/case_events/views.py
@@ -107,8 +107,11 @@ class ManualNoteView(APIView):
 
         case_iri = build_case_iri(data["case_slug"])
         actor = self._actor(request)
-        # Deterministic in the fact, not the moment: the same caseworker filing
-        # the same note about the same case twice is a duplicate, not two facts.
+        # Deterministic in the fact, not the moment: the same note about the
+        # same case is a duplicate however many times it is filed. Note that the
+        # key does NOT include the caseworker, so two people who independently
+        # notice the same thing collapse to one proposal — which is the point,
+        # and worth stating because it is not what "who filed it" would suggest.
         # Hashed because a note is long and free-form, and dedup_key is bounded.
         import hashlib
 
@@ -129,6 +132,14 @@ class ManualNoteView(APIView):
             dedup_key=dedup_key,
             source=data["source"] or "caseworker",
             occurred_at=data["occurred_at"],
+            # Wait for the broker's answer before telling a human it worked.
+            # Fire-and-forget returns True the moment the publish is scheduled,
+            # so a 202 would have been indistinguishable from a broker that
+            # rejected every message — which is exactly what a fresh one does
+            # until `nats_bootstrap` has run. This endpoint doubles as the
+            # bus's acceptance test; a green light it cannot back up is worse
+            # than no endpoint at all. Costs one round trip on a hand-typed note.
+            wait=True,
         )
 
         logger.info(

--- a/case_proposals/job_kind.py
+++ b/case_proposals/job_kind.py
@@ -348,7 +348,13 @@ def on_failure(job) -> None:
 
 SPEC = KindSpec(
     kind=KIND,
-    # A premium-tier call is 30–90s; the worker heartbeats and extends this.
+    # A premium-tier call is 30–90s, so 300 is generous — but it is a HARD
+    # ceiling, not a soft one, and an earlier comment here wrongly said the
+    # worker heartbeats through it. It does not: `job_handlers` calls `on_stage`
+    # exactly once, BEFORE `spec.invoke`, so nothing extends the lease while the
+    # model is thinking. A call that runs past this is reaped mid-flight and its
+    # eventual result POST 409s. Raising this is the fix if that ever shows up;
+    # heartbeating from inside the provider call is not available to us.
     lease_seconds=300,
     # Two, matching case_review's reasoning: a model that produced unusable
     # output for this input will usually do it again, and each attempt costs a

--- a/case_proposals/migrations/0003_alter_caseupdateproposal_origin_msg_id.py
+++ b/case_proposals/migrations/0003_alter_caseupdateproposal_origin_msg_id.py
@@ -1,0 +1,32 @@
+"""Widen origin_msg_id 100 -> 300, to fit the values it is actually given.
+
+The proposal-builder consumer sets ``origin_msg_id`` to the matched signal's
+dedup key, and those keys embed a full court-case IRI plus a case slug — a
+routine one is 108 characters. At 100 the serializer rejected every
+docket-derived proposal as a validation failure, which read as "the model
+produced something unusable" and left no row behind, so the duplicate check
+found nothing and the next scrape bought another premium model call.
+
+Widening rather than truncating: the value's whole purpose is to be traceable
+back to the message that caused the proposal, and a truncated key is not.
+
+Cheap on Postgres — a varchar length increase is a catalogue change, no table
+rewrite and no long lock.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('case_proposals', '0002_remove_caseupdateproposal_supersedes_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='caseupdateproposal',
+            name='origin_msg_id',
+            field=models.CharField(blank=True, default='', max_length=300),
+        ),
+    ]

--- a/case_proposals/models.py
+++ b/case_proposals/models.py
@@ -66,7 +66,15 @@ class CaseUpdateProposal(models.Model):
 
     # ── originating bus event (populated later by the consumer) ───────────────
     origin_subject = models.CharField(max_length=100, blank=True, default="")
-    origin_msg_id = models.CharField(max_length=100, blank=True, default="")
+    # 300, matching `dedup_key`, because that is literally what goes in it: the
+    # proposal-builder sets origin_msg_id to the matched signal's dedup key. At
+    # the original 100 it was too small for the values it is given — a routine
+    # docket key ("matched:docket:<courtcase IRI>:hearing:<bs-date>:<slug>") is
+    # 108 characters — so every docket-derived proposal failed serializer
+    # validation, was recorded as "the model produced something unusable", and
+    # left no row for the duplicate check to find. The next scrape then bought
+    # another premium model call to fail the same way. Keep these two equal.
+    origin_msg_id = models.CharField(max_length=300, blank=True, default="")
     subject_refs = models.JSONField(default=list, blank=True)
 
     # ── review ────────────────────────────────────────────────────────────────

--- a/case_proposals/tests/test_intent_job.py
+++ b/case_proposals/tests/test_intent_job.py
@@ -22,6 +22,7 @@ from case_proposals import job_kind
 from case_proposals.job_kind import BadIntentPayload, build_payload, on_result
 from case_proposals.models import CaseUpdateProposal, ProposalStatus
 from cases.models import Case, CaseType
+from jawafdehi_shared.entities.ids import build_courtcase_iri
 from jobs.models import Job
 
 pytestmark = pytest.mark.django_db
@@ -143,6 +144,35 @@ class TestStagingAProposal:
         assert proposal.detected_by == job_kind.DETECTED_BY
         assert proposal.dedup_key == "docket:abc:hearing:2082-12-01"
         assert proposal.origin_subject == "jaw.case.matched"
+
+    def test_a_REALISTIC_docket_key_stages_rather_than_failing_validation(self):
+        """The keys in the other tests here are short, and that hid a real bug.
+
+        Production keys are not ``docket:abc:...``. A docket key embeds a full
+        court-case IRI and the matched key appends the case slug, which comes to
+        108 characters for an ordinary case — over the 100 that ``origin_msg_id``
+        used to allow. Every docket-derived proposal therefore failed serializer
+        validation, was filed as "the model produced something unusable", and
+        left no row behind, so the duplicate check found nothing and the next
+        scrape bought another premium call to fail identically.
+
+        Built from the real IRI helper rather than a literal, so the day the IRI
+        grammar or the base host gets longer, this fails here instead of in a
+        cron nobody is watching.
+        """
+        case = make_case()
+        iri = build_courtcase_iri("special", "082-CR-0154")
+        matched_key = f"matched:docket:{iri}:hearing:2082-11-20:{case.slug}"
+        assert len(matched_key) > 100, "the fixture stopped exercising the overflow"
+
+        job = make_job(case, dedup_key=matched_key, origin_msg_id=matched_key)
+        on_result(job, good_result())
+
+        proposal = CaseUpdateProposal.objects.get()
+        assert proposal.origin_msg_id == matched_key
+        # Not truncated: the value's whole job is to lead back to the message
+        # that caused the proposal, and a clipped key leads nowhere.
+        assert job.result["staged"]["proposal_id"] == proposal.pk
 
     def test_the_staged_proposal_is_recorded_on_the_job(self):
         case = make_case()

--- a/cases/search_index.py
+++ b/cases/search_index.py
@@ -30,7 +30,10 @@ re-indexed when a referenced entity is renamed (a scheduled ``reindex_cases``
 reconcile covers this — see the plan's WS3); the write-time signals only fire on
 ``Case`` itself.
 
-Best-effort: an OpenSearch error is logged and swallowed.
+Best-effort: ``index`` / ``delete`` log and swallow an OpenSearch error, because
+they run from write-time signals where a search blip must not fail a case save.
+``index_now`` / ``delete_now`` are the same functions without the swallow, for
+callers that have a retry budget to spend on the failure.
 """
 
 from __future__ import annotations
@@ -256,22 +259,26 @@ def build_indexed_doc(case: Any) -> dict[str, Any]:
     return build_doc(case, entities=_safe_resolve_entities(case))
 
 
-@best_effort("index case")
-def index(case: Any, *, client=None) -> None:
-    """Upsert a PUBLISHED case; otherwise remove it from the index (best-effort).
+def index_now(case: Any, *, client=None) -> None:
+    """Upsert a PUBLISHED case; otherwise remove it from the index. RAISES.
 
     The case-only-published rule: publishing indexes; any non-PUBLISHED state
-    (draft/in-review/closed) deletes the doc so it never appears in search."""
+    (draft/in-review/closed) deletes the doc so it never appears in search.
+
+    The raising twin of :func:`index`, for the one caller that has somewhere to
+    put a failure. Write-time signal paths want best-effort — an OpenSearch blip
+    must not fail a case save — but a caller with a retry budget and a dead
+    letter queue (``case_events.consumers.handlers.handle_derive``) needs the
+    error, and swallowing it turns that budget into decoration."""
     cl = client or make_client()
     if should_index(case):
         upsert_doc(cl, CASE_INDEX, build_indexed_doc(case))
     else:
-        delete(case, client=cl)
+        delete_now(case, client=cl)
 
 
-@best_effort("delete case")
-def delete(case: Any, *, client=None) -> None:
-    """Delete the case's doc from ``jawafdehi-cases`` (best-effort).
+def delete_now(case: Any, *, client=None) -> None:
+    """Delete the case's doc from ``jawafdehi-cases``. RAISES.
 
     Uses the public IRI when the case is (or was) published; falls back to
     building one from the slug so a case that has just LEFT published state can
@@ -288,3 +295,11 @@ def delete(case: Any, *, client=None) -> None:
                 iri = None
     if iri:
         delete_doc(client or make_client(), CASE_INDEX, iri)
+
+
+#: The best-effort forms — what every write-time signal path wants, and the
+#: names every existing caller already imports. Derived from the raising twins
+#: rather than the other way round, so there is one implementation of the rule
+#: and the swallow is visibly a wrapper over it.
+index = best_effort("index case")(index_now)
+delete = best_effort("delete case")(delete_now)

--- a/cases/search_index.py
+++ b/cases/search_index.py
@@ -301,5 +301,20 @@ def delete_now(case: Any, *, client=None) -> None:
 #: names every existing caller already imports. Derived from the raising twins
 #: rather than the other way round, so there is one implementation of the rule
 #: and the swallow is visibly a wrapper over it.
+#:
+#: **Patching note for tests.** These are bound at import, so
+#: ``mock.patch("cases.search_index.index_now")`` does NOT intercept a caller
+#: that went through ``index`` — the wrapper closed over the original function
+#: object. Patch the name the code under test actually calls: ``index`` for the
+#: write-time signal paths, ``index_now`` for the bus consumer.
 index = best_effort("index case")(index_now)
 delete = best_effort("delete case")(delete_now)
+
+# best_effort copies __name__/__doc__ off the wrapped function, so without this
+# `index` introspects as "index_now" and carries a docstring beginning "RAISES."
+# — the opposite of what it does. Anything reading help() or a traceback frame
+# would be told the wrong contract about the more widely used of the two.
+index.__name__ = "index"
+index.__doc__ = "Upsert a PUBLISHED case, else evict it. Best-effort: logs and swallows. See index_now."
+delete.__name__ = "delete"
+delete.__doc__ = "Delete the case's doc. Best-effort: logs and swallows. See delete_now."

--- a/config/urls.py
+++ b/config/urls.py
@@ -81,6 +81,9 @@ urlpatterns = [
     path("api/", include("newsletter.urls")),
     # Case-update proposals — before cases.urls (whose router is broad).
     path("api/", include("case_proposals.urls")),
+    # Filing a signal by hand — the one producer a human drives. Also before
+    # cases.urls, for the same reason.
+    path("api/", include("case_events.urls")),
     path("api/", include("cases.urls")),
     path("oembed/", OEmbedView.as_view(), name="oembed"),
     path("api/caseworker/me", MeView.as_view(), name="cw-me"),


### PR DESCRIPTION
## Why this PR exists

**#403 merged an earlier snapshot of its branch than the branch had reached.** The squash (`2e4b8ce`, 31 Jul) contains the branch as of `21b6eeb` — the intent job and the four consumers. Two things landed on that branch afterwards and are therefore *not* on main:

- **#405, the four producers**, which merged into `feat/enrichment-consumers` on 1 Aug — after that branch's own PR had already been merged and closed. It went to a branch nobody was going to merge again.
- **The fixes from the review of #403/#405**, pushed to the same branch on 1 Aug.

So main currently has half the pipeline — consumers with no producers to feed them, and with all six reviewed defects still in it. It is inert (nothing emits a signal, and the manual-note endpoint is not there), but it is wrong. This PR is those two commits cherry-picked onto current main; nothing here is new work.

## What it carries

### The producers (`bd7fe1e`, previously #405)
Docket change-detect, court-order published, CIAA press releases, caseworker manual note. Stateless by design — an overlapping 48h window rather than a watermark, because the dedup spine that makes that safe has to work anyway.

### Six defects that all failed silently (`19ecd16`, `de9af91`)

| | Defect | Effect |
|---|---|---|
| 1 | `origin_msg_id` was 100 chars, given a 108-char matched dedup key | **Every docket-derived proposal failed validation**, was filed as "the model produced something unusable", left no row — so the duplicate check found nothing and the next scrape bought another premium model call to fail identically |
| 2 | Matcher discarded `bus.publish`'s return | A broker blip acked the signal and produced nothing: no retry, no DLQ, nothing above DEBUG |
| 3 | `run()` reported a crash only after all four consumers finished — which in continuous mode is never | A dead matcher left a **Ready pod consuming nothing**, indefinitely |
| 4 | `handle_derive` called the `@best_effort` indexer, which swallows | Its retry budget and DLQ were decoration |
| 5 | Nothing waited for the JetStream ack | The manual-note 202 and the cron's "not accepted" count were blind to a broker rejecting everything — which is what a fresh one does until `nats_bootstrap` runs |
| 6 | `--limit` dropped facts permanently while the warning said they'd "wait for the next run" | With no watermark the next run reaches the same rows; the tail is lost when it ages out |

Plus: the matcher no longer matches CLOSED (soft-deleted) cases; an unknown delivery count buries rather than retrying into a silent JetStream drop; DLQ publishes carry a `Nats-Msg-Id`; the backoff schedule is derived from `max_deliver` rather than independently settable into a subscribe-time rejection; `dlq_hint` → `dlq_pattern` (it is a wildcard NATS would refuse as a publish subject); the bus closes the event loops it abandons; and the `lease_seconds` comment no longer claims a heartbeat the worker does not send.

## :warning: This PR adds a migration, and this repo does not auto-migrate

`case_proposals/0003` widens `origin_msg_id` 100 → 300. keel ships the image; `manage.py migrate` is manual. **Merging without running it leaves defect 1 live** — the code deploys happily and then rejects every docket proposal, billing a model call per rejection.

```bash
kubectl -n platform exec deploy/jawafdehi-platform -- uv run python manage.py migrate case_proposals
```

A varchar widening is a catalogue change on Postgres: no table rewrite, no long lock.

## Testing

- Full suite on this branch: **3095 passed, 4 skipped**; `ruff check` clean; `makemigrations --check` reports no missing migrations.
- **20 mutations** run against the fixes, all killed. Five re-run after the cherry-pick onto current main, all still killed.
- Two of the new tests were weak on first pass and the mutation run caught them: the fetch-ceiling test *hung* rather than failed (now bounded with `wait_for` — a wedged CI job is a bad way to learn about a bug), and nothing covered the failure counter resetting between non-consecutive failures.

The finding worth carrying forward: the existing tests used short synthetic identifiers (`docket:abc:hearing:...`) and small windows, so every size-dependent failure was invisible. Defect 1's test now builds its key from the real IRI helper, so if the IRI grammar or base host ever grows, it fails here rather than in a cron nobody is watching.

Runbook and design docs updated in meta (`eaf2af9`), including four claims these documents made that the review disproved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual caseworker-note API for publishing validated case signals.
  * Added docket signal reporting and publishing for hearings and verdicts.
  * Added automatic signals for newly created supported court materials.
* **Bug Fixes**
  * Improved consumer retry, dead-letter handling, deduplication, and shutdown reliability.
  * Closed cases are no longer matched for new signals.
  * Search indexing errors can now be reported instead of silently ignored when required.
  * Expanded proposal message ID support for longer identifiers.
* **Documentation**
  * Clarified job lease-duration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->