### PR TITLE
fix(events): dedup before the model call, and stop inferring onto DRAFT cases

### DIFF
--- a/case_events/consumers/handlers.py
+++ b/case_events/consumers/handlers.py
@@ -55,20 +55,55 @@ def _producer(name: str) -> str:
 # ── matcher ──────────────────────────────────────────────────────────────────
 
 
-def _enrichable():
-    """Cases an observed fact may be proposed against.
+#: The case states an INFERRED match may be proposed against.
+#:
+#: An allowlist rather than ``exclude(CLOSED)``, so that adding a state to the
+#: workflow does not silently opt it in. A new state should have to be argued for
+#: here, not inherited by default.
+ENRICHABLE_STATES = ("IN_REVIEW", "PUBLISHED")
 
-    Excludes CLOSED, which on this platform is the soft delete: ``Case.delete()``
-    flips the state and keeps the row (accountability archive — nothing is hard
-    deleted). Without this filter a deleted case still joins on its court-case
-    references, so every scrape of that docket buys a premium model call and puts
-    a review item in front of a caseworker for a case somebody deliberately
-    removed. DRAFT and IN_REVIEW are deliberately kept: a case being built is
-    exactly the sort of thing new facts should land on.
+
+def _not_deleted():
+    """Every case that still exists, whatever its workflow state.
+
+    CLOSED is this platform's soft delete: ``Case.delete()`` flips the state and
+    keeps the row (accountability archive — nothing is hard deleted). Without this
+    filter a deleted case still joins on its court-case references, so every
+    re-scrape of that docket buys a premium model call and puts a review item in
+    front of a caseworker for a case somebody deliberately removed.
+
+    This is the floor, and it applies to every path. Nothing may be proposed
+    against a deleted case, however the match was arrived at.
     """
     from cases.models import Case, CaseState
 
     return Case.objects.exclude(state=CaseState.CLOSED)
+
+
+def _enrichable():
+    """Cases an INFERRED fact may be proposed against — the narrower set.
+
+    Used by :func:`_cases_for_refs`, where we joined a docket or a material to a
+    case ourselves and nobody asked us to. Deliberately NOT used by
+    :func:`_cases_named_directly`, where a human named the case; see there for why
+    the two differ.
+
+    **DRAFT is excluded, reversing what this used to do.** The old reasoning was
+    that "a case being built is exactly the sort of thing new facts should land
+    on" — true of a case someone is actively writing, false of this archive.
+    Measured 2026-08-04: DRAFT is 2919 of 3003 non-closed cases, 97%, and is
+    overwhelmingly bulk-imported stubs nobody has opened rather than
+    work-in-progress. Inferring facts onto those proposes against cases with no
+    editorial owner, filling a review queue nobody is clearing at the price of a
+    premium call each.
+
+    The cost of the reversal, stated because it is not free: the inferrable set
+    goes from 3003 cases to 84, and matching signals in a 48h window from 6 to 3.
+    Half of what this pipeline can currently see is now deliberately ignored. A
+    DRAFT case that wants enrichment gets it by being moved to IN_REVIEW — a
+    caseworker action, and a cheap one.
+    """
+    return _not_deleted().filter(state__in=ENRICHABLE_STATES)
 
 
 def _cases_for_refs(refs: list[str]):
@@ -106,6 +141,18 @@ def _cases_named_directly(refs: list[str]):
     Separate from the join above because a signal that names the case outright
     is not a match at all — it is an assertion, and it should not be scored as
     though we inferred it.
+
+    **That distinction is now load-bearing, not just cosmetic.** This path uses
+    :func:`_not_deleted`, so DRAFT is allowed here and refused by
+    :func:`_cases_for_refs`. The reason is who is asking. A docket join is us
+    guessing that a fact belongs to a case, and guessing onto 2919 ownerless DRAFT
+    stubs is the waste ``ENRICHABLE_STATES`` exists to stop. A manual note is a
+    caseworker naming the case, and refusing that would make the note endpoint
+    silently useless on 97% of the archive — it answers 202 "a proposal will
+    appear if the note warrants one", and none ever would.
+
+    CLOSED remains refused on both paths. Being named by a human is not a reason
+    to enrich a case somebody deleted.
     """
     from jawafdehi_shared.entities.ids import parse_case_iri
 
@@ -118,7 +165,7 @@ def _cases_named_directly(refs: list[str]):
     if not slugs:
         return []
 
-    return list(_enrichable().filter(slug__in=slugs).only("id", "slug", "title"))
+    return list(_not_deleted().filter(slug__in=slugs).only("id", "slug", "title"))
 
 
 def handle_matcher(envelope: dict, context) -> None:
