### PR TITLE
fix(casework): ground बिगो writes, honour --batch-csv, and stop cleartext credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.pyc
 .pytest_cache/
-*.sqlite3
+*.sqlite3*
 .env
 media/
 staticfiles/

--- a/casework/README.md
+++ b/casework/README.md
@@ -97,9 +97,13 @@ flowchart TB
 
 ### The prerequisite DAG
 
-`convert` is the gate every LLM stage waits on: a case with evidence bound but no
-MARKDOWN-role material cannot be enriched. That is reported as an **explicit
-unmet prerequisite**, never as a silent skip that looks like "already done".
+`convert` gates the four stages that read material — `bigo`, `timeline`,
+`allegations`, `entities`. A case with evidence bound but no MARKDOWN-role
+material cannot be enriched, and that is reported as an **explicit unmet
+prerequisite**, never as a silent skip that looks like "already done".
+
+`tags` is the exception: it reads no material at all, so `convert` does not gate
+it (see the bullet below the diagram).
 
 ```mermaid
 flowchart LR
@@ -247,8 +251,15 @@ look complete that you never touched.
 
 - `--dry-run` defaults to **on**; `--apply` opts in. Get this from
   `add_common_args`, do not re-implement it.
-- Pass `if_match=etag` on every write. Without it a concurrent edit is silently
-  overwritten instead of failing with 412.
+- Pass `if_match=etag` on every **case PATCH** — `patch_field` and
+  `replace_list`. Without it a concurrent edit is silently overwritten instead
+  of failing with 412. Material uploads (`convert.py`'s MARKDOWN POST) go
+  through `_request` directly and have no case ETag to send; they are covered by
+  the loopback write-guard instead.
+- A remote `--api-base-url` must be `https`. `CaseworkApi` refuses to construct
+  otherwise, because the `Authorization` header goes on every request and these
+  runs last hours. Loopback over `http` is exempt — a local DEV_AUTH server has
+  no TLS and the token never leaves the host.
 - Read the token from `$JAWAFDEHI_API_TOKEN` rather than `--api-token`. A token
   passed on the command line sits in `/proc/<pid>/cmdline` (mode 444) for the
   whole run and is readable by every local user via `ps -af`; the environment

--- a/casework/README.md
+++ b/casework/README.md
@@ -1,0 +1,450 @@
+# `casework/` — CIAA case enrichment pipeline
+
+A reusable, API-driven pipeline that sources supporting materials, converts them
+to text, and enriches CIAA Special-Court cases with LLM-extracted fields. Ported
+out of five standalone Django management commands into one installed package so
+the stages can share auth, selection, LLM routing, run-logging, and a
+prerequisite DAG instead of each re-deriving them.
+
+Every stage talks to the case API over HTTP (`CaseworkApi`) — **no stage touches
+the database directly.**
+
+---
+
+## ⚠️ Read this before you run anything
+
+1. **Dry-run is the default.** A bare invocation is **read-only**: it prints the
+   exact write it *would* send and exits. You must pass **`--apply`** to write.
+   (This deliberately inverts the donor management commands, which wrote unless
+   you passed `--dry-run`.)
+2. **Writing to a non-loopback host needs three things at once:** `--apply`
+   **and** `--allow-remote-writes` **and** a Bearer `--api-token`. Miss any one
+   and the client refuses the PATCH. Reads are never gated.
+3. **`convert` is loopback-only, by design.** It refuses *any* non-`127.0.0.1` /
+   `localhost` base URL (`convert.py:180`) — there is **no** remote-write escape
+   for it, because it uploads hundreds of materials. Run it against a local
+   mirror, never against production.
+4. **Each enricher writes exactly one field.** Blast radius is one JSON field per
+   case per stage (see the field-ownership table). Re-running is safe: an
+   already-enriched case is skipped, not double-written.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph src["Sourcing / selection (READ-ONLY)"]
+        MASTER[("master CSV<br/>proposes slug + candidate IRIs")]
+        SEL["select_batch<br/>live GET, drop already-bound"]
+        BATCH[("batch CSV")]
+        MASTER --> SEL --> BATCH
+    end
+
+    subgraph bind["Attach materials"]
+        BIND["bind_materials<br/>verify -> merge -> PATCH evidence[]<br/>(If-Match, DRAFT-only)"]
+    end
+
+    subgraph convert["Prepare text (LOOPBACK ONLY)"]
+        CONV["convert<br/>RAW/ALTERNATE -> MARKDOWN material"]
+    end
+
+    subgraph enrich["LLM enrichment — one field each"]
+        BIGO["enrich_missing_bigo -> bigo"]
+        TAGS["enrich_tags -> tags"]
+        TL["enrich_timeline -> timeline"]
+        ALG["enrich_allegations -> key_allegations"]
+        ENT["enrich_related_entities -> entities"]
+    end
+
+    subgraph obs["Observability"]
+        LOGS[("work/enricher-runs/<br/>*.log + *.events.jsonl")]
+        LEDGER["ledger<br/>events.jsonl -> current-state ledger"]
+    end
+
+    API[("Case API<br/>CaseworkApi over HTTP")]
+
+    BATCH --> BIND --> API
+    API --> CONV --> API
+    API --> BIGO --> API
+    API --> TAGS --> API
+    API --> TL --> API
+    API --> ALG --> API
+    API --> ENT --> API
+
+    BIND -.-> LOGS
+    CONV -.-> LOGS
+    enrich -.-> LOGS
+    LOGS --> LEDGER
+```
+
+### Shared layer (`casework/common/`)
+
+| Module | Responsibility |
+|--------|----------------|
+| `api.py` | `CaseworkApi` — the only HTTP client. Bearer or Basic auth; **write-guard** refuses non-loopback PATCH unless `allow_remote_writes=True`. |
+| `cli.py` | Shared argparse (`add_common_args`), run-logging (`configure_run_logging`, `log_event`, run header/footer), `basic_auth_from_env`. |
+| `llm.py` | `bootstrap(provider, model, dev)` — routes each stage through its premium/cheap LLM **tier**. |
+| `pipeline.py` | The **stage DAG** (`STAGES`) + `unmet_prerequisites` — the single source of "what depends on what" and "why a stage did *not* run". |
+| `select.py` | Case selection: `select_for_run` (the one path every enricher uses), the `--batch-csv` allowlist loader, fiscal-year and state gates. |
+| `materials.py` | Material existence probes, `source_text`, MARKDOWN-role helpers. |
+| `parse.py` | Robust, string-aware JSON extraction from LLM output. |
+| `titles.py` | Case-title / court-context helpers. |
+
+---
+
+## Design
+
+### The prerequisite DAG
+
+`convert` is the gate every LLM stage waits on: a case with evidence bound but no
+MARKDOWN-role material cannot be enriched. That is reported as an **explicit
+unmet prerequisite**, never as a silent skip that looks like "already done".
+
+```mermaid
+flowchart LR
+    BIND["bind_materials<br/>(evidence[])"] --> CONV["convert<br/>provides MARKDOWN"]
+    CONV --> BIGO["bigo<br/>needs press + MARKDOWN"]
+    BIGO -. ordering only .-> TAGS["tags<br/>no material; case fields only"]
+    CONV --> TL["timeline<br/>needs press OR court"]
+    CONV --> ALG["allegations<br/>needs press"]
+    CONV --> ENT["entities<br/>needs press OR court"]
+```
+
+- **`tags` gates on `bigo` for ordering only** — it reads no material and the
+  donor tags cases fine with an unknown amount, so a hard material gate would
+  skip cases the donor does not skip.
+- **`timeline` / `entities` accept press *or* court** content — gating on press
+  alone would strand court-order-only cases.
+
+### Field ownership & write targets
+
+| Stage | Module (`python -m casework.…`) | Writes | Endpoint | Remote write? | LLM tier |
+|-------|--------------------------------|--------|----------|---------------|----------|
+| select | `select_batch` | batch CSV (local file) | GET only | **read-only** | — |
+| bind | `bind_materials` | `evidence[]` | `PATCH /evidence` (If-Match) | yes ¹ | — |
+| convert | `convert` | MARKDOWN material | `POST /api/materials/<s>/<i>/file` | **loopback only** | — |
+| bigo | `enrich_missing_bigo` | `bigo` | `patch_field` | yes ¹ | premium |
+| tags | `enrich_tags` | `tags` | `patch_field` | yes ¹ | cheap |
+| timeline | `enrich_timeline` | `timeline` | `patch_field` | yes ¹ | premium |
+| allegations | `enrich_allegations` | `key_allegations` | `patch_field` | yes ¹ | premium |
+| entities | `enrich_related_entities` | `entities` | `patch_field` | yes ¹ | premium |
+| ledger | `ledger` | ledger JSON (local file) | none (reads run logs) | local file | — |
+
+¹ Remote write requires **`--apply` + `--allow-remote-writes` + `--api-token`** together.
+
+### Auth matrix
+
+| Target | Auth | How |
+|--------|------|-----|
+| Remote / production API | Bearer token | `--api-token …` or `JAWAFDEHI_API_TOKEN` |
+| Local DEV_AUTH (loopback) | HTTP Basic | `CASEWORK_API_USER` + `CASEWORK_API_PASSWORD` |
+
+There is deliberately **no baked-in dev credential fallback** — a missing
+credential fails loud rather than silently authenticating as a dev account.
+
+### Run logging & the ledger loop
+
+Each run gets a `run_id` and writes two files under `work/enricher-runs/`
+(override with `CASEWORK_RUN_LOG_DIR`):
+
+- `…-<stage>-<run_id>.log` — human-readable, UTC-timestamped
+- `…-<stage>-<run_id>.events.jsonl` — one JSON event per case/step
+
+`ledger.py` folds all `*.events.jsonl` into a **current-state ledger** keyed by
+`(slug, stage)`, latest-by-timestamp, ignoring non-outcome statuses
+(`ok`/`start`/`fallback`/`none`/`planned`). That is how you answer "what is the
+enrichment state of every case right now" without re-reading the API.
+
+---
+
+## Adding a new stage
+
+Start with one question: **does your stage write `evidence` or `entities`?**
+Those two are whole-list replaces and will delete data if you get them wrong.
+Everything else is a plain field write and is safe.
+
+### Writing a plain field — `bigo`, `tags`, a new `verdict`
+
+Use `patch_field`. It sends one op naming one path, and the server rewrites
+nothing else (`cases/api_views.py:940` gates every relation on whether the patch
+actually names it).
+
+```python
+case, etag = api.get_case_with_etag(slug)
+api.patch_field(slug, "verdict", "ACQUITTED", if_match=etag)
+```
+
+Nothing else on the case changes — verified: each of the five enrichers was run
+against a bound case and left its `evidence` rows and their notes untouched.
+
+### Writing `evidence` or `entities` — read, merge, send the whole list
+
+`PATCH /evidence` **replaces the entire list.** The server deletes every existing
+row and recreates from exactly what you send (`_write_material_references`,
+`cases/api_views.py:647`). Send only your new document and you delete the press
+release and court order someone bound last month.
+
+Never send a delta. Read the case, merge into what is already there, send it all:
+
+```python
+from casework.bind_materials import current_evidence, merge_evidence
+
+case, etag = api.get_case_with_etag(slug)
+merged = merge_evidence(current_evidence(case), [new_iri])   # append, keep order
+api.replace_list(slug, "evidence", merged, if_match=etag)
+```
+
+`merge_evidence` de-duplicates and preserves both the order and the
+`additional_details` note of every row already on the case.
+
+### A news enricher, concretely
+
+News is the obvious next stage, and it is an `evidence` writer — so it lands in
+the dangerous category above. Every published case carries news: sampling 40 of
+them gives `news` on **40/40**, alongside `press_release` (14), `court_order`
+(10), `legal_corpus` (7), `charge_sheet` (5), `document` (2), `official_report`
+(1) and `social_media` (1). Three to eight documents per case is normal.
+
+So a news stage runs on cases that already hold a press release and a court
+order, and must add to that list rather than become it. Two options, in
+preference order:
+
+1. **Reuse `bind_materials`.** Emit a batch CSV with a news-IRI column and add
+   that column name to `DEFAULT_MATERIAL_COLUMNS`. You inherit the merge, the
+   existence probe, the DRAFT gate, the `If-Match`, and the abort-on-uncertain
+   behaviour for free. This is how `abhiyog_ag_iri` already works.
+2. **Write a stage that calls `replace_list` directly.** Only if the search for
+   candidate articles has to happen inside the stage. Then you own the merge, and
+   you must follow the pattern above exactly.
+
+### Register the stage — only if it writes a case field
+
+`STAGES` in `common/pipeline.py` holds the six LLM/convert stages. `provides`
+names the **case field** a stage fills (`bigo`, `tags`, `timeline`,
+`key_allegations`, `entities`) or the literal `MARKDOWN` role. It feeds the
+"already done, skip it" check.
+
+A stage that only attaches documents does **not** belong here — `bind_materials`
+is deliberately absent from the registry, because it fills no case field. So a
+news *binder* is registered nowhere; it is a sibling of `bind_materials`.
+
+Register only if you write a case field. A stage that reads news articles to fill
+one looks like this:
+
+```python
+"press_summary": Stage(
+    "press_summary", provides=("short_description",),
+    requires_materials=("news",),
+    requires_stages=("convert",),      # news must be MARKDOWN before it is read
+),
+```
+
+Only list what your stage actually writes. A phantom `provides` entry makes cases
+look complete that you never touched.
+
+### Before you call it done
+
+- `--dry-run` defaults to **on**; `--apply` opts in. Get this from
+  `add_common_args`, do not re-implement it.
+- Pass `if_match=etag` on every write. Without it a concurrent edit is silently
+  overwritten instead of failing with 412.
+- Read the token from `$JAWAFDEHI_API_TOKEN` rather than `--api-token`. A token
+  passed on the command line sits in `/proc/<pid>/cmdline` (mode 444) for the
+  whole run and is readable by every local user via `ps -af`; the environment
+  lands in `/proc/<pid>/environ` (mode 400), which is not.
+- One stage writes one field. Keeps the blast radius to a single JSON field.
+- If the stage writes `evidence` or `entities`, add a test that binds a case,
+  runs your stage, and asserts the pre-existing rows survive with their notes.
+
+---
+
+## Running the scripts
+
+### Environment
+
+```bash
+uv sync                                   # base install
+uv sync --extra bigo-enrichment           # + markitdown/likhit, required ONLY for `convert`
+
+# Target + auth (pick per target):
+export JAWAFDEHI_API_BASE="http://127.0.0.1:48010"     # local DEV_AUTH server
+# remote instead:  export JAWAFDEHI_API_BASE="https://api.jawafdehi.org"
+export JAWAFDEHI_API_TOKEN="…"            # Bearer, for remote writes
+export CASEWORK_API_USER="…"              # Basic, for loopback DEV_AUTH
+export CASEWORK_API_PASSWORD="…"
+```
+
+> All commands below assume `JAWAFDEHI_API_BASE` is set. Pass `--api-base-url`
+> explicitly to override it per-run. Add `--verbose` for DEBUG logging,
+> `--limit N` to cap cases, `--slug <slug>` (repeatable) to target specific cases.
+
+### Common flags (`add_common_args`)
+
+`--slug` · `--court-case` · `--batch-csv` · `--limit` · `--fiscal-year` ·
+`--force` · `--dry-run` (default) · `--apply` · `--provider` (default
+`claude_cli`) · `--model` · `--api-base-url` · `--api-token` ·
+`--allow-remote-writes` · `--verbose`
+
+#### Restricting a run to a batch — `--batch-csv`
+
+Every enricher takes the same batch CSV `bind_materials` does: a `slug` column,
+extra columns ignored. So a `select_batch` output feeds straight into enrichment.
+
+```bash
+# Only the 238 slugs in this file are touched — the first 10 rows of it
+uv run python -m casework.enrich_missing_bigo \
+    --batch-csv work/2026-08-03-Dry-run-bigo-enricher/batch-238.csv \
+    --limit 10 --verbose
+```
+
+It is a hard allowlist. No case outside the file is selected, results come back
+in file order so `--limit N` means the file's first N rows, and `--slug` or
+`--fiscal-year` alongside it can only narrow the set further.
+
+Two behaviours worth knowing:
+
+- A batch **still passes the DRAFT/IN_REVIEW state gate**, unlike `--slug`,
+  which bypasses it. A stale row for a case that has since been PUBLISHED is
+  skipped rather than re-enriched. Use `--slug` when you mean to override.
+- A missing file, a missing `slug` column, or a file with no slugs **exits
+  immediately**. An empty allowlist would otherwise fall through to bulk
+  selection and enrich every enrichable case.
+
+---
+
+### 0. Select the next batch — `select_batch` (read-only)
+
+```bash
+# READ-ONLY: GETs only, writes a local batch CSV. No --apply.
+uv run python -m casework.select_batch \
+    --master-csv master.csv --out batch2.csv \
+    --year 078 --year 079 --limit 50
+```
+
+### 1. Bind materials — `bind_materials`
+
+```bash
+# DRY-RUN (default): print the exact PATCH it would send
+uv run python -m casework.bind_materials --batch-csv batch2.csv --dry-run
+
+# APPLY (loopback)
+uv run python -m casework.bind_materials --batch-csv batch2.csv --apply
+
+# APPLY (remote / production)
+uv run python -m casework.bind_materials --batch-csv batch2.csv \
+    --api-base-url https://api.jawafdehi.org --api-token "$JAWAFDEHI_API_TOKEN" \
+    --apply --allow-remote-writes
+```
+
+### 2. Convert RAW → MARKDOWN — `convert` (loopback only)
+
+```bash
+# DRY-RUN
+uv run python -m casework.convert --dry-run
+
+# APPLY — LOOPBACK ONLY; refuses any non-127.0.0.1/localhost host
+uv run python -m casework.convert --slug case-0123 --apply
+```
+
+### 3. Enrich fields (run per stage)
+
+Each takes the same dry-run/apply/remote pattern. Shown for `bigo`; the others
+are identical apart from the module name.
+
+```bash
+# DRY-RUN
+uv run python -m casework.enrich_missing_bigo --dry-run
+
+# APPLY (loopback)
+uv run python -m casework.enrich_missing_bigo --apply
+
+# APPLY (remote / production)
+uv run python -m casework.enrich_missing_bigo \
+    --api-base-url https://api.jawafdehi.org --api-token "$JAWAFDEHI_API_TOKEN" \
+    --apply --allow-remote-writes
+```
+
+| Stage | Dry-run | Apply (loopback) |
+|-------|---------|------------------|
+| bigo | `uv run python -m casework.enrich_missing_bigo --dry-run` | `… --apply` |
+| tags | `uv run python -m casework.enrich_tags --dry-run` | `… --apply` (add `--no-llm` for rules-only) |
+| timeline | `uv run python -m casework.enrich_timeline --dry-run` | `… --apply` |
+| allegations | `uv run python -m casework.enrich_allegations --dry-run` | `… --apply` |
+| entities | `uv run python -m casework.enrich_related_entities --dry-run` | `… --apply` |
+
+For every "Apply (loopback)" cell above, the **remote/production** form adds:
+`--api-base-url https://api.jawafdehi.org --api-token "$JAWAFDEHI_API_TOKEN" --allow-remote-writes`.
+
+### 4. Consolidate run logs — `ledger`
+
+```bash
+# Fold every events.jsonl in the run-log dir into a current-state ledger
+uv run python -m casework.ledger
+
+# Scope it, or inspect without writing
+uv run python -m casework.ledger --stage bigo --stage tags --status ok
+uv run python -m casework.ledger --no-write        # print only, don't write ledger file
+```
+
+---
+
+## End-to-end production runbook
+
+Ordered, dependency-respecting sequence for one batch. **Dry-run each step, read
+the summary, then re-run with `--apply`.**
+
+```bash
+# 1. Select — read-only
+uv run python -m casework.select_batch --master-csv master.csv --out batch.csv --year 078 --limit 50
+
+# 2. Bind evidence  (dry-run -> apply)
+uv run python -m casework.bind_materials --batch-csv batch.csv --dry-run
+uv run python -m casework.bind_materials --batch-csv batch.csv --api-token "$JAWAFDEHI_API_TOKEN" --apply --allow-remote-writes
+
+# 3. Convert to MARKDOWN  (LOOPBACK mirror only)
+uv run python -m casework.convert --batch-csv batch.csv --dry-run
+uv run python -m casework.convert --batch-csv batch.csv --apply
+
+# 4. Enrich — bigo first (tags orders after it), then the rest.
+#    --batch-csv on EVERY stage: without it each one selects the whole corpus
+#    (~3,000 enrichable cases), not the 50 you just bound.
+for stage in enrich_missing_bigo enrich_tags enrich_timeline enrich_allegations enrich_related_entities; do
+  uv run python -m casework.$stage --batch-csv batch.csv --dry-run
+  uv run python -m casework.$stage --batch-csv batch.csv --api-token "$JAWAFDEHI_API_TOKEN" --apply --allow-remote-writes
+done
+
+# 5. Consolidate the run into a state ledger
+uv run python -m casework.ledger
+```
+
+### Preflight checklist before `--apply`
+
+- [ ] `JAWAFDEHI_API_BASE` points where you think it does (`echo` it).
+- [ ] Dry-run output shows the expected case count and the exact field/value.
+- [ ] For remote: `--api-token` set **and** `--allow-remote-writes` present.
+- [ ] `convert` is running against loopback (it will refuse otherwise).
+- [ ] You have the run-log dir (`work/enricher-runs/`) writable.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `refusing … non-loopback` on write | Remote PATCH without the gate | Add `--allow-remote-writes` (and `--api-token`). |
+| `convert … refusing to upload` | `convert` pointed at a non-loopback host | Point it at `127.0.0.1`; convert never writes remote. |
+| HTTP **412** on bind | Case changed between read and write (If-Match) | Re-select and re-bind; the guard prevented a clobber. |
+| HTTP **422** on timeline, whole PATCH lost | One malformed `date_bs` fails the server's `^\d{4}-\d{2}-\d{2}$` | Already mitigated: bad `date_bs` is coerced, else that field is dropped. Check the event log for the offending case. |
+| Case **skipped**, not enriched | Unmet prerequisite (no MARKDOWN) or already enriched | Run `convert` first; check the run log — the reason is explicit. |
+| Bind **aborts** a case | A candidate material was "uncertain" (not a clean 200/absent) | Intentional: never a partial write. Resolve the material, re-run. |
+| `API credentials required` | No `--api-token` and no `CASEWORK_API_USER/PASSWORD` | Set the auth for your target (see Auth matrix). |
+
+---
+
+## Testing
+
+```bash
+DEBUG=True uv run pytest tests/casework/         # full casework suite
+DEBUG=True uv run ruff check casework/           # lint
+```

