### PR TITLE
feat(events): give the notifier a real channel, and bound what it may say

### DIFF
--- a/case_events/consumers/handlers.py
+++ b/case_events/consumers/handlers.py
@@ -327,19 +327,26 @@ def _source_kind_for(subject: str) -> str:
 def handle_notifier(envelope: dict, context) -> None:
     """Tell a caseworker that a proposal needs them, or that one was decided.
 
-    **The delivery channel is not chosen yet, and this does not invent one.**
-    Outbound mail from this application is currently disabled, and picking
-    between mail, the SPA's own queue badge and a chat ping is a product
-    decision rather than a plumbing one. So this emits one structured event per
-    decision and no more.
+    Two outputs, and the order is deliberate. The structured log line comes FIRST
+    and unconditionally: it is the record that a transition happened, it answers
+    "did anyone ever see this?", and it must not depend on an external service
+    being reachable. The webhook is best-effort on top of it.
 
-    That is deliberately not a placeholder that does nothing: the queue UI is
-    already the primary surface, so the useful thing a notifier adds today is a
-    single greppable line per proposal lifecycle transition — which is what a
-    "did anyone ever see this?" question needs and does not currently have.
-    Wiring a real channel means replacing the body of this function and nothing
-    else, because the subscription, the retries and the DLQ are already here.
+    **Mail was considered and ruled out.** Outbound mail from this application is
+    disabled, and enabling it for automated per-proposal messages is a larger
+    decision than this needs. A webhook reaches a channel people already watch and
+    costs one POST.
+
+    **What that POST may carry is constrained** — see :mod:`case_events.notify`.
+    The short version: a PENDING proposal is unreviewed model output about named
+    individuals, so the notification links to it rather than quoting it.
+
+    A webhook failure is swallowed, never raised. Raising would redeliver the
+    message, and redelivery would re-notify rather than re-do anything useful: the
+    proposal row already exists and the queue is the surface that matters.
     """
+    from case_events import notify
+
     payload = envelope.get("payload") or {}
     logger.info(
         "case_events.caseworker_notified",
@@ -350,6 +357,7 @@ def handle_notifier(envelope: dict, context) -> None:
         confidence=payload.get("confidence"),
         reviewer=payload.get("reviewer"),
     )
+    notify.post(payload)
 
 
 # ── derive ───────────────────────────────────────────────────────────────────

--- a/case_events/notify.py
+++ b/case_events/notify.py
@@ -34,10 +34,37 @@ logger = structlog.get_logger(__name__)
 #: request, because a consumer has no request to build one from.
 QUEUE_PATH = "/admin/proposals"
 
+#: U+200B. Named and escaped so it is visible in source — see
+#: :func:`defang_mentions`.
+ZERO_WIDTH_SPACE = "\u200b"
+
 
 def _base_url() -> str:
     configured = (getattr(settings, "FRONTEND_BASE_URL", "") or "").rstrip("/")
     return configured or "https://jawafdehi.org"
+
+
+def defang_mentions(text: str) -> str:
+    """Make ``@`` in interpolated text unable to ping anyone.
+
+    Found in review, and it is a gap the module docstring did not cover: that
+    docstring bounds what the payload CONTAINS, and this is about what it can DO.
+    Two of the interpolated fields are human-authored — ``case_slug`` derives from
+    a title a caseworker wrote, and ``reviewer`` is an account handle — so
+    ``@everyone`` reaching the rendered line would ping an entire server from a
+    case record. That is not a data leak, it is worse in one respect: it is a
+    notification channel becoming a nuisance channel, which gets it muted, which
+    silently ends the notifications.
+
+    A zero-width space after the ``@`` is the standard trick: it renders
+    indistinguishably and stops the mention resolving.
+
+    Written as the ``\\u200b`` ESCAPE rather than the character itself, on purpose.
+    A literal zero-width space in source is invisible: it can be deleted by an
+    editor, a reformat or a careless selection with nothing looking wrong
+    afterwards, and the test for this would then be the only sign left.
+    """
+    return text.replace("@", f"@{ZERO_WIDTH_SPACE}")
 
 
 def build_message(payload: dict) -> dict:
