### PR TITLE
fix(proposals): budget the intent prompt for reasoning, not just for the answer

### DIFF
--- a/case_proposals/job_handlers.py
+++ b/case_proposals/job_handlers.py
@@ -16,9 +16,22 @@ import time
 import structlog
 
 from llm import prompts as prompt_registry
+from llm.exhaustion import is_exhaustion
 from llm.templating import fence
 
 logger = structlog.get_logger(__name__)
+
+#: Budget for a SECOND attempt, used only after the first died of exhaustion.
+#: Mirrors `courts.extract_verdicts`, including the ordering: the first attempt
+#: always uses the spec's own budget, so the parameters an answer was produced
+#: under are the parameters the spec documents. A first attempt at the larger
+#: budget would be simpler and would quietly make the spec's `max_tokens` a
+#: fiction.
+#:
+#: One retry, not a ladder. Exhaustion means the reasoning outran the allowance,
+#: and 4x is a large enough step that a second failure is evidence about the
+#: prompt rather than the budget — worth surfacing instead of spending through.
+ESCALATED_MAX_TOKENS = 32_000
 
 #: Cap on the fenced observation. A signal payload is small by construction, but
 #: it can carry a scraped page excerpt, and a runaway one would otherwise push
@@ -82,7 +95,7 @@ def handle_case_proposal_intent(payload: dict, *, on_stage) -> dict:
 
     on_stage("prompting")
     started = time.monotonic()
-    answer = spec.invoke(**context)
+    answer, escalated = _invoke_escalating(spec, context, on_stage=on_stage)
     duration = round(time.monotonic() - started, 3)
 
     if not isinstance(answer, dict):
@@ -93,7 +106,7 @@ def handle_case_proposal_intent(payload: dict, *, on_stage) -> dict:
             "case_proposal.intent_answer_not_an_object", got=type(answer).__name__
         )
         return {"intent": None, "rationale": "", "malformed_answer": True,
-                "duration_seconds": duration}
+                "escalated": escalated, "duration_seconds": duration}
 
     return {
         "intent": answer.get("intent"),
@@ -102,8 +115,40 @@ def handle_case_proposal_intent(payload: dict, *, on_stage) -> dict:
         # Recorded on the job so a proposal that later turns out to be wrong can
         # be traced to the exact prompt text that drafted it.
         "prompt": {"name": spec.name, "version": spec.version, "tier": spec.tier},
+        # Recorded because it is a cost signal, not a curiosity: a spec that
+        # escalates routinely is a spec whose budget is wrong, and the only place
+        # that is visible is on the jobs it produced.
+        "escalated": escalated,
         "duration_seconds": duration,
     }
+
+
+def _invoke_escalating(spec, context, *, on_stage):
+    """Invoke ``spec``; on exhaustion, retry once at ``ESCALATED_MAX_TOKENS``.
+
+    Returns ``(answer, escalated)``.
+
+    Only exhaustion is retried. A malformed answer, a transport error or an auth
+    failure is re-raised untouched — retrying those at 4x the budget would spend
+    four times as much to fail identically, which is the trap
+    :func:`llm.exhaustion.is_exhaustion` exists to avoid.
+    """
+    try:
+        return spec.invoke(**context), False
+    except Exception as exc:  # noqa: BLE001 - re-raised unless it is exhaustion
+        if not is_exhaustion(exc):
+            raise
+        logger.warning(
+            "case_proposal.intent_budget_exhausted",
+            budget=spec.max_tokens,
+            retrying_at=ESCALATED_MAX_TOKENS,
+            error=str(exc)[:200],
+        )
+        # The lease is extended before paying for a second, slower call: the first
+        # attempt has already spent the ack window's slack, and a job whose lease
+        # expires mid-retry gets claimed by another poller and billed twice.
+        on_stage("prompting (escalated)")
+        return spec.invoke(max_tokens=ESCALATED_MAX_TOKENS, **context), True
 
 
 #: kind -> worker-side handler, merged into the poller's HANDLERS registry.