@@ -252,8 +299,12 @@ def handle_proposal_builder(envelope: dict, context) -> None:
     long enough to cover the worst case, and make every redelivery pay for a
     fresh premium call. Enqueue-and-ack hands all of that to the jobs queue,
     where the lease, the retry budget and terminal handling already exist.
+
+    **A fact already staged is dropped here, before a job exists.** See
+    :func:`case_proposals.job_kind.already_staged` for why the check downstream is
+    not enough on its own.
     """
-    from case_proposals.job_kind import DETECTED_BY, KIND
+    from case_proposals.job_kind import DETECTED_BY, KIND, already_staged
     from jobs import queue as jobs_queue
 
     payload = envelope.get("payload") or {}
@@ -267,6 +318,22 @@ def handle_proposal_builder(envelope: dict, context) -> None:
     dedup_key = envelope.get("dedup_key") or ""
     if not dedup_key:
         raise PoisonMessage(f"{subjects.CASE_MATCHED} envelope has no dedup_key to key a proposal on")
+
+    if already_staged(dedup_key):
+        # Ack and stop. The downstream check in `on_result` would also catch this
+        # and mark the job a duplicate — but only AFTER paying for the model call,
+        # which is the entire cost of the job. Nothing upstream prevents the
+        # repeat: the streams' duplicate_window is 120s while the docket producer
+        # rescans a 48h window every 6h, and `jobs.queue.enqueue` frees a
+        # dedup_key as soon as the previous job reaches a terminal state. So every
+        # fact was re-observed ~8 times and paid for ~8 times to produce one
+        # proposal.
+        logger.info(
+            "case_events.intent_skipped_already_staged",
+            case_id=case_id,
+            dedup_key=dedup_key,
+        )
+        return
 
     job = jobs_queue.enqueue(
         KIND,

--- a/case_events/tests/test_consumer_handlers.py
+++ b/case_events/tests/test_consumer_handlers.py
@@ -17,7 +17,13 @@ import pytest
 
 from case_events import subjects
 from case_events.consumers import PoisonMessage, handlers
-from cases.models import Case, CaseCourtCaseReference, CaseMaterialReference, CaseType
+from cases.models import (
+    Case,
+    CaseCourtCaseReference,
+    CaseMaterialReference,
+    CaseState,
+    CaseType,
+)
 from jawafdehi_shared.entities.ids import (
     build_case_iri,
     build_courtcase_iri,
@@ -28,8 +34,17 @@ from jawafdehi_shared.entities.ids import (
 pytestmark = pytest.mark.django_db
 
 
-def make_case(slug="lalita-niwas-land-scam", title="Lalita Niwas land scam"):
-    return Case.objects.create(title=title, case_type=CaseType.CORRUPTION, slug=slug)
+def make_case(slug="lalita-niwas-land-scam", title="Lalita Niwas land scam", state=CaseState.IN_REVIEW):
+    """A case the matcher is allowed to propose against.
+
+    ``state`` is explicit and does NOT default to the model's own default. The
+    model defaults to DRAFT, and DRAFT is deliberately not enrichable — see
+    ``handlers.ENRICHABLE_STATES``. A fixture that inherited the model default
+    would make every matcher test here assert against a case the matcher is
+    supposed to ignore, and they would all fail for the same uninformative
+    reason.
+    """
+    return Case.objects.create(title=title, case_type=CaseType.CORRUPTION, slug=slug, state=state)
 
 
 def signal_envelope(**overrides):
@@ -254,10 +269,60 @@ class TestMatcher:
 
         assert published(pub) == []
 
-    def test_a_draft_case_IS_matched(self):
-        """Kept deliberately: a case being built is what new facts should land on."""
-        case = make_case()
-        assert case.state == "DRAFT"
+    def test_a_draft_case_is_NOT_matched(self):
+        """Reverses what this test used to assert, and the reversal is the point.
+
+        It previously read `test_a_draft_case_IS_matched`, on the reasoning that
+        a case being built is what new facts should land on. True of a case a
+        human is writing; false of this archive, where DRAFT was 2919 of 3003
+        non-closed cases on 2026-08-04 and is overwhelmingly bulk-imported stubs
+        with no editorial owner. Proposing against those spends a premium call
+        each to fill a queue nobody is clearing.
+        """
+        case = make_case(state=CaseState.DRAFT)
+        iri = build_courtcase_iri("special", "082-CR-0154")
+        CaseCourtCaseReference.objects.create(case=case, courtcase_iri=iri, ordinal=1)
+
+        with mock.patch("case_events.bus.publish") as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
+
+        assert published(pub) == []
+
+    def test_a_draft_case_NAMED_OUTRIGHT_is_still_matched(self):
+        """The asymmetry, and it is deliberate — inference is filtered, assertion
+        is not.
+
+        A docket join is us guessing a fact belongs to a case, and guessing onto
+        ownerless DRAFT stubs is the waste ENRICHABLE_STATES exists to stop. A
+        caseworker's manual note names the case, and this is the path it takes;
+        filtering it would make the note endpoint silently useless on 97% of the
+        archive — it answers 202 "a proposal will appear if the note warrants
+        one" and none ever would.
+        """
+        case = make_case(state=CaseState.DRAFT)
+
+        with mock.patch("case_events.bus.publish") as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[build_case_iri(case.slug)]), None)
+
+        assert len(published(pub)) == 1
+
+    def test_a_closed_case_is_refused_on_the_assertion_path_too(self):
+        """The floor that has no exception. Being named by a human is not a
+        reason to enrich a case somebody deleted, so the assertion path relaxes
+        DRAFT and nothing else."""
+        case = make_case(state=CaseState.DRAFT)
+        case.delete()
+
+        with mock.patch("case_events.bus.publish") as pub:
+            handlers.handle_matcher(signal_envelope(subject_refs=[build_case_iri(case.slug)]), None)
+
+        assert published(pub) == []
+
+    @pytest.mark.parametrize("state", [CaseState.IN_REVIEW, CaseState.PUBLISHED])
+    def test_the_two_enrichable_states_are_matched(self, state):
+        """The positive half, pinned per state rather than left to the fixture's
+        default — otherwise retuning that default silently drops the coverage."""
+        case = make_case(state=state)
         iri = build_courtcase_iri("special", "082-CR-0154")
         CaseCourtCaseReference.objects.create(case=case, courtcase_iri=iri, ordinal=1)
 
@@ -265,6 +330,11 @@ class TestMatcher:
             handlers.handle_matcher(signal_envelope(subject_refs=[iri]), None)
 
         assert len(published(pub)) == 1
+
+    def test_every_enrichable_state_is_a_real_case_state(self):
+        """Guards a typo in the allowlist, which would fail open to silence: an
+        unknown string matches nothing and looks exactly like a quiet window."""
+        assert set(handlers.ENRICHABLE_STATES) <= set(CaseState.values)
 
 
 def matched_envelope(case, **overrides):
@@ -281,6 +351,20 @@ def matched_envelope(case, **overrides):
         },
         **overrides,
     }
+
+
+def stage_proposal(case, envelope, **overrides):
+    """The row that means "this exact fact has already been proposed"."""
+    from case_proposals.models import CaseUpdateProposal
+
+    return CaseUpdateProposal.objects.create(
+        case_slug=case.slug,
+        dedup_key=envelope["dedup_key"],
+        source_kind="ngm_docket",
+        intent={"type": "append_timeline_entry", "entry": {}},
+        confidence=0.9,
+        **overrides,
+    )
 
 
 class TestProposalBuilder:
@@ -317,6 +401,63 @@ class TestProposalBuilder:
         handlers.handle_proposal_builder(envelope, None)
 
         assert Job.objects.count() == 1
+
+    def test_a_fact_already_staged_never_becomes_a_job(self):
+        """The whole point of the check: no job means no premium call.
+
+        The queue's own dedup does NOT cover this. ``jobs.queue.enqueue`` frees a
+        dedup_key the moment the prior job is terminal, so once the first job is
+        `done` the next observation of the same fact enqueues cleanly, pays for a
+        full model call, and is only then discarded by ``on_result``. With the
+        docket producer rescanning a 48h window every 6h, that is ~8 calls per
+        fact for one proposal.
+        """
+        from jobs.models import Job
+
+        case = make_case()
+        envelope = matched_envelope(case)
+        stage_proposal(case, envelope)
+
+        with mock.patch("llm.prompts.PromptSpec.invoke") as invoke:
+            handlers.handle_proposal_builder(envelope, None)
+
+        assert Job.objects.count() == 0
+        invoke.assert_not_called()
+
+    def test_the_skip_survives_the_first_job_reaching_a_terminal_state(self):
+        """The regression this actually fixes, reproduced through the real queue.
+
+        Asserted by driving the job to `done` — the state that frees the dedup
+        key — rather than by trusting the docstring above. Without the check in
+        the handler this enqueues a second job and the test fails.
+        """
+        from jobs.models import Job
+
+        case = make_case()
+        envelope = matched_envelope(case)
+        handlers.handle_proposal_builder(envelope, None)
+
+        job = Job.objects.get()
+        job.status = "done"
+        job.save(update_fields=["status"])
+        stage_proposal(case, envelope)
+
+        handlers.handle_proposal_builder(envelope, None)
+
+        assert Job.objects.count() == 1
+
+    def test_a_rejected_proposal_also_blocks_the_rebuild(self):
+        """Rejection has to stay sticky, and cheaply. A caseworker saying no to a
+        fact must not buy another call to re-propose it next window."""
+        from jobs.models import Job
+
+        case = make_case()
+        envelope = matched_envelope(case)
+        stage_proposal(case, envelope, status="rejected")
+
+        handlers.handle_proposal_builder(envelope, None)
+
+        assert Job.objects.count() == 0
 
     def test_the_signals_subject_becomes_the_proposals_source_kind(self):
         from jobs.models import Job

--- a/case_proposals/job_kind.py
+++ b/case_proposals/job_kind.py
@@ -197,13 +197,21 @@ def _validation_failure(job, reason: str, **context) -> None:
     _record(job, proposal_id=None, rejected=reason, **context)
 
 
-def _already_staged(dedup_key: str) -> bool:
+def already_staged(dedup_key: str) -> bool:
     """True if this fact has already been proposed, whatever was decided about it.
 
     Deliberately not filtered by status. A REJECTED proposal is a caseworker
     saying no to this exact fact, and the rejection has to stay sticky — a
     re-observed docket entry must not come back a week later as a fresh pending
     item for someone to reject again.