@@ -58,12 +85,21 @@ def build_message(payload: dict) -> dict:
     tail = f" by {reviewer}" if reviewer else ""
     confidence_note = f", confidence {confidence}" if confidence is not None else ""
 
+    content = defang_mentions(
+        f"Case update proposal {where} is **{status}**{tail} "
+        f"on `{case_slug}`{confidence_note}. Review: {link}"
+    )
+
     return {
         # No case title and no drafted text — see the module docstring.
-        "content": (
-            f"Case update proposal {where} is **{status}**{tail} "
-            f"on `{case_slug}`{confidence_note}. Review: {link}"
-        ),
+        "content": content,
+        # Belt to the escaping's braces, and the half that actually binds a Discord
+        # receiver: with `parse` empty, even an unescaped mention is not resolved.
+        # Harmless to any other receiver, which ignores a field it does not know.
+        "allowed_mentions": {"parse": []},
+        # NOT defanged. The structured half is for machines, and mangling an
+        # identifier a receiver might match on would be worse than the risk this
+        # guards. Only the prose that gets RENDERED is escaped.
         "proposal_id": proposal_id,
         "case_slug": case_slug,
         "status": status,

--- a/case_events/notify.py
+++ b/case_events/notify.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Announcing a proposal decision to an outbound webhook.
+
+Separate from :mod:`case_events.consumers.handlers` because the interesting parts
+here are about *what may leave the building*, not about consuming a message.
+
+**The payload deliberately omits the drafted intent.** A PENDING proposal is
+unreviewed model output about named individuals in corruption cases, and the whole
+point of the review queue is that nothing is published until a human agrees with
+it. Posting the draft text to an external chat service would publish it — to a
+third party, in a channel with its own retention, before anyone has checked it. So
+the notification says *that* a proposal needs review and *where to find it*, and
+the reviewer reads the content in the app behind SSO. This is a smaller message
+and a correct one, not a compromise.
+
+**Failures never propagate.** The proposal row already exists and the queue UI is
+the primary surface; a webhook that is down must not cause a JetStream redelivery,
+because redelivery would re-notify rather than re-do anything useful. Every failure
+mode logs and returns False.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+import structlog
+from django.conf import settings
+
+logger = structlog.get_logger(__name__)
+
+#: What the reviewer is being pointed at. Kept here rather than built from a
+#: request, because a consumer has no request to build one from.
+QUEUE_PATH = "/admin/proposals"
+
+
+def _base_url() -> str:
+    configured = (getattr(settings, "FRONTEND_BASE_URL", "") or "").rstrip("/")
+    return configured or "https://jawafdehi.org"
+
+
+def build_message(payload: dict) -> dict:
+    """The body posted to the webhook.
+
+    Carries both a rendered ``content`` line (Discord and most chat receivers
+    require one) and the structured fields beside it, so a different receiver does
+    not have to parse the prose back out.
+    """
+    status = payload.get("status") or "updated"
+    case_slug = payload.get("case_slug") or "unknown-case"
+    proposal_id = payload.get("proposal_id")
+    confidence = payload.get("confidence")
+    reviewer = payload.get("reviewer")
+
+    link = f"{_base_url()}{QUEUE_PATH}"
+    where = f"#{proposal_id}" if proposal_id else "(id unknown)"
+    tail = f" by {reviewer}" if reviewer else ""
+    confidence_note = f", confidence {confidence}" if confidence is not None else ""
+
+    return {
+        # No case title and no drafted text — see the module docstring.
+        "content": (
+            f"Case update proposal {where} is **{status}**{tail} "
+            f"on `{case_slug}`{confidence_note}. Review: {link}"
+        ),
+        "proposal_id": proposal_id,
+        "case_slug": case_slug,
+        "status": status,
+        "confidence": confidence,
+        "reviewer": reviewer,
+        "url": link,
+    }
+
+
+def post(payload: dict) -> bool:
+    """Announce one proposal transition. Returns whether it was delivered.
+
+    Never raises. A notification is the least important thing on this thread.
+    """
+    url = getattr(settings, "CASE_EVENTS_WEBHOOK_URL", "") or ""
+    if not url:
+        # Not a warning. Log-only is the documented default, and a warning per
+        # proposal would train people to ignore the log this consumer exists for.
+        logger.debug("case_events.webhook_not_configured")
+        return False
+
+    body = json.dumps(build_message(payload)).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "jawafdehi-case-events/1.0"},
+        method="POST",
+    )
+    timeout = float(getattr(settings, "CASE_EVENTS_WEBHOOK_TIMEOUT", 5))
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            # 2xx. Discord answers 204 with no body; treat any 2xx as delivered
+            # rather than pinning one code a different receiver would not use.
+            delivered = 200 <= response.status < 300
+    except urllib.error.HTTPError as exc:
+        # The endpoint answered and refused. Worth a warning: a rotated or revoked
+        # webhook fails this way forever and silently, and the URL must NOT be
+        # logged — it is the credential.
+        logger.warning("case_events.webhook_rejected", status=exc.code, reason=str(exc.reason)[:200])
+        return False
+    except Exception as exc:  # noqa: BLE001 - timeouts, DNS, TLS, malformed URL
+        logger.warning("case_events.webhook_failed", error=str(exc)[:200])
+        return False
+
+    if not delivered:
+        logger.warning("case_events.webhook_unexpected_status", status=response.status)
+    return delivered