--- a/case_proposals/prompts.py
+++ b/case_proposals/prompts.py
@@ -29,9 +29,25 @@ intent = register(
         # raising — so a downgrade here would surface as a slow rise in
         # unparseable results, not as an error.
         tier="premium",
-        # A drafted intent is small; the budget is for the rationale and for
-        # salvageable overrun, not for the model to think out loud.
-        max_tokens=1200,
+        # Sized for the model's REASONING, not for the answer. A drafted intent is
+        # small, and this used to say so — "the budget is for the rationale and for
+        # salvageable overrun, not for the model to think out loud", at 1200 tokens.
+        # That reasons about the API's `max_tokens`, which bounds the response and
+        # leaves thinking its own allowance. The tier this is pinned to reaches the
+        # model through the CLI provider, where the budget becomes
+        # CLAUDE_CODE_MAX_OUTPUT_TOKENS and caps reasoning and answer together.
+        #
+        # So 1200 was not a tight budget, it was an impossible one: the first
+        # production invocation spent it thinking, ended its turn unfinished, and
+        # aborted as `error_max_turns` — having billed a full premium call. Every
+        # attempt failed the same way, twice per job before it went dead.
+        #
+        # 8000 is not a guess. `courts.extract_verdicts` measured exactly this on a
+        # comparable read-and-judge prompt: 1200 failed 3 of 24 eval cases outright
+        # after spending ~4800 output tokens, and 8000 is the figure that run
+        # settled on. Overrun beyond it escalates once — see
+        # `case_proposals.job_handlers.ESCALATED_MAX_TOKENS`.
+        max_tokens=8000,
         # `language` is read only inside an {% if %}, which the missing-variable
         # sentinel cannot see. Without declaring it, omitting the key silently
         # produces an English prompt for a Nepali case.

--- a/case_proposals/tests/test_intent_handler.py
+++ b/case_proposals/tests/test_intent_handler.py
@@ -11,7 +11,10 @@ from unittest import mock
 
 import pytest
 
-from case_proposals.job_handlers import handle_case_proposal_intent
+from case_proposals.job_handlers import (
+    ESCALATED_MAX_TOKENS,
+    handle_case_proposal_intent,
+)
 from llm import templating
 
 pytestmark = pytest.mark.django_db
@@ -136,3 +139,85 @@ class TestPayloadGuards:
         """The whole point of the build_payload seam: the worker runs DB-free."""
         with django_assert_num_queries(0):
             run(payload())
+
+
+class TestAnExhaustedBudgetIsRetriedOnce:
+    """The failure that shipped: a budget spent thinking, billed and useless.
+
+    The first production invocation of this kind died as ``error_max_turns`` after
+    a full premium call, and would have done so on every attempt. These pin both
+    halves of the fix — that exhaustion escalates, and that nothing else does.
+    """
+
+    def test_it_retries_at_the_escalated_budget_and_succeeds(self):
+        answer = {"intent": {"kind": "add_timeline_entry"}, "rationale": "new hearing"}
+        with mock.patch(
+            "llm.prompts.PromptSpec.invoke",
+            side_effect=[RuntimeError("subtype: error_max_turns"), answer],
+        ) as invoke:
+            result = handle_case_proposal_intent(payload(), on_stage=lambda s: None)
+
+        assert invoke.call_count == 2
+        assert result["intent"] == {"kind": "add_timeline_entry"}
+        assert result["escalated"] is True
+
+    def test_the_first_attempt_uses_the_specs_own_budget(self):
+        """Not the escalated one. An answer must come from the documented params."""
+        with mock.patch(
+            "llm.prompts.PromptSpec.invoke",
+            side_effect=[RuntimeError("error_max_turns"), {"intent": None}],
+        ) as invoke:
+            handle_case_proposal_intent(payload(), on_stage=lambda s: None)
+
+        assert "max_tokens" not in invoke.call_args_list[0].kwargs
+        assert invoke.call_args_list[1].kwargs["max_tokens"] == ESCALATED_MAX_TOKENS
+
+    def test_the_lease_is_extended_again_before_paying_for_the_retry(self):
+        """The first call has already eaten the lease's slack."""
+        stages = []
+        with mock.patch(
+            "llm.prompts.PromptSpec.invoke",
+            side_effect=[RuntimeError("error_max_turns"), {"intent": None}],
+        ):
+            handle_case_proposal_intent(payload(), on_stage=stages.append)
+        assert stages == ["prompting", "prompting (escalated)"]
+
+    def test_it_escalates_at_most_once(self):
+        """A second exhaustion is evidence about the prompt, not the budget."""
+        with mock.patch(
+            "llm.prompts.PromptSpec.invoke",
+            side_effect=RuntimeError("error_max_turns"),
+        ) as invoke:
+            with pytest.raises(RuntimeError, match="error_max_turns"):
+                handle_case_proposal_intent(payload(), on_stage=lambda s: None)
+        assert invoke.call_count == 2
+
+    @pytest.mark.parametrize(
+        "message", ["401 Unauthorized", "connection reset", "no such template"]
+    )
+    def test_an_unrelated_failure_is_not_retried(self, message):
+        """Retrying these would spend four times as much to fail the same way."""
+        with mock.patch(
+            "llm.prompts.PromptSpec.invoke", side_effect=RuntimeError(message)
+        ) as invoke:
+            with pytest.raises(RuntimeError, match=message):
+                handle_case_proposal_intent(payload(), on_stage=lambda s: None)
+        assert invoke.call_count == 1
+
+    def test_a_call_that_succeeds_first_time_is_not_marked_escalated(self):
+        result, _ = run(payload())
+        assert result["escalated"] is False
+
+
+class TestTheBudgetIsBigEnoughToFinishAnAnswer:
+    def test_the_spec_budgets_for_reasoning_not_just_for_the_answer(self):
+        """1200 could not finish one. Pinned so it cannot quietly go back.
+
+        The number is not sacred; the property is. On the CLI provider the budget
+        becomes CLAUDE_CODE_MAX_OUTPUT_TOKENS and caps reasoning as well as
+        output, and `courts.extract_verdicts` measured 1200 failing outright after
+        ~4800 output tokens on a comparable prompt.
+        """
+        from llm import prompts as registry
+
+        assert registry.get("case_proposal.intent").max_tokens >= 8000

--- a/courts/management/commands/extract_verdicts.py
+++ b/courts/management/commands/extract_verdicts.py
@@ -36,6 +36,7 @@ from django.utils import timezone
 
 from courts.models import CourtCase, CourtCaseHearing
 from courts.scraper.registers import NGM_DB
+from llm.exhaustion import is_exhaustion
 from courts.scraper.verdicts import (
     DECISION_TYPES,
     PROVENANCE_KEY,
@@ -62,24 +63,12 @@ MAX_TOKENS = 8000
 #: The 2026-07-31 production run lost 3 of 84 cases this way, all of them long
 #: multi-defendant judgments where the reasoning alone outran 8000 tokens.
 ESCALATED_MAX_TOKENS = 32000
-#: How exhaustion presents. ``claude -p`` does not report "out of output tokens":
-#: the assistant turn simply ends unfinished, the CLI wants another turn to
-#: continue, ``--max-turns 1`` denies it, and the run aborts as
-#: ``error_max_turns`` -- "Reached maximum number of turns (1)". So the turn
-#: limit is the messenger and the token budget is the cause, which is why
-#: escalation raises the budget rather than the turn count.
-_EXHAUSTED = ("error_max_turns", "maximum number of turns", "max_tokens")
-
-
-def _is_exhaustion(exc):
-    """True if this failure looks like the model ran out of room, not out of luck.
-
-    Deliberately narrow. A convert failure, a missing document, an auth 403 or a
-    malformed response must NOT be retried at 4x the budget -- that would just
-    spend four times as much to fail the same way.
-    """
-    msg = str(exc).lower()
-    return any(s.lower() in msg for s in _EXHAUSTED)
+#: How exhaustion presents -- and why the turn limit is only the messenger, while
+#: the token budget is the cause -- now lives in :mod:`llm.exhaustion`. It moved
+#: because the same failure was diagnosed from scratch a second time, in
+#: `case_proposals`, which is once too often for it to stay private to this
+#: command. Kept as a module-level alias so this file's tests still name it.
+_is_exhaustion = is_exhaustion
 
 
 class Command(BaseCommand):

--- a/llm/exhaustion.py
+++ b/llm/exhaustion.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Recognising "the model ran out of room" across providers.
+
+This lives here rather than beside one caller because the same failure has now
+been diagnosed twice from scratch — once in ``courts`` (the verdict extractor,
+API#407) and once in ``case_proposals`` (the intent job, which shipped a 1200
+budget that could not finish a single answer). Both times the symptom was an
+error that does not mention tokens at all.
+
+**How exhaustion presents on the CLI provider.** ``claude -p`` has no output-cap
+flag, so ``llm.providers.cli`` enforces the caller's budget through
+``CLAUDE_CODE_MAX_OUTPUT_TOKENS``. That variable caps *everything the model
+emits, reasoning included* — it is not the API's ``max_tokens``, which bounds
+the response and leaves thinking to its own budget. A model that spends the
+allowance thinking simply ends its turn unfinished; the CLI wants another turn to
+continue; ``--max-turns 1`` denies it; and the run aborts as
+``error_max_turns`` — "Reached maximum number of turns (1)".
+
+So the turn limit is the messenger and the token budget is the cause. Raising
+``--max-turns`` would not help and would let the model ramble at cost. The fix is
+always a bigger budget.
+
+That distinction is the part worth keeping in one place: a budget sized as though
+it only had to cover the answer is a budget that cannot finish one.
+"""
+
+from __future__ import annotations
+
+#: Substrings that mean "out of room", matched case-insensitively against the
+#: exception text. Deliberately narrow: a convert failure, a missing document, an
+#: auth 403 or a malformed response must NOT be retried at a larger budget —
+#: that spends several times as much to fail the same way.
+EXHAUSTION_MARKERS = ("error_max_turns", "maximum number of turns", "max_tokens")
+
+
+def is_exhaustion(exc: BaseException | str) -> bool:
+    """True if ``exc`` looks like the model ran out of room, not out of luck.
+
+    Args:
+        exc: The raised exception, or a message already extracted from one.
+
+    Returns:
+        Whether a retry at a larger token budget is worth paying for.
+    """
+    message = str(exc).lower()
+    return any(marker.lower() in message for marker in EXHAUSTION_MARKERS)

--- a/llm/exhaustion.py
+++ b/llm/exhaustion.py
@@ -26,11 +26,25 @@ it only had to cover the answer is a budget that cannot finish one.
 
 from __future__ import annotations
 
-#: Substrings that mean "out of room", matched case-insensitively against the
-#: exception text. Deliberately narrow: a convert failure, a missing document, an
-#: auth 403 or a malformed response must NOT be retried at a larger budget —
-#: that spends several times as much to fail the same way.
-EXHAUSTION_MARKERS = ("error_max_turns", "maximum number of turns", "max_tokens")
+import re
+
+#: Plain substrings that mean "out of room", matched case-insensitively.
+#: Deliberately narrow: a convert failure, a missing document, an auth 403 or a
+#: malformed response must NOT be retried at a larger budget — that spends
+#: several times as much to fail the same way.
+EXHAUSTION_MARKERS = ("error_max_turns", "maximum number of turns")
+
+#: The API side of the same condition, where the provider reports it properly as
+#: a stop reason. Matched as a PATTERN rather than as the bare substring
+#: "max_tokens", which the version this was lifted from used.
+#:
+#: That bare form is too generous in a way that inverts the whole point: the
+#: string "max_tokens" also appears in *configuration* errors — "invalid
+#: max_tokens value", "max_tokens: field required" — which are bugs, not
+#: exhaustion. Treating one as exhaustion buys an escalated call at several times
+#: the price and then fails identically, which is exactly what this module exists
+#: to prevent. Requiring it to be attached to a stop reason keeps the meaning.
+_STOP_REASON_MAX_TOKENS = re.compile(r"""stop[_ ]?reason["']?\s*[:=]\s*["']?max_tokens""", re.I)
 
 
 def is_exhaustion(exc: BaseException | str) -> bool:
@@ -43,4 +57,6 @@ def is_exhaustion(exc: BaseException | str) -> bool:
         Whether a retry at a larger token budget is worth paying for.
     """
     message = str(exc).lower()
-    return any(marker.lower() in message for marker in EXHAUSTION_MARKERS)
+    if any(marker.lower() in message for marker in EXHAUSTION_MARKERS):
+        return True
+    return bool(_STOP_REASON_MAX_TOKENS.search(message))

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -123,7 +123,7 @@ class PromptSpec:
         """
         return render_prompt(self.content_template, context, required=self.required)
 
-    def invoke(self, usage=None, **context) -> Any:
+    def invoke(self, usage=None, max_tokens=None, **context) -> Any:
         """Render both templates and invoke the model, returning parsed JSON.
 
         Thin by design — ``invoke_json`` already salvages dirty/truncated output,
@@ -135,7 +135,13 @@ class PromptSpec:
 
         Args:
             usage: Optional UsageAccumulator, forwarded to ``invoke_json``.
-            **context: Template context.
+            max_tokens: Override the spec's budget for this one call. Exists for
+                retry-at-a-larger-budget after :func:`llm.exhaustion.is_exhaustion`
+                — see ``case_proposals.job_handlers``. The spec's own value stays
+                the default so the escalation is visible at the call site rather
+                than hidden in the registry.
+            **context: Template context. Note that ``usage`` and ``max_tokens``
+                are therefore reserved names and cannot be template variables.
 
         Returns:
             Parsed JSON (dict or list), per ``invoke_json``.
@@ -147,20 +153,24 @@ class PromptSpec:
         """
         system = self.render_system(**context)
         content = self.render(**context)
+        budget = self.max_tokens if max_tokens is None else max_tokens
         # Logged BEFORE the call as well as after, so a spec that reliably times
-        # out or blows its token budget is still attributable to a version.
+        # out or blows its token budget is still attributable to a version. Logs
+        # the EFFECTIVE budget, not the spec's, or an escalated retry would be
+        # indistinguishable from the attempt that provoked it.
         logger.info(
             "prompt.invoke",
             prompt=self.name,
             version=self.version,
             tier=self.tier,
-            max_tokens=self.max_tokens,
+            max_tokens=budget,
+            escalated=budget != self.max_tokens,
             content_chars=len(content),
         )
         return invoke_json(
             system,
             content,
-            max_tokens=self.max_tokens,
+            max_tokens=budget,
             tier=self.tier,
             usage=usage,
         )

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -151,6 +151,15 @@ class PromptSpec:
                 either template is missing or a variable did not resolve, so a
                 broken prompt costs nothing.
         """
+        if max_tokens is not None and max_tokens < 1:
+            # Same rule __post_init__ applies to the configured budget. Without it
+            # the override was the one way past that check, and a zero budget is
+            # the pathological case this whole seam exists to fix: it reaches the
+            # provider, bills a call, and cannot produce a token.
+            raise ValueError(
+                f"{self.name}: max_tokens override must be >= 1, got {max_tokens!r}."
+            )
+
         system = self.render_system(**context)
         content = self.render(**context)
         budget = self.max_tokens if max_tokens is None else max_tokens

--- a/llm/tests/test_exhaustion.py
+++ b/llm/tests/test_exhaustion.py
@@ -22,8 +22,17 @@ class TestFailuresThatMeanOutOfRoom:
     def test_the_prose_form_is_read_as_exhaustion(self):
         assert is_exhaustion(RuntimeError("Reached maximum number of turns (1)"))
 
-    def test_an_explicit_token_cap_is_read_as_exhaustion(self):
-        assert is_exhaustion(RuntimeError("stop_reason: max_tokens"))
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "stop_reason: max_tokens",
+            "stop_reason=max_tokens",
+            '{"stop_reason":"max_tokens"}',
+            "stop reason: max_tokens",
+        ],
+    )
+    def test_an_explicit_stop_reason_is_read_as_exhaustion(self, message):
+        assert is_exhaustion(RuntimeError(message))
 
     def test_matching_ignores_case(self):
         assert is_exhaustion(RuntimeError("ERROR_MAX_TURNS"))
@@ -54,6 +63,22 @@ class TestFailuresThatMustNotBeRetriedAtFourTimesTheCost:
         ],
     )
     def test_an_unrelated_failure_is_not_exhaustion(self, message):
+        assert not is_exhaustion(RuntimeError(message))
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "invalid max_tokens value",
+            "max_tokens: field required",
+            "max_tokens must be >= 1, got 0",
+            "unknown parameter: max_tokens",
+        ],
+    )
+    def test_a_max_tokens_CONFIGURATION_error_is_not_exhaustion(self, message):
+        """The bare substring "max_tokens" was the original marker, and it made
+        every one of these look like an exhausted generation. They are bugs: an
+        escalated retry pays several times over to fail in exactly the same way,
+        which is the trap this module exists to avoid."""
         assert not is_exhaustion(RuntimeError(message))
 
     def test_a_timeout_is_not_exhaustion(self):

--- a/llm/tests/test_exhaustion.py
+++ b/llm/tests/test_exhaustion.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Recognising an exhausted token budget.
+
+The point of these is the NEGATIVE cases. A helper that says yes too often does
+not fail a test — it silently quadruples the bill on every unrelated error, which
+is exactly the trap the narrowness is for.
+"""
+
+import pytest
+
+from llm.exhaustion import EXHAUSTION_MARKERS, is_exhaustion
+
+
+class TestFailuresThatMeanOutOfRoom:
+    def test_the_cli_turn_limit_is_read_as_exhaustion(self):
+        # How it actually presents: the budget is the cause, the turn limit is
+        # only the messenger. This exact string came off a production job.
+        assert is_exhaustion(
+            RuntimeError('claude_cli failed (rc=1): "subtype":"error_max_turns"')
+        )
+
+    def test_the_prose_form_is_read_as_exhaustion(self):
+        assert is_exhaustion(RuntimeError("Reached maximum number of turns (1)"))
+
+    def test_an_explicit_token_cap_is_read_as_exhaustion(self):
+        assert is_exhaustion(RuntimeError("stop_reason: max_tokens"))
+
+    def test_matching_ignores_case(self):
+        assert is_exhaustion(RuntimeError("ERROR_MAX_TURNS"))
+
+    def test_a_bare_message_works_as_well_as_an_exception(self):
+        # Callers that have already unwrapped the error should not have to re-wrap.
+        assert is_exhaustion("error_max_turns")
+
+    @pytest.mark.parametrize("marker", EXHAUSTION_MARKERS)
+    def test_every_advertised_marker_is_actually_matched(self, marker):
+        # Guards against a marker being added to the tuple in a form the matcher
+        # cannot see — e.g. with different casing or surrounding punctuation.
+        assert is_exhaustion(RuntimeError(f"upstream said: {marker}"))
+
+
+class TestFailuresThatMustNotBeRetriedAtFourTimesTheCost:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "convert failed: no converter for application/zip",
+            "no order url on case",
+            "401 Unauthorized",
+            "403 Forbidden: subscription required",
+            "Expecting value: line 1 column 1 (char 0)",
+            "Connection reset by peer",
+            "model produced a list, not an object",
+            "",
+        ],
+    )
+    def test_an_unrelated_failure_is_not_exhaustion(self, message):
+        assert not is_exhaustion(RuntimeError(message))
+
+    def test_a_timeout_is_not_exhaustion(self):
+        # Tempting to treat as "it needed more room", but a bigger budget makes a
+        # timeout MORE likely, not less: the model has more it is allowed to emit.
+        assert not is_exhaustion(TimeoutError("timed out after 120s"))

--- a/llm/tests/test_prompts.py
+++ b/llm/tests/test_prompts.py
@@ -201,6 +201,49 @@ class TestInvoke:
         assert kwargs["version"] == 7
 
 
+class TestTheBudgetCanBeOverriddenForOneCall:
+    """The seam an escalated retry hangs off (case_proposals.job_handlers)."""
+
+    def test_the_specs_budget_is_used_when_nothing_is_passed(self):
+        spec = _spec(max_tokens=8000)
+        with mock.patch("llm.prompts.invoke_json", return_value={}) as invoke:
+            spec.invoke(case_title="X", excerpts=[])
+        assert invoke.call_args.kwargs["max_tokens"] == 8000
+
+    def test_an_override_reaches_the_provider(self):
+        spec = _spec(max_tokens=8000)
+        with mock.patch("llm.prompts.invoke_json", return_value={}) as invoke:
+            spec.invoke(case_title="X", excerpts=[], max_tokens=32_000)
+        assert invoke.call_args.kwargs["max_tokens"] == 32_000
+
+    def test_the_override_does_not_mutate_the_registered_spec(self):
+        """Specs are frozen, and a retry must not widen the budget for everyone."""
+        spec = _spec(max_tokens=8000)
+        with mock.patch("llm.prompts.invoke_json", return_value={}):
+            spec.invoke(case_title="X", excerpts=[], max_tokens=32_000)
+        assert spec.max_tokens == 8000
+
+    def test_the_log_records_the_effective_budget_not_the_specs(self):
+        """Otherwise an escalated retry is indistinguishable in the logs from the
+        attempt that provoked it, and a spec that escalates every single time
+        looks exactly like one that never does."""
+        spec = _spec(max_tokens=8000)
+        with mock.patch("llm.prompts.invoke_json", return_value={}):
+            with mock.patch.object(prompts.logger, "info") as log:
+                spec.invoke(case_title="X", excerpts=[], max_tokens=32_000)
+
+        kwargs = log.call_args.kwargs
+        assert kwargs["max_tokens"] == 32_000
+        assert kwargs["escalated"] is True
+
+    def test_an_unescalated_call_says_so(self):
+        spec = _spec(max_tokens=8000)
+        with mock.patch("llm.prompts.invoke_json", return_value={}):
+            with mock.patch.object(prompts.logger, "info") as log:
+                spec.invoke(case_title="X", excerpts=[])
+        assert log.call_args.kwargs["escalated"] is False
+
+
 class TestRequiredAppliesToBothTemplates:
     """`required` must cover the system prompt too, not just the content.
 

--- a/llm/tests/test_prompts.py
+++ b/llm/tests/test_prompts.py
@@ -223,6 +223,18 @@ class TestTheBudgetCanBeOverriddenForOneCall:
             spec.invoke(case_title="X", excerpts=[], max_tokens=32_000)
         assert spec.max_tokens == 8000
 
+    @pytest.mark.parametrize("bad", [0, -1, -32_000])
+    def test_a_non_positive_override_is_refused_before_any_call(self, bad):
+        """__post_init__ guards the configured budget; the override was the way
+        past it. A zero budget still reaches the provider and still bills a call,
+        and cannot produce a token — the pathological form of the very bug this
+        seam was added to fix."""
+        spec = _spec(max_tokens=8000)
+        with mock.patch("llm.prompts.invoke_json") as invoke:
+            with pytest.raises(ValueError, match="max_tokens override"):
+                spec.invoke(case_title="X", excerpts=[], max_tokens=bad)
+        invoke.assert_not_called()
+
     def test_the_log_records_the_effective_budget_not_the_specs(self):
         """Otherwise an escalated retry is indistinguishable in the logs from the
         attempt that provoked it, and a spec that escalates every single time


### PR DESCRIPTION
### **User description**
## What was wrong

The first production invocation of `case_proposal_intent` failed, and every one after it would have failed identically.

The spec budgeted `max_tokens=1200`, with the comment *"the budget is for the rationale and for salvageable overrun, not for the model to think out loud."* That describes the **API's** `max_tokens`, where thinking has its own allowance. This spec is pinned to the premium tier, which reaches the model through the CLI provider — where the budget becomes `CLAUDE_CODE_MAX_OUTPUT_TOKENS` and caps **reasoning and answer together**.

So 1200 was not a tight budget, it was an impossible one. The model spent it thinking, ended its turn unfinished, and the run aborted as:

```
claude_cli failed (rc=1): ... "terminal_reason":"max_turns",
"errors":["Reached maximum number of turns (1)"], "subtype":"error_max_turns"
```

The turn limit is the messenger; the token budget is the cause. **Cost of the observed failure: a full premium call (~$0.27) for no output, twice per job before it went dead.**

## This repo already knew

`courts.extract_verdicts` measured exactly this on a comparable read-and-judge prompt — *"a 1200 budget failed 3 of 24 eval cases outright (rc=1 after spending ~4800 output tokens)"* — settled on 8000, and added an escalated retry in #407.

The knowledge existed and was private to one command module, so it got rediagnosed from scratch here. That is the part worth fixing structurally, not just the number.

## Changes

- **`llm/exhaustion.py`** (new) — `is_exhaustion()` plus the explanation of why the turn limit is only the symptom. `courts.extract_verdicts` imports it instead of keeping its own copy.
- **The intent spec goes to 8000**, with the API-vs-CLI distinction written down so the next person sizing a budget doesn't repeat the reasoning error.
- **`PromptSpec.invoke` takes an optional `max_tokens` override**, and logs the *effective* budget with an `escalated` flag — otherwise an escalated retry is indistinguishable in the logs from the attempt that provoked it.
- **The handler escalates once to 32000 on exhaustion and only on exhaustion**, and records `escalated` on the result: a spec that escalates routinely has the wrong budget, and the jobs it produced are the only place that shows.

First attempt always uses the spec's own budget, mirroring `extract_verdicts`, so an answer is produced under the parameters the spec documents. One retry, not a ladder — at 4x, a second exhaustion is evidence about the prompt.

## Verification

713 tests pass across `llm` / `case_proposals` / `courts`; `ruff check` clean.

**Six mutations killed:** reverting the budget to 1200; forcing `is_exhaustion` true; forcing it false; escalating on the first attempt; logging the spec's budget instead of the effective one; dropping a marker from `EXHAUSTION_MARKERS`.

**Two mutations are not claimed.** My first harness scored a mutant KILLED whenever pytest printed "error" — which a syntactically invalid mutant does during collection. "No escalation at all" and "escalate without limit" were scored that way, so those results were unsound and are withdrawn rather than restated. The behaviours have tests (`test_it_escalates_at_most_once`, `test_an_unrelated_failure_is_not_retried`); what's missing is proof those tests bite.

## Not yet enabled in production

`k8s/platform/jobs-processor.yaml` must add `case_proposal_intent` to `--kinds` before the pipeline can complete — `review_poller` defaults to every registered handler, but the CronJob passes the flag explicitly, which overrides that. It is held back in the infra repo with the reasoning recorded, and the docket producer CronJob stays suspended until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Retry exhausted intent prompts once

- Raise intent budget to `8000`

- Centralize LLM exhaustion detection

- Add budget override tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Intent prompt"] -- "uses" --> B["8000 token budget"]
  B -- "exhausted" --> C["is_exhaustion"]
  C -- "retry once" --> D["32000 token override"]
  D -- "logs" --> E["escalated flag"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>job_handlers.py</strong><dd><code>Retry exhausted intent prompts once</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-84ced2bb8aa5172735f756cef238c486ee4aaad4ca1b85f858e794bbabede51f">+47/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>prompts.py</strong><dd><code>Increase intent prompt reasoning budget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-db7df04c7be28d671b95996b6a6a77e371021324f756db341624bbe93bc00394">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_intent_handler.py</strong><dd><code>Cover escalated intent retry behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-579b2ee9baae01e2c8e2964ba7f669ff54e94cba92fed2ad62a507488566472f">+86/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_exhaustion.py</strong><dd><code>Test narrow exhaustion marker matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-e00fafc2c6c0b69888b8448665737094440407923b252dfa57b0af940faffa40">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_prompts.py</strong><dd><code>Test prompt budget override logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-f8fa7d594fb0676aa7d9c62ee36a0cf5dadc4faad22d824b95a511f140dde2a1">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>extract_verdicts.py</strong><dd><code>Reuse shared exhaustion classifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-c8ff536e8aa7d0e69aff97198f936c7b3db19c75074f19175dc4700429d024a0">+7/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exhaustion.py</strong><dd><code>Add shared LLM exhaustion detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-e59d0d9fa4ba4df5482fb61c8402cfc209cd7eb973d81bb98c9041ea6f31cf40">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prompts.py</strong><dd><code>Allow one-call max token override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/411/files#diff-e8feb186070d118bed7fe59a343b04fc9c4f62e3b2d7181339e3e03e703fe72a">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case proposal generation now retries once with an expanded token budget when processing reaches a model limit.
  * Retry attempts extend their processing lease and record whether escalation occurred.
  * Prompt token budgets can be adjusted for individual requests.

* **Bug Fixes**
  * Improved detection of token and turn-limit exhaustion while preserving existing handling for unrelated errors.

* **Tests**
  * Added coverage for retry behavior, escalation tracking, lease notifications, budget overrides, and exhaustion detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->