### PR TITLE
fix(llm): raise the claude -p turn cap — one turn is not one answer

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1074,6 +1074,14 @@ CLAUDE_CLI_MODEL_PREMIUM = os.getenv("CLAUDE_CLI_MODEL_PREMIUM", "")
 CLAUDE_CLI_MODEL_CHEAP = os.getenv("CLAUDE_CLI_MODEL_CHEAP", "")
 # claude -p reasoning budget: low/medium/high/xhigh/max ("" -> CLI default).
 CLAUDE_CLI_EFFORT = os.getenv("CLAUDE_CLI_EFFORT", "")
+# Turn cap for a plain (tool-less) `claude -p` call. Was hardcoded to 1, which is
+# not the same as "one model response": a turn that runs long wants a
+# continuation, and denying it aborts the entire call as error_max_turns with
+# nothing returned — after billing for the work already done. Measured on the
+# case_proposal.intent prompt (2026-08-03, identical payload and budget, arms
+# interleaved): 3/5 succeeded at 1 turn, 5/5 at 3. Env-tunable because the right
+# number is an empirical question that should not need a code deploy to revisit.
+CLAUDE_CLI_MAX_TURNS = int(os.getenv("CLAUDE_CLI_MAX_TURNS", "3"))
 REVIEW_CLI_MAX_WORKERS = int(os.getenv("REVIEW_CLI_MAX_WORKERS", "2"))
 REVIEW_CLI_TIMEOUT = int(os.getenv("REVIEW_CLI_TIMEOUT", "300"))
 REVIEW_CLI_MAX_RETRIES = int(os.getenv("REVIEW_CLI_MAX_RETRIES", "3"))

--- a/llm/exhaustion.py
+++ b/llm/exhaustion.py
@@ -34,8 +34,13 @@ at three, while raising the budget from 2000 to 8000 to 32000 changed nothing.
 not pretend otherwise: :func:`is_exhaustion` answers only "is a retry at a larger
 budget worth paying for?" With the turn cap raised, a surviving ``error_max_turns``
 is more likely to be a genuine budget problem, which is what makes that retry a
-reasonable fallback rather than a guess. Callers that need certainty should look
-at ``num_turns`` in the provider's result envelope, not at the message.
+reasonable fallback rather than a guess.
+
+Telling them apart would need ``num_turns`` from the CLI's result envelope, and
+**no caller can currently reach it**: ``ClaudeCliProvider.invoke_text`` returns
+``data["result"]`` as stripped text and discards the rest. Distinguishing the two
+properly therefore means exposing that metadata first — worth doing if this
+ambiguity bites again, but it is not available to reason about today.
 """
 
 from __future__ import annotations

--- a/llm/exhaustion.py
+++ b/llm/exhaustion.py
@@ -1,27 +1,41 @@
 # SPDX-License-Identifier: Hippocratic-3.0
-"""Recognising "the model ran out of room" across providers.
+"""Recognising "the model could not finish" across providers.
 
-This lives here rather than beside one caller because the same failure has now
-been diagnosed twice from scratch — once in ``courts`` (the verdict extractor,
-API#407) and once in ``case_proposals`` (the intent job, which shipped a 1200
-budget that could not finish a single answer). Both times the symptom was an
-error that does not mention tokens at all.
+This lives here rather than beside one caller because the same failure has been
+diagnosed from scratch twice — in ``courts`` (the verdict extractor, API#407) and
+in ``case_proposals`` (the intent job, API#411). Both times the symptom was an
+error that does not mention tokens at all, and both times it was read as an
+exhausted token budget.
 
-**How exhaustion presents on the CLI provider.** ``claude -p`` has no output-cap
-flag, so ``llm.providers.cli`` enforces the caller's budget through
-``CLAUDE_CODE_MAX_OUTPUT_TOKENS``. That variable caps *everything the model
-emits, reasoning included* — it is not the API's ``max_tokens``, which bounds
-the response and leaves thinking to its own budget. A model that spends the
-allowance thinking simply ends its turn unfinished; the CLI wants another turn to
-continue; ``--max-turns 1`` denies it; and the run aborts as
-``error_max_turns`` — "Reached maximum number of turns (1)".
+**``error_max_turns`` has two causes, and they want opposite fixes.**
 
-So the turn limit is the messenger and the token budget is the cause. Raising
-``--max-turns`` would not help and would let the model ramble at cost. The fix is
-always a bigger budget.
+*Out of turns.* An assistant turn that runs long asks to continue. If the turn cap
+denies it, the whole call aborts as ``error_max_turns`` — "Reached maximum number
+of turns (N)" — returning nothing, having billed for the work already done. The
+remedy is a higher cap, and a bigger token budget does nothing at all.
 
-That distinction is the part worth keeping in one place: a budget sized as though
-it only had to cover the answer is a budget that cannot finish one.
+*Out of output tokens.* ``claude -p`` has no output-cap flag, so
+``llm.providers.cli`` enforces the caller's budget through
+``CLAUDE_CODE_MAX_OUTPUT_TOKENS``, which caps *everything the model emits,
+reasoning included* — unlike the API's ``max_tokens``, which bounds the response
+and leaves thinking its own allowance. A model that spends the allowance thinking
+also ends its turn unfinished, and surfaces the same way. The remedy here is a
+bigger budget, and a higher turn cap does nothing.
+
+**An earlier version of this docstring asserted the second cause was the only
+one**, and said in terms that raising ``--max-turns`` "would not help". That was
+wrong, and it was load-bearing: it is why the intent job's budget was raised twice
+and still failed. Measured on ``case_proposal.intent`` (2026-08-03, identical
+payload and budget, arms interleaved) the call succeeded 3/5 at one turn and 5/5
+at three, while raising the budget from 2000 to 8000 to 32000 changed nothing.
+``llm/providers/cli.py`` now defaults the cap to ``CLAUDE_CLI_MAX_TURNS`` (3).
+
+**So the two are not distinguishable from the error text**, and this module does
+not pretend otherwise: :func:`is_exhaustion` answers only "is a retry at a larger
+budget worth paying for?" With the turn cap raised, a surviving ``error_max_turns``
+is more likely to be a genuine budget problem, which is what makes that retry a
+reasonable fallback rather than a guess. Callers that need certainty should look
+at ``num_turns`` in the provider's result envelope, not at the message.
 """
 
 from __future__ import annotations