--- a/case_events/subjects.py
+++ b/case_events/subjects.py
@@ -12,6 +12,11 @@ off the wire, where a bare string is what you actually have.
 """
 
 # ── jaw.signal.> — raw observed facts from producers ─────────────────────────
+#
+# Declaring a subject is not the same as emitting one. Two of these have NO
+# producer, and that is recorded in :data:`UNPRODUCED` below rather than left for
+# a reader to infer from the absence of a call site — the consumer side maps all
+# of them, so the map reads as five wired sources when three are.
 SIGNAL_DOCKET_HEARING_ADDED = "jaw.signal.docket.hearing.added"
 SIGNAL_DOCKET_VERDICT_ENTERED = "jaw.signal.docket.verdict.entered"
 SIGNAL_DOCKET_STATUS_CHANGED = "jaw.signal.docket.status.changed"
@@ -19,6 +24,26 @@ SIGNAL_COURTORDER_PUBLISHED = "jaw.signal.courtorder.published"
 SIGNAL_CIAA_PRESSRELEASE = "jaw.signal.ciaa.pressrelease"
 SIGNAL_NEWS_MATCHED = "jaw.signal.news.matched"
 SIGNAL_MANUAL_NOTE = "jaw.signal.manual.note"
+
+#: Subjects declared and consumable, but which nothing currently publishes —
+#: mapped to why, because "why not" is the useful half.
+#:
+#: Kept rather than deleted so the intended shape of the vocabulary stays visible,
+#: but named explicitly so nobody reads the consumer's provenance map as evidence
+#: of coverage. A subject leaving this dict is how a producer announces itself.
+UNPRODUCED = {
+    SIGNAL_DOCKET_STATUS_CHANGED: (
+        "Not derivable from the lake as it stands. Detecting a status CHANGE needs "
+        "the previous value, and the mirror overwrites case_status in place without "
+        "retaining history — so a producer would need a snapshot table or a schema "
+        "change first. See case_events.producers.dockets, which says the same thing "
+        "at the point where it would otherwise be emitted."
+    ),
+    SIGNAL_NEWS_MATCHED: (
+        "No news ingestion exists yet. There is no source to observe, so this is a "
+        "placeholder for a pipeline rather than a gap in one that runs."
+    ),
+}
 
 # ── jaw.case.> — the case-domain log ─────────────────────────────────────────
 CASE_MATCHED = "jaw.case.matched"

--- a/case_events/tests/test_consumer_handlers.py
+++ b/case_events/tests/test_consumer_handlers.py
@@ -354,6 +354,49 @@ class TestProposalBuilder:
         }
         assert declared == set(handlers._SOURCE_KIND_BY_SUBJECT)
 
+    def test_the_unproduced_subjects_are_real_subjects_with_a_stated_reason(self):
+        """`UNPRODUCED` is documentation, and documentation that drifts is worse
+        than none — a stale entry would claim a producer is missing after someone
+        built it, or name a subject that no longer exists."""
+        declared = {
+            value
+            for name, value in vars(subjects).items()
+            if name.startswith("SIGNAL_") and isinstance(value, str)
+        }
+        assert set(subjects.UNPRODUCED) <= declared
+        for subject, reason in subjects.UNPRODUCED.items():
+            assert len(reason) > 40, f"{subject} needs a reason, not a label"
+
+    def test_a_subject_listed_as_unproduced_really_has_no_producer(self):
+        """The claim `UNPRODUCED` makes, checked against the code rather than
+        trusted. A subject someone wired up while leaving the note behind is
+        exactly the drift this guards.
+
+        Parsed with ``ast`` rather than grepped, and that distinction IS the test:
+        a substring search matches the comment in ``producers/dockets.py`` that
+        explains why ``status.changed`` cannot be emitted, and so reports a
+        producer that does not exist. This failed exactly that way when first
+        written. ``ast`` sees ``subjects.X`` attribute access and never sees a
+        comment.
+        """
+        import ast
+        import pathlib
+
+        producers = pathlib.Path(subjects.__file__).parent / "producers"
+        referenced = set()
+        for path in producers.glob("*.py"):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                    if node.value.id == "subjects":
+                        referenced.add(node.attr)
+
+        for name, value in vars(subjects).items():
+            if name.startswith("SIGNAL_") and value in subjects.UNPRODUCED:
+                assert name not in referenced, f"{name} has a producer now; drop it from UNPRODUCED"
+
+        # The converse, so the guard cannot pass by finding nothing at all.
+        assert "SIGNAL_DOCKET_HEARING_ADDED" in referenced
+
     @pytest.mark.parametrize("broken", [{"case_id": None}, {"case_id": 0}])
     def test_an_envelope_with_no_case_is_poison_not_a_retry(self, broken):
         case = make_case()

--- a/case_events/tests/test_notify.py
+++ b/case_events/tests/test_notify.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""The outbound webhook, and what it is not allowed to carry.
+
+Most of these are about restraint rather than function: a PENDING proposal is
+unreviewed model output naming real people in corruption cases, and this is the
+one code path that sends anything about it to a third party. The assertions that
+matter are the negative ones.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+from case_events import notify
+
+PAYLOAD = {
+    "proposal_id": 7,
+    "case_slug": "lalita-niwas-land-scam",
+    "status": "pending",
+    "confidence": 0.88,
+    "reviewer": None,
+    # Present in the real envelope, and must NOT be forwarded.
+    "intent": {
+        "type": "append_timeline_entry",
+        "entry": {"title": "विशेष अदालतबाट सफाईको फैसला", "description": "…judges named…"},
+    },
+    "case_title": "Lalita Niwas land scam",
+}
+
+WEBHOOK = "https://example.test/webhooks/abc/secret-token"
+
+
+def posted(mock_urlopen):
+    """The decoded JSON body of the single POST made."""
+    request = mock_urlopen.call_args.args[0]
+    return json.loads(request.data.decode("utf-8"))
+
+
+class _Response:
+    def __init__(self, status=204):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class TestWhatLeavesTheBuilding:
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_the_drafted_intent_is_never_forwarded(self):
+        """The whole reason this module exists separately.
+
+        Sending the draft would publish an unreviewed model claim about named
+        individuals to a third party with its own retention, before any human
+        agreed with it. The review queue's entire purpose is that this does not
+        happen.
+        """
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            assert notify.post(PAYLOAD) is True
+
+        body = json.dumps(posted(urlopen), ensure_ascii=False)
+        assert "intent" not in posted(urlopen)
+        assert "सफाईको" not in body
+        assert "judges named" not in body
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_the_case_title_is_not_forwarded_either(self):
+        """A slug is an identifier; a title is editorial prose about an accusation.
+        The reviewer resolves the slug in the app, behind SSO."""
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            notify.post(PAYLOAD)
+
+        assert "Lalita Niwas land scam" not in json.dumps(posted(urlopen))
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_it_carries_enough_to_act_on(self):
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            notify.post(PAYLOAD)
+
+        body = posted(urlopen)
+        assert body["proposal_id"] == 7
+        assert body["case_slug"] == "lalita-niwas-land-scam"
+        assert body["status"] == "pending"
+        # Chat receivers require a rendered line; a structured-only body renders
+        # as an empty message in Discord and as nothing useful anywhere else.
+        assert "content" in body and body["content"]
+        assert body["url"].endswith(notify.QUEUE_PATH)
+
+
+class TestItNeverBreaksTheConsumer:
+    def test_no_url_configured_is_a_silent_no_op(self):
+        """Log-only is the documented default, so this must not warn or raise —
+        and must not attempt a request."""
+        with override_settings(CASE_EVENTS_WEBHOOK_URL=""):
+            with mock.patch("urllib.request.urlopen") as urlopen:
+                assert notify.post(PAYLOAD) is False
+            urlopen.assert_not_called()
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    @pytest.mark.parametrize(
+        "boom",
+        [
+            TimeoutError("timed out"),
+            OSError("dns"),
+            ValueError("unknown url type"),
+        ],
+    )
+    def test_a_transport_failure_is_swallowed(self, boom):
+        """Raising would redeliver the JetStream message, and redelivery would
+        re-notify rather than re-do anything useful."""
+        with mock.patch("urllib.request.urlopen", side_effect=boom):
+            assert notify.post(PAYLOAD) is False
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_a_rejection_is_reported_without_logging_the_url(self, caplog):
+        """A revoked webhook 404s forever and silently. It has to be visible — but
+        the URL is the credential, so it must not reach the log that makes it
+        visible."""
+        import urllib.error
+
+        err = urllib.error.HTTPError(WEBHOOK, 404, "Not Found", {}, None)
+        with caplog.at_level("WARNING"):
+            with mock.patch("urllib.request.urlopen", side_effect=err):
+                assert notify.post(PAYLOAD) is False
+
+        assert "404" in caplog.text
+        assert "secret-token" not in caplog.text
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_a_non_2xx_answer_is_not_counted_as_delivered(self):
+        with mock.patch("urllib.request.urlopen", return_value=_Response(status=302)):
+            assert notify.post(PAYLOAD) is False
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_204_counts_as_delivered(self):
+        """Discord answers 204 with no body; pinning 200 would read every
+        successful post as a failure."""
+        with mock.patch("urllib.request.urlopen", return_value=_Response(status=204)):
+            assert notify.post(PAYLOAD) is True
+
+
+class TestTheHandlerUsesIt:
+    @pytest.mark.django_db
+    def test_the_log_line_survives_a_webhook_that_is_down(self, caplog):
+        """The log is the record; the webhook is a convenience. If an outage could
+        suppress the record, the notifier would be less useful than before it had
+        a channel at all."""
+        from case_events.consumers import handlers
+
+        with override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK):
+            with mock.patch("urllib.request.urlopen", side_effect=OSError("down")):
+                with caplog.at_level("INFO"):
+                    handlers.handle_notifier({"subject": "jaw.case.update.proposed", "payload": PAYLOAD}, None)
+
+        assert "caseworker_notified" in caplog.text
+
+    @pytest.mark.django_db
+    def test_the_handler_posts_when_configured(self):
+        from case_events.consumers import handlers
+
+        with override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK):
+            with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+                handlers.handle_notifier({"subject": "jaw.case.update.proposed", "payload": PAYLOAD}, None)
+
+        assert urlopen.called

--- a/case_events/tests/test_notify.py
+++ b/case_events/tests/test_notify.py
@@ -93,6 +93,58 @@ class TestWhatLeavesTheBuilding:
         assert body["url"].endswith(notify.QUEUE_PATH)
 
 
+class TestItCannotPingAnyone:
+    """Raised in review, and a gap the module's own docstring did not cover: that
+    docstring bounds what the payload CONTAINS; this is about what it can DO."""
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_a_mention_smuggled_through_a_case_slug_is_defanged(self):
+        """`case_slug` derives from a title a caseworker wrote, so it is
+        human-authored text reaching a rendered chat line."""
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            notify.post({**PAYLOAD, "case_slug": "@everyone-scandal"})
+
+        content = posted(urlopen)["content"]
+        assert "@everyone" not in content
+        assert f"@{notify.ZERO_WIDTH_SPACE}everyone" in content
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_a_mention_in_the_reviewer_handle_is_defanged_too(self):
+        """The other human-authored field: an account handle."""
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            notify.post({**PAYLOAD, "reviewer": "@here"})
+
+        assert "@here" not in posted(urlopen)["content"]
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_mentions_are_refused_at_the_receiver_as_well(self):
+        """The escaping is belt; this is braces. With `parse` empty a Discord
+        receiver resolves no mention even from text that escaped defanging."""
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            notify.post(PAYLOAD)
+
+        assert posted(urlopen)["allowed_mentions"] == {"parse": []}
+
+    @override_settings(CASE_EVENTS_WEBHOOK_URL=WEBHOOK)
+    def test_the_structured_fields_are_left_verbatim(self):
+        """Only the RENDERED prose is escaped. Mangling an identifier a receiver
+        might match on would be worse than the risk being guarded."""
+        with mock.patch("urllib.request.urlopen", return_value=_Response()) as urlopen:
+            notify.post({**PAYLOAD, "case_slug": "@everyone-scandal"})
+
+        assert posted(urlopen)["case_slug"] == "@everyone-scandal"
+
+    def test_the_zero_width_space_is_not_a_literal_in_the_source(self):
+        """A literal U+200B is invisible in source: an editor, a reformat or a
+        careless selection can delete it with nothing looking wrong afterwards.
+        Written as an escape so the guard stays legible."""
+        import pathlib
+
+        source = pathlib.Path(notify.__file__).read_text()
+        assert notify.ZERO_WIDTH_SPACE not in source, "use the \\u200b escape, not the character"
+        assert notify.ZERO_WIDTH_SPACE == "\u200b"
+
+
 class TestItNeverBreaksTheConsumer:
     def test_no_url_configured_is_a_silent_no_op(self):
         """Log-only is the documented default, so this must not warn or raise —

