### PR TITLE
feat(casework): local response cache for invoke_text

### DIFF
--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -270,8 +270,15 @@ def log_run_header(logger, *, stage, base_url, dry_run, provider, model,
 
 
 def log_run_footer(logger, *, stage, stats: dict, duration_s: float,
-                   usage_summary: str = "") -> None:
-    """One INFO block: per-status counts, wall-clock duration, usage summary."""
+                   usage_summary: str = "", cache_summary: str = "") -> None:
+    """One INFO block: per-status counts, wall-clock duration, usage + cache.
+
+    `cache_summary` belongs in the durable run log, not just on stdout: a run
+    served entirely from the response cache makes zero LLM calls, so
+    `usage_summary` is empty and the log would carry no record of where the
+    output came from. The provenance of a cached run is exactly the thing a
+    reader needs weeks later.
+    """
     counts = ", ".join(f"{k}={v}" for k, v in sorted(stats.items())) or "(no cases)"
     lines = [
         f"=== casework run complete: {stage} ===",
@@ -280,4 +287,6 @@ def log_run_footer(logger, *, stage, stats: dict, duration_s: float,
     ]
     if usage_summary:
         lines.append(f"  usage    : {usage_summary}")
+    if cache_summary:
+        lines.append(f"  cache    : {cache_summary}")
     logger.info("\n".join(lines))

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -81,6 +81,23 @@ def add_common_args(parser):
             "this is set."
         ),
     )
+    # Local dev response cache for invoke_text (casework/common/llm_cache.py).
+    # ON by default: a dry run bills exactly like an apply, so re-running a batch
+    # after a parser fix otherwise pays twice for byte-identical calls. The key
+    # includes the resolved model, so changing --model or the prompt correctly
+    # misses. Pass --no-llm-cache for the run you sign off on.
+    parser.add_argument(
+        "--llm-cache", action="store_true", default=True,
+        help="Serve identical invoke_text calls from the local disk cache "
+             "(default on). Cache hits record no token usage.")
+    parser.add_argument(
+        "--no-llm-cache", dest="llm_cache", action="store_false",
+        help="Force fresh LLM calls. Use for a final verification run.")
+    parser.add_argument(
+        "--llm-cache-dir", default="",
+        help="Override the cache directory; defaults to "
+             "$CASEWORK_LLM_CACHE_DIR, then <repo>/work/llm-cache. Point every "
+             "worktree at one shared dir to reuse entries across sessions.")
     parser.add_argument("--verbose", action="store_true")
     return parser
 

--- a/casework/common/llm_cache.py
+++ b/casework/common/llm_cache.py
@@ -154,17 +154,28 @@ class LlmCache:
             "response": response,
             **(meta or {}),
         }
+        # `tmp_name` is bound BEFORE the write, and the cleanup catches Exception
+        # rather than OSError. Both matter: binding it inside the `with` (after
+        # json.dump returns) leaves it unbound if the dump raises, so the handler
+        # itself would raise NameError -- and a non-OSError escaping here would
+        # break this method's contract that an unwritable cache costs a saving,
+        # never a run. It also leaves the temp file on disk to be re-found later.
+        tmp_name = None
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
             with tempfile.NamedTemporaryFile(
                 "w", encoding="utf-8", dir=str(path.parent),
                 prefix=f".{key[:8]}-", suffix=".tmp", delete=False,
             ) as fh:
-                json.dump(record, fh, ensure_ascii=False)
                 tmp_name = fh.name
+                json.dump(record, fh, ensure_ascii=False)
             os.replace(tmp_name, path)
-        except OSError as exc:
-            # An unwritable cache is a lost saving, not a failed run.
+        except Exception as exc:
+            if tmp_name:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
             self._log.warning(
                 "llm-cache: could not write %s (%s)", path.name, type(exc).__name__
             )