--- a/llm/providers/cli.py
+++ b/llm/providers/cli.py
@@ -221,9 +221,25 @@ class ClaudeCliProvider(_CliProvider):
             RuntimeError: If invocation fails or output is malformed.
         """
         # NB: no --permission-mode plan. Plan mode makes claude -p emit a plan and
-        # then try to ExitPlanMode (a tool turn); with --max-turns 1 and no tools
-        # that aborts as error_max_turns before producing a result. Tools are
-        # already disabled via --allowedTools "", so default mode never prompts.
+        # then try to ExitPlanMode (a tool turn), which with no tools available
+        # aborts as error_max_turns before producing a result. Tools are already
+        # disabled via --allowedTools "", so default mode never prompts.
+        #
+        # --max-turns was hardcoded to 1 here, on the reading that one turn is one
+        # answer. It is not. A turn that runs long asks to continue, and a cap of 1
+        # refuses — aborting the whole call as error_max_turns and returning
+        # nothing, having already billed for the work done. The failure names the
+        # turn limit but reads like an exhausted token budget, which is how it was
+        # twice misdiagnosed (see llm/exhaustion.py).
+        #
+        # Measured on case_proposal.intent, identical payload and budget, arms
+        # interleaved (2026-08-03): 3/5 succeeded at 1 turn, 5/5 at 3. Successful
+        # 3-turn runs averaged ~25s against ~15s for successful 1-turn runs, so the
+        # extra turn is genuinely used rather than idle.
+        #
+        # Raising the cap does not make a short call longer or dearer: a response
+        # that completes in one turn never requests a second. It only stops
+        # long-running answers from being thrown away.
         argv = [
             getattr(settings, "CLAUDE_CLI_BIN", "claude"),
             "-p",
@@ -232,7 +248,7 @@ class ClaudeCliProvider(_CliProvider):
             "--system-prompt",
             system,
             "--max-turns",
-            "1",
+            str(max(1, getattr(settings, "CLAUDE_CLI_MAX_TURNS", 3))),
             "--allowedTools",
             "",
         ]

--- a/llm/tests/test_cli_provider_turns.py
+++ b/llm/tests/test_cli_provider_turns.py
@@ -33,11 +33,22 @@ def turns(argv):
 
 class TestTheTurnCap:
     def test_it_defaults_to_more_than_one_turn(self):
-        """The whole fix. At 1, an answer that needs a continuation is discarded.
-
-        Measured on case_proposal.intent: 3/5 at one turn, 5/5 at three.
-        """
+        """The property the fix is about: at 1, an answer that needs a
+        continuation is thrown away. Asserted as a range rather than a number so
+        that retuning the default does not read as breaking the behaviour."""
         assert int(turns(argv_for())) >= 2
+
+    def test_the_shipped_default_is_three(self):
+        """And the number itself, pinned separately.
+
+        The range check above cannot catch a silent regression from 3 to 2, which
+        would look fine and quietly restore part of the failure rate. Kept as its
+        own test so that deliberately retuning the default touches one obvious
+        assertion, rather than being caught by a test about something else.
+
+        Measured on case_proposal.intent: 3/5 succeeded at one turn, 5/5 at three.
+        """
+        assert turns(argv_for()) == "3"
 
     def test_it_is_read_from_settings(self):
         assert turns(argv_for(CLAUDE_CLI_MAX_TURNS=7)) == "7"

--- a/llm/tests/test_cli_provider_turns.py
+++ b/llm/tests/test_cli_provider_turns.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The turn cap on a plain `claude -p` call.
+
+`--max-turns 1` was a hardcoded literal with no test, and it cost two wrong
+diagnoses: a long answer asks to continue, the cap refuses, and the call aborts
+as `error_max_turns` — which reads like an exhausted token budget. These pin the
+flag so it cannot silently return to 1, and pin the arithmetic that stops a
+misconfigured value from being worse than the bug.
+"""
+
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+from llm.providers.cli import ClaudeCliProvider
+
+RESULT = '{"type":"result","subtype":"success","result":"{}","usage":{}}'
+
+
+def argv_for(**settings_overrides):
+    """Capture the argv the provider would run, without running anything."""
+    provider = ClaudeCliProvider()
+    with override_settings(**settings_overrides):
+        with mock.patch.object(ClaudeCliProvider, "_run", return_value=RESULT) as run:
+            provider.invoke_text("sys", "content", 2000, "claude-opus-4-8", "premium")
+    return run.call_args.args[0]
+
+
+def turns(argv):
+    return argv[argv.index("--max-turns") + 1]
+
+
+class TestTheTurnCap:
+    def test_it_defaults_to_more_than_one_turn(self):
+        """The whole fix. At 1, an answer that needs a continuation is discarded.
+
+        Measured on case_proposal.intent: 3/5 at one turn, 5/5 at three.
+        """
+        assert int(turns(argv_for())) >= 2
+
+    def test_it_is_read_from_settings(self):
+        assert turns(argv_for(CLAUDE_CLI_MAX_TURNS=7)) == "7"
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_a_non_positive_setting_cannot_produce_an_unrunnable_call(self, bad):
+        """`--max-turns 0` would reject every call outright. Floor it at 1 rather
+        than fail the process: a misconfigured env var should degrade to the old
+        behaviour, not take the worker down."""
+        assert turns(argv_for(CLAUDE_CLI_MAX_TURNS=bad)) == "1"
+
+    def test_tools_stay_disabled(self):
+        """Raising the cap must not hand the model tools. More turns is about
+        letting one answer finish, not about letting it act."""
+        argv = argv_for()
+        assert argv[argv.index("--allowedTools") + 1] == ""
+        assert "--permission-mode" not in argv