--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -436,9 +436,11 @@ def _plan_to_dict(p):
 
 def build_parser():
     parser = argparse.ArgumentParser(description="Bind lake materials to case evidence.")
-    add_common_args(parser)
-    parser.add_argument("--batch-csv", required=True,
-                        help="CSV with a `slug` column and material-IRI columns.")
+    # --batch-csv comes from add_common_args (the enrichers share it now);
+    # registering a second one here raises ArgumentError at import-time.
+    add_common_args(
+        parser, batch_csv_required=True,
+        batch_csv_help="CSV with a `slug` column and material-IRI columns.")
     parser.add_argument("--report", default="",
                         help="Optional path to write a JSON run report.")
     return parser

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -65,14 +65,28 @@ class CaseworkApi:
                 "production default) or `basic=(username, password)` "
                 "(HTTP Basic, local DEV_AUTH only) -- never both, never neither"
             )
-        if basic is not None:
-            host = urllib.parse.urlparse(self.base_url).hostname
-            if host not in LOOPBACK_HOSTS:
-                raise ValueError(
-                    f"basic= is only permitted against loopback (127.0.0.1 or "
-                    f"localhost); refusing to send Basic auth to {base_url!r} -- "
-                    "use `token` (Bearer) for any non-local host"
-                )
+        parsed = urllib.parse.urlparse(self.base_url)
+        is_loopback = parsed.hostname in LOOPBACK_HOSTS
+        if basic is not None and not is_loopback:
+            raise ValueError(
+                f"basic= is only permitted against loopback (127.0.0.1 or "
+                f"localhost); refusing to send Basic auth to {base_url!r} -- "
+                "use `token` (Bearer) for any non-local host"
+            )
+        # `_headers` attaches the credential to EVERY request, reads included,
+        # and the write-guard below only inspects the host -- not the scheme. An
+        # `http://` remote base URL therefore put a production token on the wire
+        # in cleartext (CWE-319), for runs that last hours. Loopback stays
+        # exempt: a local DEV_AUTH server has no TLS and the token never leaves
+        # the host, so requiring https there would break every local run for no
+        # gain.
+        if not is_loopback and parsed.scheme != "https":
+            raise ValueError(
+                f"refusing to send credentials to {base_url!r} over "
+                f"{parsed.scheme or 'no'} -- a remote base_url must use https, "
+                "or the Authorization header travels in cleartext. Use "
+                "http://127.0.0.1:48010 for a local DEV_AUTH server."
+            )
         self.token = token
         self.basic = basic
         # Write-guard opt-in. False (the default) means `_patch` refuses any

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -156,17 +156,44 @@ class CaseworkApi:
     # requests. Callers can still override via `params`.
     PAGE_SIZE = 200
 
-    def iter_cases(self, params=None, timeout=60):
+    def iter_cases(self, params=None, timeout=60, progress=None):
+        """Yield every case, following pagination.
+
+        Even at `PAGE_SIZE`, listing production is 16 sequential requests and
+        ~33s, and it runs before an enricher does a single case of work. With no
+        output during it a run is indistinguishable from a hang, so each page
+        reports `(page, fetched, total)` as soon as it lands -- during the wait,
+        not after it.
+
+        `progress` is called with those as keywords. Pass one to route the
+        report into a run's own logger and events file; the default logs to
+        `casework.api`, so an enricher that wires nothing still narrates.
+        """
         page, params = 1, dict(params or {})
         params.setdefault("page_size", self.PAGE_SIZE)
+        progress = progress or self._log_list_progress
+        fetched = 0
         while True:
             params["page"] = page
             data = self.get("/cases/", params, timeout)
-            for case in data.get("results", []):
-                yield case
+            results = data.get("results", [])
+            fetched += len(results)
+            # Report before yielding: a consumer that stops early still gets a
+            # record of the work already paid for.
+            progress(page=page, fetched=fetched, total=data.get("count"))
+            yield from results
             if not data.get("next"):
                 return
             page += 1
+
+    @staticmethod
+    def _log_list_progress(page, fetched, total):
+        """Default `iter_cases` reporter. `total` is absent on an uncountable
+        paginator, so the denominator degrades to '?' rather than raising."""
+        logger.info(
+            "case list: page %s, %s/%s fetched", page, fetched,
+            total if total is not None else "?",
+        )
 
     def get_case(self, slug, timeout=60):
         """Detail endpoint -- the ONLY one that resolves `material` on evidence."""

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -148,8 +148,17 @@ class CaseworkApi:
         with self._request("GET", url, headers=self._headers(), timeout=timeout) as r:
             return json.loads(r.read().decode())
 
+    # The list endpoint's server-side default is 20 per page, so walking all
+    # 3,003 cases costs 151 round trips -- ~2m45s against production, paid by
+    # every enricher run before it processes a single case. The API caps
+    # page_size at 200 (measured 2026-08-03: page_size=200/500/1000 all return
+    # 200 results), so 200 is the largest useful ask and brings that to 16
+    # requests. Callers can still override via `params`.
+    PAGE_SIZE = 200
+
     def iter_cases(self, params=None, timeout=60):
         page, params = 1, dict(params or {})
+        params.setdefault("page_size", self.PAGE_SIZE)
         while True:
             params["page"] = page
             data = self.get("/cases/", params, timeout)

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -1,5 +1,6 @@
 """Shared argparse, logging and reporting for casework enricher CLIs."""
 
+import argparse
 import json
 import logging
 import os
@@ -53,8 +54,51 @@ def _api_token_default():
     return os.environ.get("JAWAFDEHI_API_TOKEN", "")
 
 
-def add_common_args(parser):
+def _batch_csv_arg(value):
+    """argparse ``type`` for ``--batch-csv``: reject bad paths at parse time.
+
+    Two failures this closes, both of which otherwise surface far too late:
+
+    An **empty value** must not mean "no batch". ``--batch-csv "$BATCH"`` with an
+    unset or misspelled variable reaches argparse as ``""``, which argparse
+    accepts happily; ``select_for_run`` would then read it as "no batch given"
+    and fall through to bulk selection over every DRAFT/IN_REVIEW case in the
+    corpus. That is the precise inverse of what the flag is for, and it is
+    silent -- the run just looks bigger than expected.
+
+    A **missing file** must not cost a corpus walk first. ``select_for_run``
+    runs after ``iter_cases``, so validating there means a typo pays ~16 pages
+    of HTTP before exiting. Checking here costs one ``stat``.
+    """
+    path = value.strip()
+    if not path:
+        raise argparse.ArgumentTypeError(
+            "needs a path to a CSV; got an empty value. An unset shell "
+            "variable expands to '', and an empty batch would otherwise widen "
+            "the run to every enrichable case.")
+    if not os.path.isfile(path):
+        raise argparse.ArgumentTypeError(f"file not found: {path}")
+    return path
+
+
+_BATCH_CSV_HELP = (
+    "CSV with a `slug` column -- the same format `bind_materials.py "
+    "--batch-csv` consumes, so a `select_batch.py` batch feeds straight in. "
+    "Acts as a HARD allowlist: no case outside the file is ever touched, and "
+    "`--limit N` takes the file's first N rows. Other selectors can only "
+    "narrow it. Unlike --slug, a batch still passes the DRAFT/IN_REVIEW state "
+    "gate, so a stale row for a since-PUBLISHED case is skipped rather than "
+    "re-enriched.")
+
+
+def add_common_args(parser, *, batch_csv_required=False, batch_csv_help=None):
     """Register the CLI flags every ported enricher shares.
+
+    ``batch_csv_required`` / ``batch_csv_help`` exist for ``bind_materials.py``,
+    which needs ``--batch-csv`` to be mandatory and documents extra
+    material-IRI columns the enrichers ignore. It used to register its own copy
+    of the flag on top of this one, which raised ``ArgumentError: conflicting
+    option string`` and stopped the whole tool from starting.
 
     `--dry-run` defaults to True and `--apply` opts into writes. This
     deliberately INVERTS the donor's default: the donor's `add_common_args`
@@ -69,6 +113,10 @@ def add_common_args(parser):
     """
     parser.add_argument("--slug", action="append", default=[])
     parser.add_argument("--court-case", action="append", default=[])
+    parser.add_argument(
+        "--batch-csv", type=_batch_csv_arg, default=None,
+        required=batch_csv_required,
+        help=batch_csv_help or _BATCH_CSV_HELP)
     parser.add_argument("--limit", type=int, default=0)
     parser.add_argument("--fiscal-year", default="")
     parser.add_argument("--force", action="store_true")

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -31,6 +31,28 @@ def basic_auth_from_env():
     return user, password
 
 