+
+    **Called in two places, for two different reasons.** The proposal-builder
+    consumer calls it before enqueueing, which is where the money is saved: no
+    job, no model call. :func:`on_result` calls it again after the call, which is
+    where correctness is guaranteed — the two are separated by 30–90 seconds of
+    inference, and a concurrent decision inside that gap is entirely possible.
+    Neither makes the other redundant: drop the first and every re-observation is
+    paid for, drop the second and a race writes a duplicate row.
     """
     from case_proposals.models import CaseUpdateProposal
 
@@ -266,7 +274,7 @@ def on_result(job, result: dict) -> None:
     # Those need to stay distinguishable: the first is the idempotency spine
     # working, the second is a prompt regression, and conflating them means a
     # dashboard full of validation failures that are all benign.
-    if _already_staged(dedup_key):
+    if already_staged(dedup_key):
         logger.info("case_proposal.intent_already_staged", job_id=job.pk, dedup_key=dedup_key)
         return _record(job, proposal_id=None, duplicate=True, dedup_key=dedup_key)
 


### PR DESCRIPTION
### **User description**
Two changes to the matcher / proposal-builder pair. Both are about spending a premium call only where it buys something. Found while sizing the docket window before unsuspending the producer — the window was fine, what it fed was not.

## 1. The dedup check ran after the money was spent

`already_staged` was consulted **only** in `case_proposals.job_kind.on_result`, which runs after 30–90s of inference has been paid for. Nothing upstream stopped the repeat:

- The JetStream streams' `duplicate_window` is **120s**, while the docket producer rescans a **48h** window every **6h**. Broker dedup never engages.
- `jobs.queue.enqueue` frees a `dedup_key` as soon as the prior job is terminal — its own docstring says so: *"If the prior same-key job is terminal (done/failed/dead), the key is freed and a fresh job is created."*
- `build_payload`, the only pre-call hook, does not check.

So a fact entering the window was re-observed **~8 times** (48h ÷ 6h) and **7 of those 8 bought a full premium call whose result was immediately discarded as a duplicate.** The output was always correct — `CaseUpdateProposal.dedup_key` is unique — which is why this never presented as a bug, only as a bill. It also scales with the archive.

The check now also runs in `handle_proposal_builder`, before a job exists. `on_result` keeps its copy deliberately: the two are separated by the inference itself, so a decision landing in that gap is real. **Consumer = cost filter, `on_result` = correctness.** Neither makes the other redundant — drop the first and every re-observation is paid for; drop the second and a race writes a duplicate row.

`_already_staged` → `already_staged`, since it is now called across modules.

## 2. DRAFT is no longer enrichable by inference

Requested, and it reverses this file's own prior reasoning — the old docstring argued *"a case being built is exactly the sort of thing new facts should land on."* That is true of a case a human is actively writing and false of this archive:

| state | cases |
|---|---|
| DRAFT | **2919** |
| PUBLISHED | 59 |
| IN_REVIEW | 25 |
| CLOSED | 16 |

DRAFT is 97% of non-closed cases and is overwhelmingly bulk-imported stubs nobody has opened. Inferring onto those proposes against cases with no editorial owner — filling a review queue nobody is clearing, at a premium call each.

**The measured cost of the change, stated because it is not free:** the inferrable set goes from 3003 cases to 84, and matching signals in a 48h window from 6 to 3. Half of what this pipeline can currently see is now deliberately ignored. A DRAFT case that wants enrichment gets it by being moved to IN_REVIEW.

### The restriction is on inference only

`_cases_named_directly` — the path a caseworker's **manual note** takes — keeps the CLOSED-only floor. Filtering it would make that endpoint answer `202 "a proposal will appear if the note warrants one"` and then never produce one, on 97% of the archive. The matcher already drew the assertion/inference line for confidence scoring; it is now load-bearing rather than cosmetic.

CLOSED stays refused on both paths. Being named by a human is not a reason to enrich a case somebody deleted.

## Verification

- **3157 pass** across the suite, `ruff check` clean (formatting is not gated in this repo, by design).
- **Six mutations, all killed**, tree verified clean against the commit after each:
  1. remove the pre-enqueue skip
  2. drop the state filter (restore old behaviour)
  3. point the assertion path at the narrow set
  4. `ENRICHABLE_STATES` loses `PUBLISHED`
  5. `ENRICHABLE_STATES` loses `IN_REVIEW`
  6. (plus the allowlist-typo guard, which fails open to silence)
- The test fixture no longer inherits the model's `DRAFT` default — that would have made every matcher test assert against a case the matcher must ignore, all failing for the same uninformative reason.

## Context

The pipeline produced **its first ever proposal** earlier today, once the turn-cap fix (#412) landed and `case_proposal_intent` was claimed: a real Special Court fact (071-CR-0160, फैसला/सफाई, 2075-09-02 BS) drafted in Nepali at confidence 0.88, job `done` on **attempt 1**.

Note that the acceptance case was itself DRAFT, so **that proposal would not be created under this PR.** The 3 remaining matching signals per window are IN_REVIEW/PUBLISHED and unaffected.

`platform-docket-signals` is still **suspended** and I would keep it that way until this merges — unsuspending first is what makes the repeat-billing real at 4 runs/day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Skip duplicate proposal jobs pre-inference

- Restrict inferred matches to active states

- Preserve direct DRAFT case assertions

- Cover dedup, state-filter regressions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  signal["Matched signal"]
  staged["already_staged check"]
  job["Proposal job"]
  model["Model inference"]
  proposal["Proposal result"]
  states["ENRICHABLE_STATES filter"]
  signal -- "dedup absent" --> staged
  staged -- "new fact" --> job
  job -- "runs" --> model
  model -- "checked again" --> proposal
  signal -- "inferred refs" --> states
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.py</strong><dd><code>Filter inferred states; skip staged jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/consumers/handlers.py

<ul><li>Add <code>ENRICHABLE_STATES</code> allowlist.<br> <li> Split <code>_not_deleted</code> from <code>_enrichable</code>.<br> <li> Keep direct case refs open to DRAFT.<br> <li> Skip <code>already_staged</code> before enqueue.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/413/files#diff-f87d31efbe6c6bbc7a10839b8ddba88bcd2d6a29902e84a314dda2a56a750eb2">+79/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>job_kind.py</strong><dd><code>Export staged-proposal dedup helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/job_kind.py

<ul><li>Rename <code>_already_staged</code> to <code>already_staged</code>.<br> <li> Document pre-job cost filter usage.<br> <li> Keep post-inference duplicate guard.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/413/files#diff-3eb9480104e521129e2f2d00d434e81a5c67b23f9fbf8d5c01c35627f8ee711c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_consumer_handlers.py</strong><dd><code>Cover state filtering and dedup skips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/tests/test_consumer_handlers.py

<ul><li>Default test cases to <code>IN_REVIEW</code>.<br> <li> Assert DRAFT inferred refs ignored.<br> <li> Assert direct DRAFT refs still matched.<br> <li> Assert staged proposals block jobs.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/413/files#diff-2bfa2148749a8975d65fa6ec905d77a523a8abec2c80b4ef442a75596d93db19">+148/-7</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case matching so inferred enrichment excludes draft and closed cases while continuing to support eligible review and published cases.
  * Preserved direct matching for draft cases when explicitly referenced.
  * Prevented duplicate proposal jobs when matching proposals are already staged, completed, or rejected.
* **Tests**
  * Added coverage for case eligibility and duplicate proposal prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->