### PR TITLE
fix(courts): record why a verdict needed a second attempt, and retract the reason given for it

### DIFF
--- a/courts/management/commands/extract_verdicts.py
+++ b/courts/management/commands/extract_verdicts.py
@@ -60,14 +60,34 @@ DEFAULT_DELAY = 1.0
 #: at -- but they are lost coverage, so give reasoning real headroom.
 MAX_TOKENS = 8000
 #: Second-attempt budget, used ONLY after a first attempt died of exhaustion.
-#: The 2026-07-31 production run lost 3 of 84 cases this way, all of them long
-#: multi-defendant judgments where the reasoning alone outran 8000 tokens.
+#:
+#: The 2026-07-31 production run escalated 3 of 84 cases. **The claim that these
+#: were "long multi-defendant judgments where the reasoning alone outran 8000
+#: tokens" has been removed, because nothing measured it** -- it was inferred from
+#: the error text, and that inference is now known to be unreliable (see below).
+#: Whether raising the budget is the right remedy for those 3 is an open question,
+#: not a settled one.
 ESCALATED_MAX_TOKENS = 32000
-#: How exhaustion presents -- and why the turn limit is only the messenger, while
-#: the token budget is the cause -- now lives in :mod:`llm.exhaustion`. It moved
-#: because the same failure was diagnosed from scratch a second time, in
+#: How exhaustion presents now lives in :mod:`llm.exhaustion`. It moved because
+#: the same failure was diagnosed from scratch a second time, in
 #: `case_proposals`, which is once too often for it to stay private to this
-#: command. Kept as a module-level alias so this file's tests still name it.
+#: command.
+#:
+#: **This comment used to say the turn limit was "only the messenger, while the
+#: token budget is the cause". That was wrong.** ``error_max_turns`` has two
+#: causes wanting opposite remedies, and they are not distinguishable from the
+#: error text; on `case_proposal.intent` the turn cap was the whole cause and
+#: three successive budget increases changed nothing (JawafdehiAPI#412 raised the
+#: cap to ``CLAUDE_CLI_MAX_TURNS``, default 3).
+#:
+#: Which means the escalation below may now be treating a symptom this codebase
+#: no longer has, at 4x the tokens each time it fires. It is kept rather than
+#: removed because a budget-caused exhaustion is still real and still wants
+#: exactly this remedy -- but the next run's ``escalated`` count is the number to
+#: watch, and it is now recorded per case (see ``build_hearing``) so that the
+#: question can actually be answered instead of re-inferred.
+#:
+#: Kept as a module-level alias so this file's tests still name it.
 _is_exhaustion = is_exhaustion
 
 
@@ -265,7 +285,9 @@ class Command(BaseCommand):
 
             now = timezone.now()
             try:
-                hearing = build_hearing(case, ex, order_url=url, model=model, now=now)
+                hearing = build_hearing(
+                    case, ex, order_url=url, model=model, now=now, escalated=escalated
+                )
             except ValueError as exc:
                 failed += 1
                 self.stdout.write(f"  {i:>3} {case.case_number}  FAILED {exc}")

--- a/courts/scraper/verdicts.py
+++ b/courts/scraper/verdicts.py
@@ -326,11 +326,22 @@ def derived_hearing_filter() -> Q:
     return Q(**{f"extra_data__{PROVENANCE_KEY}__isnull": False})
 
 
-def build_hearing(case, extraction: VerdictExtraction, *, order_url, model, now):
+def build_hearing(case, extraction: VerdictExtraction, *, order_url, model, now, escalated=False):
     """The unsaved :class:`CourtCaseHearing` for one recovered verdict.
 
     The verdict DATE comes from ``case_status`` -- that is the court's own field
     and is not in question. Only the disposition is model-derived.
+
+    ``escalated`` records whether this row needed a second attempt at a larger
+    token budget. It is persisted because it previously was not: the 2026-07-31
+    run escalated 3 of 84 cases, printed that count to stdout, and kept nothing --
+    so when the diagnosis behind the escalation was later found to be wrong, those
+    3 cases could not be identified to re-check. A per-run count that survives
+    only in a terminal scrollback cannot answer a question asked a week later.
+
+    Defaulted to False rather than made required so that a caller that has not
+    been taught about escalation records "not escalated" instead of crashing; the
+    one caller that CAN escalate passes it explicitly.
     """
     if extraction.abstained:
         raise ValueError("refusing to build a hearing from an abstention")
@@ -357,6 +368,7 @@ def build_hearing(case, extraction: VerdictExtraction, *, order_url, model, now)
                 "evidence": extraction.evidence,
                 "model_verdict_date_bs": extraction.verdict_date_bs,
                 "extracted_at": now.isoformat(),
+                "escalated": escalated,
             }
         },
     )

--- a/courts/tests/test_scraper_verdicts.py
+++ b/courts/tests/test_scraper_verdicts.py
@@ -136,6 +136,38 @@ class BuildHearingTests(TestCase):
         found = CourtCaseHearing.objects.using("ngm").filter(derived_hearing_filter())
         self.assertNotIn(scraped.pk, [h.pk for h in found])
 
