### PR TITLE
fix(events): bound SIGNALS retention, and make ensure_streams able to apply a change

### DIFF
--- a/case_events/streams.py
+++ b/case_events/streams.py
@@ -43,9 +43,33 @@ from case_events import subjects
 
 logger = structlog.get_logger(__name__)
 
-#: One year, in seconds — the retention window for all three streams in the
-#: pilot. SIGNALS is the one that could grow enough to want trimming first.
+#: One year, in seconds. The right window for the two streams that are RECORDS —
+#: the case-domain log and the poison queue.
 ONE_YEAR_SECONDS = 365 * 24 * 60 * 60
+
+#: Seven days, for SIGNALS. The earlier version of this file gave all three streams
+#: a year and noted that "SIGNALS is the one that could grow enough to want
+#: trimming first". Measured 2026-08-04, that guess was right and the number is
+#: worse than it looks: the docket producer is STATELESS by design, rescanning a
+#: 48h window every 6h, so every observed fact is re-published 8 times. At 4831
+#: signals per scan that is roughly 19k messages and ~12MB a day, which a
+#: year-long window turns into ~4.5GB — against a JetStream ceiling of 8GiB
+#: shared with CASE_EVENTS.
+#:
+#: Seven days loses nothing. Signals are "noisy, re-derivable" by the subject
+#: vocabulary's own description, the consumers are durable and ack immediately, and
+#: the dedup spine that makes a re-observation harmless lives in Postgres
+#: (``CaseUpdateProposal.dedup_key``), not in stream history. The only thing stream
+#: retention buys here is replay while debugging, and a week is generous for that.
+SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60
+
+#: A hard byte backstop for SIGNALS, well above the ~88MB a week should hold. Its
+#: job is not trimming — ``max_age`` does that — but to stop a runaway or
+#: backfilling producer from consuming the shared JetStream store and taking
+#: CASE_EVENTS down with it. Publishes into a full store FAIL, and
+#: ``handle_matcher`` raises on a failed publish, so an unbounded SIGNALS stream is
+#: a way for noise to wedge the audit trail.
+ONE_GIBIBYTE = 1024**3
 
 
 @dataclass(frozen=True)
@@ -54,6 +78,8 @@ class StreamSpec:
     subjects: tuple[str, ...]
     description: str
     max_age_seconds: int = ONE_YEAR_SECONDS
+    #: -1 means unlimited, which is JetStream's own sentinel.
+    max_bytes: int = -1
     replicas: int = 1
 
 