--- a/casework/common/llm_cache.py
+++ b/casework/common/llm_cache.py
@@ -1,0 +1,281 @@
+"""Content-addressed disk cache for `llm.invoke.invoke_text` — local dev runs only.
+
+WHY. A `--dry-run` bills exactly like an `--apply`: the only thing dry-run skips is
+the PATCH, every LLM call still happens. So the normal loop -- dry-run 238 cases,
+read the review file, spot that the parser drops a section, fix the parser, dry-run
+again -- pays twice for byte-identical calls, and the second payment tests nothing
+but our own parsing code. This module makes that second run free.
+
+WHERE THIS SITS, AND WHY NOT IN `llm/`. This wraps `invoke_text` from inside
+`casework/`, deliberately NOT inside the shared `llm/` package. `llm/` is also
+imported by `review/judge.py`, `review/runner.py` and `case_proposals/job_handlers.py`,
+which run in production under the Django app. A disk cache that can answer a live
+review job should not be constructible, so the wrapper lives on the standalone-script
+side of the fence and the Django paths never see it.
+
+The enrichers make this cheap: each one does `from llm.invoke import invoke_text`
+inside `main()` and passes it down as a parameter (e.g.
+`_extract_bigo(text, detail, invoke_text, usage)`), so rebinding that one local name
+routes every downstream call through the cache without touching any extraction
+function.
+
+THE KEY INCLUDES THE RESOLVED MODEL, NOT THE TIER. `invoke_text` is called with
+`tier="premium"`; the tier -> model mapping is resolved later, inside the provider.
+Keying on the tier would mean switching `CLAUDE_CLI_MODEL_PREMIUM` from haiku to opus
+leaves the key unchanged -- you would read back the haiku answer and conclude the
+model swap did nothing. So the key resolves the provider + model at call time via
+`llm.routing`. A cache that lies is worse than no cache.
+
+WHAT IS NOT CACHED. `invoke_with_tools` (timeline's main extraction) is left alone: a
+multi-turn tool loop has no stable key, and a half-replayed tool conversation is worse
+than a fresh call. Timeline's plain `invoke_text` uses (verdict summarisation) still
+benefit.
+
+A CACHE HIT RECORDS NO TOKEN USAGE. `UsageAccumulator` feeds the run's cost report;
+counting a call that never happened would inflate it and hide the real spend. So the
+hit path deliberately does not touch `usage`.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# casework/common/llm_cache.py -> casework/common -> casework -> <repo-root>
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CACHE_DIR = _REPO_ROOT / "work" / "llm-cache"
+
+#: Bump to invalidate every stored entry at once (e.g. if the record shape changes).
+#: Part of the key, so an old entry simply stops being found rather than being
+#: misread -- no migration, no deletion pass.
+CACHE_VERSION = 1
+
+
+def _canonical_content(content):
+    """`content` is a str for most calls and a list of blocks for cache_control
+    prompts (see `llm/providers/cli.py`). Both have to hash stably, and a list
+    whose keys happen to be ordered differently must not produce a second entry.
+    """
+    if isinstance(content, str):
+        return content
+    return json.dumps(content, sort_keys=True, ensure_ascii=False, default=str)
+
+
+def cache_key(*, provider, model, system, content, max_tokens):
+    """sha256 over everything that can change the answer.
+
+    Fields are NUL-separated: without a separator ("ab", "c") and ("a", "bc")
+    would hash identically, which is exactly the kind of collision that makes a
+    cache serve one prompt's answer to another.
+    """
+    h = hashlib.sha256()
+    for part in (
+        str(CACHE_VERSION),
+        str(provider),
+        str(model),
+        system or "",
+        _canonical_content(content),
+        str(max_tokens),
+    ):
+        h.update(part.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+class LlmCache:
+    """Read/write of cached responses under `cache_dir`, plus hit/miss counters.
+
+    Never raises on a bad entry. A truncated or non-JSON file is reported once and
+    treated as a miss -- a corrupt cache must degrade to "pay for the call", never
+    to a crashed run mid-batch.
+    """
+
+    def __init__(self, cache_dir=None, enabled=True, logger=None):
+        self.enabled = bool(enabled)
+        self.dir = Path(
+            cache_dir
+            or os.environ.get("CASEWORK_LLM_CACHE_DIR")
+            or DEFAULT_CACHE_DIR
+        )
+        self.hits = 0
+        self.misses = 0
+        self.writes = 0
+        self._log = logger or logging.getLogger("casework.llm_cache")
+
+    def _path(self, key):
+        # Sharded on the first two hex chars: a 238-case batch across six stages is
+        # low thousands of files, and one flat directory of those is unpleasant to
+        # inspect by hand.
+        return self.dir / key[:2] / f"{key}.json"
+
+    def get(self, key):
+        """Stored response text, or None for a miss. Counts the miss."""
+        if not self.enabled:
+            return None
+        path = self._path(key)
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            self.misses += 1
+            return None
+        except (OSError, ValueError, UnicodeDecodeError) as exc:
+            self._log.warning(
+                "llm-cache: unreadable entry %s (%s) -- treating as a miss",
+                path.name, type(exc).__name__,
+            )
+            self.misses += 1
+            return None
+        response = record.get("response") if isinstance(record, dict) else None
+        if not isinstance(response, str) or not response.strip():
+            # A stored blank is a stored failure. Re-ask rather than replay it.
+            self.misses += 1
+            return None
+        self.hits += 1
+        return response
+
+    def put(self, key, response, *, meta=None):
+        """Store `response` under `key`. Blank responses are not stored.
+
+        Writes via a temp file + `os.replace` so a run killed mid-write leaves
+        either the old entry or the new one, never a truncated file that the next
+        run has to recover from.
+        """
+        if not self.enabled:
+            return False
+        if not isinstance(response, str) or not response.strip():
+            return False
+        path = self._path(key)
+        record = {
+            "version": CACHE_VERSION,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "response": response,
+            **(meta or {}),
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=str(path.parent),
+                prefix=f".{key[:8]}-", suffix=".tmp", delete=False,
+            ) as fh:
+                json.dump(record, fh, ensure_ascii=False)
+                tmp_name = fh.name
+            os.replace(tmp_name, path)
+        except OSError as exc:
+            # An unwritable cache is a lost saving, not a failed run.
+            self._log.warning(
+                "llm-cache: could not write %s (%s)", path.name, type(exc).__name__
+            )
+            return False
+        self.writes += 1
+        return True
+
+    def summary(self):
+        """One line for the run footer. Says 'off' rather than '0 hits' when
+        disabled, so a run with no savings is distinguishable from a run that
+        never tried."""
+        if not self.enabled:
+            return "llm cache: off"
+        looked_up = self.hits + self.misses
+        pct = (100.0 * self.hits / looked_up) if looked_up else 0.0
+        return (
+            f"llm cache: {self.hits} hit / {self.misses} miss "
+            f"({pct:.0f}% served from disk), {self.writes} stored, dir={self.dir}"
+        )
+
+
+#: `llm.invoke.invoke_text`'s positional parameter order, used only to read the
+#: key fields out of a call. The enrichers call it entirely by keyword
+#: (`invoke_text(system=..., content=..., max_tokens=..., tier=..., usage=...)`)
+#: and their tests stub it with keyword-only lambdas, so the wrapper must accept
+#: either form and forward whatever it was given, verbatim.
+_INVOKE_TEXT_PARAMS = ("system", "content", "max_tokens", "tier", "usage")
+
+
+def _call_fields(args, kwargs):
+    """Resolve (system, content, max_tokens, tier) from a call made positionally,
+    by keyword, or in any mix. Returns None when a required field is absent --
+    the caller then bypasses the cache rather than keying on a guess."""
+    bound = dict(zip(_INVOKE_TEXT_PARAMS, args))
+    bound.update(kwargs)
+    if "system" not in bound or "content" not in bound or "max_tokens" not in bound:
+        return None
+    return bound["system"], bound["content"], bound["max_tokens"], bound.get(
+        "tier", "premium"
+    )
+
+
+def wrap_invoke_text(invoke_text, cache):
+    """A call-convention-transparent replacement for `llm.invoke.invoke_text`.
+
+    Returns `invoke_text` unchanged when there is no cache or it is disabled, so
+    callers need no conditional of their own.
+
+    The wrapper forwards `*args, **kwargs` UNTOUCHED. It must not normalise a
+    keyword call into a positional one: every enricher calls `invoke_text` by
+    keyword, and their tests stub it with keyword-only lambdas
+    (`lambda **kw: response`), so a positional forward raises TypeError and the
+    enricher swallows it as an `llm-error`, silently degrading to the rule-based
+    path. That failure is invisible in the run output -- it looks like the model
+    simply declined -- which is why the transparency is load-bearing rather than
+    stylistic.
+
+    Only successful, non-blank responses are stored: an exception propagates
+    untouched and nothing is written, so a transient provider failure cannot be
+    frozen into the cache and replayed for the rest of the batch.
+    """
+    if cache is None or not cache.enabled:
+        return invoke_text
+
+    def cached_invoke_text(*args, **kwargs):
+        fields = _call_fields(args, kwargs)
+        if fields is None:
+            return invoke_text(*args, **kwargs)
+        system, content, max_tokens, tier = fields
+
+        from llm import routing
+
+        provider = routing.provider_for_tier(tier)
+        model = provider.model_for_tier(tier)
+        key = cache_key(
+            provider=type(provider).__name__,
+            model=model,
+            system=system,
+            content=content,
+            max_tokens=max_tokens,
+        )
+        hit = cache.get(key)
+        if hit is not None:
+            # NOTE: `usage` is intentionally untouched -- see module docstring.
+            return hit
+        response = invoke_text(*args, **kwargs)
+        cache.put(key, response, meta={
+            "provider": type(provider).__name__,
+            "model": model,
+            "tier": tier,
+            "max_tokens": max_tokens,
+            # Hashes, not the prompts: a batch of 238 legacy-font press releases
+            # would otherwise put tens of MB of duplicated source text on disk.
+            "system_sha256": hashlib.sha256((system or "").encode()).hexdigest(),
+            "content_sha256": hashlib.sha256(
+                _canonical_content(content).encode()
+            ).hexdigest(),
+        })
+        return response
+
+    return cached_invoke_text
+
+
+def build_llm_cache(args, logger=None):
+    """Build an `LlmCache` from parsed CLI args (see `cli.add_common_args`).
+
+    Enabled by default: the cost problem this solves is the default situation, and
+    `--no-llm-cache` is the opt-out for the run you actually sign off on.
+    """
+    return LlmCache(
+        cache_dir=getattr(args, "llm_cache_dir", "") or None,
+        enabled=getattr(args, "llm_cache", True),
+        logger=logger,
+    )

--- a/casework/enrich_allegations.py
+++ b/casework/enrich_allegations.py
@@ -436,6 +436,7 @@ def main(argv=None):
     log_run_footer(
         logger, stage="allegations", stats=stats,
         duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        cache_summary=cache_summary,
     )
 
     return report

--- a/casework/enrich_allegations.py
+++ b/casework/enrich_allegations.py
@@ -255,6 +255,15 @@ def main(argv=None):
 
     from llm.invoke import invoke_text
     from llm.usage import UsageAccumulator, render_usage_table
+    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
+
+    # Local dev response cache (see casework/common/llm_cache.py). A dry run bills
+    # exactly like an apply, so re-running this batch after a parser fix would
+    # otherwise pay twice for byte-identical calls. --no-llm-cache forces fresh.
+    # invoke_with_tools is deliberately NOT wrapped: a multi-turn tool loop has no
+    # stable key.
+    llm_cache = build_llm_cache(args)
+    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
 
     api = build_api(args)
     usage = UsageAccumulator()
@@ -417,6 +426,12 @@ def main(argv=None):
             usage.as_dict()["by_provider"], title="allegations usage")
         print()
         print(usage_summary)
+
+    # Unconditional, outside the `if usage.calls` guard above: a run served
+    # entirely from cache makes zero calls, and that is exactly the run whose
+    # provenance must not be silent.
+    cache_summary = llm_cache.summary()
+    print(cache_summary)
 
     log_run_footer(
         logger, stage="allegations", stats=stats,

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -544,6 +544,7 @@ def main(argv=None):
     log_run_footer(
         logger, stage="bigo", stats=stats,
         duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        cache_summary=cache_summary,
     )
 
     return report

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -389,6 +389,15 @@ def main(argv=None):
 
     from llm.invoke import invoke_text
     from llm.usage import UsageAccumulator, render_usage_table
+    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
+
+    # Local dev response cache (see casework/common/llm_cache.py). A dry run bills
+    # exactly like an apply, so re-running this batch after a parser fix would
+    # otherwise pay twice for byte-identical calls. --no-llm-cache forces fresh.
+    # invoke_with_tools is deliberately NOT wrapped: a multi-turn tool loop has no
+    # stable key.
+    llm_cache = build_llm_cache(args)
+    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
 
     api = build_api(args)
     usage = UsageAccumulator()
@@ -525,6 +534,12 @@ def main(argv=None):
         usage_summary = render_usage_table(usage.as_dict()["by_provider"], title="bigo usage")
         print()
         print(usage_summary)
+
+    # Unconditional, outside the `if usage.calls` guard above: a run served
+    # entirely from cache makes zero calls, and that is exactly the run whose
+    # provenance must not be silent.
+    cache_summary = llm_cache.summary()
+    print(cache_summary)
 
     log_run_footer(
         logger, stage="bigo", stats=stats,

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -388,6 +388,15 @@ def main(argv=None):
 
     from llm.invoke import invoke_text
     from llm.usage import UsageAccumulator, render_usage_table
+    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
+
+    # Local dev response cache (see casework/common/llm_cache.py). A dry run bills
+    # exactly like an apply, so re-running this batch after a parser fix would
+    # otherwise pay twice for byte-identical calls. --no-llm-cache forces fresh.
+    # invoke_with_tools is deliberately NOT wrapped: a multi-turn tool loop has no
+    # stable key.
+    llm_cache = build_llm_cache(args)
+    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
 
     api = build_api(args)
     usage = UsageAccumulator()
@@ -573,6 +582,12 @@ def main(argv=None):
             usage.as_dict()["by_provider"], title="entities usage")
         print()
         print(usage_summary)
+
+    # Unconditional, outside the `if usage.calls` guard above: a run served
+    # entirely from cache makes zero calls, and that is exactly the run whose
+    # provenance must not be silent.
+    cache_summary = llm_cache.summary()
+    print(cache_summary)
 
     log_run_footer(
         logger, stage="entities", stats=stats,

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -592,6 +592,7 @@ def main(argv=None):
     log_run_footer(
         logger, stage="entities", stats=stats,
         duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        cache_summary=cache_summary,
     )
 
     return report

--- a/casework/enrich_tags.py
+++ b/casework/enrich_tags.py
@@ -1251,6 +1251,7 @@ def main(argv=None):
     log_run_footer(
         logger, stage="tags", stats=stats,
         duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        cache_summary=cache_summary,
     )
 
     return report

--- a/casework/enrich_tags.py
+++ b/casework/enrich_tags.py
@@ -1088,6 +1088,15 @@ def main(argv=None):
 
     from llm.invoke import invoke_text
     from llm.usage import UsageAccumulator, render_usage_table
+    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
+
+    # Local dev response cache (see casework/common/llm_cache.py). A dry run bills
+    # exactly like an apply, so re-running this batch after a parser fix would
+    # otherwise pay twice for byte-identical calls. --no-llm-cache forces fresh.
+    # invoke_with_tools is deliberately NOT wrapped: a multi-turn tool loop has no
+    # stable key.
+    llm_cache = build_llm_cache(args)
+    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
 
     api = build_api(args)
     usage = UsageAccumulator()
@@ -1232,6 +1241,12 @@ def main(argv=None):
         usage_summary = render_usage_table(usage.as_dict()["by_provider"], title="tags usage")
         print()
         print(usage_summary)
+
+    # Unconditional, outside the `if usage.calls` guard above: a run served
+    # entirely from cache makes zero calls, and that is exactly the run whose
+    # provenance must not be silent.
+    cache_summary = llm_cache.summary()
+    print(cache_summary)
 
     log_run_footer(
         logger, stage="tags", stats=stats,

--- a/casework/enrich_timeline.py
+++ b/casework/enrich_timeline.py
@@ -959,6 +959,7 @@ def main(argv=None):
     log_run_footer(
         logger, stage="timeline", stats=stats,
         duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        cache_summary=cache_summary,
     )
 
     return report

--- a/casework/enrich_timeline.py
+++ b/casework/enrich_timeline.py
@@ -765,6 +765,15 @@ def main(argv=None):
 
     from llm.invoke import invoke_text, invoke_with_tools
     from llm.usage import UsageAccumulator, render_usage_table
+    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
+
+    # Local dev response cache (see casework/common/llm_cache.py). A dry run bills
+    # exactly like an apply, so re-running this batch after a parser fix would
+    # otherwise pay twice for byte-identical calls. --no-llm-cache forces fresh.
+    # invoke_with_tools is deliberately NOT wrapped: a multi-turn tool loop has no
+    # stable key.
+    llm_cache = build_llm_cache(args)
+    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
 
     api = build_api(args)
     usage = UsageAccumulator()
@@ -940,6 +949,12 @@ def main(argv=None):
             usage.as_dict()["by_provider"], title="timeline usage")
         print()
         print(usage_summary)
+
+    # Unconditional, outside the `if usage.calls` guard above: a run served
+    # entirely from cache makes zero calls, and that is exactly the run whose
+    # provenance must not be silent.
+    cache_summary = llm_cache.summary()
+    print(cache_summary)
 
     log_run_footer(
         logger, stage="timeline", stats=stats,

--- a/tests/casework/conftest.py
+++ b/tests/casework/conftest.py
@@ -17,3 +17,21 @@ def _isolate_casework_run_logs(monkeypatch, tmp_path):
     for itself.
     """
     monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_llm_response_cache(monkeypatch, tmp_path):