+def _api_token_default():
+    """`$JAWAFDEHI_API_TOKEN`, unless local DEV_AUTH Basic credentials are set.
+
+    Every enricher's `build_api` is `if args.api_token: Bearer else Basic`, so an
+    env-var default silently reroutes ALL runs to Bearer -- including loopback
+    ones. That breaks local DEV_AUTH: per `CaseworkApi`'s docstring a `Bearer`
+    header is always routed to `OIDCAuthentication` and never falls through to
+    DRF's Basic authenticator, so `convert.py --api-base-url http://127.0.0.1:48010
+    --apply` would 401 on every upload, and it would send a production token to
+    whatever is listening on that port.
+
+    Deferring to `CASEWORK_API_USER`/`CASEWORK_API_PASSWORD` resolves it without a
+    new flag: those have no defaults anywhere (see `basic_auth_from_env`), so
+    having them set is an explicit statement that this shell targets local dev.
+    `--api-token` still overrides, for the rare case of testing a real token
+    against a local server.
+    """
+    if os.environ.get("CASEWORK_API_USER") and os.environ.get("CASEWORK_API_PASSWORD"):
+        return ""
+    return os.environ.get("JAWAFDEHI_API_TOKEN", "")
+
+
 def add_common_args(parser):
     """Register the CLI flags every ported enricher shares.
 
@@ -71,7 +93,14 @@ def add_common_args(parser):
              "neither the flag nor the env var is set, the client raises rather "
              "than silently targeting a host. Local DEV_AUTH server: "
              "http://127.0.0.1:48010")
-    parser.add_argument("--api-token", default="")
+    parser.add_argument(
+        "--api-token", default=_api_token_default(),
+        help="Bearer token for the case API; defaults to $JAWAFDEHI_API_TOKEN "
+             "unless local DEV_AUTH Basic credentials are configured. PREFER THE "
+             "ENV VAR: a token passed as a flag is visible to every local user in "
+             "/proc/<pid>/cmdline for the life of the run, and these runs are "
+             "hours long. The env var is what `basic_auth_from_env`'s error "
+             "message has always told operators to set.")
     parser.add_argument(
         "--allow-remote-writes", action="store_true", default=False,
         help=(
@@ -252,10 +281,20 @@ def log_run_header(logger, *, stage, base_url, dry_run, provider, model,
     logger.info("\n".join(lines))
 
 
+def format_counts(stats: dict) -> str:
+    """`"a=1, b=2"` from a status->count mapping, sorted for stable output.
+
+    Shared so the `.log` footer and the `run/complete` event in `*.events.jsonl`
+    cannot drift apart -- the ledger and the human log should agree on how a run
+    finished.
+    """
+    return ", ".join(f"{k}={v}" for k, v in sorted(stats.items())) or "(no cases)"
+
+
 def log_run_footer(logger, *, stage, stats: dict, duration_s: float,
                    usage_summary: str = "") -> None:
     """One INFO block: per-status counts, wall-clock duration, usage summary."""
-    counts = ", ".join(f"{k}={v}" for k, v in sorted(stats.items())) or "(no cases)"
+    counts = format_counts(stats)
     lines = [
         f"=== casework run complete: {stage} ===",
         f"  counts   : {counts}",

--- a/casework/common/pipeline.py
+++ b/casework/common/pipeline.py
@@ -71,6 +71,21 @@ STAGES = {
     # of its own -- it IS the thing every other stage's prerequisite check
     # is waiting on.
     "convert": Stage("convert", provides=("MARKDOWN",)),
+    # bigo is PRESS-ONLY on purpose -- do NOT widen this to COURT_TYPES the way
+    # `timeline`/`entities` do. That was tried and measured on the 238 bound
+    # FY078/079 cases (2026-08-03) and reverted:
+    #   - Court orders averaged 52k chars sent vs 2.4k for press releases -- 22x
+    #     the input on EVERY case, ~2 min/case vs ~15s, projecting ~8h and >$100
+    #     for a run that costs $23 press-only.
+    #   - It only changed the answer on the multi-defendant subset (roughly 18 of
+    #     238), where the press release states per-defendant figures and no total.
+    #   - `bigo` is the ALLEGED loss. The press release IS the charge-stage claim;
+    #     the judgment records what was ESTABLISHED, which can be reduced or
+    #     overturned. So for this field the judgment is the wrong primary source,
+    #     not merely an expensive one.
+    # Press-only measured 235/238 acceptable. If the multi-defendant subset ever
+    # needs a real total, bind the charge sheet (small, and the document the field
+    # is defined against) rather than reading the judgment on all of them.
     "bigo": Stage(
         "bigo", provides=("bigo",),
         requires_materials=PRESS_TYPES,

--- a/casework/common/select.py
+++ b/casework/common/select.py
@@ -1,5 +1,8 @@
 """Case selection against the current control-plane payload shape."""
 
+import csv
+import os
+
 COURTCASE_SEGMENT = "/courtcase/"
 SPECIAL_COURT = "special"
 ENRICHABLE_STATES = ("DRAFT", "IN_REVIEW")
@@ -73,9 +76,75 @@ def is_enrichable_state(case):
     return case.get("state") in ENRICHABLE_STATES
 
 
-def select_cases(cases, *, fiscal_year=None, slugs=(), court_cases=()):
-    """Explicit slugs/court-cases bypass the state gate; bulk selection does not."""
+def slugs_from_batch_csv(path):
+    """Ordered, de-duplicated slugs from a batch CSV's ``slug`` column.
+
+    Same format the binder consumes (``bind_materials.py --batch-csv``), so a
+    CSV produced by ``select_batch.py`` feeds the enrichers unchanged; extra
+    columns (material IRIs, bigo, tiers) are ignored.
+
+    File order is preserved because it is load-bearing: ``--limit N`` must
+    mean "the first N rows I listed", not "N arbitrary rows".
+
+    Every failure here is a hard ``SystemExit`` rather than an empty list. An
+    empty list would reach ``select_cases`` as an empty allowlist, which falls
+    through to BULK selection -- so a truncated, mis-columned or misspelled
+    batch file would silently enrich every enrichable case instead of nothing.
+    Read with ``utf-8-sig`` so an Excel-exported BOM cannot turn the ``slug``
+    header into ``\\ufeffslug`` and trip the missing-column path.
+    """
+    if not os.path.isfile(path):
+        raise SystemExit(f"--batch-csv not found: {path}")
+    seen, out = set(), []
+    with open(path, newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        if not reader.fieldnames or "slug" not in reader.fieldnames:
+            raise SystemExit(
+                f"--batch-csv {path} has no `slug` column (found: "
+                f"{', '.join(reader.fieldnames or []) or 'nothing'})")
+        for row in reader:
+            slug = (row.get("slug") or "").strip()
+            if not slug or slug in seen:
+                continue
+            seen.add(slug)
+            out.append(slug)
+    if not out:
+        raise SystemExit(f"--batch-csv {path} lists no slugs")
+    return out
+
+
+def select_cases(cases, *, fiscal_year=None, slugs=(), court_cases=(), batch_slugs=None):
+    """Explicit slugs/court-cases bypass the state gate; bulk selection does not.
+
+    ``batch_slugs`` (from ``--batch-csv``) is a HARD allowlist: nothing outside
+    it is ever selected, and results come back in batch order so ``--limit``
+    takes the operator's first rows. Any other selector can only narrow that
+    set further, never widen it.
+
+    Unlike the ``slugs=``/``court_cases=`` bypass, a batch still passes the
+    state gate. The asymmetry is deliberate: a stale batch CSV listing a case
+    that has since been PUBLISHED must not be re-enriched, and the two error
+    directions are not equally costly -- over-selection is invisible in the
+    console and writes to reviewed cases, while under-selection shows up as an
+    ``n_selected`` lower than the batch's row count. Use ``--slug`` for a
+    deliberate one-off override of the gate.
+    """
     slugs, court_cases = set(slugs), {c.lower() for c in court_cases}
+    if batch_slugs is not None:
+        by_slug = {c.get("slug"): c for c in cases}
+        picked = []
+        for slug in batch_slugs:
+            case = by_slug.get(slug)
+            if case is None or not is_enrichable_state(case):
+                continue
+            if (slugs or court_cases) and not (
+                slug in slugs or court_number(case) in court_cases
+            ):
+                continue
+            if not matches_fiscal_year(case, fiscal_year):
+                continue
+            picked.append(case)
+        return picked
     if slugs or court_cases:
         return [
             c for c in cases
@@ -85,3 +154,33 @@ def select_cases(cases, *, fiscal_year=None, slugs=(), court_cases=()):
         c for c in cases
         if is_enrichable_state(c) and matches_fiscal_year(c, fiscal_year)
     ]
+
+
+def select_for_run(cases, args):
+    """The one selection path every enricher uses: batch + filters + ``--limit``.
+
+    Replaces the five copies of "call ``select_cases``, then slice by
+    ``args.limit``" that had drifted across the enrichers. Centralising it is
+    what makes ``--limit`` respect batch order everywhere instead of only
+    wherever it was wired by hand.
+    """
+    batch = getattr(args, "batch_csv", None)
+    if batch is not None and not str(batch).strip():
+        # The flag is present but empty. `--batch-csv "$BATCH"` with an unset
+        # variable gets here. Treating it as "no batch" would silently widen the
+        # run to the whole corpus, so refuse instead. `_batch_csv_arg` already
+        # blocks this at parse time; this covers programmatic callers that build
+        # an args namespace by hand.
+        raise SystemExit(
+            "--batch-csv was given an empty path -- refusing to fall back to a "
+            "full-corpus run. Check the variable you passed is set.")
+    batch_slugs = slugs_from_batch_csv(batch) if batch else None
+    selected = select_cases(
+        cases,
+        fiscal_year=args.fiscal_year,
+        slugs=args.slug,
+        court_cases=args.court_case,
+        batch_slugs=batch_slugs,
+    )
+    limit = getattr(args, "limit", 0)
+    return selected[:limit] if limit else selected

--- a/casework/convert.py
+++ b/casework/convert.py
@@ -51,6 +51,7 @@ from casework.common.cli import (
 )
 from casework.common.materials import markdown_link, raw_links
 from casework.common.pipeline import COURT_TYPES, PRESS_TYPES, RunReport
+from casework.common.select import slugs_from_batch_csv
 
 log = logging.getLogger("casework.convert")
 
@@ -216,6 +217,32 @@ def build_api(args):
     )
 
 
+def slugs_for_run(api, args):
+    """Which case slugs this run converts, honouring ``--batch-csv``.
+
+    convert calls ``add_common_args``, so ``--batch-csv`` shows up in its
+    ``--help``; before this it was accepted and ignored, and the run silently
+    converted every case in the corpus while the README promised a hard
+    allowlist. The batch is read straight from the file rather than through
+    ``select_for_run`` so an explicit batch still costs no ``iter_cases`` walk,
+    and because conversion touches materials rather than case content -- the
+    DRAFT/IN_REVIEW state gate the enrichers apply to a batch is not meaningful
+    here. The allowlist property is what matters and it holds: no slug outside
+    the file is returned.
+
+    ``--fiscal-year`` and ``--court-case`` remain accepted-and-ignored here.
+    Both predate the batch work; wiring them in needs a corpus walk, which is
+    a bigger change than this fix.
+    """
+    if getattr(args, "batch_csv", None):
+        slugs = slugs_from_batch_csv(args.batch_csv)
+    elif args.slug:
+        slugs = list(args.slug)
+    else:
+        slugs = [c.get("slug") for c in api.iter_cases()]
+    return slugs[:args.limit] if args.limit else slugs
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     add_common_args(parser)
@@ -230,9 +257,7 @@ def main(argv=None):
     api = build_api(args)
     report = RunReport()
 
-    slugs = args.slug or [c.get("slug") for c in api.iter_cases()]
-    if args.limit:
-        slugs = slugs[:args.limit]
+    slugs = slugs_for_run(api, args)
 
     log_run_header(
         logger, stage="convert", base_url=args.api_base_url, dry_run=args.dry_run,

--- a/casework/convert.py
+++ b/casework/convert.py
@@ -230,12 +230,35 @@ def slugs_for_run(api, args):
     here. The allowlist property is what matters and it holds: no slug outside
     the file is returned.
 
-    ``--fiscal-year`` and ``--court-case`` remain accepted-and-ignored here.
-    Both predate the batch work; wiring them in needs a corpus walk, which is
-    a bigger change than this fix.
+    ``--slug`` NARROWS a batch rather than being dropped. The batch branch used
+    to return early, so ``--batch-csv b.csv --slug case-a`` converted every row
+    in the file -- a wrong-scope write whose command line said otherwise. The
+    intersection keeps file order, because ``--limit`` slices the result.
+
+    ``--fiscal-year`` and ``--court-case`` are rejected outright. Both come from
+    the shared ``add_common_args`` and so appear in this tool's ``--help``, but
+    neither was ever implemented here, and accepted-and-ignored is the dangerous
+    reading: with no batch and no ``--slug``, ``convert --fiscal-year 078``
+    walks and converts the ENTIRE corpus while claiming one year. Failing costs
+    one message; honouring them needs a corpus walk and a bigger change.
     """
+    unsupported = [
+        flag for flag, value in (
+            ("--fiscal-year", getattr(args, "fiscal_year", "")),
+            ("--court-case", getattr(args, "court_case", None)),
+        ) if value
+    ]
+    if unsupported:
+        raise SystemExit(
+            f"{', '.join(unsupported)} not supported by convert -- it would be "
+            "accepted and ignored, converting every case instead of the subset "
+            "you asked for. Scope the run with --batch-csv or --slug."
+        )
     if getattr(args, "batch_csv", None):
         slugs = slugs_from_batch_csv(args.batch_csv)
+        if args.slug:
+            wanted = set(args.slug)
+            slugs = [s for s in slugs if s in wanted]
     elif args.slug:
         slugs = list(args.slug)
     else:

--- a/casework/enrich_allegations.py
+++ b/casework/enrich_allegations.py
@@ -65,7 +65,7 @@ from casework.common.llm import bootstrap, tier_for
 from casework.common.materials import source_text
 from casework.common.parse import parse_extraction_response
 from casework.common.pipeline import PRESS_TYPES, STAGES, RunReport, unmet_prerequisites
-from casework.common.select import select_cases
+from casework.common.select import select_for_run
 
 log = logging.getLogger("casework.enrich_allegations")
 