+    def test_whether_a_row_needed_an_escalated_budget_is_persisted(self):
+        """Recorded per case, not just counted per run.
+
+        The 2026-07-31 run escalated 3 of 84 cases and printed only the count.
+        When the reasoning behind escalating was later found to be wrong -- the
+        error it triggers on has two causes, and the one assumed was not the one
+        that mattered -- those 3 cases could not be identified to re-check,
+        because nothing about them survived the terminal scrollback. A run whose
+        only record is its own stdout cannot answer a question asked afterwards.
+        """
+        plain = build_hearing(self.case, self.ex, order_url="u", model="m", now=timezone.now())
+        self.assertFalse(plain.extra_data[PROVENANCE_KEY]["escalated"])
+
+        hard = build_hearing(
+            self.case, self.ex, order_url="u", model="m", now=timezone.now(), escalated=True
+        )
+        self.assertTrue(hard.extra_data[PROVENANCE_KEY]["escalated"])
+
+        hard.save(using="ngm")
+        reloaded = CourtCaseHearing.objects.using("ngm").get(pk=hard.pk)
+        self.assertTrue(
+            reloaded.extra_data[PROVENANCE_KEY]["escalated"],
+            "the flag has to survive the round trip, or it answers nothing later",
+        )
+
+    def test_the_escalation_flag_defaults_to_not_escalated(self):
+        """A caller that has not been taught about escalation must record False,
+        not crash and not omit the key — an absent key would read as 'unknown'
+        for every historical row and make the next comparison ambiguous again."""
+        h = build_hearing(self.case, self.ex, order_url="u", model="m", now=timezone.now())
+        self.assertIn("escalated", h.extra_data[PROVENANCE_KEY])
+
     def test_an_abstention_can_never_become_a_row(self):
         with self.assertRaises(ValueError):
             build_hearing(self.case, parse_response(_resp(decision_type="ABSTAIN")),


### PR DESCRIPTION
### **User description**
The verdict extractor retries a case at **4× the token budget** when the first attempt dies of `error_max_turns`. This PR does not change that behaviour. It fixes the two things that made the behaviour impossible to evaluate.

## The stated cause was wrong

`extract_verdicts.py` asserted, in a comment:

> *"why the turn limit is only the messenger, while the token budget is the cause"*

and, of the 2026-07-31 run's 3 escalations:

> *"all of them long multi-defendant judgments where the reasoning alone outran 8000 tokens"*

**Nothing measured either claim.** Both were inferred from an error string. `error_max_turns` has two causes that want opposite remedies and are not distinguishable from the text — on `case_proposal.intent` the turn cap was the entire cause, and three successive budget increases (1200 → 8000 → 32000) changed nothing; #412 fixed it by raising the cap instead.

Both sentences are removed, with the retraction left in their place rather than a silent edit. The inference they encode is precisely the one that produced two wrong fixes elsewhere, so it is worth a marker.

## The escalation left no evidence behind

`escalated` was counted per run and printed to stdout. So when the reasoning behind it was found to be unsound, **the 3 cases could not be identified to re-check** — a count surviving only in a terminal scrollback cannot answer a question asked a week later.

It is now persisted per row under `extra_data['verdict_extraction']['escalated']`, defaulted to `False` rather than omitted so that historical rows compare unambiguously instead of reading absent-as-unknown.

## Why not just remove the escalation

Because a budget-caused exhaustion is real and wants exactly this remedy. The claim that it is *no longer* what happens here is plausible and untested — and replacing one unmeasured assertion with its opposite is the same mistake facing the other way.

## The open item, stated plainly

**I could not re-measure the 3-of-84 losses, and that is the finding.** They are unidentifiable retrospectively for exactly the reason this PR fixes. A broad re-run would cost 84 premium calls and would not reliably hit the same cases, so it is not worth it — whereas the next ordinary production run now answers the question for free, via the `escalated` count and the per-row flag.

If that count comes back **0**, the escalation is dead code paying 4× whenever it fires and should go.

## Verification

- **473 courts tests pass**, `ruff check` clean.
- New tests pin that the flag survives a DB round trip (the point — an in-memory-only flag answers nothing later) and that it defaults to present-and-False rather than missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Persist verdict escalation provenance

- Retract unsupported exhaustion diagnosis

- Default escalation flag to `False`

- Add persistence regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Verdict extraction"] -- "tracks retry" --> B["build_hearing"]
  B -- "stores flag" --> C["extra_data.verdict_extraction.escalated"]
  C -- "enables" --> D["later audit"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>extract_verdicts.py</strong><dd><code>Pass escalation state during verdict extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/management/commands/extract_verdicts.py

<ul><li>Adds retraction comments for unmeasured budget-cause claims<br> <li> Documents ambiguous <code>error_max_turns</code> causes<br> <li> Passes per-case <code>escalated</code> flag into <code>build_hearing</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/414/files#diff-c8ff536e8aa7d0e69aff97198f936c7b3db19c75074f19175dc4700429d024a0">+29/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verdicts.py</strong><dd><code>Persist verdict escalation metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/scraper/verdicts.py

<ul><li>Adds <code>escalated=False</code> parameter to <code>build_hearing</code><br> <li> Documents why escalation provenance must persist<br> <li> Stores <code>escalated</code> under verdict extraction <code>extra_data</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/414/files#diff-1f9063bc82549eb37ddf549626dc541c506ad76a7eb1efb41ba94812655331fb">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scraper_verdicts.py</strong><dd><code>Test escalation provenance persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_scraper_verdicts.py

<ul><li>Tests default <code>escalated</code> value is persisted as <code>False</code><br> <li> Tests explicit <code>escalated=True</code> survives DB round trip<br> <li> Verifies key presence avoids ambiguous missing provenance</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/414/files#diff-b2a388ba5a152e32197edf5692f6cfabbf5cf60c3f096201a1961a831e1fdb6d">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