--- a/config/settings.py
+++ b/config/settings.py
@@ -1139,3 +1139,27 @@ OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD", "")
 # Credentials ride in the URL (nats://user:pass@host:4222) and are per identity,
 # not shared — the monolith publishes as itself, and consumers get their own.
 NATS_URL = os.getenv("NATS_URL", "")
+
+# Where the notifier consumer announces a proposal decision. Empty means "log
+# only", which is what it did before this existed and remains the safe default:
+# no URL, no outbound request, no behaviour change.
+#
+# A SECRET, despite looking like a URL. A webhook endpoint carries its own
+# authentication in the path — anyone holding it can post to the channel — so it
+# belongs in OpenBao and reaches the pod through an ExternalSecret, never a
+# manifest and never a settings literal.
+#
+# Deliberately provider-agnostic in name. The first consumer of it is a Discord
+# webhook, which needs a top-level `content` string; the body sent also carries
+# the structured fields so a different receiver can read it without parsing prose.
+CASE_EVENTS_WEBHOOK_URL = os.getenv("CASE_EVENTS_WEBHOOK_URL", "")
+
+# Seconds. Short on purpose: this runs on a consumer's worker thread, and a
+# notification is the least important thing that thread does. A slow endpoint must
+# not extend the message's ack window.
+CASE_EVENTS_WEBHOOK_TIMEOUT = float(os.getenv("CASE_EVENTS_WEBHOOK_TIMEOUT", "5"))
+
+# Public origin of the SPA, used to build the review link in that notification. A
+# consumer has no request to derive it from, and ALLOWED_HOSTS is the API's host
+# rather than the front end's, so this is its own setting rather than a guess.
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "https://jawafdehi.org")