@@ -62,6 +88,8 @@ STREAMS: tuple[StreamSpec, ...] = (
         name="SIGNALS",
         subjects=(subjects.ALL_SIGNALS,),
         description="Raw observed facts from producers. Replayable, re-derivable.",
+        max_age_seconds=SEVEN_DAYS_SECONDS,
+        max_bytes=ONE_GIBIBYTE,
     ),
     StreamSpec(
         name="CASE_EVENTS",
@@ -77,7 +105,24 @@ STREAMS: tuple[StreamSpec, ...] = (
 
 
 async def ensure_streams(js) -> list[str]:
-    """Idempotently assert every stream in :data:`STREAMS`.
+    """Idempotently assert every stream in :data:`STREAMS`, creating OR converging.
+
+    **The "or converging" half was missing, and the docstring was wrong without
+    it.** This used to call ``add_stream`` only. JetStream's STREAM.CREATE accepts a
+    request that matches the existing stream and REJECTS one that differs, so the
+    function was idempotent in the trivial sense — re-running it changed nothing —
+    while any actual edit to :data:`STREAMS` failed against a live broker with
+    "stream name already in use". Since the whole point of the spec table is that
+    it describes what the streams should be, that made it a table of what they were
+    when first created.
+
+    So an existing stream is UPDATED to match the spec. The bootstrap identity was
+    already granted ``$JS.API.STREAM.UPDATE.>``, which says the intent was there.
+
+    Note what an update cannot do: shrinking ``max_age`` takes effect immediately
+    and messages outside the new window are dropped on the next enforcement pass.
+    That is intended here — see :data:`SEVEN_DAYS_SECONDS` — but it is a deletion,
+    so it should be a considered edit rather than a passing one.
 
     Args:
         js: A JetStream context (``nats.aio.client.Client.jetstream()``).
@@ -94,22 +139,46 @@ async def ensure_streams(js) -> list[str]:
 
     asserted = []
     for spec in STREAMS:
-        await js.add_stream(
-            StreamConfig(
-                name=spec.name,
-                subjects=list(spec.subjects),
-                description=spec.description,
-                retention=RetentionPolicy.LIMITS,
-                storage=StorageType.FILE,
-                max_age=spec.max_age_seconds,
-                num_replicas=spec.replicas,
-            )
+        config = StreamConfig(
+            name=spec.name,
+            subjects=list(spec.subjects),
+            description=spec.description,
+            retention=RetentionPolicy.LIMITS,
+            storage=StorageType.FILE,
+            max_age=spec.max_age_seconds,
+            max_bytes=spec.max_bytes,
+            num_replicas=spec.replicas,
         )
+
+        # Ask first, rather than reading an error message to find out. Matching on
+        # exception text couples this to a server's wording; `stream_info` raising
+        # NotFoundError is the documented way to ask whether a stream exists.
+        try:
+            await js.stream_info(spec.name)
+        except Exception:  # noqa: BLE001 - NotFoundError, and anything else means "try to create"
+            existed = False
+        else:
+            existed = True
+
+        if existed:
+            await js.update_stream(config)
+        else:
+            try:
+                await js.add_stream(config)
+            except Exception:
+                # Lost a race with another bootstrap between the check and the
+                # create. Converge rather than fail: the loser's job is to leave
+                # the stream matching the spec, and it now does either way.
+                await js.update_stream(config)
+
         asserted.append(spec.name)
         logger.info(
             "case_events.stream_asserted",
             stream=spec.name,
             subjects=list(spec.subjects),
             replicas=spec.replicas,
+            max_age_seconds=spec.max_age_seconds,
+            max_bytes=spec.max_bytes,
+            created=not existed,
         )
     return asserted

--- a/case_events/tests/test_bus.py
+++ b/case_events/tests/test_bus.py
@@ -137,27 +137,94 @@ class TestEnsureStreams:
     suite.
     """
 
-    async def _assert_streams(self):
+    @staticmethod
+    def _fresh_broker():
+        """A JetStream mock where no stream exists yet.
+
+        The ``stream_info`` side effect is load-bearing and easy to omit: a bare
+        ``AsyncMock`` answers every call successfully, so ``stream_info`` "finds"
+        every stream and ``ensure_streams`` takes the UPDATE path. A test that
+        forgets this asserts nothing about creation while looking like it does —
+        which is how the first draft of these tests passed with ``add_stream``
+        never called at all.
+        """
         js = mock.AsyncMock()
+        js.stream_info.side_effect = RuntimeError("stream not found")
+        return js
+
+    async def _created_configs(self):
+        js = self._fresh_broker()
         await streams.ensure_streams(js)
         return [call.args[0] for call in js.add_stream.await_args_list]
 
     async def test_asserts_every_stream_with_the_configured_values(self):
-        configs = await self._assert_streams()
+        configs = await self._created_configs()
         assert [c.name for c in configs] == ["SIGNALS", "CASE_EVENTS", "DLQ"]
         for config in configs:
             # File storage: a memory stream silently loses everything on a
-            # broker restart, which for a 1-year retention window is not a
+            # broker restart, which for a year-long retention window is not a
             # degraded bus but a broken one.
             assert config.storage == "file", config.name
             assert config.num_replicas == 1, config.name
-            assert config.max_age == streams.ONE_YEAR_SECONDS, config.name
+
+    async def test_signals_is_trimmed_harder_than_the_records_are(self):
+        """The two streams that are RECORDS keep a year; the noisy one does not.
+
+        SIGNALS receives every observation EIGHT times, because the docket producer
+        is stateless and rescans a 48h window every 6h — ~19k messages and ~12MB a
+        day, which a year-long window would turn into ~4.5GB against an 8GiB
+        JetStream store shared with CASE_EVENTS.
+        """
+        by_name = {c.name: c for c in await self._created_configs()}
+        assert by_name["SIGNALS"].max_age == streams.SEVEN_DAYS_SECONDS
+        assert by_name["CASE_EVENTS"].max_age == streams.ONE_YEAR_SECONDS
+        assert by_name["DLQ"].max_age == streams.ONE_YEAR_SECONDS
+
+    async def test_only_signals_carries_a_byte_ceiling(self):
+        """A backstop, not the trimming mechanism.
+
+        Publishes into a full JetStream store FAIL, and ``handle_matcher`` raises on
+        a failed publish — so an unbounded noise stream is a route for noise to
+        wedge the audit trail.
+        """
+        by_name = {c.name: c for c in await self._created_configs()}
+        assert by_name["SIGNALS"].max_bytes == streams.ONE_GIBIBYTE
+        assert by_name["CASE_EVENTS"].max_bytes == -1
+        assert by_name["DLQ"].max_bytes == -1
+
+    async def test_an_existing_stream_is_updated_rather_than_re_created(self):
+        """The bug this fixes. ``add_stream`` alone is idempotent only in the
+        trivial sense: JetStream rejects a CREATE whose config differs from the
+        live stream, so editing STREAMS used to fail against a real broker with
+        "stream name already in use" — making the spec table a record of what the
+        streams were when first created, not what they should be."""
+        js = mock.AsyncMock()  # every stream_info succeeds -> all three exist
+        await streams.ensure_streams(js)
+
+        assert js.add_stream.await_count == 0
+        assert [c.args[0].name for c in js.update_stream.await_args_list] == [
+            "SIGNALS",
+            "CASE_EVENTS",
+            "DLQ",
+        ]
+
+    async def test_losing_a_create_race_converges_instead_of_failing(self):
+        """Two bootstraps can interleave between the check and the create. The
+        loser's job is to leave the stream matching the spec, which an update
+        does."""
+        js = self._fresh_broker()
+        js.add_stream.side_effect = RuntimeError("stream name already in use")
+
+        await streams.ensure_streams(js)
+
+        assert js.update_stream.await_count == len(streams.STREAMS)
 
     async def test_a_client_error_is_not_swallowed(self):
         # Unlike publishing, this is deliberately NOT best-effort: a consumer
-        # that cannot see its stream should fail loudly at startup.
+        # that cannot see its stream should fail loudly at startup. Asserted on
+        # the UPDATE path, since that is the one a running broker takes.
         js = mock.AsyncMock()
-        js.add_stream.side_effect = RuntimeError("jetstream unavailable")
+        js.update_stream.side_effect = RuntimeError("jetstream unavailable")
         with pytest.raises(RuntimeError):
             await streams.ensure_streams(js)
 


### PR DESCRIPTION
### **User description**
Two problems, both found while sizing the docket window before unsuspending its producer. **This blocks turning that producer on.**

## 1. SIGNALS was unbounded, on a stream that receives every fact eight times

All three streams had a **one-year** window and **no byte ceiling** (`max_bytes = -1`). That is right for the two that are *records* — the case-domain log and the poison queue — and wrong for the noise.

The docket producer is **stateless by design**: it rescans a 48h window every 6h and re-publishes whatever it finds, because a gap is a permanently missed fact while an overlap is free. Free *downstream* — the dedup spine collapses it — but not free *in the stream*:

| | |
|---|---|
| signals per scan | **4,831** (measured 2026-08-04) |
| scans per day | 4 |
| re-publishes per fact | **8** (48h ÷ 6h) |
| ≈ per day | 19k messages, ~12MB |
| ≈ per year | **~4.5GB** |
| JetStream store ceiling | **8GiB**, shared with CASE_EVENTS |

And this is not merely untidy. **Publishes into a full store fail, and `handle_matcher` raises on a failed publish** — by design, since a dropped `jaw.case.matched` is a silently lost fact. So an unbounded noise stream is a route for noise to fill the store, wedge the audit trail, and jam the matcher in redelivery.

SIGNALS now keeps **7 days** with a **1GiB** backstop. CASE_EVENTS and DLQ are unchanged.

**Seven days loses nothing.** Signals are *"noisy, re-derivable"* by the subject vocabulary's own description; consumers are durable and ack immediately; and the dedup spine that makes a re-observation harmless lives in Postgres (`CaseUpdateProposal.dedup_key`), not in stream history. The only thing retention buys here is replay while debugging, and a week is generous.

The old comment on `ONE_YEAR_SECONDS` read *"SIGNALS is the one that could grow enough to want trimming first."* Good guess; this is the measurement.

## 2. `ensure_streams` could not assert anything but the first version

It called `add_stream` only. JetStream's `STREAM.CREATE` accepts a request that **matches** the live stream and **rejects** one that differs. So the function was idempotent in the trivial sense — re-running changed nothing — while any real edit to `STREAMS` would fail against a running broker with `stream name already in use`.

The docstring said "idempotently assert". In practice the spec table described what the streams *were when first created*, not what they *should be* — **and the change in part 1 could not have been applied at all.**

An existing stream is now `update_stream`d to match. The bootstrap identity was already granted `$JS.API.STREAM.UPDATE.>`, so the intent was there from the start.

Two details:
- Existence is checked via `stream_info`, not by matching an error string — that would couple this to one server's wording.
- A lost create race falls back to update rather than failing. The loser's job is to leave the stream matching the spec, which it now does either way.

**One thing to be aware of when merging:** shrinking `max_age` takes effect immediately, and messages outside the new window are dropped on the next enforcement pass. That is intended here, but it *is* a deletion — currently 6 messages, so the practical impact is nil.

## Verification

- **227 `case_events` tests pass**, `ruff check` clean.
- Retention split and byte ceiling pinned per stream; both create and update paths asserted; the race covered.

Worth a look at the `_fresh_broker` fixture comment: **a bare `AsyncMock` answers `stream_info` successfully**, so every stream looks like it already exists and the creation path silently goes untested. The first draft of these tests passed with `add_stream` never called at all.

## Sequencing

Once this merges, `nats_bootstrap` needs to re-run to converge the live streams, then `platform-docket-signals` can be unsuspended. It is still suspended, and I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Limit noisy `SIGNALS` storage

- Add `max_bytes` stream specs

- Update existing JetStream streams

- Cover retention and convergence paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  spec["STREAMS specs"] -- "build config" --> ensure["ensure_streams"]
  ensure -- "missing" --> create["add_stream"]
  ensure -- "existing/race" --> update["update_stream"]
  config["SIGNALS limits"] -- "7d + 1GiB" --> store["bounded JetStream store"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streams.py</strong><dd><code>Bound signals and converge streams</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/streams.py

<ul><li>Add <code>SEVEN_DAYS_SECONDS</code><br> <li> Add <code>ONE_GIBIBYTE</code><br> <li> Set <code>SIGNALS</code> <code>max_age</code> and <code>max_bytes</code><br> <li> Update existing streams via <code>update_stream</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/416/files#diff-396f1e0872afc2583a8cfa947ca303e98ce2a928fc9f1fd148ef4d7bc0eb5b0c">+82/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bus.py</strong><dd><code>Test stream limits and updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/tests/test_bus.py

<ul><li>Add fresh broker mock helper<br> <li> Assert <code>SIGNALS</code> shorter retention<br> <li> Assert only <code>SIGNALS</code> byte ceiling<br> <li> Test update and create-race convergence</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/416/files#diff-f8e20eef689e0e56d5c15aa6890b0d212802a58fbc46f4f2ca3333393f9bcf5f">+73/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