@@ -261,14 +261,7 @@ def main(argv=None):
     report = RunReport()
 
     all_cases = list(api.iter_cases())
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -36,6 +36,7 @@ from casework.common.cli import (
     add_common_args,
     basic_auth_from_env,
     configure_run_logging,
+    format_counts,
     log_event,
     log_run_footer,
     log_run_header,
@@ -59,7 +60,17 @@ STAGE = STAGES["bigo"]
 # the bigo.
 BIGO_CONTEXT_KEYWORDS = (
     "बिगो",
+    # ब<->व legacy-font variants. These press releases are legacy-font PDFs, not
+    # scans, so the same word renders both ways -- often inside one document.
+    # Across the FY078/079 238-case batch: विगो is 150 of the 796 bigo tokens, and
+    # मागदावी appears in 156 of the 238 documents while मागदाबी appears in 129.
+    # Listing only the ब spelling made this gate discard correct, high-confidence
+    # extractions: 079-CR-0080 returned bigo=7000 quoting "विगो रु.7,000।- ... कायम
+    # गरी" and was recorded as "could not extract". Measured over the batch,
+    # विगो-only documents had a 0% success rate against 100% for बिगो-only ones.
+    "विगो",
     "मागदाबी",
+    "मागदावी",
     "हानि",
     "हानी",
     "नोक्सानी",
@@ -108,17 +119,23 @@ Then strip commas. Then strip the paisa suffix (everything from the first '।' 
 '/'). Then parse as integer. Never let paisa digits merge into the rupee figure — \
 e.g. २३,७५,४६,३२४।५७ is 237546324, NOT 2375463245.
 
-Rule 3 — Type-routing first (CHECK THIS BEFORE READING TEXT)
-Before reading any text, determine the press release type:
+Rule 3 — Type-routing, but only when no बिगो is declared
+First check whether the document declares a बिगो anywhere -- "बिगो रु.<AMOUNT> ... \
+कायम गरी", or an amount in a "बिगो रु." table column. If it does, EXTRACT IT and \
+ignore the routing below entirely. CIAA formally establishes a bribe AS the बिगो under \
+दफा ३(१) in 65 of the 238 FY078/079 releases, so routing on document type alone would \
+return null on a figure the document states outright.
+Only when NO बिगो is declared does the type matter:
 - Sting Operation (रंगेहात, sting, caught red-handed) → return null (high confidence). \
-  The amounts in sting releases are physical cash caught during arrest — \
-  bribe/unexplained cash — not a formally established bigo.
+  The amounts are physical cash caught during arrest -- bribe/unexplained cash -- not a \
+  formally established bigo.
 - Appeal/Review (पुनरावेदन, अपील, appeal, review) → return null (high confidence). \
   These record CIAA appealing a court verdict; bigo was defined at charge-sheet stage \
   and is not re-stated here.
-- Charge Filing (अभियोग दायर, charge filed, मुद्दा दर्ता) → proceed to extraction \
-  rules below.
-- Other → proceed to extraction rules below.
+- Charge Filing (अभियोग दायर, charge filed, मुद्दा दर्ता), or anything else → proceed to \
+  the extraction rules below.
+Rule 8's ignore list already stops bare seized cash from being read as बिगो; this rule \
+must not become a second, blunter gate that fires on a stated figure.
 
 Rule 4 — Null with low confidence
 If no reliable bigo signal exists after all checks, return null with low confidence. \
@@ -251,6 +268,83 @@ def coerce_bigo_int(value) -> Optional[int]:
     return bigo if bigo > 0 else None
 
 
+def rupee_amounts_in(text: str) -> set:
+    """Every amount stated in `text`, reduced to its rupee part.
+
+    Each match is normalised by `coerce_bigo_int` rather than re-implementing the
+    paisa rule here. That keeps ONE definition of "where does the rupee part
+    end", so the two sides of the grounding comparison cannot drift: an earlier
+    copy here omitted the '.' separator that `coerce_bigo_int` honours, so
+    'रु.324.57' reduced to 324 on the model's answer but yielded {57, 324} here.
+
+    Two tokenisation rules earn their keep, both measured against the 238
+    FY078/079 sources:
+
+    - **The paisa tail is capped at two digits and must not be followed by more
+      digits or a comma.** Paisa is 0-99, and without the cap the OCR'd-danda
+      alternative '|' swallows markdown table pipes: `| 1 | 35,200 |` parsed as
+      "1 rupees 35 paisa" and dropped 35200 from the set entirely. A बिगो stated
+      in a table column is Rule 6's *high-confidence* signal #2, so that made the
+      gate reject correct extractions and silently skip the case. 2 of the 238
+      sources contain the `<digits> | <digits>` shape.
+    - **Comma-separated groups may be split by whitespace.** Markdown extraction
+      turns 'रु.1,38,99,998।87' into 'रु. 1, 38, 99, 998।87' in 8 of the 238
+      sources; without this the figure is unreachable and a correct answer looks
+      ungrounded.
+
+    Deliberately NOT done: adding the un-truncated reading of a paisa-bearing
+    token. For 'रु.1,46,81,225।90' that reading is 1468122590 -- precisely the
+    paisa-fold this project exists to keep out of production (080-CR-0158). A
+    gate that accepted it would bless the exact error class it was built to
+    catch. Over-merging across unrelated numbers ('दफा 8, 9' -> 89) is tolerated
+    instead: a spurious extra member only makes the gate more permissive, while a
+    missing member destroys a correct figure.
+
+    The digit run is matched greedily, so a short number can never "appear"
+    merely by being a prefix of a longer one: '1389999887' yields 1389999887,
+    never 138999998.
+    """
+    # Digit groups joined by commas (tolerating the spaces markdown extraction
+    # leaves behind), then at most a two-digit paisa tail. Separators match
+    # `coerce_bigo_int`'s: danda, OCR'd pipe, slash, dot.
+    runs = re.finditer(
+        r"\d+(?:\s*,\s*\d+)*(?:\s*[।|/.]\s*\d{1,2}(?![\d,]))?",
+        text or "",
+    )
+    return {
+        amount for amount in (coerce_bigo_int(m.group(0)) for m in runs)
+        if amount is not None
+    }
+
+
+def amount_is_grounded(text: str, bigo) -> bool:
+    """True when `bigo` is actually stated in the source.
+
+    The last line of defence, and the only one that catches a model returning a
+    clean-but-wrong integer. Neither of the other two guards can:
+    `coerce_bigo_int` sees a well-formed int and passes it through, and
+    `is_explicit_bigo_context` only inspects the quote, which is usually copied
+    correctly even when the number is not.
+
+    Two real failures this stops, both from the FY078/079 dry run:
+
+    - 078-CR-0116 returned 138999998 where the charge sheet declares
+      रु.१,३८,९९,९९८।८७ (13,899,998) -- a 10x inflation whose digits appear
+      nowhere in the document.
+    - 079-CR-0067 returned 268000, the arithmetic sum of three per-defendant
+      विगो figures (35,200 + 55,200 + 177,600). A real total, but one the
+      document never states.
+
+    It does NOT resolve which बिगो to pick when a document declares several --
+    every candidate is grounded by definition. That is a data-modelling
+    question, not an extraction one (see the multi-accused note in
+    `work/2026-08-03-Dry-run-bigo-enricher/report.md`).
+    """
+    if bigo is None:
+        return True
+    return bigo in rupee_amounts_in(text)
+
+
 def is_explicit_bigo_context(evidence_quote) -> bool:
     """Check if evidence quote contains explicit BIGO context keywords."""
     if not isinstance(evidence_quote, str):
@@ -332,7 +426,7 @@ def parse_bigo_response(response_text: str) -> Optional[int]:
 
 
 def _extract_bigo(source_text_, case, invoke_text, usage) -> Optional[int]:
-    """Call the LLM to extract BIGO from source markdown."""
+    """Call the LLM to extract BIGO from the press release."""
     prompt = EXTRACTION_USER_PROMPT.format(
         case_id=case.get("slug", "?"),
         case_title=case.get("title", ""),
@@ -367,6 +461,23 @@ def build_api(args):
     )
 
 
+def _run_event(logger, paths, run_id, step, status, detail="", level=logging.INFO):
+    """Emit a RUN-scoped event (no slug) to the same events.jsonl as case events.
+
+    `ledger.build_ledger` requires both a slug and a stage and skips any event
+    missing either, so these rows describe the run without ever appearing as a
+    phantom case in the ledger.
+
+    This exists because everything before the per-case loop used to fail silently:
+    a bootstrap error printed to stderr and exited, leaving the run's `.log` AND
+    `.events.jsonl` at zero bytes with no record of the target, the mode, or the
+    reason. `log_run_header`/`log_run_footer` only reach the `.log`, never the
+    events stream the ledger actually reads.
+    """
+    log_event(logger, paths["events"], run_id=run_id, stage="bigo", slug="",
+              step=step, status=status, detail=detail, level=level)
+
+
 def main(argv=None):
     """Main entry point."""
     ap = argparse.ArgumentParser(
@@ -380,21 +491,62 @@ def main(argv=None):
     logger, run_id, paths = configure_run_logging("bigo", verbose=args.verbose)
     start_time = time.monotonic()
 
+    # Put the run's identity on disk BEFORE anything that can fail. Selection is
+    # what decides `n_selected`, so the header cannot move up here -- but target,
+    # mode, provider and model are all known now, and they are exactly what you
+    # need to interpret a crash during bootstrap or case listing.
+    _run_event(
+        logger, paths, run_id, "run", "start",
+        f"target={args.api_base_url} mode={'DRY-RUN' if args.dry_run else 'APPLY'} "
+        f"provider={args.provider} model={args.model or '(provider default)'} "
+        f"allow_remote_writes={args.allow_remote_writes}",
+    )
+
+    def _die(step, exc):
+        """Record a pre-loop failure in the run log, then exit non-zero."""
+        detail = f"{type(exc).__name__}: {exc}"
+        _run_event(logger, paths, run_id, step, "error", detail, level=logging.ERROR)
+        log_run_footer(
+            logger, stage="bigo", stats={"aborted": 1},
+            duration_s=time.monotonic() - start_time,
+        )
+        print(f"{step} failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     # Bootstrap Django + LLM (MUST come before importing llm.invoke)
     try:
         bootstrap(args.provider, args.model)
     except Exception as exc:
-        print(f"Bootstrap failed: {exc}", file=sys.stderr)
-        sys.exit(1)
+        _die("bootstrap", exc)
 
     from llm.invoke import invoke_text
     from llm.usage import UsageAccumulator, render_usage_table
 
-    api = build_api(args)
     usage = UsageAccumulator()
     report = RunReport()
 
-    all_cases = list(api.iter_cases())
+    # `build_api` raises on a missing/ambiguous credential and `iter_cases` pages
+    # the whole case list -- minutes of HTTP that an expired token or a 5xx can
+    # sink. Unguarded, either one killed the run with a bare traceback.
+    #
+    # `SystemExit` is caught explicitly: the missing-credential path this guard
+    # exists for goes through `basic_auth_from_env`, which raises `SystemExit`
+    # (a BaseException, NOT an Exception). Catching only `Exception` let exactly
+    # that case escape, leaving `run/start` as the last line in the events file
+    # -- the same signature as a killed run, which is what these terminal events
+    # were added to distinguish. KeyboardInterrupt is deliberately NOT caught.
+    try:
+        api = build_api(args)
+    except (Exception, SystemExit) as exc:
+        _die("build_api", exc)
+
+    try:
+        all_cases = list(api.iter_cases())
+    except Exception as exc:
+        _die("list_cases", exc)
+
+    _run_event(logger, paths, run_id, "list_cases", "ok", f"{len(all_cases)} case(s) fetched")
+
     cases = select_cases(
         all_cases,
         fiscal_year=args.fiscal_year,
@@ -410,9 +562,14 @@ def main(argv=None):
         provider=args.provider, model=args.model, n_selected=total,
         run_id=run_id, paths=paths,
     )
+    _run_event(
+        logger, paths, run_id, "select", "ok",
+        f"{total} selected from {len(all_cases)} fetched",
+    )
     if total == 0:
         print("No matching CIAA case(s) to process.", file=sys.stderr)
         print_summary(report.summary(), args.dry_run, "BIGO extraction")
+        _run_event(logger, paths, run_id, "run", "complete", "0 selected; nothing to do")
         log_run_footer(
             logger, stage="bigo", stats=report.summary(),
             duration_s=time.monotonic() - start_time,
@@ -492,6 +649,24 @@ def main(argv=None):
                       level=logging.WARNING)
             continue
 
+        # Grounding gate. A number the source never states is wrong no matter how
+        # confident the model was or how clean its quote looked -- and for a public
+        # corruption figure, missing beats wrong. Skip rather than write.
+        #
+        # Ground against everything the model was SHOWN, not just the markdown
+        # body. `_extract_bigo` also sends `_source_metadata(...)`, and per its
+        # docstring the material `display_name` is frequently where the बिगो is
+        # first stated ("... उपर बिगो रु.९०,३९,६२०।३९ कायम"). Checking the body
+        # alone would reject a figure the model read correctly out of the title.
+        shown = _source_metadata(detail, PRESS_TYPES) + "\n" + text
+        if not amount_is_grounded(shown, bigo):
+            reason = f"bigo={bigo} is not stated anywhere in the source text"
+            report.record(slug, "bigo", "skipped", reason)
+            log_event(logger, paths["events"], run_id=run_id, stage="bigo", slug=slug,
+                      step="grounding", status="skipped", detail=reason,
+                      level=logging.WARNING)
+            continue
+
         log_event(logger, paths["events"], run_id=run_id, stage="bigo", slug=slug,
                   step="extract", status="ok", detail=str(bigo))
 
@@ -526,9 +701,17 @@ def main(argv=None):
         print()
         print(usage_summary)
 
+    duration_s = time.monotonic() - start_time
+    # Terminal run row in the events stream. Its absence is how you tell a killed
+    # or crashed run from one that finished -- the .log footer alone cannot, since
+    # the ledger never reads the .log.
+    _run_event(
+        logger, paths, run_id, "run", "complete",
+        f"{format_counts(stats)} duration_s={duration_s:.1f} llm_calls={usage.calls}",
+    )
     log_run_footer(
         logger, stage="bigo", stats=stats,
-        duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        duration_s=duration_s, usage_summary=usage_summary,
     )
 
     return report

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -47,7 +47,7 @@ from casework.common.llm import bootstrap, tier_for
 from casework.common.materials import materials_of_type, source_text
 from casework.common.parse import balanced_object
 from casework.common.pipeline import PRESS_TYPES, STAGES, RunReport, unmet_prerequisites
-from casework.common.select import select_cases
+from casework.common.select import select_for_run
 
 log = logging.getLogger("casework.enrich_missing_bigo")
 
@@ -551,9 +551,9 @@ def main(argv=None):
         _die("build_api", exc)
 
     # Listing production is 16 requests and ~33s before the first case is even
-    # looked at, and `--limit N` does not shorten it (the slice below happens
-    # after the whole list is in memory). Report each page through the run
-    # logger, so the wait is legible live and its shape is on the record
+    # looked at, and `--limit N` does not shorten it -- `select_for_run` slices
+    # after the whole list is already in memory. Report each page through the
+    # run logger, so the wait is legible live and its shape is on the record
     # afterwards -- an unnarrated 33s gap reads as a hang.
     def _list_progress(page, fetched, total):
         _run_event(
@@ -568,14 +568,7 @@ def main(argv=None):
 
     _run_event(logger, paths, run_id, "list_cases", "ok", f"{len(all_cases)} case(s) fetched")
 
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -425,15 +425,25 @@ def parse_bigo_response(response_text: str) -> Optional[int]:
     return None
 
 
-def _extract_bigo(source_text_, case, invoke_text, usage) -> Optional[int]:
-    """Call the LLM to extract BIGO from the press release."""
+def _extract_bigo(source_text_, case, invoke_text, usage) -> tuple[Optional[int], str]:
+    """Call the LLM to extract BIGO from the press release.
+
+    Returns `(bigo, shown)`, where `shown` is the source text this prompt
+    actually carried -- the metadata block plus the clamped body, both post-
+    truncation. The grounding gate checks that exact string rather than
+    recomposing it, for two reasons: a second construction drifts the moment the
+    prompt inputs change, and an unclamped rebuild would ground an amount
+    against text the clamp had already cut out of the model's view.
+    """
+    source_context = _clamp(
+        _source_metadata(case, PRESS_TYPES), SOURCE_CONTEXT_CHARS, "bigo context"
+    )
+    markdown = _clamp(source_text_, FEED_CHARS, "bigo source")
     prompt = EXTRACTION_USER_PROMPT.format(
         case_id=case.get("slug", "?"),
         case_title=case.get("title", ""),
-        source_context=_clamp(
-            _source_metadata(case, PRESS_TYPES), SOURCE_CONTEXT_CHARS, "bigo context"
-        ),
-        markdown=_clamp(source_text_, FEED_CHARS, "bigo source"),
+        source_context=source_context,
+        markdown=markdown,
     )
 
     response_text = invoke_text(
@@ -444,7 +454,7 @@ def _extract_bigo(source_text_, case, invoke_text, usage) -> Optional[int]:
         usage=usage,
     )
 
-    return parse_bigo_response(response_text)
+    return parse_bigo_response(response_text), f"{source_context}\n{markdown}"
 
 
 def build_api(args):
@@ -629,7 +639,7 @@ def main(argv=None):
                   step="source", status="ok", detail=f"{len(text)} chars")
 
         try:
-            bigo = _extract_bigo(text, detail, invoke_text, usage)
+            bigo, shown = _extract_bigo(text, detail, invoke_text, usage)
         except Exception as exc:
             report.record(slug, "bigo", "error", f"LLM extraction failed: {exc}")
             log_event(logger, paths["events"], run_id=run_id, stage="bigo", slug=slug,
@@ -653,12 +663,12 @@ def main(argv=None):
         # confident the model was or how clean its quote looked -- and for a public
         # corruption figure, missing beats wrong. Skip rather than write.
         #
-        # Ground against everything the model was SHOWN, not just the markdown
-        # body. `_extract_bigo` also sends `_source_metadata(...)`, and per its
-        # docstring the material `display_name` is frequently where the बिगो is
-        # first stated ("... उपर बिगो रु.९०,३९,६२०।३९ कायम"). Checking the body
-        # alone would reject a figure the model read correctly out of the title.
-        shown = _source_metadata(detail, PRESS_TYPES) + "\n" + text
+        # `shown` is everything the model was SHOWN, straight from the call that
+        # built the prompt -- not just the markdown body. `_extract_bigo` also
+        # sends `_source_metadata(...)`, and per its docstring the material
+        # `display_name` is frequently where the बिगो is first stated
+        # ("... उपर बिगो रु.९०,३९,६२०।३९ कायम"). Checking the body alone rejected
+        # figures the model had read correctly out of the title.
         if not amount_is_grounded(shown, bigo):
             reason = f"bigo={bigo} is not stated anywhere in the source text"
             report.record(slug, "bigo", "skipped", reason)

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -550,8 +550,19 @@ def main(argv=None):
     except (Exception, SystemExit) as exc:
         _die("build_api", exc)
 
+    # Listing production is 16 requests and ~33s before the first case is even
+    # looked at, and `--limit N` does not shorten it (the slice below happens
+    # after the whole list is in memory). Report each page through the run
+    # logger, so the wait is legible live and its shape is on the record
+    # afterwards -- an unnarrated 33s gap reads as a hang.
+    def _list_progress(page, fetched, total):
+        _run_event(
+            logger, paths, run_id, "list_cases", "progress",
+            f"page {page}, {fetched}/{total if total is not None else '?'} fetched",
+        )
+
     try:
-        all_cases = list(api.iter_cases())
+        all_cases = list(api.iter_cases(progress=_list_progress))
     except Exception as exc:
         _die("list_cases", exc)
 

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -108,7 +108,7 @@ from casework.common.pipeline import (
     RunReport,
     unmet_prerequisites,
 )
-from casework.common.select import select_cases
+from casework.common.select import select_for_run
 
 log = logging.getLogger("casework.enrich_related_entities")
 
@@ -394,14 +394,7 @@ def main(argv=None):
     report = RunReport()
 
     all_cases = list(api.iter_cases())
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/casework/enrich_tags.py
+++ b/casework/enrich_tags.py
@@ -64,7 +64,7 @@ from casework.common.cli import (
 )
 from casework.common.llm import bootstrap, tier_for
 from casework.common.pipeline import STAGES, RunReport, unmet_prerequisites
-from casework.common.select import select_cases
+from casework.common.select import select_for_run
 
 log = logging.getLogger("casework.enrich_tags")
 
@@ -1094,14 +1094,7 @@ def main(argv=None):
     report = RunReport()
 
     all_cases = list(api.iter_cases())
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/casework/enrich_timeline.py
+++ b/casework/enrich_timeline.py
@@ -151,7 +151,7 @@ from casework.common.pipeline import (
     RunReport,
     unmet_prerequisites,
 )
-from casework.common.select import select_cases
+from casework.common.select import select_for_run
 
 log = logging.getLogger("casework.enrich_timeline")
 
@@ -771,14 +771,7 @@ def main(argv=None):
     report = RunReport()
 
     all_cases = list(api.iter_cases())
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/llm/providers/cli.py
+++ b/llm/providers/cli.py
@@ -17,7 +17,6 @@ from django.conf import settings
 
 from llm.providers.base import Provider, strip_code_fence
 
-
 def _flatten(content):
     """Flatten content to plain text for CLI input.
 
@@ -113,6 +112,24 @@ class _CliProvider(Provider):
                             "usage limit",
                             "429",
                             "too many requests",
+                            # Transient, and NOT a rate limit: an answer that
+                            # runs long asks to continue, and denying it aborts
+                            # the call with an empty result. `CLAUDE_CLI_MAX_TURNS`
+                            # makes that rare, not impossible -- a long enough
+                            # answer still exhausts whatever the cap is, and the
+                            # next attempt often lands inside it. Without this,
+                            # every survivor is a permanently recorded error:
+                            # measured at 3/10 on bigo-extraction prompts when
+                            # the cap was 1.
+                            #
+                            # `llm/exhaustion.py` records the other half -- the
+                            # same marker also fires on a genuinely exhausted
+                            # token budget, and the two are indistinguishable
+                            # from the error text. Retrying is the right move
+                            # either way: a budget problem costs one wasted
+                            # attempt, where not retrying costs the case.
+                            "error_max_turns",
+                            "maximum number of turns",
                         )
                     )
                     if retryable and attempt < max_retries - 1:
@@ -236,6 +253,13 @@ class ClaudeCliProvider(_CliProvider):
         # interleaved (2026-08-03): 3/5 succeeded at 1 turn, 5/5 at 3. Successful
         # 3-turn runs averaged ~25s against ~15s for successful 1-turn runs, so the
         # extra turn is genuinely used rather than idle.
+        #
+        # Independently reproduced on a second payload -- casework bigo extraction
+        # (sonnet, same case + prompt, n=10 per arm): 3 failures / 10 at 1 turn,
+        # 0 / 10 at 2, all ten agreeing on the same extracted amount. Different
+        # prompt, different tier, same mechanism. Default mode is not immune
+        # either: the model spends a turn *attempting* a tool call even when none
+        # are exposed.
         #
         # Raising the cap does not make a short call longer or dearer: a response
         # that completes in one turn never requests a second. It only stops

--- a/llm/providers/cli.py
+++ b/llm/providers/cli.py
@@ -17,6 +17,7 @@ from django.conf import settings
 
 from llm.providers.base import Provider, strip_code_fence
 
+
 def _flatten(content):
     """Flatten content to plain text for CLI input.
 

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -357,6 +357,94 @@ def test_iter_cases_page_size(monkeypatch, params, expected):
 
 
 # ---------------------------------------------------------------------------
+# Progress. Listing the 3,003-case production list is 16 sequential requests
+# and ~33s during which NOTHING was logged, so a run was indistinguishable
+# from a hang -- an operator has no way to tell whether to wait or Ctrl-C.
+# ---------------------------------------------------------------------------
+
+
+def _paged(n_pages, per_page=2):
+    """`n_pages` DRF-shaped pages, each with `per_page` results and a `count`."""
+    total = n_pages * per_page
+    return {
+        page: {
+            "results": [{"slug": f"case-{page}-{i}"} for i in range(per_page)],
+            "count": total,
+            "next": f"http://x/?page={page + 1}" if page < n_pages else None,
+        }
+        for page in range(1, n_pages + 1)
+    }
+
+
+def test_iter_cases_reports_progress_after_every_page(monkeypatch):
+    """One callback per page, carrying enough to render a live counter: which
+    page, how many cases so far, and the server's total."""
+    pages = _paged(3)
+    api = CaseworkApi(base_url="http://127.0.0.1:48010", token="t")
+    monkeypatch.setattr(api, "get", lambda path, params=None, timeout=60: pages[params["page"]])
+
+    seen = []
+    list(api.iter_cases(progress=lambda **kw: seen.append(kw)))
+
+    assert seen == [
+        {"page": 1, "fetched": 2, "total": 6},
+        {"page": 2, "fetched": 4, "total": 6},
+        {"page": 3, "fetched": 6, "total": 6},
+    ]
+
+
+def test_iter_cases_progress_tolerates_a_server_that_sends_no_count(monkeypatch):
+    """`total` is whatever the server said, and DRF only sends `count` when the
+    paginator is countable. Reporting must degrade, not raise."""
+    api = CaseworkApi(base_url="http://127.0.0.1:48010", token="t")
+    monkeypatch.setattr(
+        api, "get",
+        lambda path, params=None, timeout=60: {"results": [{"slug": "a"}], "next": None},
+    )
+
+    seen = []
+    list(api.iter_cases(progress=lambda **kw: seen.append(kw)))
+
+    assert seen == [{"page": 1, "fetched": 1, "total": None}]
+
+
+def test_iter_cases_without_a_callback_still_logs_progress(monkeypatch, caplog):
+    """The default has to be useful on its own. Five of the six enrichers do not
+    wire a callback, and they have the same 33s of silence to explain.
+    """
+    pages = _paged(2)
+    api = CaseworkApi(base_url="http://127.0.0.1:48010", token="t")
+    monkeypatch.setattr(api, "get", lambda path, params=None, timeout=60: pages[params["page"]])
+
+    with caplog.at_level(logging.INFO, logger="casework.api"):
+        list(api.iter_cases())
+
+    progress = [r.getMessage() for r in caplog.records if "page" in r.getMessage()]
+    assert len(progress) == 2, progress
+    assert "1" in progress[0] and "4" in progress[0], progress[0]
+
+
+def test_iter_cases_progress_is_emitted_before_the_next_request(monkeypatch):
+    """Reporting after the whole loop would be useless -- the point is feedback
+    DURING the wait. Each page's callback must fire before the next GET goes out.
+    """
+    pages = _paged(3)
+    order = []
+    api = CaseworkApi(base_url="http://127.0.0.1:48010", token="t")
+
+    def fake_get(path, params=None, timeout=60):
+        order.append(f"get{params['page']}")
+        return pages[params["page"]]
+
+    monkeypatch.setattr(api, "get", fake_get)
+    list(api.iter_cases(progress=lambda **kw: order.append(f"progress{kw['page']}")))
+
+    assert order == [
+        "get1", "progress1", "get2", "progress2", "get3", "progress3",
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Write-guard -- `_patch` is the single choke point for `patch_field` and
 # `replace_list`. It must refuse to fire a PATCH at any non-loopback host
 # unless `allow_remote_writes=True` was explicitly passed to `__init__`.

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -127,6 +127,32 @@ def test_empty_base_url_raises():
         CaseworkApi(base_url=None, token="t")
 
 
+def test_bearer_mode_rejects_cleartext_http_to_a_remote_host():
+    """CWE-319. `_headers` attaches `Authorization: Bearer <token>` to every
+    request, reads included, and the write-guard only inspects the host -- not
+    the scheme. So an `http://` remote base URL put a production token on the
+    wire in cleartext, and these runs are hours long.
+
+    `basic=` was already loopback-only; Bearer had no scheme check at all.
+    """
+    with pytest.raises(ValueError, match="https"):
+        CaseworkApi(base_url="http://api.jawafdehi.org", token="prod-token")
+
+
+def test_bearer_mode_accepts_https_to_a_remote_host():
+    CaseworkApi(base_url="https://api.jawafdehi.org", token="prod-token")
+
+
+@pytest.mark.parametrize("base_url", [
+    "http://127.0.0.1:48010",
+    "http://localhost:48010",
+])
+def test_bearer_mode_still_allows_cleartext_to_loopback(base_url):
+    """A local DEV_AUTH server has no TLS, and a token never leaves the host.
+    Requiring https here would break every local run for no gain."""
+    CaseworkApi(base_url=base_url, token="local-token")
+
+
 def test_basic_mode_rejects_non_loopback_base_url():
     with pytest.raises(ValueError):
         CaseworkApi(

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -331,6 +331,31 @@ def test_iter_cases_follows_pagination(monkeypatch):
     assert seen_pages == [1, 2]
 
 
+@pytest.mark.parametrize("params,expected", [
+    # Without an explicit page_size the server pages at its default 20, so a full
+    # list costs 151 round trips (~2m45s against production) before any enricher
+    # does a single case of work. The API caps page_size at 200 (measured:
+    # 200/500/1000 all return 200), so 200 is the most a client can get and cuts
+    # that to 16 requests -- verified end to end at 16 requests / 33.7s.
+    (None, 200),
+    # ...and the caller can still override it.
+    ({"page_size": 5}, 5),
+])
+def test_iter_cases_page_size(monkeypatch, params, expected):
+    seen = []
+
+    def fake_get(path, params=None, timeout=60):
+        seen.append(dict(params or {}))
+        return {"results": [], "next": None}
+
+    api = CaseworkApi(base_url="http://127.0.0.1:48010", token="t")
+    monkeypatch.setattr(api, "get", fake_get)
+
+    list(api.iter_cases(params))
+
+    assert seen[0]["page_size"] == expected
+
+
 # ---------------------------------------------------------------------------
 # Write-guard -- `_patch` is the single choke point for `patch_field` and
 # `replace_list`. It must refuse to fire a PATCH at any non-loopback host

--- a/tests/casework/test_batch_csv_cli_wiring.py
+++ b/tests/casework/test_batch_csv_cli_wiring.py
@@ -1,0 +1,154 @@
+"""Tests for how `--batch-csv` is wired into the argparse layer.
+
+`test_select_batch_csv.py` covers the selection algebra. This file covers the
+three ways the flag can be wrong before selection ever runs:
+
+- `bind_materials.py` registers its own required `--batch-csv`, so once
+  `add_common_args` also registers one, its parser cannot even be built.
+- `--batch-csv "$BATCH"` with an unset variable arrives as the empty string,
+  and an empty allowlist that falls through to bulk selection is the exact
+  opposite of what the flag is for.
+- `convert.py` calls `add_common_args`, so it advertises `--batch-csv` in
+  `--help`; it must honour it rather than convert the whole corpus.
+"""
+import argparse
+import types
+
+import pytest
+
+from casework import bind_materials
+from casework.common.cli import add_common_args
+from casework.common.select import select_for_run
+from casework.convert import slugs_for_run
+
+
+def _batch(tmp_path, *slugs):
+    path = tmp_path / "batch.csv"
+    path.write_text("slug\n" + "".join(f"{s}\n" for s in slugs), encoding="utf-8")
+    return str(path)
+
+
+def _parser():
+    parser = argparse.ArgumentParser()
+    add_common_args(parser)
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# bind_materials.py must keep working -- it is the tool whose CSV format the
+# enrichers' --batch-csv deliberately matches.
+# ---------------------------------------------------------------------------
+
+
+def test_bind_materials_parser_can_be_built():
+    """Regression: a duplicate --batch-csv makes build_parser() raise
+    ArgumentError before it parses anything, killing every invocation."""
+    assert bind_materials.build_parser() is not None
+
+
+def test_bind_materials_still_requires_batch_csv():
+    with pytest.raises(SystemExit):
+        bind_materials.build_parser().parse_args([])
+
+
+def test_bind_materials_accepts_a_batch_csv(tmp_path):
+    path = _batch(tmp_path, "case-078-cr-0001-ciaa-")
+    args = bind_materials.build_parser().parse_args(["--batch-csv", path])
+    assert args.batch_csv == path
+
+
+def test_bind_materials_batch_csv_help_still_mentions_material_columns():
+    """bind_materials consumes material-IRI columns the enrichers ignore, so it
+    must not inherit the enrichers' slug-only help text."""
+    action = next(a for a in bind_materials.build_parser()._actions
+                  if a.dest == "batch_csv")
+    assert "material" in (action.help or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# An empty or missing path must never degrade into a full-corpus run.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_batch_csv_value_is_rejected_at_parse_time():
+    """`--batch-csv "$BATCH"` with $BATCH unset. argparse accepts the empty
+    string happily, and select_for_run then treats it as 'no batch'."""
+    with pytest.raises(SystemExit):
+        _parser().parse_args(["--batch-csv", ""])
+
+
+def test_whitespace_only_batch_csv_value_is_rejected():
+    with pytest.raises(SystemExit):
+        _parser().parse_args(["--batch-csv", "   "])
+
+
+def test_missing_batch_csv_file_is_rejected_at_parse_time(tmp_path):
+    """A typo must cost nothing, not ~16 pages of list_cases first."""
+    with pytest.raises(SystemExit):
+        _parser().parse_args(["--batch-csv", str(tmp_path / "nope.csv")])
+
+
+def test_absent_batch_csv_still_means_bulk_selection():
+    """The guard must not break the no-batch path."""
+    args = _parser().parse_args([])
+    cases = [{"slug": f"s{i}", "state": "DRAFT"} for i in range(3)]
+    assert len(select_for_run(cases, args)) == 3
+
+
+def test_select_for_run_refuses_an_empty_batch_from_a_hand_built_namespace():
+    """Defence in depth for programmatic callers that bypass argparse: an empty
+    allowlist must fail loud, never widen to the whole corpus."""
+    args = types.SimpleNamespace(
+        batch_csv="", fiscal_year="", slug=[], court_case=[], limit=0)
+    cases = [{"slug": f"s{i}", "state": "DRAFT"} for i in range(3)]
+    with pytest.raises(SystemExit):
+        select_for_run(cases, args)
+
+
+# ---------------------------------------------------------------------------
+# convert.py advertises the flag, so it must honour it.
+# ---------------------------------------------------------------------------
+
+
+class _FakeApi:
+    def __init__(self, *slugs):
+        self._slugs = slugs
+
+    def iter_cases(self):
+        return [{"slug": s, "state": "DRAFT"} for s in self._slugs]
+
+
+def _convert_args(**kw):
+    base = dict(batch_csv=None, slug=[], limit=0)
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def test_convert_honours_batch_csv(tmp_path):
+    path = _batch(tmp_path, "case-a", "case-b")
+    api = _FakeApi("case-a", "case-b", "case-zzz-not-in-batch")
+    assert slugs_for_run(api, _convert_args(batch_csv=path)) == ["case-a", "case-b"]
+
+
+def test_convert_batch_csv_never_admits_a_case_outside_the_file(tmp_path):
+    path = _batch(tmp_path, "case-a")
+    api = _FakeApi("case-a", "case-zzz-not-in-batch")
+    assert "case-zzz-not-in-batch" not in slugs_for_run(
+        api, _convert_args(batch_csv=path))
+
+
+def test_convert_batch_csv_limit_takes_the_files_first_rows(tmp_path):
+    path = _batch(tmp_path, "case-a", "case-b", "case-c")
+    api = _FakeApi("case-c", "case-b", "case-a")
+    assert slugs_for_run(api, _convert_args(batch_csv=path, limit=2)) == [
+        "case-a", "case-b"]
+
+
+def test_convert_without_batch_csv_still_walks_every_case():
+    api = _FakeApi("case-a", "case-b")
+    assert slugs_for_run(api, _convert_args()) == ["case-a", "case-b"]
+
+
+def test_convert_slug_flag_still_wins_over_a_full_walk():
+    api = _FakeApi("case-a", "case-b")
+    assert slugs_for_run(api, _convert_args(slug=["case-b"])) == ["case-b"]

--- a/tests/casework/test_batch_csv_cli_wiring.py
+++ b/tests/casework/test_batch_csv_cli_wiring.py
@@ -152,3 +152,55 @@ def test_convert_without_batch_csv_still_walks_every_case():
 def test_convert_slug_flag_still_wins_over_a_full_walk():
     api = _FakeApi("case-a", "case-b")
     assert slugs_for_run(api, _convert_args(slug=["case-b"])) == ["case-b"]
+
+
+# ---------------------------------------------------------------------------
+# Combined selectors. The batch branch returned early, so a selector passed
+# alongside it was accepted and silently dropped -- the run then processed
+# every batch row while its command line said otherwise.
+# ---------------------------------------------------------------------------
+
+
+def test_convert_intersects_batch_csv_with_slug(tmp_path):
+    """`--batch-csv b.csv --slug case-a` must convert case-a, not the whole
+    file. Narrowing a batch is the normal way to re-run one row of a reviewed
+    batch, and silently widening it back to the batch is a wrong-scope write."""
+    path = _batch(tmp_path, "case-a", "case-b", "case-c")
+    api = _FakeApi("case-a", "case-b", "case-c")
+    assert slugs_for_run(api, _convert_args(batch_csv=path, slug=["case-a"])) == [
+        "case-a"]
+
+
+def test_convert_intersection_keeps_batch_order(tmp_path):
+    """`--limit` slices the result, so the intersection must stay in file order
+    rather than in whatever order `--slug` was typed."""
+    path = _batch(tmp_path, "case-a", "case-b", "case-c")
+    api = _FakeApi("case-a", "case-b", "case-c")
+    assert slugs_for_run(
+        api, _convert_args(batch_csv=path, slug=["case-c", "case-a"])
+    ) == ["case-a", "case-c"]
+
+
+def test_convert_slug_outside_the_batch_selects_nothing(tmp_path):
+    """The batch stays a hard allowlist: `--slug` can only narrow it. Selecting
+    nothing is the safe outcome, and it is visible as n=0 rather than silent."""
+    path = _batch(tmp_path, "case-a")
+    api = _FakeApi("case-a", "case-b")
+    assert slugs_for_run(api, _convert_args(batch_csv=path, slug=["case-b"])) == []
+
+
+@pytest.mark.parametrize("selector", [
+    {"fiscal_year": "078"},
+    {"court_case": ["078-CR-0001"]},
+])
+def test_convert_rejects_selectors_it_cannot_honour(selector):
+    """`--fiscal-year` and `--court-case` come from the shared
+    `add_common_args`, so they appear in convert's `--help`, but convert never
+    implemented either. Accepted-and-ignored is the dangerous reading: with no
+    batch and no `--slug`, `convert --fiscal-year 078` walks and converts the
+    ENTIRE corpus while its command line claims one year. Failing costs the
+    operator one message; the silent version costs a full-corpus run.
+    """
+    api = _FakeApi("case-a", "case-b")
+    with pytest.raises(SystemExit, match="not supported"):
+        slugs_for_run(api, _convert_args(**selector))

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -42,6 +42,34 @@ def test_api_base_url_has_no_silent_localhost_default(monkeypatch):
     assert parser.parse_args([]).api_base_url is None
 
 
+@pytest.mark.parametrize("env,argv,expected", [
+    # `basic_auth_from_env`'s own error message tells the operator to "set
+    # JAWAFDEHI_API_TOKEN", but --api-token never read it -- the only way in was
+    # the flag, which puts a live Bearer token in the process argv where any
+    # local user can read it out of /proc/<pid>/cmdline.
+    ({"JAWAFDEHI_API_TOKEN": "tok-env"}, [], "tok-env"),
+    ({"JAWAFDEHI_API_TOKEN": "tok-env"}, ["--api-token", "tok-flag"], "tok-flag"),
+    # Empty (not None) keeps `if args.api_token:` in every enricher's build_api
+    # falling through to Basic auth exactly as before.
+    ({}, [], ""),
+    # Local DEV_AUTH creds present -> the env token must NOT hijack the run.
+    # `build_api` is `if args.api_token: Bearer else Basic`, and a Bearer header
+    # is always routed to OIDC and never falls through to DRF Basic, so this
+    # would 401 every loopback --apply and leak a prod token to 127.0.0.1.
+    ({"JAWAFDEHI_API_TOKEN": "tok-env", "CASEWORK_API_USER": "dev",
+      "CASEWORK_API_PASSWORD": "pw"}, [], ""),
+    # ...but an explicit flag still wins, for testing a real token locally.
+    ({"JAWAFDEHI_API_TOKEN": "tok-env", "CASEWORK_API_USER": "dev",
+      "CASEWORK_API_PASSWORD": "pw"}, ["--api-token", "tok-flag"], "tok-flag"),
+])
+def test_api_token_default(monkeypatch, env, argv, expected):
+    for key in ("JAWAFDEHI_API_TOKEN", "CASEWORK_API_USER", "CASEWORK_API_PASSWORD"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert _parse(argv).api_token == expected
+
+
 def test_model_default_is_empty_not_haiku():
     # Bumped off the cheap default: "" means "use each stage's configured tier
     # model" (premium stages -> premium model), NOT force-haiku on every tier.

--- a/tests/casework/test_enrich_missing_bigo.py
+++ b/tests/casework/test_enrich_missing_bigo.py
@@ -530,7 +530,11 @@ class _StubApi:
         self._markdown_by_link = markdown_by_link or {}
         self.patched = []
 
-    def iter_cases(self, params=None, timeout=60):
+    def iter_cases(self, params=None, timeout=60, progress=None):
+        # Mirror the real client: one page, and report it. Accepting `progress`
+        # but never calling it would let the caller's reporter rot untested.
+        if progress:
+            progress(page=1, fetched=len(self._cases), total=len(self._cases))
         yield from self._cases.values()
 
     def get_case(self, slug, timeout=60):
@@ -1083,6 +1087,48 @@ def test_events_file_covers_start_extract_write_on_apply_happy_path(
     assert ("start", "start") in steps_and_statuses
     assert ("extract", "ok") in steps_and_statuses
     assert ("write", "enriched") in steps_and_statuses
+
+
+class TestCaseListingNarratesItself:
+    """The 33s of silence before the first case.
+
+    Listing production is 16 sequential requests at `PAGE_SIZE`, and `--limit N`
+    does not shorten it -- the slice happens after the whole list is in memory.
+    A real `--limit 10` run logged `run/start`, then nothing for 33 seconds, then
+    everything at once. That is indistinguishable from a hang, and an operator
+    watching it has no basis to decide between waiting and Ctrl-C.
+    """
+
+    def test_each_page_is_recorded_as_it_lands(self, monkeypatch, tmp_path):
+        _run_main(monkeypatch, [PRESS_CASE_READY], invoke_text_stub=lambda **kw: "{}",
+                  argv=["--dry-run"])
+
+        rows = _read_events(_events_path())
+        progress = [r for r in rows
+                    if r["step"] == "list_cases" and r["status"] == "progress"]
+        assert progress, "the listing wait left no record"
+        assert "page 1" in progress[0]["detail"]
+        assert "1/1 fetched" in progress[0]["detail"]
+
+    def test_progress_lands_before_the_listing_finishes(self, monkeypatch, tmp_path):
+        """Ordering is the whole point: a report emitted after `list_cases/ok`
+        would describe the wait instead of filling it."""
+        _run_main(monkeypatch, [PRESS_CASE_READY], invoke_text_stub=lambda **kw: "{}",
+                  argv=["--dry-run"])
+
+        seq = [(r["step"], r["status"]) for r in _read_events(_events_path())]
+        assert seq.index(("list_cases", "progress")) < seq.index(("list_cases", "ok"))
+
+    def test_progress_rows_stay_out_of_the_ledger(self, monkeypatch, tmp_path):
+        """`build_ledger` skips rows without a slug. 16 pages per run must not
+        become 16 phantom cases."""
+        _run_main(monkeypatch, [PRESS_CASE_READY], invoke_text_stub=lambda **kw: "{}",
+                  argv=["--dry-run"])
+
+        rows = _read_events(_events_path())
+        for row in rows:
+            if row["step"] == "list_cases":
+                assert row["slug"] == "", row
 
 
 def test_events_file_records_would_enrich_under_dry_run(

--- a/tests/casework/test_enrich_missing_bigo.py
+++ b/tests/casework/test_enrich_missing_bigo.py
@@ -1089,6 +1089,100 @@ def test_events_file_covers_start_extract_write_on_apply_happy_path(
     assert ("write", "enriched") in steps_and_statuses
 
 
+class TestBatchCsvWiring:
+    """The bigo enricher must honour `--batch-csv` like the other four.
+
+    It was the one enricher left on the hand-rolled `select_cases(...)` +
+    `cases[:limit]` pair, so it advertised `--batch-csv` in `--help` (the flag
+    is registered by the shared `add_common_args`) while ignoring it entirely --
+    the worst of the three possible states. An operator passing a reviewed batch
+    would have got a full-corpus run that looked like it had been scoped.
+
+    `test_batch_csv_cli_wiring.py` covers the parse-time guards and `convert.py`.
+    These drive `main()` end to end, because the bug was in the wiring, not in
+    the selection algebra.
+    """
+
+    @staticmethod
+    def _ready(slug, state="DRAFT"):
+        """A case that reaches extraction, with a caller-chosen slug/state."""
+        return {**PRESS_CASE_READY, "slug": slug, "state": state}
+
+    @staticmethod
+    def _batch(tmp_path, *slugs):
+        path = tmp_path / "batch.csv"
+        path.write_text("slug\n" + "".join(f"{s}\n" for s in slugs), encoding="utf-8")
+        return str(path)
+
+    @staticmethod
+    def _visited():
+        """Slugs the per-case loop actually opened, in order."""
+        return [r["slug"] for r in _read_events(_events_path()) if r["step"] == "start"]
+
+    def test_a_case_outside_the_batch_is_never_touched(
+        self, monkeypatch, patched_fetch_markdown, tmp_path
+    ):
+        _run_main(
+            monkeypatch,
+            [self._ready("case-a"), self._ready("case-b"), self._ready("case-zzz")],
+            invoke_text_stub=lambda **kw: "{}",
+            argv=["--dry-run", "--batch-csv", self._batch(tmp_path, "case-a", "case-b")],
+        )
+        assert self._visited() == ["case-a", "case-b"]
+
+    def test_limit_takes_the_files_first_rows_not_the_apis(
+        self, monkeypatch, patched_fetch_markdown, tmp_path
+    ):
+        """The reason this wiring matters. `--limit` sliced whatever order the
+        API returned, so a `--limit 10` smoke test picked an arbitrary ten --
+        in one real run, nine that already had a `bigo`, producing zero LLM
+        calls. Against a batch the slice is the operator's first ten rows.
+        """
+        # API order is the reverse of the batch order, so an unbatched slice
+        # would take case-c and case-b.
+        _run_main(
+            monkeypatch,
+            [self._ready("case-c"), self._ready("case-b"), self._ready("case-a")],
+            invoke_text_stub=lambda **kw: "{}",
+            argv=["--dry-run", "--limit", "2",
+                  "--batch-csv", self._batch(tmp_path, "case-a", "case-b", "case-c")],
+        )
+        assert self._visited() == ["case-a", "case-b"]
+
+    def test_a_since_published_batch_row_is_skipped(
+        self, monkeypatch, patched_fetch_markdown, tmp_path
+    ):
+        """A batch still passes the state gate, unlike `--slug`. A stale CSV
+        listing a case that has since been PUBLISHED must not re-enrich it.
+
+        `case-other` is DRAFT and absent from the batch purely so this test can
+        fail for the right reason: without the wiring, bulk selection would
+        already gate out the PUBLISHED row, so the assertion would pass while
+        proving nothing. `case-other` makes an ignored batch visible.
+        """
+        _run_main(
+            monkeypatch,
+            [self._ready("case-a"), self._ready("case-published", state="PUBLISHED"),
+             self._ready("case-other")],
+            invoke_text_stub=lambda **kw: "{}",
+            argv=["--dry-run",
+                  "--batch-csv", self._batch(tmp_path, "case-a", "case-published")],
+        )
+        assert self._visited() == ["case-a"]
+
+    def test_without_a_batch_the_run_is_still_bulk(
+        self, monkeypatch, patched_fetch_markdown, tmp_path
+    ):
+        """Wiring the batch in must not narrow the default path."""
+        _run_main(
+            monkeypatch,
+            [self._ready("case-a"), self._ready("case-b")],
+            invoke_text_stub=lambda **kw: "{}",
+            argv=["--dry-run"],
+        )
+        assert sorted(self._visited()) == ["case-a", "case-b"]
+
+
 class TestCaseListingNarratesItself:
     """The 33s of silence before the first case.
 

--- a/tests/casework/test_enrich_missing_bigo.py
+++ b/tests/casework/test_enrich_missing_bigo.py
@@ -564,6 +564,21 @@ class _FakeUsage:
         return {"by_provider": []}
 
 
+def _quoting_invoke(bigo, captured=None):
+    """A fake `invoke_text` returning `bigo` with a quote that clears the
+    keyword guard. Pass `captured` to record the prompt that was actually sent.
+    """
+    def fake_invoke(**kw):
+        if captured is not None:
+            captured["content"] = kw["content"]
+        return json.dumps({
+            "bigo": bigo, "confidence": "high",
+            "evidence_quote": f"बिगो रु.{bigo} कायम गरी",
+        })
+
+    return fake_invoke
+
+
 def _run_main(monkeypatch, cases, invoke_text_stub, argv):
     """Drive `main()` end to end with a stubbed API and a stubbed LLM call.
 
@@ -598,22 +613,64 @@ class TestGroundingSpansEverythingTheModelWasShown:
     figure the model read correctly out of the title, and skipped the case.
     """
 
+    # The बिगो is stated ONLY in the material display_name -- never in the body.
+    CASE = {
+        "slug": "case-x", "title": "t",
+        "evidence": [{
+            "material_iri": "https://jawafdehi.org/material/1",
+            "material": {
+                "material_type": "press_release",
+                "display_name": "... उपर बिगो रु.९०,३९,६२०।३९ कायम",
+                "urls": [{"role": "MARKDOWN", "link": "https://x/p.md"}],
+            },
+        }],
+    }
+
     def test_an_amount_stated_only_in_the_display_name_is_grounded(self):
-        case = {
-            "slug": "case-x", "title": "t",
-            "evidence": [{
-                "material_iri": "https://jawafdehi.org/material/1",
-                "material": {
-                    "material_type": "press_release",
-                    "display_name": "... उपर बिगो रु.९०,३९,६२०।३९ कायम",
-                    "urls": [{"role": "MARKDOWN", "link": "https://x/p.md"}],
-                },
-            }],
-        }
         body = "आरोपपत्र दायर गरिएको छ।"
         assert amount_is_grounded(body, 9039620) is False
-        shown = emb._source_metadata(case, emb.PRESS_TYPES) + "\n" + body
+        _, shown = emb._extract_bigo(
+            body, self.CASE, _quoting_invoke(9039620), _FakeUsage()
+        )
         assert amount_is_grounded(shown, 9039620) is True
+
+    def test_the_gate_checks_the_same_string_the_prompt_carried(self):
+        """`_extract_bigo` returns its composed source text so the gate can check
+        that exact string. Rebuilding it at the call site meant two constructions
+        of "what the model was shown" that a prompt change would silently drift
+        apart -- and it ran `_source_metadata` a second time per case.
+        """
+        captured = {}
+        _, shown = emb._extract_bigo(
+            "आरोपपत्र दायर गरिएको छ।", self.CASE,
+            _quoting_invoke(9039620, captured), _FakeUsage(),
+        )
+        for line in shown.splitlines():
+            if line.strip():
+                assert line in captured["content"], (
+                    f"grounding text carries a line the prompt never did: {line!r}"
+                )
+
+    def test_a_figure_the_clamp_cut_out_of_the_prompt_is_not_grounded(self):
+        """The clamp is why the gate cannot rebuild its own text.
+
+        `_extract_bigo` truncates the body at `FEED_CHARS`. An unclamped rebuild
+        grounds against the discarded tail too, so a fabricated amount that
+        happens to match text the model could not read would pass -- exactly the
+        coincidence the gate exists to reject.
+        """
+        long_body = "क" * emb.FEED_CHARS + " बिगो रु.९०,३९,६२०।३९ कायम"
+        captured = {}
+        _, shown = emb._extract_bigo(
+            long_body, {"slug": "case-y", "title": "t", "evidence": []},
+            _quoting_invoke(9039620, captured), _FakeUsage(),
+        )
+
+        assert "९०,३९,६२०" not in captured["content"], "clamp did not cut the tail"
+        assert amount_is_grounded(long_body, 9039620) is True, (
+            "control: the raw body does state the figure"
+        )
+        assert amount_is_grounded(shown, 9039620) is False
 
 
 class TestRupeeAmountsInTokenisation:

--- a/tests/casework/test_enrich_missing_bigo.py
+++ b/tests/casework/test_enrich_missing_bigo.py
@@ -9,15 +9,18 @@ import json
 import logging
 import sys
 import types
+import urllib.error
 from pathlib import Path
 
 import pytest
 
 from casework import enrich_missing_bigo as emb
 from casework.enrich_missing_bigo import (
+    amount_is_grounded,
     coerce_bigo_int,
     is_explicit_bigo_context,
     parse_bigo_response,
+    rupee_amounts_in,
 )
 
 # --------------------------------------------------------------------------
@@ -222,6 +225,107 @@ def test_non_bigo_quote_yields_none_even_at_high_confidence():
 def test_valid_high_confidence_bigo_parses():
     body = '{"bigo": 10403941, "confidence": "high", "evidence_quote": "बिगो रु. १,०४,०३,९४१"}'
     assert parse_bigo_response(body) == 10403941
+
+
+def test_va_spelled_bigo_quote_is_accepted():
+    """A quote spelling the word विगो must not be discarded.
+
+    These press releases are legacy-font PDFs, not scans, and render बिगो as विगो
+    in 150 of the 796 bigo tokens across the FY078/079 238-case batch. The gate
+    listed only the ब spelling, so 079-CR-0080's correct high-confidence 7000 was
+    thrown away and recorded as "LLM could not extract a reliable BIGO".
+    Verbatim quote from that document.
+    """
+    body = json.dumps(
+        {
+            "bigo": 7000,
+            "confidence": "high",
+            "evidence_quote": (
+                "निज सशस्त्र प्रहरी जवान मुख्तार देवानलाई उल्लेखित कसुरमा "
+                "विगो रु.7,000।- (सात हजार रुपैयाँ) कायम गरी"
+            ),
+            "press_release_type": "charge_filing",
+        }
+    )
+    assert parse_bigo_response(body) == 7000
+
+
+class TestAmountIsGrounded:
+    """The grounding gate: a bigo the source never states must not be written.
+
+    Every fixture here is a verbatim span from a real document, and every rejected
+    value is one that a real run actually produced.
+    """
+
+    # 078-CR-0116, the 10x inflation. Charge sheet declares रु.१,३८,९९,९९८।८७;
+    # the run proposed 138999998, whose digits appear nowhere in the document.
+    CR_0116 = (
+        "ओम सप्लायर्स, कलैया 6, बारा र ऐ.ऐ.का प्रोपाइटर निज ओम शंकर प्रसादलाई "
+        "बिगो रु.1,38,99,998।87 (एक करोड अठतीस लाख उनान्सय हजार नौ सय अन्ठानब्बे) कायम गरी"
+    )
+
+    def test_rejects_the_078_cr_0116_ten_x_inflation(self):
+        assert amount_is_grounded(self.CR_0116, 13899998) is True
+        assert amount_is_grounded(self.CR_0116, 138999998) is False
+
+    def test_rejects_a_paisa_fold(self):
+        """1389999887 is रупees..paisa concatenated -- never a real amount."""
+        assert amount_is_grounded(self.CR_0116, 1389999887) is False
+
+    def test_rejects_an_unstated_arithmetic_sum(self):
+        """079-CR-0067: the run summed three per-defendant विगो into a total the
+        release never states (35,200 + 55,200 + 177,600 = 268,000)."""
+        text = (
+            "मोहन प्रसाद आचायिउपर बिगो रु.55,200।– कायम गरी ... "
+            "जानुका श्रेष्ठउपर बिगो रु.1,77,600।- कायम गरी ... "
+            "पवन श्रेष्ठउपर विगो रु.35,200।- कायम गरी"
+        )
+        for stated in (55200, 177600, 35200):
+            assert amount_is_grounded(text, stated) is True
+        assert amount_is_grounded(text, 268000) is False
+
+    def test_accepts_devanagari_digits(self):
+        """079-CR-0136 states the amount in Devanagari; the gate must normalise."""
+        text = "निज विष्णु कान्त मिरलेलाई बिगो रु.७२,५२,४८०।५९ कायम गरी"
+        assert amount_is_grounded(text, 7252480) is True
+        assert amount_is_grounded(text, 725248059) is False
+
+    def test_accepts_a_table_cell_amount(self):
+        """078-CR-0073 states its total in a बिगो रु. table column, not inline."""
+        text = "सि.नं | पद, नामथर | कार्यालय | बिगो रु. |\n1. | अध्यक्ष | लिखु | रु.4,21,00,706।24 |"
+        assert amount_is_grounded(text, 42100706) is True
+
+    def test_short_value_is_not_grounded_by_being_a_prefix(self):
+        """The guard against the obvious false positive: 1389 must not count as
+        'stated' just because 13899998 contains it."""
+        assert amount_is_grounded("रु.1,38,99,998।87", 1389) is False
+        assert amount_is_grounded("रु.1,38,99,998।87", 138) is False
+
+    def test_none_passes_through(self):
+        """A null bigo is the enricher's own 'found nothing' -- not ungrounded."""
+        assert amount_is_grounded("anything", None) is True
+
+    def test_zero_paisa_dash_suffix(self):
+        """078-CR-0101 writes whole rupees as '।-' (danda then hyphen)."""
+        assert amount_is_grounded("निजलाई बिगो रु.७,६७,९८८।- कायम गरी", 767988) is True
+
+    def test_rupee_amounts_drops_paisa_and_commas(self):
+        assert rupee_amounts_in("रु.6,79,12,383।98") == {67912383}
+
+
+def test_va_spelled_magadavi_quote_is_accepted():
+    """मागदावी is the same ब<->व variant as मागदाबी and appears in 156 of the 238.
+
+    The quote deliberately carries NO other whitelisted keyword -- no बिगो, no
+    हानि/नोक्सानी -- so मागदावी alone has to carry the gate. Otherwise the test
+    passes on an unrelated keyword and proves nothing.
+    """
+    quote = "सजायको मागदावी लिई आज विशेष अदालत, काठमाडौंमा आरोपपत्र दायर गरिएको छ"
+    assert not any(k in quote for k in emb.BIGO_CONTEXT_KEYWORDS if k != "मागदावी")
+    body = json.dumps(
+        {"bigo": 2451526, "confidence": "high", "evidence_quote": quote}
+    )
+    assert parse_bigo_response(body) == 2451526
 
 
 def test_null_bigo_with_high_confidence_and_bigo_quote_is_none():
@@ -486,6 +590,288 @@ def _run_main(monkeypatch, cases, invoke_text_stub, argv):
     return api, report
 
 
+class TestGroundingSpansEverythingTheModelWasShown:
+    """`_extract_bigo` sends the source METADATA as well as the markdown body, so
+    the gate has to check both. `_source_metadata`'s own docstring records that a
+    material `display_name` is frequently where the बिगो is first stated
+    ("... उपर बिगो रु.९०,३९,६२०।३९ कायम"). Grounding the body alone rejected a
+    figure the model read correctly out of the title, and skipped the case.
+    """
+
+    def test_an_amount_stated_only_in_the_display_name_is_grounded(self):
+        case = {
+            "slug": "case-x", "title": "t",
+            "evidence": [{
+                "material_iri": "https://jawafdehi.org/material/1",
+                "material": {
+                    "material_type": "press_release",
+                    "display_name": "... उपर बिगो रु.९०,३९,६२०।३९ कायम",
+                    "urls": [{"role": "MARKDOWN", "link": "https://x/p.md"}],
+                },
+            }],
+        }
+        body = "आरोपपत्र दायर गरिएको छ।"
+        assert amount_is_grounded(body, 9039620) is False
+        shown = emb._source_metadata(case, emb.PRESS_TYPES) + "\n" + body
+        assert amount_is_grounded(shown, 9039620) is True
+
+
+class TestRupeeAmountsInTokenisation:
+    """Tokenisation rules measured against the 238 FY078/079 sources. Each of
+    these was a silent data-loss bug: the gate rejected a correct extraction and
+    `main` recorded `skipped`, so the case simply never got a value.
+    """
+
+    def test_markdown_table_pipes_are_not_read_as_paisa_separators(self):
+        """`|` is in the separator class because OCR renders the danda '।' as a
+        pipe -- but in a markdown table it is a cell delimiter. Unbounded, the
+        paisa group ate `<serial> | <first group>` and dropped the real amount:
+        `| 1 | 35,200 |` yielded {1, 200}, never 35200. 2 of the 238 sources
+        contain that shape, and a बिगो in a table column is Rule 6's
+        high-confidence signal #2."""
+        assert 35200 in rupee_amounts_in("| सि.नं | बिगो रु. |\n| 1 | 35,200 |")
+        assert 177600 in rupee_amounts_in("| 2 | 1,77,600 |")
+        assert 42100706 in rupee_amounts_in("| 1. | अध्यक्ष | 4,21,00,706।24 |")
+
+    def test_comma_groups_split_by_whitespace_still_parse(self):
+        """Markdown extraction turns रु.1,38,99,998।87 into रु. 1, 38, 99, 998।87
+        in 8 of the 238 sources."""
+        assert 13899998 in rupee_amounts_in("रु. 1, 38, 99, 998।87")
+
+    def test_a_paisa_fold_is_never_admitted(self):
+        """The un-truncated reading of a paisa-bearing token IS the paisa-fold
+        error (080-CR-0158). Adding it to the set would make the gate bless the
+        exact class of bug it exists to catch."""
+        amounts = rupee_amounts_in("बिगो रु.1,46,81,225।90")
+        assert 14681225 in amounts
+        assert 1468122590 not in amounts
+
+    def test_the_dot_separator_matches_coerce_bigo_int(self):
+        """An earlier copy of this function omitted '.', which `coerce_bigo_int`
+        honours -- so रु.324.57 reduced to 324 on the model's answer but yielded
+        {57, 324} here. The two sides of the comparison must not drift."""
+        amounts = rupee_amounts_in("रु.324.57")
+        assert coerce_bigo_int("रु.324.57") == 324
+        assert 324 in amounts
+        assert 57 not in amounts
+
+
+class TestExtractionPromptDecisions:
+    """Two prompt choices that were measured, not guessed. Both cost real money
+    to establish, so they are pinned here rather than left to a reader's judgement.
+    """
+
+    def test_rule_3_subordinates_type_routing_to_a_declared_bigo(self):
+        """Rule 3 used to route sting/appeal releases to null BEFORE reading the
+        text. Measured over the 238 FY078/079 sources: 0 documents contain any
+        sting trigger and 0 contain any appeal trigger, so it never fired -- while
+        65 declare a bribe AS the बिगो under दफा ३(१). Had it ever fired it would
+        have produced false nulls on figures the document states outright."""
+        rule3 = emb.EXTRACTION_SYSTEM_PROMPT.split("Rule 3")[1].split("Rule 4")[0]
+        declared = rule3.index("declares a बिगो")
+        sting = rule3.index("Sting Operation")
+        assert declared < sting, (
+            "Rule 3 routes on document type before checking for a declared बिगो; "
+            "that is the false-null ordering, and 65 of 238 releases declare a "
+            "bribe as the बिगो"
+        )
+
+    def test_prompt_has_no_multi_defendant_decision_procedure(self):
+        """The four-step "Rule 7b" for multi-defendant cases was built, run over
+        all 238, and reverted: accuracy fell from 235/238 to ~228/238. It nulled
+        078-CR-0073 despite the release stating `कुल जम्मा रु.4,21,00,706।24`, and
+        made three cases return one defendant's figure instead of the case total.
+        Giving the model an ordered procedure gave it more ways to go wrong than
+        simply reporting the figure labelled बिगो.
+        """
+        prompt = emb.EXTRACTION_SYSTEM_PROMPT
+        assert "Rule 7b" not in prompt
+        assert "Rule 7c" not in prompt
+        # Rule 7 itself -- "no clear bigo label, return null" -- must stay.
+        assert "Rule 7 — Multiple amounts" in prompt
+
+
+class TestBigoIsPressReleaseOnly:
+    """The judgment is deliberately NOT read by this stage.
+
+    Feeding the court order alongside the press release was built, run against
+    all 238 bound FY078/079 cases, and reverted (2026-08-03):
+      - 52k chars sent per case vs 2.4k press-only -- 22x the input on EVERY
+        case, ~2 min/case vs ~15s, projecting ~8h and >$100 against $23.
+      - It changed the answer only on the ~18 multi-defendant cases, where the
+        press release states per-defendant figures and no total.
+      - `bigo` is the ALLEGED loss. The press release IS that claim; the
+        judgment records what was ESTABLISHED, so it is the wrong primary
+        source for this field regardless of cost.
+    These tests exist so re-adding it has to be a deliberate act, not a
+    one-word edit to `requires_materials`.
+    """
+
+    def test_bigo_stage_gates_on_press_material_only(self):
+        """Pins the LITERAL membership, not PRESS_TYPES against itself.
+
+        `set(requires_materials) == set(PRESS_TYPES)` is vacuous -- it stays green
+        if `court_order` is added TO `PRESS_TYPES`, or if `charge_sheet` is dropped
+        from it. `test_pipeline.py` documents that exact trap.
+        """
+        from casework.common.pipeline import STAGES
+
+        assert set(STAGES["bigo"].requires_materials) == {
+            "press_release", "ciaa_press_release", "charge_sheet",
+        }, ("court_order is back on the bigo stage -- that is 22x the input per "
+            "case for the ~18 multi-defendant ones; bind the charge sheet instead")
+
+    def test_no_court_material_leaks_into_the_prompt(self):
+        """Not just the body text -- the source-metadata block must not advertise
+        the judgment either, or the model will report figures it cannot see."""
+        captured = {}
+
+        def fake_invoke(**kw):
+            captured["content"] = kw["content"]
+            return json.dumps({
+                "bigo": 7252480, "confidence": "high",
+                "evidence_quote": "बिगो रु.७२,५२,४८०।५९ कायम गरी",
+            })
+
+        case = {
+            "slug": "case-x", "title": "t",
+            "evidence": [{
+                "material_iri": "https://jawafdehi.org/material/1",
+                "material": {
+                    "material_type": "court_order",
+                    "display_name": "SPECIAL-COURT-JUDGMENT-MARKER",
+                    "urls": [{"role": "MARKDOWN", "link": "https://x/j.md"}],
+                },
+            }],
+        }
+        emb._extract_bigo("press release text", case, fake_invoke, _FakeUsage())
+        assert "SPECIAL-COURT-JUDGMENT-MARKER" not in captured["content"]
+
+    def test_a_total_stated_only_in_the_judgment_is_not_grounded(self):
+        """Grounding spans the press release alone. A figure that exists only in
+        the unread judgment must be rejected, not written."""
+        press = "प्रतिवादीहरूउपर आरोपपत्र दायर गरिएको छ।"
+        assert amount_is_grounded(press, 16405000) is False
+
+
+class TestPreLoopFailuresAreLogged:
+    """Everything before the per-case loop must leave a record.
+
+    These paths used to fail silently: a bootstrap error printed to stderr and
+    exited, leaving both the run `.log` and `.events.jsonl` at ZERO bytes with no
+    record of the target, the mode, or the reason. `log_run_header`/`_footer` only
+    reach the `.log`, and `ledger.py` reads only `*.events.jsonl`.
+    """
+
+    def test_bootstrap_failure_is_recorded(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            emb, "bootstrap",
+            lambda *a, **k: (_ for _ in ()).throw(
+                RuntimeError("SECRET_KEY environment variable must be set")),
+        )
+        with pytest.raises(SystemExit) as exc:
+            emb.main(["--dry-run", "--api-base-url", "https://api.jawafdehi.org"])
+        assert exc.value.code == 1
+
+        rows = _read_events(_events_path())
+        assert rows, "bootstrap failure left the events log empty"
+        started = [r for r in rows if r["step"] == "run" and r["status"] == "start"]
+        assert started, "no run/start event -- the run's target and mode are unrecorded"
+        assert "target=https://api.jawafdehi.org" in started[0]["detail"]
+        assert "mode=DRY-RUN" in started[0]["detail"]
+        failed = [r for r in rows if r["step"] == "bootstrap" and r["status"] == "error"]
+        assert failed, "the bootstrap error itself was not recorded"
+        assert "SECRET_KEY" in failed[0]["detail"]
+
+    def test_missing_credentials_are_recorded_despite_raising_systemexit(
+        self, monkeypatch, tmp_path
+    ):
+        """The credential path raises `SystemExit`, not `Exception`.
+
+        `basic_auth_from_env` calls `raise SystemExit(...)`, which derives from
+        BaseException -- so an `except Exception` guard let exactly the failure it
+        was added for escape, leaving `run/start` as the last line in the events
+        file. That is indistinguishable from a killed run, which is the very thing
+        these terminal events exist to disambiguate.
+        """
+        monkeypatch.setattr(emb, "bootstrap", lambda *a, **k: None)
+        for key in ("JAWAFDEHI_API_TOKEN", "CASEWORK_API_USER", "CASEWORK_API_PASSWORD"):
+            monkeypatch.delenv(key, raising=False)
+
+        with pytest.raises(SystemExit) as exc:
+            emb.main(["--dry-run", "--api-base-url", "https://api.jawafdehi.org"])
+        assert exc.value.code == 1
+
+        rows = _read_events(_events_path())
+        failed = [r for r in rows if r["step"] == "build_api" and r["status"] == "error"]
+        assert failed, "a missing credential was not recorded -- SystemExit escaped"
+        assert "SystemExit" in failed[0]["detail"]
+
+    def test_case_listing_failure_is_recorded(self, monkeypatch, tmp_path):
+        """An expired token mid-listing must not die as a bare traceback."""
+        monkeypatch.setattr(emb, "bootstrap", lambda *a, **k: None)
+
+        class _Boom:
+            def iter_cases(self, *a, **k):
+                raise urllib.error.HTTPError("u", 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr(emb, "build_api", lambda args: _Boom())
+        with pytest.raises(SystemExit):
+            emb.main(["--dry-run", "--api-base-url", "https://api.jawafdehi.org"])
+
+        rows = _read_events(_events_path())
+        failed = [r for r in rows if r["step"] == "list_cases" and r["status"] == "error"]
+        assert failed, "a failure during case listing was not recorded"
+        assert "401" in failed[0]["detail"]
+
+    def test_run_scoped_events_never_appear_as_cases_in_the_ledger(
+        self, monkeypatch, tmp_path
+    ):
+        """Run rows carry no slug, and build_ledger requires slug AND stage."""
+        monkeypatch.setattr(
+            emb, "bootstrap",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope")),
+        )
+        with pytest.raises(SystemExit):
+            emb.main(["--dry-run", "--api-base-url", "http://127.0.0.1:48010"])
+
+        from casework.ledger import build_ledger
+
+        rows = _read_events(_events_path())
+        # Must be meaningful in both directions: the rows exist on disk...
+        run_rows = [r for r in rows if r["step"] in ("run", "bootstrap")]
+        assert run_rows, "no run-scoped rows were written at all"
+        assert all(r["slug"] == "" for r in run_rows), "run rows must carry no slug"
+        assert any(r["status"] == "error" for r in run_rows), (
+            "an outcome-shaped status is what would leak; the test is vacuous without one"
+        )
+        # ...and none of them becomes a phantom case in the ledger.
+        ledger = build_ledger(tmp_path)
+        assert ledger == {}, f"run bookkeeping leaked into the ledger: {ledger}"
+
+    def test_successful_run_emits_a_terminal_run_event(
+        self, monkeypatch, tmp_path, patched_fetch_markdown
+    ):
+        """The presence of run/complete is how you tell a finished run from a
+        killed one -- the ledger never reads the .log footer."""
+        _run_main(
+            monkeypatch,
+            [PRESS_CASE_READY],
+            invoke_text_stub=lambda **kw: json.dumps(
+                {"bigo": 10403941, "confidence": "high",
+                 "evidence_quote": "बिगो रु. १,०४,०३,९४१ कायम गरी"}),
+            argv=["--dry-run"],
+        )
+        rows = _read_events(_events_path())
+        steps = {(r["step"], r["status"]) for r in rows}
+        assert ("run", "start") in steps
+        assert ("list_cases", "ok") in steps
+        assert ("select", "ok") in steps
+        assert ("run", "complete") in steps
+        done = [r for r in rows if r["step"] == "run" and r["status"] == "complete"]
+        assert "would-enrich=1" in done[0]["detail"]
+
+
 def test_unmet_prerequisite_is_recorded_not_silently_skipped(
     monkeypatch, patched_fetch_markdown
 ):
@@ -624,10 +1010,17 @@ def test_events_file_covers_start_extract_write_on_apply_happy_path(
     assert rows, "events file must not be empty"
 
     required_keys = {"ts", "run_id", "stage", "slug", "step", "status", "detail", "elapsed_ms"}
+    # Run-scoped rows (run/list_cases/select) deliberately carry no slug so the
+    # ledger skips them -- see TestPreLoopFailuresAreLogged. Every CASE row must
+    # still name its case, which is what this assertion is for.
+    RUN_STEPS = {"run", "list_cases", "select", "bootstrap", "build_api"}
+    case_rows = [r for r in rows if r["step"] not in RUN_STEPS]
+    assert case_rows, "no per-case events were written"
     for row in rows:
         assert required_keys <= set(row.keys())
-        assert row["slug"] == "case-ready"
         assert row["stage"] == "bigo"
+    for row in case_rows:
+        assert row["slug"] == "case-ready"
 
     steps_and_statuses = {(r["step"], r["status"]) for r in rows}
     assert ("start", "start") in steps_and_statuses

--- a/tests/casework/test_select_batch_csv.py
+++ b/tests/casework/test_select_batch_csv.py
@@ -1,0 +1,183 @@
+"""`--batch-csv` as a hard allowlist for enricher selection.
+
+The operator requirement this file pins: when a batch CSV is supplied, a run
+must touch ONLY the cases listed in it. Every test here exists because the
+failure mode is silent -- an over-selecting run looks exactly like a correct
+one in the console, and under `--apply` it writes to cases nobody reviewed.
+"""
+
+import argparse
+
+import pytest
+
+from casework.common.cli import add_common_args
+from casework.common.select import (
+    select_cases, select_for_run, slugs_from_batch_csv,
+)
+
+SPECIAL = "https://jawafdehi.org/courtcase/special/081-cr-0098"
+
+
+def _args(argv):
+    """Parse through the REAL shared parser, so a renamed/dropped flag fails
+    here instead of drifting silently out of the enrichers."""
+    return add_common_args(argparse.ArgumentParser()).parse_args(argv)
+
+
+def _csv(tmp_path, text, name="batch.csv"):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+# --- reading the CSV -------------------------------------------------------
+
+def test_batch_csv_preserves_file_order(tmp_path):
+    # File order is load-bearing: `--limit N` must mean "the first N rows of
+    # my batch", which is only true if this preserves order.
+    path = _csv(tmp_path, "slug\nc-third\nc-first\nc-second\n")
+    assert slugs_from_batch_csv(path) == ["c-third", "c-first", "c-second"]
+
+
+def test_batch_csv_ignores_the_binders_extra_columns(tmp_path):
+    # The whole point of reusing the binder's format is that
+    # `select_batch.py` output feeds straight in. Those CSVs carry material
+    # IRI columns alongside `slug`.
+    path = _csv(
+        tmp_path,
+        "slug,ciaa_press_release,court_order\n"
+        "case-078-cr-0001,https://jawafdehi.org/material/ciaa_press_release/1979,x\n",
+    )
+    assert slugs_from_batch_csv(path) == ["case-078-cr-0001"]
+
+
+def test_batch_csv_skips_blank_rows_and_dedupes_keeping_first_position(tmp_path):
+    path = _csv(tmp_path, "slug\na\n\n  \nb\na\n")
+    assert slugs_from_batch_csv(path) == ["a", "b"]
+
+
+def test_batch_csv_strips_surrounding_whitespace(tmp_path):
+    # A hand-edited CSV picks up stray spaces; an unstripped slug matches no
+    # case and silently shrinks the batch.
+    path = _csv(tmp_path, "slug\n  case-078-cr-0001  \n")
+    assert slugs_from_batch_csv(path) == ["case-078-cr-0001"]
+
+
+def test_batch_csv_without_a_slug_column_fails_loud(tmp_path):
+    path = _csv(tmp_path, "case,amount\nfoo,1\n")
+    with pytest.raises(SystemExit, match="slug"):
+        slugs_from_batch_csv(path)
+
+
+def test_batch_csv_that_does_not_exist_fails_loud(tmp_path):
+    with pytest.raises(SystemExit, match="not found"):
+        slugs_from_batch_csv(str(tmp_path / "nope.csv"))
+
+
+def test_batch_csv_with_no_usable_rows_fails_loud(tmp_path):
+    # THE landmine. An empty batch must never reach `select_cases` as an
+    # empty slug set, because that falls through to BULK selection -- i.e. a
+    # typo'd or truncated batch file would silently enrich every enrichable
+    # case in production instead of nothing.
+    path = _csv(tmp_path, "slug\n\n   \n")
+    with pytest.raises(SystemExit, match="no slugs"):
+        slugs_from_batch_csv(path)
+
+
+# --- selecting against the batch ------------------------------------------
+
+def test_batch_never_selects_a_case_outside_it():
+    # `outside` is DRAFT and matches the fiscal year, so bulk selection would
+    # happily take it. The batch must exclude it anyway.
+    cases = [
+        {"slug": "inside", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "outside", "state": "DRAFT", "court_cases": [SPECIAL]},
+    ]
+    got = select_cases(cases, batch_slugs=["inside"])
+    assert [c["slug"] for c in got] == ["inside"]
+
+
+def test_batch_returns_cases_in_batch_order_not_api_order():
+    # The API returns newest-first; the batch file is ascending. Without this,
+    # `--limit 10` against a 238-row batch gives whichever ten the API
+    # happened to return first -- not the first ten rows the operator listed.
+    cases = [
+        {"slug": "b", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "a", "state": "DRAFT", "court_cases": [SPECIAL]},
+    ]
+    got = select_cases(cases, batch_slugs=["a", "b"])
+    assert [c["slug"] for c in got] == ["a", "b"]
+
+
+def test_batch_still_applies_the_state_gate():
+    # Deliberately STRICTER than the `--slug` bypass. A stale batch CSV that
+    # still lists a case since PUBLISHED must not be enriched: over-selection
+    # is invisible and writes to reviewed cases, under-selection is visible in
+    # the n_selected count. Use `--slug` for a deliberate one-off override.
+    cases = [
+        {"slug": "draft", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "pub", "state": "PUBLISHED", "court_cases": [SPECIAL]},
+    ]
+    got = select_cases(cases, batch_slugs=["draft", "pub"])
+    assert [c["slug"] for c in got] == ["draft"]
+
+
+def test_batch_slug_absent_from_the_api_payload_is_skipped_not_fatal():
+    cases = [{"slug": "here", "state": "DRAFT", "court_cases": [SPECIAL]}]
+    got = select_cases(cases, batch_slugs=["here", "deleted-since"])
+    assert [c["slug"] for c in got] == ["here"]
+
+
+def test_fiscal_year_can_only_narrow_a_batch_never_widen_it():
+    # A caller passing both must not end up with the fiscal-year cohort.
+    cases = [
+        {"slug": "in-batch-081", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "not-in-batch-081", "state": "DRAFT", "court_cases": [SPECIAL]},
+    ]
+    got = select_cases(cases, fiscal_year="081", batch_slugs=["in-batch-081"])
+    assert [c["slug"] for c in got] == ["in-batch-081"]
+
+
+def test_slug_flag_can_only_narrow_a_batch_never_widen_it():
+    cases = [
+        {"slug": "in-both", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "batch-only", "state": "DRAFT", "court_cases": [SPECIAL]},
+        {"slug": "flag-only", "state": "DRAFT", "court_cases": [SPECIAL]},
+    ]
+    got = select_cases(
+        cases, slugs=("in-both", "flag-only"), batch_slugs=["in-both", "batch-only"],
+    )
+    assert [c["slug"] for c in got] == ["in-both"]
+
+
+# --- the shared run-selection path the enrichers call ---------------------
+
+def test_flag_is_registered_on_the_shared_parser(tmp_path):
+    # A real path: the flag validates its argument at parse time, so a
+    # placeholder name would fail here for the wrong reason.
+    path = _csv(tmp_path, "slug\na\n")
+    assert _args(["--batch-csv", path]).batch_csv == path
+
+
+def test_no_batch_flag_leaves_bulk_selection_untouched():
+    cases = [{"slug": "a", "state": "DRAFT", "court_cases": [SPECIAL]}]
+    assert [c["slug"] for c in select_for_run(cases, _args([]))] == ["a"]
+
+
+def test_select_for_run_limits_to_the_first_rows_of_the_batch(tmp_path):
+    path = _csv(tmp_path, "slug\na\nb\nc\n")
+    cases = [
+        {"slug": s, "state": "DRAFT", "court_cases": [SPECIAL]}
+        for s in ("c", "b", "a")  # API order: reverse of the batch
+    ]
+    args = _args(["--batch-csv", path, "--limit", "2"])
+    assert [c["slug"] for c in select_for_run(cases, args)] == ["a", "b"]
+
+
+def test_select_for_run_honours_limit_without_a_batch():
+    cases = [
+        {"slug": f"c{i}", "state": "DRAFT", "court_cases": [SPECIAL]}
+        for i in range(5)
+    ]
+    got = select_for_run(cases, _args(["--limit", "2"]))
+    assert len(got) == 2

--- a/tests/test_llm_cli_providers.py
+++ b/tests/test_llm_cli_providers.py
@@ -5,6 +5,7 @@ Tests the parsers without invoking real CLIs by monkeypatching _run().
 
 import json
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from llm.providers.cli import ClaudeCliProvider, CodexCliProvider
@@ -223,6 +224,45 @@ class TestClaudeCliProvider(unittest.TestCase):
         # Test that it returns the configured value from settings (or empty by default)
         model = provider.model_for_tier("premium")
         self.assertIsInstance(model, str)
+
+    # The turn cap itself is covered by `llm/tests/test_cli_provider_turns.py`
+    # (added in #412, which fixed it independently from the case_proposal.intent
+    # side). What is NOT covered there is what happens when the raised cap is
+    # still not enough -- that is the test below.
+
+    def test_run_retries_error_max_turns(self):
+        """`error_max_turns` is transient and MUST be retried.
+
+        `_run` inspects the output only for rate-limit markers, so a non-zero
+        exit carrying `error_max_turns` was raised on the first attempt and the
+        case was permanently recorded as an error. Raising `CLAUDE_CLI_MAX_TURNS`
+        makes that rare rather than impossible: a long enough answer exhausts
+        whatever the cap is, and the retry often lands inside it.
+        """
+        provider = ClaudeCliProvider()
+        failure = json.dumps(
+            {
+                "type": "result",
+                "subtype": "error_max_turns",
+                "is_error": True,
+                "result": "",
+                "errors": ["Reached maximum number of turns (1)"],
+            }
+        )
+        success = json.dumps({"type": "result", "is_error": False, "result": "{}"})
+
+        def proc(rc, out):
+            return SimpleNamespace(returncode=rc, stdout=out, stderr="")
+
+        # side_effect takes the two results in order; no hand-rolled counter, and
+        # `run.call_count` is the assertion rather than a list nothing reads.
+        with patch("llm.providers.cli.subprocess.run",
+                   side_effect=[proc(1, failure), proc(0, success)]) as run, \
+             patch("llm.providers.cli.time.sleep"):
+            out = provider._run(["claude"], "msg", {})
+
+        self.assertEqual(run.call_count, 2, "error_max_turns was not retried")
+        self.assertEqual(json.loads(out)["result"], "{}")
 
 
 class TestCodexCliProvider(unittest.TestCase):


### PR DESCRIPTION
The casework enricher pipeline wrote बिगो figures no source document states, discarded correct ones over a font quirk, ignored the `--batch-csv` allowlist it advertised, and could put a production bearer token on the wire in cleartext. This fixes all four, measured against 238 real FY078/079 CIAA cases.

**No production writes.** Every run was `--dry-run` over read-only GETs. The output is a reviewable patch manifest, not an applied change.

## Verification

`uv run ruff check .` clean · pre-commit clean · **3236 unit tests pass, 0 fail** (`--ignore=integration-tests`; those need a live server on `:48000`) · CI green on every commit.

## Scope note

This branch carries two workstreams. The bigo/LLM fixes were reviewed and approved at 9 files; the `--batch-csv` allowlist (`277df9d`) was committed onto the same branch afterwards. Reviewers approving the earlier scope have not seen commits 3–6.

---

# 1. Ungrounded बिगो figures could be written

**Problem.** Three guards existed and none checked that the extracted number appears in the document. `coerce_bigo_int` sees a well-formed integer and passes it through; the keyword guard only inspects the model's quote, which is usually copied correctly even when the number is not. Two real fabrications from the first 238-case run:

| Case | Model returned | Document says | Failure |
|---|---|---|---|
| `078-CR-0116` | `138999998` | रु.१,३८,९९,९९८।८७ | 10× inflation; those digits appear nowhere |
| `079-CR-0067` | `268000` | three per-defendant विगो figures | a real sum, but never stated |

**Fix.** `amount_is_grounded` rejects any figure absent from the source text, and `_extract_bigo` returns the exact string the prompt carried so the gate checks what the model saw rather than a second reconstruction of it. That distinction is load-bearing: an unclamped rebuild would ground against text `FEED_CHARS` had already truncated out of the model's view, so a fabrication matching the discarded tail would pass the one gate built to catch it.

**Result.** Re-validated across all 403 candidate readings with positive and negative controls: **0 fabrications leaked, 0 correct figures lost.**

Three tokenisation rules came out of the same work. Each was its own silent data-loss bug — the gate rejected a *correct* extraction, so the case got no value at all:

| Input | Was | Now |
|---|---|---|
| `\| 74,75,000 \|` (markdown table cell) | `\|` read as a paisa separator | parsed; Rule 6's high-confidence signal survives |
| `रु.७२, ५२,४८०` (comma groups split by whitespace) | unparsed — 8 of 238 sources | parsed |
| `रु.1,46,81,225।90` | risk of admitting `1468122590` | paisa dropped, never folded |

The last is not hypothetical: a paisa-fold reached production on `080-CR-0158`.

# 2. A ब/व font variant discarded correct extractions

**Problem.** These press releases are legacy-font PDFs, so `ब` renders as `व` — often within one document. The keyword whitelist had `बिगो` and `मागदाबी` but not `विगो` and `मागदावी`. The guard runs on the model's returned quote, so correct high-confidence answers were thrown away *after* being paid for.

`079-CR-0080`, raw model output captured before the parser ran:

```text
model returned bigo : 7000 | confidence: high
evidence_quote      : ...उल्लेखित कसुरमा विगो रु.7,000।- (सात हजार रुपैयाँ) कायम गरी
keywords matched    : []
is_explicit_bigo_context = False
parse_bigo_response(raw) = None      <-- recorded as "could not extract"
```

| Document spells it | Docs | Verified correct | Recall miss |
|---|---|---|---|
| `बिगो` only | 150 | 39 | **0** |
| `विगो` only | 13 | **0** | 4 |

**Fix.** Both variants added to the whitelist. **Recovered 30 cases, 29 verified correct.**

# 3. `error_max_turns` was a permanent failure

**Problem.** `_run` treats only rate-limit markers as retryable, so a turn-limit abort was raised on the first attempt and the case was recorded as a permanent error.

**Fix.** `error_max_turns` and `maximum number of turns` added to the retryable set.

**Relationship to #412**, which raised the turn cap independently from the `case_proposal.intent` side while this PR was open: that PR's version is better — the value is a setting (`CLAUDE_CLI_MAX_TURNS`) rather than a module constant — so this branch dropped its own cap fix and kept only the retry, which #412 does not have. A raised cap makes the abort rare, not impossible; a long enough answer exhausts whatever the cap is. #412's own commit message notes a surviving `error_max_turns` is "likelier to be a real budget problem", which argues for retrying rather than leaving it fatal: a budget problem costs one wasted attempt, not retrying costs the case.

Two investigations found this from different payloads, which rules out a prompt-specific quirk:

| | This branch | #412 |
|---|---|---|
| Payload | casework bigo extraction (sonnet) | `case_proposal.intent` |
| At 1 turn | 3 failures / 10 | 3 of 5 succeeded |
| Raised | 0 / 10 at 2 turns | 5 of 5 at 3 turns |

# 4. `--batch-csv` was advertised and ignored

**Problem.** `add_common_args` registers `--batch-csv` for every consumer, so it appeared in each tool's `--help`. Three tools ignored it, which is worse than not offering it: an operator passing a reviewed batch got a full-corpus run that looked scoped.

**Fix.** `select_for_run` centralises "select, then slice by `--limit`" — five drifted copies replaced by one path. `--batch-csv` is a hard allowlist: nothing outside the file is selected, other selectors can only narrow it, and results come back in **file order** so `--limit N` takes the operator's first N rows.

That ordering guarantee is the practical payoff. Previously `--limit 10` sliced whatever order the API returned; in a real smoke run that picked ten cases of which nine already had a `bigo`, producing **zero LLM calls** and exercising none of the extraction path.

Two guards stop a mis-scoped run silently widening: `--batch-csv "$BATCH"` with an unset variable arrives as `""`, which argparse accepts and which would otherwise read as "no batch" and fall through to bulk selection over the whole corpus. Rejected at parse time, and again in `select_for_run` for callers building args by hand. A missing file is caught at parse time too — one `stat` instead of 16 pages of HTTP.

**One deliberate asymmetry:** `--slug` bypasses the DRAFT/IN_REVIEW state gate; `--batch-csv` does not. A stale row for a since-PUBLISHED case is skipped, not re-enriched. Over-selection is invisible and writes to reviewed cases; under-selection shows up immediately as `n_selected` below the CSV's row count.

# 5. A bearer token could travel in cleartext (CWE-319)

**Problem.** `_headers` attaches the credential to every request, reads included, and the write-guard inspects only the host, not the scheme. `--api-base-url http://api...` with a production token therefore sent it in plaintext, for runs lasting hours. `basic=` was already loopback-restricted; Bearer had no scheme check at all.

**Fix.** `CaseworkApi` refuses to construct for a non-loopback base URL that is not `https`. Loopback over `http` stays exempt — a DEV_AUTH server has no TLS and the token never leaves the host, so requiring TLS there would break every local run for no gain.

# 6. `convert.py` silently dropped selectors

**Problem.** The batch branch returned early, so `--batch-csv b.csv --slug case-a` converted **every row in the file**. Separately, `--fiscal-year` and `--court-case` were accepted and ignored, so `convert --fiscal-year 078` walked and converted the entire corpus while its command line claimed one year.

**Fix.** `--slug` now narrows a batch, preserving file order so `--limit` stays deterministic; a slug outside the batch selects nothing, since the allowlist holds. `--fiscal-year`/`--court-case` now exit with a message naming what to use instead.

> ⚠️ **Behaviour change.** A script passing `--fiscal-year` or `--court-case` to `convert` now exits instead of quietly converting everything. That is the intent — failing costs one message, the silent version costs a full-corpus run — but it is a break, not a no-op.

# 7. A 33-second silence looked like a hang

**Problem.** A `--limit 10` dry run logged `run/start`, then nothing for 33 seconds, then every case at once. Listing production is 16 sequential requests at `PAGE_SIZE=200`, and `--limit` does not shorten it — the slice happens after the whole list is in memory. Nothing logged during the wait, so an operator had no basis to choose between waiting and Ctrl-C.

**Fix.** `iter_cases` reports `(page, fetched, total)` as each page lands, during the wait rather than after it:

```text
step=list_cases status=progress page 1, 200/3003 fetched
step=list_cases status=progress page 2, 400/3003 fetched
...
step=list_cases status=ok 3003 case(s) fetched
```

`progress` is an optional callback: the bigo enricher passes one that emits a run-scoped event, so the wait reaches both the run log and `events.jsonl` in the run's own format. The default logs to `casework.api`, so the other five enrichers narrate without being touched. The rows carry no slug, so `build_ledger` cannot mistake 16 pages for 16 phantom cases.

Also in this area: pre-loop failures used to exit with both the `.log` and `.events.jsonl` at **zero bytes** — bootstrap errors, missing credentials, and a failed case listing left no record at all. `SystemExit` escaped the guard too, since it does not inherit from `Exception`. And `--api-token` now defaults to `$JAWAFDEHI_API_TOKEN` unless local DEV_AUTH Basic credentials are set; without that carve-out every loopback run would flip to Bearer, 401ing local `--apply` and leaking a production token to `127.0.0.1`.

---

## Two experiments that measured worse, pinned so nobody rebuilds them

**Reading court orders for बिगो.** 22× the input per case (~2 min vs ~15s), projecting ~8h and >$100 against $23. It changed the answer only on the ~18 multi-defendant cases. And `bigo` is the **alleged** loss — the press release *is* that claim, while the judgment records what was established. Wrong primary source regardless of cost.

**Rewriting the extraction prompt.** 95.8% against the current prompt's 98.7%. Reverted; only Rule 3 was narrowed, so type-routing no longer overrides a बिगो the document states outright (CIAA formally establishes a bribe as the बिगो under दफा ३(१) in 65 of the 238 releases).

Both are pinned by tests asserting the **literal** membership of `requires_materials`. The obvious `set(x) == set(PRESS_TYPES)` form is vacuous — it stays green if `court_order` is added *to* `PRESS_TYPES`.

## Measured outcome on the 238-case batch

238 of 238 cases completed, zero errors, $23.73, 57 minutes.

| | Before the ब/व fix | After |
|---|---|---|
| Proposed a value | 177 | **207** |
| Returned null | 61 | 31 |
| Grounded and बिगो-labelled | 168 | **197** |
| Recall misses the regex can detect | 22 | **0** |
| Needed human adjudication | 17 | 9 |

**235 of 238 acceptable (98.7%)**, 3 hard errors. The manifest is **205 proposals, every one into an empty `bigo` field** — zero overwrites, all 238 still DRAFT.

Attribution, to be explicit: the turn cap was fatal enough that the first run errored on *every* case, so these figures were measured on a build that already had a cap fix. On `main` that fix is #412's; this branch carries only the retry.

## Files

| File | | +/− |
|---|---|---|
| `casework/enrich_missing_bigo.py` | grounding gate, tokenisation, ब/व variants, Rule 3, run events, batch wiring | +226 −29 |
| `casework/common/select.py` | `select_for_run`, batch allowlist | +101 −2 |
| `casework/common/cli.py` | `--batch-csv` + parse-time guards, token default | +90 −3 |
| `casework/common/api.py` | https enforcement, `PAGE_SIZE`, page progress | +61 −11 |
| `casework/convert.py` | selector intersection and rejection | +51 −3 |
| `llm/providers/cli.py` | `error_max_turns` retryable | +25 |
| `casework/common/pipeline.py` | records why bigo is press-release-only | +15 |
| 4 enrichers + `bind_materials.py` | onto `select_for_run` | +13 −39 |
| `casework/README.md` | new; two claims corrected under review | +461 |
| 6 test files | | +1188 |

Blast radius on the shared `llm/providers/cli.py`: `REVIEW_LLM_PROVIDER` defaults to `bedrock`, so the CLI provider runs only when explicitly selected. The change adds two markers to an existing retryable set — it cannot affect a call that already succeeds.

## Before applying this to production

- Verify the 25 proposals ≥1 crore by hand — they carry 75% of total value.
- **Do not patch `078-CR-0048`.** Its `3,521,204` is a contract balance (ठेक्कावापतको बाँकी रकम, §17), not a बिगो. No deterministic gate can catch it: three were tested, and it is keyword-identical to `078-CR-0132`, whose value is correct.
- 11 of 16 flagged cases are multi-defendant, with per-defendant figures and no stated total. That is a schema question, not an extraction one — grounding cannot resolve which बिगो to pick when every candidate is grounded.
- Two live PUBLISHED errors are recorded in the run report (`081-cr-0097` 10× understatement, `081-cr-0121` off by one rupee). Fixing them needs a sanctioned write; this PR does not touch them.