### PR DESCRIPTION
### **User description**
## What was wrong

`--max-turns 1` was hardcoded in the plain (tool-less) CLI path, on the reading that one turn equals one response. It does not. An assistant turn that runs long asks to continue; a cap of 1 refuses; the **entire call aborts as `error_max_turns` and returns nothing** — having already billed for the work done.

## Evidence

Measured on `case_proposal.intent`, identical payload and budget, arms interleaved (2026-08-03):

| cap | result | timings |
|---|---|---|
| `--max-turns 1` | **3/5** | failures at 12.6s, 17.0s |
| `--max-turns 3` | **5/5** | — |

Pooling every run of that payload: **4/7 vs 6/6**. Small samples — Fisher's exact on the pooled counts is ≈ **p=0.07**, so this is strong support rather than a proven rate. But the mechanism accounts for it and the timings corroborate: successful three-turn runs averaged **~25s** against **~15s** at one turn, so the extra turn is genuinely used, not idle.

The shape of it: a call that must *draft* a timeline entry and check it against 16 existing ones sometimes needs a continuation. A call that merely *declines* returns in ~5s and has never failed — which is why every small-prompt probe passed, and why this was twice misdiagnosed.

## Why this should be safe for other callers

`--max-turns` is shared by the review judge, verdict extraction and material conversion. **A response that completes in one turn never requests a second**, so raising the cap cannot make a short call longer or dearer — it only stops long answers from being discarded. `invoke_with_tools` already used `max(2, max_iterations)` and is untouched.