+    """The `invoke_text` response cache (`casework/common/llm_cache.py`) is ON by
+    default and defaults to `<repo>/work/llm-cache/`, so without this fixture the
+    suite both litters that real directory and -- much worse -- READS from it.
+
+    That second failure is the one to keep in mind: a test whose stub returns a
+    fixed string writes an entry keyed on its own prompt, and the next run of any
+    test using the same prompt gets a cache HIT, so its stub is never called and
+    assertions like `assert seen_tiers == ["premium"]` fail against an empty list.
+    The suite would pass or fail depending on what a previous run left on disk.
+    Per-test tmp dir keeps every test's cache empty at start.
+
+    A test that wants real default-directory behaviour delenv's this itself.
+    """
+    monkeypatch.setenv("CASEWORK_LLM_CACHE_DIR", str(tmp_path / "llm-cache"))

--- a/tests/casework/test_llm_cache.py
+++ b/tests/casework/test_llm_cache.py
@@ -1,0 +1,306 @@
+"""Tests for the local invoke_text response cache.
+
+The load-bearing test here is `test_key_changes_when_the_resolved_model_changes`:
+`invoke_text` is called with `tier="premium"` and the tier -> model mapping is
+resolved later inside the provider, so a key built from the tier would silently
+serve a haiku answer after the operator switched the premium model to opus. Every
+other test in this file is about not crashing a 238-case batch; that one is about
+not lying.
+"""
+
+import json
+import types
+
+import pytest
+
+from casework.common import llm_cache
+from casework.common.llm_cache import (
+    LlmCache,
+    build_llm_cache,
+    cache_key,
+    wrap_invoke_text,
+)
+
+SYSTEM = "तपाईं भ्रष्टाचार मुद्दाको विश्लेषक हुनुहुन्छ।"
+CONTENT = "विशेष अदालत मुद्दा 076-CR-0182, प्रतिवादी: बिनोद कुमार भूजेल समेत ५"
+RESPONSE = "बिगो रु. ३,२०,००,००० — नारायणी अस्पताल ठेक्का अनियमितता"
+
+
+def _key(**over):
+    base = dict(provider="ClaudeCliProvider", model="opus", system=SYSTEM,
+                content=CONTENT, max_tokens=900)
+    base.update(over)
+    return cache_key(**base)
+
+
+# --------------------------------------------------------------------------
+# Key construction
+# --------------------------------------------------------------------------
+
+def test_key_is_stable_for_identical_inputs():
+    assert _key() == _key()
+
+
+def test_key_changes_when_the_resolved_model_changes():
+    """The whole point of resolving the model at key time. If this ever passes
+    with `==`, a haiku answer can be served after switching to opus."""
+    assert _key(model="haiku") != _key(model="opus")
+
+
+@pytest.mark.parametrize("field,value", [
+    ("provider", "BedrockProvider"),
+    ("system", SYSTEM + " थप निर्देशन"),
+    ("content", CONTENT + " (संशोधित)"),
+    ("max_tokens", 1200),
+])
+def test_key_changes_when_any_input_changes(field, value):
+    assert _key(**{field: value}) != _key()
+
+
+def test_key_separates_fields_so_boundaries_cannot_collide():
+    """Without a separator between hashed parts, ("ab","c") and ("a","bc") hash
+    the same -- one prompt's answer served to a different prompt."""
+    assert _key(system="ab", content="c") != _key(system="a", content="bc")
+
+
+def test_key_is_stable_across_block_key_ordering():
+    """cache_control prompts arrive as a list of blocks; a dict built in a
+    different order is the same question and must not create a second entry."""
+    a = cache_key(provider="P", model="m", max_tokens=10,
+                  system="s", content=[{"type": "text", "text": CONTENT}])
+    b = cache_key(provider="P", model="m", max_tokens=10,
+                  system="s", content=[{"text": CONTENT, "type": "text"}])
+    assert a == b
+
+
+def test_bumping_cache_version_invalidates_every_entry(monkeypatch):
+    before = _key()
+    monkeypatch.setattr(llm_cache, "CACHE_VERSION", llm_cache.CACHE_VERSION + 1)
+    assert _key() != before
+
+
+# --------------------------------------------------------------------------
+# Store behaviour
+# --------------------------------------------------------------------------
+
+def test_put_then_get_round_trips_devanagari(tmp_path):
+    cache = LlmCache(cache_dir=tmp_path)
+    assert cache.put(_key(), RESPONSE) is True
+    assert cache.get(_key()) == RESPONSE
+    assert (cache.hits, cache.writes) == (1, 1)
+
+
+def test_miss_on_an_absent_key_is_counted_not_raised(tmp_path):
+    cache = LlmCache(cache_dir=tmp_path)
+    assert cache.get(_key()) is None
+    assert (cache.hits, cache.misses) == (0, 1)
+
+
+def test_blank_responses_are_never_stored(tmp_path):
+    """A blank response is a stored failure; freezing it would replay the
+    failure for every later run of the same case."""
+    cache = LlmCache(cache_dir=tmp_path)
+    for blank in ("", "   ", "\n"):
+        assert cache.put(_key(), blank) is False
+    assert cache.get(_key()) is None
+    assert cache.writes == 0
+
+
+def test_a_corrupt_entry_degrades_to_a_miss(tmp_path):
+    """A run killed mid-write must not crash the next 238-case batch."""
+    cache = LlmCache(cache_dir=tmp_path)
+    cache.put(_key(), RESPONSE)
+    path = cache._path(_key())
+    path.write_text("{not json", encoding="utf-8")
+    cache.hits = cache.misses = 0
+    assert cache.get(_key()) is None
+    assert (cache.hits, cache.misses) == (0, 1)
+
+
+def test_an_entry_missing_the_response_field_is_a_miss(tmp_path):
+    cache = LlmCache(cache_dir=tmp_path)
+    path = cache._path(_key())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"created_at": "2026-08-03T00:00:00Z"}), encoding="utf-8")
+    assert cache.get(_key()) is None
+
+
+def test_put_leaves_no_temp_files_behind(tmp_path):
+    cache = LlmCache(cache_dir=tmp_path)
+    cache.put(_key(), RESPONSE)
+    assert [p.name for p in cache._path(_key()).parent.iterdir()
+            if p.name.endswith(".tmp")] == []
+
+
+def test_disabled_cache_neither_reads_nor_writes(tmp_path):
+    cache = LlmCache(cache_dir=tmp_path, enabled=False)
+    assert cache.put(_key(), RESPONSE) is False
+    assert cache.get(_key()) is None
+    assert (cache.hits, cache.misses, cache.writes) == (0, 0, 0)
+    assert not any(tmp_path.iterdir())
+
+
+def test_summary_distinguishes_off_from_zero_hits(tmp_path):
+    """A run with no savings must not read like a run that never tried."""
+    assert LlmCache(cache_dir=tmp_path, enabled=False).summary() == "llm cache: off"
+    # Not a substring check: tmp_path's own name contains "off" for this test.
+    on = LlmCache(cache_dir=tmp_path).summary()
+    assert on != "llm cache: off"
+    assert on.startswith("llm cache: 0 hit / 0 miss")
+
+
+def test_env_var_sets_the_default_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("CASEWORK_LLM_CACHE_DIR", str(tmp_path / "shared"))
+    assert LlmCache().dir == tmp_path / "shared"
+
+
+def test_explicit_dir_beats_the_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("CASEWORK_LLM_CACHE_DIR", str(tmp_path / "shared"))
+    assert LlmCache(cache_dir=tmp_path / "explicit").dir == tmp_path / "explicit"
+
+
+# --------------------------------------------------------------------------
+# The invoke_text wrapper
+# --------------------------------------------------------------------------
+
+class _Usage:
+    """Stand-in for llm.usage.UsageAccumulator: only needs to notice a call."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def add(self, *a, **kw):
+        self.calls += 1
+
+
+def _fake_routing(monkeypatch, model="opus"):
+    """Patch llm.routing so the wrapper resolves a provider+model without Django."""
+    provider = types.SimpleNamespace(model_for_tier=lambda tier: model)
+    fake = types.SimpleNamespace(provider_for_tier=lambda tier: provider)
+    import sys
+    monkeypatch.setitem(sys.modules, "llm", types.SimpleNamespace(routing=fake))
+    monkeypatch.setitem(sys.modules, "llm.routing", fake)
+    return provider
+
+
+def test_second_identical_call_is_served_from_disk(tmp_path, monkeypatch):
+    _fake_routing(monkeypatch)
+    calls = []
+
+    def fake_invoke(system, content, max_tokens, tier="premium", usage=None):
+        calls.append(system)
+        return RESPONSE
+
+    cache = LlmCache(cache_dir=tmp_path)
+    wrapped = wrap_invoke_text(fake_invoke, cache)
+    assert wrapped(SYSTEM, CONTENT, 900) == RESPONSE
+    assert wrapped(SYSTEM, CONTENT, 900) == RESPONSE
+    assert len(calls) == 1, "the second call should not have reached the provider"
+    assert (cache.hits, cache.misses) == (1, 1)
+
+
+def test_a_hit_records_no_token_usage(tmp_path, monkeypatch):
+    """Counting cached calls in UsageAccumulator would inflate the cost report
+    and hide the real spend."""
+    _fake_routing(monkeypatch)
+
+    def fake_invoke(system, content, max_tokens, tier="premium", usage=None):
+        if usage:
+            usage.add()
+        return RESPONSE
+
+    cache = LlmCache(cache_dir=tmp_path)
+    wrapped = wrap_invoke_text(fake_invoke, cache)
+    usage = _Usage()
+    wrapped(SYSTEM, CONTENT, 900, "premium", usage)   # miss: provider records
+    wrapped(SYSTEM, CONTENT, 900, "premium", usage)   # hit: must record nothing
+    assert usage.calls == 1
+
+
+def test_changing_the_model_forces_a_fresh_call(tmp_path, monkeypatch):
+    """End-to-end version of the key test: the operator swaps the premium model
+    and must get a real answer from the new one, not the old one replayed."""
+    provider = _fake_routing(monkeypatch, model="haiku")
+    seen = []
+
+    def fake_invoke(system, content, max_tokens, tier="premium", usage=None):
+        seen.append(provider.model_for_tier(tier))
+        return f"answer from {provider.model_for_tier(tier)}"
+
+    cache = LlmCache(cache_dir=tmp_path)
+    wrapped = wrap_invoke_text(fake_invoke, cache)
+    assert wrapped(SYSTEM, CONTENT, 900) == "answer from haiku"
+    provider.model_for_tier = lambda tier: "opus"
+    assert wrapped(SYSTEM, CONTENT, 900) == "answer from opus"
+    assert seen == ["haiku", "opus"]
+
+
+def test_a_raising_provider_is_not_cached(tmp_path, monkeypatch):
+    """A transient provider failure must not be frozen and replayed for the
+    rest of the batch."""
+    _fake_routing(monkeypatch)
+    calls = []
+
+    def flaky(system, content, max_tokens, tier="premium", usage=None):
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("error_max_turns")
+        return RESPONSE
+
+    cache = LlmCache(cache_dir=tmp_path)
+    wrapped = wrap_invoke_text(flaky, cache)
+    with pytest.raises(RuntimeError):
+        wrapped(SYSTEM, CONTENT, 900)
+    assert cache.writes == 0
+    assert wrapped(SYSTEM, CONTENT, 900) == RESPONSE
+
+
+def test_wrapper_is_a_passthrough_when_disabled(tmp_path, monkeypatch):
+    _fake_routing(monkeypatch)
+
+    def fake_invoke(*a, **kw):
+        return RESPONSE
+
+    assert wrap_invoke_text(fake_invoke, None) is fake_invoke
+    disabled = LlmCache(cache_dir=tmp_path, enabled=False)
+    assert wrap_invoke_text(fake_invoke, disabled) is fake_invoke
+
+
+def test_stored_metadata_holds_hashes_not_prompts(tmp_path, monkeypatch):
+    """238 legacy-font press releases would put tens of MB of duplicated source
+    text on disk if the prompts themselves were stored."""
+    _fake_routing(monkeypatch)
+    cache = LlmCache(cache_dir=tmp_path)
+    wrap_invoke_text(lambda *a, **kw: RESPONSE, cache)(SYSTEM, CONTENT, 900)
+    record = json.loads(next(tmp_path.rglob("*.json")).read_text(encoding="utf-8"))
+    assert record["response"] == RESPONSE
+    assert record["model"] == "opus"
+    assert "system_sha256" in record and "content_sha256" in record
+    blob = json.dumps(record, ensure_ascii=False)
+    assert CONTENT not in blob and SYSTEM not in blob
+
+
+# --------------------------------------------------------------------------
+# CLI wiring
+# --------------------------------------------------------------------------
+
+def test_build_llm_cache_defaults_to_enabled():
+    args = types.SimpleNamespace()
+    assert build_llm_cache(args).enabled is True
+
+
+def test_no_llm_cache_flag_disables_it():
+    args = types.SimpleNamespace(llm_cache=False)
+    assert build_llm_cache(args).enabled is False
+
+
+def test_cli_exposes_the_cache_flags(tmp_path):
+    import argparse
+
+    from casework.common.cli import add_common_args
+
+    parser = add_common_args(argparse.ArgumentParser())
+    assert parser.parse_args([]).llm_cache is True
+    assert parser.parse_args(["--no-llm-cache"]).llm_cache is False
+    parsed = parser.parse_args(["--llm-cache-dir", str(tmp_path)])
+    assert build_llm_cache(parsed).dir == tmp_path

--- a/tests/casework/test_llm_cache.py
+++ b/tests/casework/test_llm_cache.py
@@ -132,6 +132,31 @@ def test_put_leaves_no_temp_files_behind(tmp_path):
             if p.name.endswith(".tmp")] == []
 
 
+def test_a_failed_write_returns_false_and_leaves_no_temp_file(tmp_path, monkeypatch):
+    """The contract is that an unwritable cache costs a saving, never a run. A
+    serialisation failure must not escape `put`, and must not strand a .tmp file
+    for a later run to trip over."""
+    cache = LlmCache(cache_dir=tmp_path)
+
+    def boom(*a, **kw):
+        raise TypeError("not JSON serialisable")
+
+    monkeypatch.setattr(llm_cache.json, "dump", boom)
+    assert cache.put(_key(), RESPONSE) is False
+    assert cache.writes == 0
+    assert list(tmp_path.rglob("*.tmp")) == []
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_a_failed_mkdir_returns_false_rather_than_raising(tmp_path, monkeypatch):
+    cache = LlmCache(cache_dir=tmp_path)
+    monkeypatch.setattr(
+        llm_cache.Path, "mkdir",
+        lambda *a, **kw: (_ for _ in ()).throw(OSError("read-only fs")),
+    )
+    assert cache.put(_key(), RESPONSE) is False
+
+
 def test_disabled_cache_neither_reads_nor_writes(tmp_path):
     cache = LlmCache(cache_dir=tmp_path, enabled=False)
     assert cache.put(_key(), RESPONSE) is False
@@ -304,3 +329,38 @@ def test_cli_exposes_the_cache_flags(tmp_path):
     assert parser.parse_args(["--no-llm-cache"]).llm_cache is False
     parsed = parser.parse_args(["--llm-cache-dir", str(tmp_path)])
     assert build_llm_cache(parsed).dir == tmp_path
+
+
+def test_invoke_text_param_names_still_match_the_real_signature():
+    """`_call_fields` maps positional args onto `_INVOKE_TEXT_PARAMS`, so that
+    constant is a duplicate of `llm.invoke.invoke_text`'s parameter list. Assert
+    the copy here rather than inspecting the signature at runtime: a rename would
+    already break every enricher (they all call invoke_text by keyword), so a
+    runtime guard defends an event that cannot happen quietly -- but it should
+    still fail in CI rather than in a batch run.
+    """
+    import inspect
+
+    from llm.invoke import invoke_text
+
+    actual = tuple(inspect.signature(invoke_text).parameters)
+    assert actual == llm_cache._INVOKE_TEXT_PARAMS, (
+        "llm.invoke.invoke_text changed shape; update _INVOKE_TEXT_PARAMS"
+    )
+
+
+def test_cache_summary_reaches_the_durable_run_log(caplog):
+    """Printing it to stdout is not enough. A run served entirely from cache
+    makes zero LLM calls, so `usage_summary` is empty and without this the log
+    file records nothing about where the output came from."""
+    import logging
+
+    from casework.common.cli import log_run_footer
+
+    logger = logging.getLogger("test.cache_footer")
+    with caplog.at_level(logging.INFO, logger="test.cache_footer"):
+        log_run_footer(
+            logger, stage="bigo", stats={"enriched": 3}, duration_s=1.0,
+            usage_summary="", cache_summary="llm cache: 3 hit / 0 miss",
+        )
+    assert "cache    : llm cache: 3 hit / 0 miss" in caplog.text


### PR DESCRIPTION
### **User description**
## Why

A `--dry-run` bills exactly like an `--apply`. The only thing dry-run skips is the PATCH — every LLM call still happens.

So the normal loop costs twice what it looks like: dry-run a batch, read the review file, spot that the parser drops a section, fix the parser, dry-run again. The second run pays full price for byte-identical calls, and what it was actually testing was our own parsing code.

This caches `invoke_text` responses on local disk. A second run over an unchanged batch makes zero provider calls.

Measured on a 3-case two-run demo:

```text
run 1: provider calls=3  |  llm cache: 0 hit / 3 miss (0% served from disk), 3 stored
run 2: provider calls=0  |  llm cache: 3 hit / 0 miss (100% served from disk), 0 stored
```

## Three decisions worth reviewing

**It wraps `invoke_text` inside `casework/`, not inside the shared `llm/` package.** `llm/` is also imported by `review/judge.py`, `review/runner.py` and `case_proposals/job_handlers.py`, which run in production under Django. A disk cache that can answer a live review job should not be constructible, so the wrapper lives on the standalone-script side and the Django paths never see it.

**The key resolves the provider + model via `llm.routing` at call time, rather than keying on the tier.** `invoke_text` receives `tier="premium"` and the tier→model mapping is resolved later inside the provider. A tier-keyed cache would leave the key unchanged after switching `CLAUDE_CLI_MODEL_PREMIUM` from haiku to opus — you would read back the haiku answer and conclude the model swap did nothing. A cache that lies is worse than no cache. Pinned by `test_key_changes_when_the_resolved_model_changes`.

**The wrapper forwards `*args`/`**kwargs` untouched.** My first version normalised to a positional call and broke 34 tests. Every enricher calls `invoke_text` by keyword and their tests stub it with keyword-only lambdas, so a positional forward raises `TypeError`, which the enricher swallows as an `llm-error` and silently degrades to the rule-based path. That failure is invisible in the run output — it reads as the model declining.

## Safety properties

- **A cache hit records no token usage.** `UsageAccumulator` feeds the cost report; counting calls that never happened would hide the real spend.
- **Blank responses and exceptions are never stored**, so a transient `error_max_turns` cannot be frozen and replayed for the rest of a batch.
- Writes go via `tempfile` + `os.replace`; an unreadable entry degrades to a miss rather than crashing a run mid-batch.
- Cache state prints in every run footer, **outside** the `if usage.calls` guard — a run served entirely from cache makes zero calls and is exactly the run whose provenance must not be silent.
- `CACHE_VERSION` is part of the key, so bumping it invalidates every entry without a migration or deletion pass.

## The conftest fixture is load-bearing, not hygiene

The cache defaults to `<repo>/work/llm-cache`, so without isolation the suite both writes to and **reads from** the real directory. A test's stubbed response gets stored under its own prompt, and the next run of any test sharing that prompt gets a hit, never calls its stub, and fails on assertions like `assert seen_tiers == ["premium"]` against an empty list. The suite would pass or fail depending on what a previous run left on disk.

Found exactly that way — 34 failures, then 14, before the cause was clear.

## Not covered

`invoke_with_tools` (timeline's main extraction) is deliberately not cached: a multi-turn tool loop has no stable key, and a half-replayed tool conversation is worse than a fresh call. Timeline's plain `invoke_text` uses still benefit.

## Testing

- `617` casework tests pass, 28 new in `tests/casework/test_llm_cache.py`
- `3133` passed in the unit gate (`uv run pytest`); the 57 `integration-tests/` errors need a live stack and fail identically on `main` with this branch stashed
- `uv run ruff check .` clean, pre-commit passed
- Flags verified on `enrich_missing_bigo --help`

## Try it

```bash
# on by default; second run of the same 3 cases should report 100% served from disk
DEBUG=True uv run python -m casework.enrich_missing_bigo \
  --api-base-url http://127.0.0.1:48010 --limit 3 --verbose

# force fresh calls for a run you sign off on
DEBUG=True uv run python -m casework.enrich_missing_bigo \
  --api-base-url http://127.0.0.1:48010 --limit 3 --no-llm-cache --verbose
```

`--llm-cache-dir` (or `$CASEWORK_LLM_CACHE_DIR`) relocates the store; point several worktrees at one directory to share entries. Default `<repo>/work/llm-cache` is already gitignored.

## Context

Step 0 of the enricher work planned in `work/2026-08-03-Migrate-AI-enricher-touse-control-plane-APIs/findings.md`: five of the donor's ten enrichers are still unported, and each port iterates over the same cases many times. Read-only work throughout — no production writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add local `invoke_text` disk cache

- Wire cache into casework enrichers

- Expose cache CLI controls

- Isolate, test cache behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["CLI flags"] -- "configure" --> cache["LlmCache"]
  enrichers["Casework enrichers"] -- "wrap" --> invoke["invoke_text"]
  invoke -- "hit" --> disk["Disk response"]
  invoke -- "miss" --> provider["LLM provider"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>cli.py</strong><dd><code>Add LLM cache CLI flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-10d5ea401a4ba97c7ae79547175e565c3b7733fa1028b64dc098719fb7f8561d">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>llm_cache.py</strong><dd><code>Implement content-addressed response cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-0f22f68f773302aa3c0dcf89623fdb6a76618692588e4f5386769df7de6afdbd">+281/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_allegations.py</strong><dd><code>Wrap allegations `invoke_text` with cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-7bafafd1f7efd8c2d5a8b2d6687d4e68fb449b2b8a6a2d15e63436a67575344b">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_missing_bigo.py</strong><dd><code>Wrap bigo `invoke_text` with cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-8f467def65557fd5e08bab577f4cd249c274ae9d7530a0496af808b55a52345b">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_related_entities.py</strong><dd><code>Wrap entities `invoke_text` with cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-8bf3ff939a79022cc02aaedae13701f729a26e22e900d041b4b928e39d06b708">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_tags.py</strong><dd><code>Wrap tags `invoke_text` with cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-af4eb9ddc030080dacdf3b7d770be8c6c6e92cea1d157c4c799d7452be584ca3">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_timeline.py</strong><dd><code>Wrap timeline `invoke_text` with cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-0f654c796620a6697e537585c97fa3106408569c8a87f339fd8e7f69da276260">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>conftest.py</strong><dd><code>Isolate LLM cache per test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-4d76bb2281eed76dab46af0dd3acf771fec111df051e3e25a58c618d068050a0">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_llm_cache.py</strong><dd><code>Test cache keys, storage, wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/409/files#diff-ba9fa3135f4522159152bd4dd8637734bc927ffc1a6301af958f24aecf7342f5">+306/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local caching for LLM responses to speed up repeated processing and reduce unnecessary calls.
  * Cache is enabled by default, with options to disable it or choose a custom directory.
  * Cache entries account for the selected provider, model, prompts, and token limits.
  * Added cache hit, miss, and write summaries to command output.

* **Bug Fixes**
  * Invalid, incomplete, or unwritable cache entries safely fall back to live processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->