--- a/config/settings.py
+++ b/config/settings.py
@@ -1157,7 +1157,15 @@ CASE_EVENTS_WEBHOOK_URL = os.getenv("CASE_EVENTS_WEBHOOK_URL", "")
 # Seconds. Short on purpose: this runs on a consumer's worker thread, and a
 # notification is the least important thing that thread does. A slow endpoint must
 # not extend the message's ack window.
-CASE_EVENTS_WEBHOOK_TIMEOUT = float(os.getenv("CASE_EVENTS_WEBHOOK_TIMEOUT", "5"))
+#
+# Parsed with a fallback rather than a bare float(), which review caught: an
+# unparseable value would raise during settings import, and settings import failing
+# takes down every pod in the deployment. A typo in the least important tuning knob
+# in this file must not be able to do that.
+try:
+    CASE_EVENTS_WEBHOOK_TIMEOUT = float(os.getenv("CASE_EVENTS_WEBHOOK_TIMEOUT", "5"))
+except (TypeError, ValueError):
+    CASE_EVENTS_WEBHOOK_TIMEOUT = 5.0
 
 # Public origin of the SPA, used to build the review link in that notification. A
 # consumer has no request to derive it from, and ALLOWED_HOSTS is the API's host


### PR DESCRIPTION
### **User description**
`handle_notifier` wrote a log line and stopped, because the delivery channel was an open question. It now posts to an outbound webhook.