The value is `CLAUDE_CLI_MAX_TURNS` (default 3), env-tunable because the right number is empirical and revisiting it shouldn't need a deploy.

## The correction that matters more than the flag

`llm/exhaustion.py` — added in #411, three days old — asserted that an exhausted token budget was the **only** cause of `error_max_turns`, and stated that raising `--max-turns` *"would not help"*.

That was wrong, and load-bearing. It is why the intent job's budget was raised twice (1200 → 8000, escalating to 32000) and still failed, while the actual constraint went unexamined. The two causes want **opposite** fixes and are indistinguishable from the error text, so the module now says so instead of picking one.

## Deliberately left alone

`is_exhaustion` still matches `error_max_turns`, and `courts.extract_verdicts` still escalates its budget on it. With the cap raised, a surviving `error_max_turns` is likelier to be a genuine budget problem, which makes that a reasonable fallback rather than a guess.

Worth re-measuring separately: whether `extract_verdicts`' documented "3 of 84" losses were this same bug wearing the same disguise. If so, its 4× budget escalation is treating a symptom it no longer has.

## Verification

The flag had **no test at all** — it was a bare literal. Added: the default is ≥ 2, the setting is honoured, a non-positive value floors to 1 rather than producing an unrunnable call, and raising the cap does not hand the model tools.

727 tests pass across `llm` / `case_proposals` / `courts` / `review`; `ruff check` clean. Three mutations killed (revert to literal 1; ignore the setting; drop the floor).

## Follow-up, not in this PR

`case_proposal_intent` is still unlisted in `k8s/platform/jobs-processor.yaml` and the docket producer CronJob is suspended. Once this ships I'd re-run the acceptance signal and only re-enable them on an observed success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Raise Claude CLI turn cap

- Add env-tunable `CLAUDE_CLI_MAX_TURNS`

- Clarify `error_max_turns` causes

- Test turn cap behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  settings["CLAUDE_CLI_MAX_TURNS setting"]
  cli["Claude CLI argv"]
  turns["Higher --max-turns"]
  result["Long answers complete"]
  docs["Exhaustion docs clarified"]
  tests["Turn cap tests"]
  settings -- "configures" --> cli
  cli -- "passes" --> turns
  turns -- "prevents aborts" --> result
  docs -- "explains" --> result
  tests -- "guards" --> cli
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Add configurable Claude CLI turn cap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/settings.py

<ul><li>Add <code>CLAUDE_CLI_MAX_TURNS</code><br> <li> Default plain Claude calls to <code>3</code><br> <li> Document measured one-turn failures<br> <li> Allow env tuning without deploy</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/412/files#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exhaustion.py</strong><dd><code>Clarify CLI exhaustion failure causes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

llm/exhaustion.py

<ul><li>Rewrite exhaustion module docstring<br> <li> Distinguish turn exhaustion versus token exhaustion<br> <li> Correct prior misleading guidance<br> <li> Reference new default turn cap</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/412/files#diff-e59d0d9fa4ba4df5482fb61c8402cfc209cd7eb973d81bb98c9041ea6f31cf40">+37/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Use configurable Claude turn limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

llm/providers/cli.py

<ul><li>Replace hardcoded <code>--max-turns 1</code><br> <li> Use <code>CLAUDE_CLI_MAX_TURNS</code>, floored at <code>1</code><br> <li> Preserve disabled tools behavior<br> <li> Add rationale comments</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/412/files#diff-aff710dfc338c22800e99e14d443f4f141eaed2ef7a6c3b74249ea34e07b1a0f">+20/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cli_provider_turns.py</strong><dd><code>Cover Claude CLI turn cap handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

llm/tests/test_cli_provider_turns.py

<ul><li>Add argv capture helper<br> <li> Verify default exceeds one turn<br> <li> Verify setting override works<br> <li> Verify non-positive values floor to <code>1</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/412/files#diff-7f530e4a207afaebe46343d493d50f95eb4b76f61ab34fefbd7c83c1bd004a6b">+57/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude CLI requests now support a configurable turn limit, defaulting to three turns.
  * Non-positive turn-limit settings are safely clamped to one.

* **Bug Fixes**
  * Long-running responses are less likely to stop prematurely due to a one-turn limit.

* **Documentation**
  * Clarified how turn exhaustion differs from output-token exhaustion and how to identify the cause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->