**Mail was ruled out, not deferred.** Outbound mail from this application is disabled, and enabling it for automated per-proposal messages is a larger decision than this needed.

## What it carries is deliberately less than what it knows

A PENDING proposal is **unreviewed model output naming real people in corruption cases**. The review queue exists precisely so that nothing is published before a human agrees with it. Posting the drafted text to an external chat service *would* publish it — to a third party, in a channel with its own retention, ahead of any review.

So the message says **that** a proposal needs attention and **where** to read it. The reviewer opens it in the app, behind SSO.

Withheld on purpose:
- the drafted `intent` (the model's actual claim)
- the case **title** — a slug identifies, a title is editorial prose about an accusation

The tests assert the *absence* of these, not just the presence of what is sent. That is the part worth reviewing.

## The URL is a credential

A webhook authenticates by being known. So it is:

- read from the environment, sourced from OpenBao at `kv/jawafdehi/private/case-events/notify`
- given **its own Secret** rather than added to `platform-env`, which the public-facing monolith's two replicas also consume — only the consumers Deployment has any use for it
- kept out of this module's own failure logs. A revoked webhook 404s forever and needs to be visible *without* the URL riding along in the line that makes it visible; there is a test for that.

**Kill switch:** empty URL means log-only, which is also the default. Blank the OpenBao field and outbound posts stop at the next refresh — no image change, no code path removed.

**Failure handling:** delivery failure never raises. Raising would redeliver the JetStream message, and redelivery would re-notify rather than re-do anything useful — the proposal row already exists. The log line is written *first* and unconditionally, so an outage cannot suppress the record.

## Also in here: `subjects.UNPRODUCED`

Two declared subjects have no producer (`jaw.signal.news.matched`, `jaw.signal.docket.status.changed`). The consumer's provenance map lists all seven, so it reads as evidence of coverage that does not exist. They are now recorded with **why** each is unwired rather than deleted.

The drift guard for it parses with `ast` rather than grepping — and that distinction is the test. A substring search matches the *comment* in `producers/dockets.py` explaining why `status.changed` cannot be emitted, and so reports a producer that isn't there. It failed exactly that way when first written; the docstring records it.

## Verification

- **376 tests pass** across `case_events` + `case_proposals`; `ruff check` clean.
- Infra side (separate repo): `notify-externalsecret.yaml`, wired into `consumers.yaml` with `optional: true` so an unsynced secret cannot stop the pods that drain the streams. `kubectl kustomize` renders clean with **zero** occurrences of the URL.

## Note for the reviewer

The webhook endpoint was shared over a chat transcript to get this built, so it should be **regenerated on the Discord side** once this is deployed. Rotating it is a one-field OpenBao update and needs no redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add best-effort webhook notifier

- Limit outbound proposal details

- Document unproduced bus subjects

- Cover privacy, failure behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Notifier event"] -- "logs first" --> B["Structured log"]
  A -- "best effort" --> C["Webhook POST"]
  C -- "omits draft/title" --> D["Review queue link"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.py</strong><dd><code>Notifier now posts after logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/consumers/handlers.py

<ul><li>Import <code>case_events.notify</code><br> <li> Keep structured log first<br> <li> Call <code>notify.post(payload)</code> after logging<br> <li> Document non-raising webhook behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/415/files#diff-f87d31efbe6c6bbc7a10839b8ddba88bcd2d6a29902e84a314dda2a56a750eb2">+20/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notify.py</strong><dd><code>Privacy-bounded webhook notification module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/notify.py

<ul><li>Add webhook message builder<br> <li> Omit <code>intent</code> and <code>case_title</code><br> <li> Add best-effort POST delivery<br> <li> Log failures without webhook URL</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/415/files#diff-a4e4faca271e25cb94b074f3fec2a4848db30bfd7a727de5297a51808d4e7083">+114/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subjects.py</strong><dd><code>Document currently unproduced subjects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/subjects.py

<ul><li>Add <code>UNPRODUCED</code> subject registry<br> <li> Explain unwired signal subjects<br> <li> Document declared versus emitted subjects</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/415/files#diff-409a0d4ac58a081b5a616e2ab3b55d4d9033f3da83ad5282400593de77df9fda">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_consumer_handlers.py</strong><dd><code>Test unproduced subject documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/tests/test_consumer_handlers.py

<ul><li>Validate <code>UNPRODUCED</code> entries reference signals<br> <li> Require explanatory reasons<br> <li> AST-check producer absence<br> <li> Guard drift with wired subject assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/415/files#diff-2bfa2148749a8975d65fa6ec905d77a523a8abec2c80b4ef442a75596d93db19">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_notify.py</strong><dd><code>Test webhook privacy and resilience</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/tests/test_notify.py

<ul><li>Test sensitive fields omitted<br> <li> Test webhook no-op and failures<br> <li> Test delivery status handling<br> <li> Test handler invokes webhook safely</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/415/files#diff-308c258a2f0fd79a09d33f5770e43deb2730ad00584b802a682b24538b4be44d">+171/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Add webhook notification settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/settings.py

<ul><li>Add <code>CASE_EVENTS_WEBHOOK_URL</code><br> <li> Add <code>CASE_EVENTS_WEBHOOK_TIMEOUT</code><br> <li> Add <code>FRONTEND_BASE_URL</code><br> <li> Document secret and default behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/415/files#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proposal status notifications through an optional webhook, including links to the review queue.
  * Added configurable frontend URL, webhook endpoint, and delivery timeout.
* **Bug Fixes**
  * Webhook failures no longer interrupt proposal event processing.
  * Notifications exclude sensitive proposal details while retaining essential identifiers.
  * All successful 2xx responses are handled correctly.
* **Documentation**
  * Clarified event signals that are defined but not currently produced.
* **Tests**
  * Added coverage for notification privacy, delivery failures, and unproduced event documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->