### PR TITLE
feat(casework): port enrich_description and enrich_card to the control-plane API

### DIFF
--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -300,6 +300,17 @@ class CaseworkApi:
         cannot work. Returns the server's response body, or `{}` when `pairs` is
         empty (no request is made).
         """
+        pairs = list(pairs)
+        # The whole-list paths are routed to `replace_list` on purpose: they are
+        # DESTRUCTIVE replaces that require the caller to have merged the full
+        # list first, and that contract is documented there, not here. Without
+        # this check, `patch_fields(slug, [("evidence", [...])])` would perform
+        # the same destructive replace while skipping the guard.
+        for field, _ in pairs:
+            if field in WHOLE_LIST_PATHS:
+                raise ValueError(
+                    f"{field} is a whole-list path -- use replace_list, which "
+                    "documents the merge-first contract")
         ops = build_replace_ops(pairs)
         if not ops:
             return {}

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -30,6 +30,28 @@ def build_replace_patch(field, value):
     return [{"op": "replace", "path": f"/{field}", "value": value}]
 
 
+def build_replace_ops(pairs):
+    """One RFC-6902 document replacing SEVERAL scalar fields at once.
+
+    `pairs` is an iterable of `(field, value)`. Empty in -> empty out, so a
+    caller whose fields all failed validation sends nothing rather than an empty
+    patch the server would have to reason about.
+
+    WHY THIS EXISTS. `patch_field` is one request per field, and each request
+    changes the case's ETag -- so a caller writing two fields under the ETag it
+    read at the top gets a 412 on the second write, every time. That is not
+    hypothetical: `enrich_card` shipped that way and could never write both
+    `title` and `short_description` in one pass (2026-08-04 smoke run). Sending
+    both ops in ONE conditional request removes the failure instead of handling
+    it -- the server applies the whole array against a single snapshot, so the
+    write is atomic and the `If-Match` covers exactly the state that was read.
+    """
+    return [
+        {"op": "replace", "path": f"/{field}", "value": value}
+        for field, value in pairs
+    ]
+
+
 class CaseworkApi:
     """Control-plane HTTP client with two mutually exclusive auth modes.
 
@@ -269,6 +291,19 @@ class CaseworkApi:
 
     def patch_field(self, slug, field, value, timeout=60, if_match=None):
         return self._patch(slug, build_replace_patch(field, value), timeout, if_match=if_match)
+
+    def patch_fields(self, slug, pairs, timeout=60, if_match=None):
+        """Write several scalar fields in ONE conditional request.
+
+        Prefer this over a `patch_field` loop whenever a caller writes more than
+        one field under a single ETag -- see `build_replace_ops` for why a loop
+        cannot work. Returns the server's response body, or `{}` when `pairs` is
+        empty (no request is made).
+        """
+        ops = build_replace_ops(pairs)
+        if not ops:
+            return {}
+        return self._patch(slug, ops, timeout, if_match=if_match)
 
     def replace_list(self, slug, path, items, timeout=60, if_match=None):
         """Whole-list replace for /evidence and /entities.

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -158,6 +158,14 @@ def add_common_args(parser, *, batch_csv_required=False, batch_csv_help=None):
             "this is set."
         ),
     )
+    # The human-accuracy deliverable (casework/common/review.py). Written on
+    # EVERY run, dry runs included -- the dry run is the read-only path, so it
+    # is where output accuracy gets judged. Point this at the meta-repo task
+    # directory when a run's file belongs with that task's notes.
+    parser.add_argument(
+        "--review-file", default="",
+        help="Write the human review file here instead of "
+             "$CASEWORK_REVIEW_DIR / <repo>/work/reviews/<ts>-<stage>-<run>.md.")
     parser.add_argument("--verbose", action="store_true")
     return parser
 

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -91,6 +91,20 @@ _BATCH_CSV_HELP = (
     "re-enriched.")
 
 
+def _stages_at_tier(tier):
+    """Stage names registered at `tier`, for `--model`'s help text.
+
+    Derived from `llm.TIERS` rather than written out, because the hand-written
+    list went stale the moment `description` and `card` were registered -- it
+    still promised "premium stages (bigo, timeline, allegations, entities)" to an
+    operator reading `--help` to find out what a run would cost. `llm` imports
+    nothing from this module, so there is no cycle.
+    """
+    from casework.common.llm import TIERS
+
+    return ", ".join(sorted(s for s, t in TIERS.items() if t == tier)) or "(none)"
+
+
 def add_common_args(parser, *, batch_csv_required=False, batch_csv_help=None):
     """Register the CLI flags every ported enricher shares.
 
@@ -130,11 +144,11 @@ def add_common_args(parser, *, batch_csv_required=False, batch_csv_help=None):
         help="LLM model/alias to force on both tiers via the claude_cli "
              "provider's model settings (other providers use their own model "
              "config and ignore this). Empty (the default) lets each stage use "
-             "its configured tier model -- premium stages (bigo, timeline, "
-             "allegations, entities) get the premium model, tags gets the cheap "
-             "one -- falling back to the provider CLI's own default. An earlier "
-             "default of 'haiku' overrode every tier with the cheap model; pass "
-             "--model haiku explicitly to restore that for a cheap run.")
+             "its configured tier model, falling back to the provider CLI's own "
+             f"default. Premium stages: {_stages_at_tier('premium')}. Cheap "
+             f"stages: {_stages_at_tier('cheap')}. An earlier default of 'haiku' "
+             "overrode every tier with the cheap model; pass --model haiku "
+             "explicitly to restore that for a cheap run.")
     parser.add_argument(
         "--api-base-url", default=os.environ.get("JAWAFDEHI_API_BASE"),
         help="Base URL of the case API; defaults to $JAWAFDEHI_API_BASE. If "

--- a/casework/common/format.py
+++ b/casework/common/format.py
@@ -1,0 +1,61 @@
+"""Prompt-context formatters, shared by every enricher that builds a prompt
+out of a case's already-populated fields.
+
+Ported VERBATIM from the deleted `casework/common.py` (donor commit `0321a85`,
+`format_bigo` / `format_list` / `format_entities`). They live here, not in an
+enricher, because in the donor they were genuinely shared: `enrich_description`,
+`enrich_title` and `enrich_card` all imported the same three functions, so a
+per-enricher copy is not a port -- it is a fork, and the first thing that
+happens to a fork is that one side's `(unknown)` becomes the other side's
+`उल्लेख छैन` and the two prompts stop agreeing about what a missing बिगो looks
+like.
+
+`format_entities` READS THE LIVE PAYLOAD, and it is worth being explicit about
+why it reads the keys it does. A case's `entities` entry is
+`{nes_id, display_name, entity_type, type, outcome, notes}` -- built by
+`cases/services/nes_resolver.py::build_entity_binds` and served by
+`CaseSerializer.get_entities`. `type` is the RELATIONSHIP type (accused /
+related / location), which is why it is what gets bracketed, and `entity_type`
+(person / organisation, from NES) is deliberately not in the line: the donor
+did not include it. There is no `role` key and no `entity_iri` key on this
+payload; reading those yields a bulleted list of blanks that looks plausible in
+a prompt and silently starves the model of every name in the case.
+"""
+
+
+def format_bigo(bigo) -> str:
+    """Render the बिगो for a prompt: thousands-separated NPR, or '(unknown)'."""
+    try:
+        value = int(bigo)
+    except (TypeError, ValueError):
+        return "(unknown)"
+    return f"{value:,}" if value > 0 else "(unknown)"
+
+
+def format_list(items) -> str:
+    """Format a list of strings as prompt bullets, or '(none provided)'."""
+    if not items:
+        return "(none provided)"
+    return "\n".join(f"- {x}" for x in items)
+
+
+def format_entities(entities) -> str:
+    """Format the case entities (accused/related/location) as prompt bullets.
+
+    A non-dict entry is skipped rather than crashing prompt assembly -- one
+    malformed row must not cost the whole case its entity context.
+    """
+    if not entities:
+        return "(none provided)"
+    lines = []
+    for e in entities:
+        if not isinstance(e, dict):
+            continue
+        name = e.get("display_name") or ""
+        etype = e.get("type") or ""
+        notes = e.get("notes") or ""
+        line = f"- [{etype}] {name}"
+        if notes:
+            line += f" — {notes}"
+        lines.append(line)
+    return "\n".join(lines) or "(none provided)"

--- a/casework/common/format.py
+++ b/casework/common/format.py
@@ -20,6 +20,16 @@ related / location), which is why it is what gets bracketed, and `entity_type`
 did not include it. There is no `role` key and no `entity_iri` key on this
 payload; reading those yields a bulleted list of blanks that looks plausible in
 a prompt and silently starves the model of every name in the case.
+
+`outcome` IS THE ONE DELIBERATE ADDITION to the donor's line, and the reason is
+narrow. Both consumers of this function require a PER-DEFENDANT outcome:
+`enrich_description`'s section ग asks for "the outcome for each defendant
+(दोषी / सफाई)", and `enrich_card`'s teaser rule says a person a court CLEARED
+must never read as convicted. The structured, per-entity answer to exactly that
+question is sitting on the payload in `outcome`, and dropping it forced both
+models to re-derive the split from prose -- which is what produced the
+misreported verdicts this branch has been fixing. Only these two enrichers call
+this function, so adding it changes no already-evaluated prompt.
 """
 
 
@@ -44,6 +54,10 @@ def format_entities(entities) -> str:
 
     A non-dict entry is skipped rather than crashing prompt assembly -- one
     malformed row must not cost the whole case its entity context.
+
+    `outcome` is labelled rather than run together with the notes, so a
+    multi-defendant split verdict reads unambiguously per person. See the module
+    docstring for why it is here at all.
     """
     if not entities:
         return "(none provided)"
@@ -53,8 +67,11 @@ def format_entities(entities) -> str:
             continue
         name = e.get("display_name") or ""
         etype = e.get("type") or ""
+        outcome = (e.get("outcome") or "").strip()
         notes = e.get("notes") or ""
         line = f"- [{etype}] {name}"
+        if outcome:
+            line += f" — फैसला: {outcome}"
         if notes:
             line += f" — {notes}"
         lines.append(line)

--- a/casework/common/judge.py
+++ b/casework/common/judge.py
@@ -1,0 +1,112 @@
+"""The cheap-model adequacy gate: is this field value real, or a placeholder?
+
+Ported VERBATIM from the deleted `casework/common.py` (donor commit `0321a85`,
+`judge_description_adequacy` / `_parse_judge_verdict` / the `_JUDGE_*`
+constants).
+
+WHY A MODEL AND NOT A REGEX. The thing being detected is a template stub, and
+the stubs on real data are not blank -- 2,666 of 2,918 DRAFT cases carry a
+`short_description` reading `अख्तियार दुरुपयोग अनुसन्धान आयोगले विशेष अदालतमा
+दायर गरेको मुद्दा 076-CR-0182, प्रतिवादी: बिनोद कुमार भूजेल समेत ५।`. That is
+120-odd characters of grammatical Nepali naming a real case and a real
+defendant. An emptiness test calls it done; a length test calls it done; a
+keyword blocklist catches this generation of stub and not the next one. What
+actually distinguishes it is that it would fit any case, and that is a
+judgement.
+
+IT FAILS TOWARD REGENERATING. An unparseable verdict, a failed call, or text
+under `_JUDGE_MIN_CHARS` all return `adequate=False`. The asymmetry is
+deliberate: a needless regeneration costs one cheap call, while silently
+keeping a placeholder ships template text to the public case list, where it is
+indistinguishable from real editorial output.
+"""
+
+import logging
+
+from casework.common.parse import parse_object_response
+
+log = logging.getLogger("casework.judge")
+
+# Below this length a text can't carry a real description -- judged a placeholder
+# without spending an LLM call.
+_JUDGE_MIN_CHARS = 15
+_JUDGE_TEXT_BUDGET = 2000
+
+_JUDGE_SYSTEM_PROMPT = """\
+You are a strict data-quality reviewer for Jawafdehi, a civic archive of Nepal's \
+anti-corruption cases. You judge whether a given TEXT is an ADEQUATE value for the \
+named field, or merely a PLACEHOLDER / STUB that should be regenerated.
+
+INADEQUATE (adequate=false) when the text is, for example:
+- empty, whitespace, or a placeholder ("description here", "TODO", "N/A", "-",
+  "News Source", "खाली", "विवरण यहाँ");
+- a bare restatement of the title / case number / file name with no substance;
+- auto-generated filler or a generic boilerplate line that fits any case;
+- so vague or truncated that it does not inform a reader.
+
+ADEQUATE (adequate=true) when the text conveys real, specific, substantive
+information appropriate to the field (names, amounts, dates, what the document is
+or what it shows), even if imperfect.
+
+Reply with ONLY a JSON object, no prose:
+{"adequate": true, "reason": "<short reason>"}
+"""
+
+
+def _parse_judge_verdict(response_text):
+    """(adequate, reason) from the judge reply, or None when no object carrying a
+    BOOLEAN `adequate` is found.
+
+    The bool check is a `predicate`, not a post-hoc test, so a near-miss object
+    (`{"adequate": "yes"}`) is rejected and the scan continues to the next `{`
+    -- donor behaviour, and the difference between reading a stray preamble and
+    reading the verdict.
+    """
+    obj = parse_object_response(
+        response_text, predicate=lambda o: isinstance(o.get("adequate"), bool))
+    if obj is None:
+        return None
+    reason = obj.get("reason")
+    reason = reason.strip() if isinstance(reason, str) else ""
+    return obj["adequate"], reason or "(no reason given)"
+
+
+def judge_description_adequacy(
+    text, *, kind, invoke_text, usage=None, context="", tier="cheap"
+):
+    """Judge whether ``text`` is an adequate value for a ``kind`` field.
+
+    Returns ``(adequate, reason)``. Blank or sub-``_JUDGE_MIN_CHARS`` text is
+    judged inadequate WITHOUT an LLM call. Otherwise the cheap tier decides.
+
+    ``invoke_text`` is the ``llm.invoke.invoke_text`` callable, passed in after
+    bootstrap -- `casework.common` never imports `llm` itself, so that a module
+    imported at test-collection time cannot drag Django settings in with it.
+    """
+    stripped = (text or "").strip()
+    if len(stripped) < _JUDGE_MIN_CHARS:
+        return False, f"blank or too short (<{_JUDGE_MIN_CHARS} chars)"
+
+    user_prompt = (
+        f"FIELD: {kind}\n"
+        + (f"CONTEXT: {context}\n" if context else "")
+        + f'\nTEXT TO JUDGE:\n"""\n{stripped[:_JUDGE_TEXT_BUDGET]}\n"""\n\n'
+        "Return ONLY the JSON object."
+    )
+    try:
+        response_text = invoke_text(
+            system=_JUDGE_SYSTEM_PROMPT,
+            content=user_prompt,
+            max_tokens=300,
+            tier=tier,
+            usage=usage,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("adequacy judge call failed (%s): %s", kind, exc)
+        return False, f"judge call failed: {exc}"
+
+    verdict = _parse_judge_verdict(response_text)
+    if verdict is None:
+        log.warning("adequacy judge returned an unparseable verdict for %s", kind)
+        return False, "judge response unparseable; treating as inadequate"
+    return verdict

--- a/casework/common/judge.py
+++ b/casework/common/judge.py
@@ -1,8 +1,11 @@
 """The cheap-model adequacy gate: is this field value real, or a placeholder?
 
-Ported VERBATIM from the deleted `casework/common.py` (donor commit `0321a85`,
+Ported from the deleted `casework/common.py` (donor commit `0321a85`,
 `judge_description_adequacy` / `_parse_judge_verdict` / the `_JUDGE_*`
-constants).
+constants) with ONE deviation: the output budget is 2000, not the donor's 300.
+See `_JUDGE_MAX_TOKENS` for the measurement that forced it. Everything else --
+the prompt, the parse, the fail-toward-regenerating default, the 15-character
+floor -- is the donor's.
 
 WHY A MODEL AND NOT A REGEX. The thing being detected is a template stub, and
 the stubs on real data are not blank -- 2,666 of 2,918 DRAFT cases carry a

--- a/casework/common/judge.py
+++ b/casework/common/judge.py
@@ -32,6 +32,19 @@ log = logging.getLogger("casework.judge")
 _JUDGE_MIN_CHARS = 15
 _JUDGE_TEXT_BUDGET = 2000
 
+#: Output budget for the verdict. 2000, NOT the donor's 300
+#: (`0321a85:casework/common.py:1016`) -- DEVIATION, measured on the 2026-08-04
+#: local smoke run. Through the `claude_cli` provider every judge call died with
+#: `API Error: Claude's response exceeded the 300 output token maximum`, and
+#: because this function fails toward regenerating, a systematically failing
+#: judge does not fail loudly: it silently reports every value inadequate. The
+#: visible symptom was `enrich_card` rewriting `short_description` on EVERY run
+#: -- no idempotency, and one wasted generation call per case per run. The
+#: verdict JSON itself is tiny; the budget has to cover the framing the provider
+#: wraps around a reply, which measured ~2,250 output tokens even for a
+#: 250-character answer.
+_JUDGE_MAX_TOKENS = 2000
+
 _JUDGE_SYSTEM_PROMPT = """\
 You are a strict data-quality reviewer for Jawafdehi, a civic archive of Nepal's \
 anti-corruption cases. You judge whether a given TEXT is an ADEQUATE value for the \
@@ -97,7 +110,7 @@ def judge_description_adequacy(
         response_text = invoke_text(
             system=_JUDGE_SYSTEM_PROMPT,
             content=user_prompt,
-            max_tokens=300,
+            max_tokens=_JUDGE_MAX_TOKENS,
             tier=tier,
             usage=usage,
         )

--- a/casework/common/llm.py
+++ b/casework/common/llm.py
@@ -22,6 +22,7 @@ import os
 #   enrich_allegations.py:350       tier="premium"
 #   enrich_related_entities.py:421  tier="premium"
 #   enrich_description.py:576       tier="premium"
+#   enrich_card.py:337              tier="cheap"
 TIERS = {
     "bigo": "premium",
     "tags": "cheap",
@@ -29,6 +30,14 @@ TIERS = {
     "allegations": "premium",
     "entities": "premium",
     "description": "premium",
+    # `card` is cheap on the donor's own authority (enrich_card.py:337) and on
+    # the merits: it fetches no source document, only summarising a
+    # `description` already on the case. NOTE the donor's OTHER title writer,
+    # the standalone `enrich_title.py`, used tier="premium" (line 275) for the
+    # same no-fetch inputs -- the two donors disagreed. `enrich_title.py` folds
+    # into this stage as `--only title`, and the brief resolves the conflict in
+    # favour of cheap. See `casework/enrich_card.py`'s deviation 2.
+    "card": "cheap",
 }
 DEFAULT_TIER = "cheap"
 

--- a/casework/common/llm.py
+++ b/casework/common/llm.py
@@ -21,12 +21,14 @@ import os
 #   enrich_timeline.py:518          tier="premium"
 #   enrich_allegations.py:350       tier="premium"
 #   enrich_related_entities.py:421  tier="premium"
+#   enrich_description.py:576       tier="premium"
 TIERS = {
     "bigo": "premium",
     "tags": "cheap",
     "timeline": "premium",
     "allegations": "premium",
     "entities": "premium",
+    "description": "premium",
 }
 DEFAULT_TIER = "cheap"
 

--- a/casework/common/materials.py
+++ b/casework/common/materials.py
@@ -113,14 +113,44 @@ def materials_of_type(case, types=None):
     return out
 
 
+def typed_materials(case, types=None):
+    """[(material_type, material_iri, material)] for the same entries
+    `materials_of_type` selects.
+
+    Exists because the `material_iri` lives on the EVIDENCE ENTRY, not inside
+    the resolved `material` dict (see `cases/serializers.py`: an entry is
+    `{material_iri, additional_details, material}` and `material` carries
+    `material_type` + `urls`, no `@id`). `materials_of_type` returns the inner
+    dict and so discards the only identifier a reader can use to find the
+    document again -- which the human review file has to print.
+    """
+    out = []
+    for entry in case.get("evidence") or []:
+        material = entry.get("material") or {}
+        if not material:
+            continue
+        mtype = material.get("material_type")
+        if types and mtype not in types:
+            continue
+        out.append((mtype or "?", entry.get("material_iri") or "", material))
+    return out
+
+
 def fetch_markdown(link, timeout=60):
     req = urllib.request.Request(link, headers={"User-Agent": BROWSER_UA})
     with urllib.request.urlopen(req, timeout=timeout) as r:
         return r.read().decode("utf-8", errors="replace")
 
 
-def source_text(case, api=None, types=None):
-    """Return (joined_text, unmet_reasons).
+def source_chunks(case, api=None, types=None):
+    """Return ([(material_type, material_iri, text)], unmet_reasons).
+
+    The typed half of :func:`source_text` -- same fetch, same unmet reporting,
+    but the caller keeps track of WHICH material each chunk came from.
+    `enrich_description` needs that twice: to order the sources by usefulness
+    (charge sheet, then press release, then verdict) rather than by whatever
+    order evidence happens to be in, and to name the material IRI beside the
+    passage in the human review file.
 
     A material without a MARKDOWN role is NEVER fabricated or guessed at --
     it is reported as an unmet prerequisite so the run summary can show it.
@@ -128,9 +158,9 @@ def source_text(case, api=None, types=None):
     chunks, unmet = [], []
     # An evidence entry whose `material` is null means the payload came from
     # the LIST endpoint, which never resolves materials. Without this check
-    # materials_of_type() drops those entries and source_text returns
-    # ("", []) -- indistinguishable from a genuinely evidence-free case, and
-    # exactly the silent false-parity failure this module exists to prevent.
+    # typed_materials() drops those entries and this returns ([], []) --
+    # indistinguishable from a genuinely evidence-free case, and exactly the
+    # silent false-parity failure this module exists to prevent.
     unresolved = sum(
         1 for e in (case.get("evidence") or []) if not (e.get("material") or {})
     )
@@ -139,8 +169,7 @@ def source_text(case, api=None, types=None):
             f"{unresolved} evidence entries with an UNRESOLVED material -- the "
             "list endpoint returns material:null; use the case DETAIL endpoint"
         )
-    for material in materials_of_type(case, types):
-        mtype = material.get("material_type") or "?"
+    for mtype, iri, material in typed_materials(case, types):
         link = markdown_link(material)
         if not link:
             unmet.append(f"{mtype}: no MARKDOWN role (has {len(raw_links(material))} RAW)")
@@ -151,7 +180,19 @@ def source_text(case, api=None, types=None):
             unmet.append(f"{mtype}: MARKDOWN fetch failed ({exc})")
             continue
         if text.strip():
-            chunks.append(text)
+            chunks.append((mtype, iri, text))
         else:
             unmet.append(f"{mtype}: MARKDOWN empty")
-    return "\n\n".join(chunks), unmet
+    return chunks, unmet
+
+
+def source_text(case, api=None, types=None):
+    """Return (joined_text, unmet_reasons). Thin join over `source_chunks`.
+
+    Kept as the entry point for every caller that only wants one blob of text
+    (`enrich_allegations`, `enrich_timeline`, `enrich_related_entities`,
+    `enrich_missing_bigo`) so there is exactly ONE implementation of the fetch
+    and of the unmet-reason wording.
+    """
+    chunks, unmet = source_chunks(case, api, types)
+    return "\n\n".join(text for _, _, text in chunks), unmet

--- a/casework/common/parse.py
+++ b/casework/common/parse.py
@@ -62,19 +62,62 @@ def balanced_array(text: str, start: int):
     return _balanced_span(text, start, "[", "]")
 
 
+def _strip_fence(text: str) -> str:
+    """Drop a leading ```-fenced block's fences, returning the body.
+
+    Returns `text` unchanged when there is no complete fence pair.
+    """
+    if "```" not in text:
+        return text
+    start = text.find("```")
+    nl = text.find("\n", start)
+    if nl == -1:
+        return text
+    end = text.find("```", nl + 1)
+    if end == -1:
+        return text
+    return text[nl + 1 : end].strip()
+
+
+def parse_object_response(response_text, required_key):
+    """First balanced JSON OBJECT in the response that carries `required_key`.
+
+    ``parse_extraction_response`` only ever returns a LIST -- it is shaped for
+    ``{"allegations": [...]}`` replies. A reply whose payload is a long STRING
+    (``{"description": "### क) …"}``) needs its own parser.
+
+    Every ``{`` position is tried, not just ``text.find("{")``: a model reply
+    can open with an unrelated object (a preamble, an echoed tool argument)
+    before the real payload, and stopping at the first brace returns None on
+    exactly those. Ported from the donor's ``_parse_response``
+    (``0321a85:casework/enrich_description.py``).
+
+    Returns the parsed dict, or None.
+    """
+    import json
+
+    text = _strip_fence((response_text or "").strip())
+    for obj_start in range(len(text)):
+        if text[obj_start] != "{":
+            continue
+        block = balanced_object(text, obj_start)
+        if block is None:
+            continue
+        try:
+            obj = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and required_key in obj:
+            return obj
+    return None
+
+
 def parse_extraction_response(response_text, wrapper_keys):
     """Extract a JSON array from an LLM response (handles ```fences``` and
     {"<key>": [...]} wrappers). Returns the list, or None."""
     import json
 
-    text = (response_text or "").strip()
-    if "```" in text:
-        start = text.find("```")
-        nl = text.find("\n", start)
-        if nl != -1:
-            end = text.find("```", nl)
-            if end != -1:
-                text = text[nl + 1 : end].strip()
+    text = _strip_fence((response_text or "").strip())
 
     obj_start = text.find("{")
     if obj_start != -1:

--- a/casework/common/parse.py
+++ b/casework/common/parse.py
@@ -62,7 +62,7 @@ def balanced_array(text: str, start: int):
     return _balanced_span(text, start, "[", "]")
 
 
-def _strip_fence(text: str) -> str:
+def strip_fence(text: str) -> str:
     """Drop a leading ```-fenced block's fences, returning the body.
 
     Returns `text` unchanged when there is no complete fence pair.
@@ -79,8 +79,8 @@ def _strip_fence(text: str) -> str:
     return text[nl + 1 : end].strip()
 
 
-def parse_object_response(response_text, required_key):
-    """First balanced JSON OBJECT in the response that carries `required_key`.
+def parse_object_response(response_text, required_key=None, *, predicate=None):
+    """First balanced JSON OBJECT in the response that the caller accepts.
 
     ``parse_extraction_response`` only ever returns a LIST -- it is shaped for
     ``{"allegations": [...]}`` replies. A reply whose payload is a long STRING
@@ -92,11 +92,20 @@ def parse_object_response(response_text, required_key):
     exactly those. Ported from the donor's ``_parse_response``
     (``0321a85:casework/enrich_description.py``).
 
+    ``predicate`` narrows acceptance beyond "the key is present" and is what
+    keeps the SCAN going past a near-miss: the judge parser needs
+    ``adequate`` to be a real bool, so an object carrying ``{"adequate":
+    "yes"}`` has to be rejected and the next ``{`` tried, not returned. Pass
+    ``required_key`` for the plain case, ``predicate`` for the rest, or both.
+
     Returns the parsed dict, or None.
     """
     import json
 
-    text = _strip_fence((response_text or "").strip())
+    if required_key is None and predicate is None:
+        raise ValueError("parse_object_response needs a required_key or a predicate")
+
+    text = strip_fence((response_text or "").strip())
     for obj_start in range(len(text)):
         if text[obj_start] != "{":
             continue
@@ -107,8 +116,13 @@ def parse_object_response(response_text, required_key):
             obj = json.loads(block)
         except json.JSONDecodeError:
             continue
-        if isinstance(obj, dict) and required_key in obj:
-            return obj
+        if not isinstance(obj, dict):
+            continue
+        if required_key is not None and required_key not in obj:
+            continue
+        if predicate is not None and not predicate(obj):
+            continue
+        return obj
     return None
 
 
@@ -117,7 +131,7 @@ def parse_extraction_response(response_text, wrapper_keys):
     {"<key>": [...]} wrappers). Returns the list, or None."""
     import json
 
-    text = _strip_fence((response_text or "").strip())
+    text = strip_fence((response_text or "").strip())
 
     obj_start = text.find("{")
     if obj_start != -1:

--- a/casework/common/pipeline.py
+++ b/casework/common/pipeline.py
@@ -140,6 +140,24 @@ STAGES = {
         requires_materials=PRESS_TYPES + COURT_TYPES,
         requires_stages=("convert",),
     ),
+    # `description` writes the long public narrative. It reads the charge
+    # sheet, the press release AND the verdict, so it gates on both material
+    # families -- the same PRESS+COURT pair as `timeline`/`entities`, and for
+    # the same reason: a court-order-only case is still describable, so
+    # gating on PRESS_TYPES alone would strand it.
+    #
+    # provides is ("description",) ONLY -- deliberately NOT ("description",
+    # "title"). The donor regenerated `Case.title` as a side effect of this
+    # pass; this port drops that (see `casework/enrich_description.py`'s
+    # docstring) and `title` has exactly one owner, `enrich_card`. Naming
+    # "title" here would be the phantom-`provides` mistake documented on
+    # `allegations` above: an idempotency check reading `provides` would call
+    # a case title-complete that this stage never touched.
+    "description": Stage(
+        "description", provides=("description",),
+        requires_materials=PRESS_TYPES + COURT_TYPES,
+        requires_stages=("convert",),
+    ),
 }
 
 

--- a/casework/common/pipeline.py
+++ b/casework/common/pipeline.py
@@ -158,6 +158,21 @@ STAGES = {
         requires_materials=PRESS_TYPES + COURT_TYPES,
         requires_stages=("convert",),
     ),
+    # `card` writes the two listing-card fields. It reads NO material -- both
+    # fields derive from the `description` already on the case, exactly like
+    # `tags` derives from case fields -- so `requires_materials` is empty and
+    # gating it on a converted document would strand every case whose
+    # description came from somewhere else.
+    #
+    # Unlike `tags`, though, `description` IS a hard gate here, not just an
+    # ordering preference: a card built from an empty description is a card
+    # built from nothing. Hence `requires_fields` AND `requires_stages` --
+    # `requires_stages` alone only orders, it never checks.
+    "card": Stage(
+        "card", provides=("title", "short_description"),
+        requires_fields=("description",),
+        requires_stages=("description",),
+    ),
 }
 
 

--- a/casework/common/pipeline.py
+++ b/casework/common/pipeline.py
@@ -43,6 +43,16 @@ from casework.common.materials import markdown_link, materials_of_type
 PRESS_TYPES = ("press_release", "ciaa_press_release", "charge_sheet")
 COURT_TYPES = ("court_order",)
 
+#: What counts as a REAL description, as opposed to a stub. Donor-verbatim from
+#: `enrich_description`'s `_has_substantial_description`.
+#:
+#: Shared, not duplicated, because two stages must agree on the answer.
+#: `enrich_description` uses it to decide a case is already done;
+#: `enrich_card` uses it to refuse to write a card grounded in nothing. When
+#: only the first held the number, `unmet_prerequisites`' emptiness test was
+#: the card's whole defence -- and it passes a whitespace-only description.
+SUBSTANTIAL_DESCRIPTION_CHARS = 600
+
 
 @dataclass(frozen=True)
 class Stage:

--- a/casework/common/review.py
+++ b/casework/common/review.py
@@ -1,0 +1,193 @@
+"""The human-accuracy deliverable: one reviewable file per enricher run.
+
+WHY THIS IS NOT THE EVENTS LOG. `configure_run_logging` already writes
+`work/enricher-runs/*.events.jsonl`, but that file answers "did the run
+work" -- it is machine-shaped, consumed by `casework/ledger.py`, and its
+`detail` field is a repr, not something anyone reads Nepali prose out of. A
+green test suite plus a clean events log together still prove only that the
+code ran. Whether the generated Nepali is TRUE about named people is a
+judgement a person has to make, and they can only make it if the run hands
+them the field's old value, its new value, and the source passage side by
+side. That is this file.
+
+DRY RUNS WRITE ONE TOO -- they are the point. A dry run makes every LLM call
+and skips only the PATCH, so it produces the full proposed output while
+writing nothing to any server. It is the read-only path, so it is where
+accuracy gets judged; a review file that only appeared on `--apply` would
+mean you could never judge output without first writing it somewhere.
+
+"THE PASSAGE THE MODEL USED" IS RECORDED AS WHAT IT WAS FED. A plain text
+completion does not report which sentences it drew on, so this module is
+careful to label its excerpts as the source text FED to the model, never as
+the span the model quoted. Presenting the former as the latter would be a
+fabricated provenance claim in the one artefact whose whole job is checking
+for fabrication.
+
+Devanagari is written through unescaped (`ensure_ascii=False` where JSON is
+involved, plain UTF-8 otherwise). A review file full of `\\u0915` cannot be
+reviewed.
+"""
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+# casework/common/review.py -> casework/common -> casework -> <repo-root>
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_REVIEW_DIR = _REPO_ROOT / "work" / "reviews"
+
+#: Per-source excerpt budget, in characters. Long enough to check an amount, a
+#: name and a दफा against the generated prose; short enough that a 30-case file
+#: stays scrollable. The excerpt is always the HEAD of the fed text -- the
+#: charge sheet's opening is where the claim, parties and बिगो are stated.
+EXCERPT_CHARS = 1200
+
+
+@dataclass
+class ReviewRow:
+    """One case's before/after/source record.
+
+    `sources` is `[(material_type, material_iri, fed_text)]` -- the same
+    triples `materials.source_chunks` returns, so a caller passes them
+    straight through and cannot accidentally re-derive (and mis-attribute)
+    the provenance.
+    """
+    slug: str
+    status: str
+    before: str = ""
+    generated: str = ""
+    sources: list = field(default_factory=list)
+    note: str = ""
+
+
+@dataclass
+class ReviewFile:
+    """Accumulates `ReviewRow`s and renders one Markdown file.
+
+    Markdown, not CSV: the values being reviewed are multi-paragraph Nepali
+    prose with Markdown headings of their own, and a CSV cell holding that is
+    unreadable in every tool a person would open it in. The summary table at
+    the top keeps the file scannable; the per-case sections below it are where
+    the actual reading happens.
+    """
+    stage: str
+    field_name: str
+    path: Path
+    dry_run: bool = True
+    base_url: str = ""
+    run_id: str = ""
+    provider: str = ""
+    model: str = ""
+    rows: list = field(default_factory=list)
+
+    def add(self, row):
+        self.rows.append(row)
+
+    def _header(self):
+        mode = "DRY RUN — nothing was written" if self.dry_run else "APPLIED"
+        return [
+            f"# {self.stage} review — `{self.field_name}`",
+            "",
+            f"- Mode: **{mode}**",
+            f"- Target: `{self.base_url}`",
+            f"- Provider/model: `{self.provider}` / `{self.model or '(provider default)'}`",
+            f"- Run id: `{self.run_id}`",
+            f"- Cases: {len(self.rows)}",
+            "",
+            "Check every monetary figure, personal name and ऐन/दफा in the generated "
+            "value against the source excerpt below it. The excerpt is the text FED "
+            "to the model, not a span the model reported quoting.",
+            "",
+        ]
+
+    def _summary_table(self):
+        lines = [
+            "## Summary",
+            "",
+            "| # | Slug | Status | Before | Generated | Sources |",
+            "|---|---|---|---|---|---|",
+        ]
+        for i, r in enumerate(self.rows, 1):
+            src = ", ".join(t for t, _, _ in r.sources) or "—"
+            lines.append(
+                f"| {i} | `{r.slug}` | {r.status} | {len(r.before):,} chars "
+                f"| {len(r.generated):,} chars | {src} |"
+            )
+        lines.append("")
+        return lines
+
+    def _case_section(self, i, r):
+        lines = [f"## {i}. `{r.slug}`", "", f"Status: **{r.status}**"]
+        if r.note:
+            lines += ["", f"Note: {r.note}"]
+        lines += ["", f"### Before ({len(r.before):,} chars)", ""]
+        lines.append(_quote(r.before) if r.before.strip() else "_(empty)_")
+        lines += ["", f"### Generated ({len(r.generated):,} chars)", ""]
+        lines.append(_quote(r.generated) if r.generated.strip() else "_(nothing generated)_")
+        lines += ["", "### Sources fed to the model", ""]
+        if not r.sources:
+            lines.append("_(none)_")
+        for mtype, iri, text in r.sources:
+            excerpt = (text or "")[:EXCERPT_CHARS]
+            capped = "" if len(excerpt) == len(text or "") else \
+                f" — excerpt, first {EXCERPT_CHARS:,} of {len(text):,}"
+            lines += [
+                f"**{mtype}** — `{iri or '(no material_iri)'}`"
+                f" ({len(text or ''):,} chars{capped})",
+                "",
+                _quote(excerpt),
+                "",
+            ]
+        lines.append("")
+        return lines
+
+    def render(self):
+        lines = self._header() + self._summary_table()
+        for i, r in enumerate(self.rows, 1):
+            lines += self._case_section(i, r)
+        return "\n".join(lines).rstrip() + "\n"
+
+    def write(self):
+        """Render to `self.path` and return it. Parent dirs are created."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(self.render(), encoding="utf-8")
+        return self.path
+
+
+def _quote(text):
+    """Blockquote `text` so its own Markdown headings (`### क)`) don't become
+    headings of the review file and swallow the section structure."""
+    body = (text or "").rstrip()
+    if not body:
+        return ""
+    return "\n".join(f"> {line}" if line.strip() else ">" for line in body.splitlines())
+
+
+def review_path(stage, run_id, override=""):
+    """Resolve where the review file goes.
+
+    Precedence: explicit `override` (the `--review-file` flag, so a run can
+    drop its file straight into the meta-repo task directory it belongs to),
+    then `$CASEWORK_REVIEW_DIR`, then `<repo>/work/reviews/`. `work/` is
+    gitignored, so the default never risks committing generated Nepali prose.
+    """
+    if override:
+        return Path(override)
+    base = Path(os.environ.get("CASEWORK_REVIEW_DIR") or _DEFAULT_REVIEW_DIR)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return base / f"{stamp}-{stage}-{run_id}.md"
+
+
+def build_review_file(args, *, stage, field_name, run_id):
+    """Construct a `ReviewFile` from parsed CLI args (see `cli.add_common_args`)."""
+    return ReviewFile(
+        stage=stage,
+        field_name=field_name,
+        path=review_path(stage, run_id, getattr(args, "review_file", "")),
+        dry_run=getattr(args, "dry_run", True),
+        base_url=getattr(args, "api_base_url", "") or "",
+        run_id=run_id,
+        provider=getattr(args, "provider", "") or "",
+        model=getattr(args, "model", "") or "",
+    )

--- a/casework/common/review.py
+++ b/casework/common/review.py
@@ -171,9 +171,22 @@ def review_path(stage, run_id, override=""):
     drop its file straight into the meta-repo task directory it belongs to),
     then `$CASEWORK_REVIEW_DIR`, then `<repo>/work/reviews/`. `work/` is
     gitignored, so the default never risks committing generated Nepali prose.
+
+    A DIRECTORY-VALUED OVERRIDE IS TREATED AS A DIRECTORY, and gets the same
+    `<ts>-<stage>-<run>.md` name the default builds. Without that, the two
+    stages of the normal workflow silently destroy each other's evidence:
+    `enrich_description --review-file work/reviews/run.md` followed by
+    `enrich_card --review-file work/reviews/run.md` leaves only the card's file,
+    and the description output the card was judged against is gone. A file-valued
+    override still lands exactly where it is pointed -- naming one file is a
+    deliberate act, naming a directory is not.
     """
     if override:
-        return Path(override)
+        path = Path(override)
+        if path.is_dir() or override.endswith(("/", os.sep)):
+            stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            return path / f"{stamp}-{stage}-{run_id}.md"
+        return path
     base = Path(os.environ.get("CASEWORK_REVIEW_DIR") or _DEFAULT_REVIEW_DIR)
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     return base / f"{stamp}-{stage}-{run_id}.md"

--- a/casework/common/titles.py
+++ b/casework/common/titles.py
@@ -1,17 +1,25 @@
-"""Case-title prompt rules and validation, shared by the description and
-title enrichers so titles stay consistent across both write paths.
+"""Case-title prompt rules and validation. ONE consumer: `casework/enrich_card.py`.
+
+`Case.title` has exactly one writer on `main`, and this module is the contract it
+writes against. That was not always true, and the earlier version of this
+docstring said so -- "shared by the description and title enrichers" described the
+DONOR, where three code paths could write a title: `enrich_description`'s
+side-write, the standalone `enrich_title.py`, and `enrich_card`. All three are now
+one. The description port drops its title pass (see `casework/enrich_description.py`,
+deviation 1) and `enrich_title.py` lives on as `enrich_card --only title`. A second
+importer of `TITLE_RULES` appearing is the bug -- not this docstring.
 
 Ported verbatim from the deleted donor (0321a85:casework/common.py, around
-``TITLE_RULES`` / ``validate_title`` / ``_HEADCOUNT_RE``).
+``TITLE_RULES`` / ``validate_title`` / ``title_is_acceptable`` / ``parse_title`` /
+``_HEADCOUNT_RE``).
 """
 
 import re
 
-# The public-headline contract. Both the description enricher (which regenerates
-# the title as a side-effect of the description pass) and the standalone title
-# enricher embed this verbatim so titles stay consistent across both paths.
-# It is the rules ONLY — each script appends its own OUTPUT FORMAT block, since
-# the description pass emits {"title", "description"} and the title pass {"title"}.
+from casework.common.parse import parse_object_response, strip_fence
+
+# The public-headline contract, embedded verbatim in the card enricher's system
+# prompt. It is the rules ONLY — the script appends its own OUTPUT FORMAT block.
 TITLE_RULES = """\
 TITLE RULES (when asked to regenerate the title):
 - Lead with the real, recognisable subject of the case — a named scheme/project,
@@ -85,3 +93,54 @@ def validate_title(title, court_number):
 def title_has_headcount(title) -> bool:
     """True if the title carries a forbidden defendant headcount."""
     return bool(_HEADCOUNT_RE.search(title or ""))
+
+
+def title_is_acceptable(title, court_number) -> bool:
+    """True when a title satisfies the full public contract: it ends with its
+    special-court number in parentheses AND carries no defendant headcount.
+
+    The shared predicate behind BOTH the "current title already good, skip it"
+    idempotency check and the "accept this regenerated title" write gate. One
+    predicate for both on purpose -- if they could disagree, a title good enough
+    to skip could be one the writer would reject, and the case would regenerate
+    forever.
+
+    A missing `court_number` makes a title unacceptable: the contract is that it
+    ends in that number, and there is nothing to end in.
+    """
+    return (
+        bool(title)
+        and bool(court_number)
+        and validate_title(title, court_number) is None
+        and not title_has_headcount(title)
+    )
+
+
+def parse_title(response_text):
+    """Pull the title out of an LLM response. Returns the title or None.
+
+    Prefers a ``{"title": "..."}`` object. The `predicate` demands a non-blank
+    STRING, so an object carrying `{"title": null}` -- which the donor's own
+    prompt invites, by telling the model to null an unrequested key -- is
+    rejected and the scan continues instead of returning a None title as if it
+    were a parse success.
+
+    Falls back to a bare single line ONLY when it looks like a title: one line,
+    no stray brace, and carrying a court-case number (every valid headline ends
+    in one). That keeps frugal models that emit the bare headline working while
+    rejecting prose the model was not asked for -- a confirmation sentence must
+    never be PATCHed as a public title. The fallback reads the FENCE-STRIPPED
+    text, matching the donor: a model that wraps a bare headline in ```-fences
+    still lands in the fallback rather than being rejected for its backticks.
+    """
+    obj = parse_object_response(
+        response_text,
+        predicate=lambda o: isinstance(o.get("title"), str) and o["title"].strip(),
+    )
+    if obj is not None:
+        return obj["title"].strip()
+
+    text = strip_fence((response_text or "").strip())
+    if text and "{" not in text and "\n" not in text and COURT_RE.search(text):
+        return text
+    return None

--- a/casework/common/titles.py
+++ b/casework/common/titles.py
@@ -119,6 +119,15 @@ def title_is_acceptable(title, court_number) -> bool:
 def parse_title(response_text):
     """Pull the title out of an LLM response. Returns the title or None.
 
+    NO PRODUCTION CALLER TODAY -- only `tests/casework/test_titles.py` reaches
+    this. `enrich_card` imports `TITLE_RULES`, `title_has_headcount`,
+    `title_is_acceptable` and `validate_title` from this module, but parses
+    responses with its own `_carries_a_field` predicate, because it asks for two
+    fields in one object and this function knows only about `title`. The module
+    header's "ONE consumer" is about `TITLE_RULES`, not about this function.
+    Consequence worth knowing before relying on the docstring below: the bare-line
+    fallback is unreachable in production, so it is tested but not exercised.
+
     Prefers a ``{"title": "..."}`` object. The `predicate` demands a non-blank
     STRING, so an object carrying `{"title": null}` -- which the donor's own
     prompt invites, by telling the model to null an unrequested key -- is

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python
+"""Write the listing-card fields `Case.title` + `Case.short_description` (DB-free).
+LOCAL WRITES ONLY.
+
+THIS SCRIPT IS THE SOLE WRITER OF `Case.title` ON `main`. Nothing else may patch
+that field. The donor had three paths that could: `enrich_description`'s title
+side-write, the standalone `enrich_title.py`, and `enrich_card`. All three are now
+this one file -- `casework/enrich_description.py` documents dropping its pass as
+deviation 1, and `enrich_title.py` folds in here as `--only title` (deviation 1
+below). A title write appearing anywhere else is the bug; `casework/common/titles.py`
+is the contract and this module is its only importer.
+
+WHAT IS BROKEN ON REAL DATA, and why this is not cosmetic work: 2,666 of 2,918
+DRAFT cases carry the importer's template in both fields --
+
+    title:             CIAA Special Court Case 076-CR-0182: बिनोद कुमार भूजेल समेत ५
+    short_description: अख्तियार दुरुपयोग अनुसन्धान आयोगले विशेष अदालतमा दायर गरेको
+                       मुद्दा 076-CR-0182, प्रतिवादी: बिनोद कुमार भूजेल समेत ५।
+
+-- so `title` reads as 100% covered and is in fact ~9% covered (only 155 DRAFT
+titles end in the case number in parens, which is the format contract). Both
+fields render on the public case list, so wrong here is wrong on the front page.
+
+Fetches NO source documents. Both fields derive from the `description` already on
+the case (falling back to `key_allegations`), which is what makes the stage cheap
+and what makes the single-owner split affordable: `order_stages` runs
+`description` first and this picks up what it wrote, no charge sheet re-fetched.
+
+Ported from two donors at commit `0321a85`: `casework/enrich_card.py` (425 lines)
+and `casework/enrich_title.py` (283 lines). Four deliberate deviations:
+
+DEVIATION 1 -- `enrich_title.py` IS NOT PORTED AS ITS OWN SCRIPT. It becomes
+`--only title`. The donor needed a separate script because `enrich_description`
+skipped its own title pass once a substantial description existed, leaving a case
+with a good description no path to a fixed title. `--only title` IS that path, and
+it must keep working standalone on a case whose `description` is already good and
+must stay untouched (`test_only_title_leaves_the_description_untouched`). Where the
+two donors' prompts differ, this takes `enrich_title`'s WIDER input set: it fed
+`entities` as well, and named accused are exactly what a headline needs. It also
+takes the shared `TITLE_RULES` from `casework/common/titles.py` over the donor
+card's own shorter restatement of the same rules -- one place to change a rule
+instead of two that quietly diverge.
+
+DEVIATION 2 -- ONE TIER FOR BOTH FIELDS, `cheap`. The donors disagreed: the card
+donor used `tier="cheap"` (line 337), `enrich_title.py` used `tier="premium"`
+(line 275) for the same no-fetch inputs, with a docstring arguing a headline needs
+"a real Opus". Resolved in favour of cheap, per the brief. The reasoning that
+settles it: this stage reads no source document, so the hard part -- being faithful
+to a charge sheet -- has already been done by the description pass, and the
+remaining job is compression. The two write gates are also unusually strong here
+(a title that fails `validate_title` is never written at all), so a weak model
+costs a rejected call, not a bad public headline.
+
+DEVIATION 3 -- NO LIST-LEVEL `skip_field`. The card donor selected cases with
+`get_target_cases(api, args, skip_field="short_description")`, on the stated
+assumption that "nothing populates it today, so virtually every card is
+processed". That assumption is now false, and expensively so: 2,666 cases carry a
+populated template stub, so a field-presence skip would skip every single case
+this script exists to fix. Selection is `select_cases` plus per-case gates, and
+the short_description gate is the content-based adequacy judge
+(`casework/common/judge.py`), which is what can tell a 120-character grammatical
+Nepali stub from a real teaser.
+
+DEVIATION 4 -- AN OVER-LENGTH TITLE FAILS THE CASE, IT IS NOT TRIMMED.
+`CasePatchSerializer` caps `title` at `max_length=200` (and so does the model), and
+the donor had no check -- it would have sent the title and taken a 422. Truncating
+a headline mid-word is worse than not having regenerated it, because a trimmed
+title looks deliberate and loses the case number the contract requires at the end.
+So over-length is reported and the case moves on. The `short_description` cap of
+320 is different in kind: the field is a `TextField` with no server limit, so that
+number is the donor's editorial judgement about a one-line card teaser, kept as-is.
+
+Usage:
+    uv run python -m casework.enrich_card --dry-run
+    uv run python -m casework.enrich_card --slug case-0123
+    uv run python -m casework.enrich_card --only title --limit 5 --verbose
+    uv run python -m casework.enrich_card --only short_description --apply
+"""
+
+import argparse
+import logging
+import sys
+import time
+from dataclasses import dataclass
+
+from casework.common.api import CaseworkApi
+from casework.common.cli import (
+    add_common_args,
+    basic_auth_from_env,
+    configure_run_logging,
+    log_event,
+    log_run_footer,
+    log_run_header,
+    print_summary,
+    setup_logging,
+)
+from casework.common.format import format_bigo, format_entities, format_list
+from casework.common.judge import judge_description_adequacy
+from casework.common.llm import bootstrap, tier_for
+from casework.common.parse import parse_object_response
+from casework.common.pipeline import STAGES, RunReport, unmet_prerequisites
+from casework.common.review import ReviewRow, build_review_file
+from casework.common.select import court_number, select_cases
+from casework.common.titles import (
+    TITLE_RULES,
+    title_has_headcount,
+    title_is_acceptable,
+    validate_title,
+)
+
+log = logging.getLogger("casework.enrich_card")
+
+STAGE = STAGES["card"]
+
+TITLE_FIELD = "title"
+SHORT_FIELD = "short_description"
+
+# The donor read neither of these from the environment (no `env_int` knob existed
+# for them), so both are the donors' own literals. 3000 is the CARD donor's
+# snippet budget; `enrich_title.py` used 2000, and the wider one wins per
+# deviation 1.
+DESCRIPTION_SNIPPET_BUDGET = 3000
+CARD_MAX_TOKENS = 1000
+
+# `title` really is capped at 200 by CasePatchSerializer AND cases/models.py.
+# `short_description` is a TextField with no server cap -- 320 is the donor's
+# editorial limit for a one-line teaser. See deviation 4.
+MAX_TITLE_CHARS = 200
+MAX_SHORT_DESCRIPTION_CHARS = 320
+
+SYSTEM_PROMPT = (
+    """\
+You are a Nepali editor writing the public listing-card fields for a case in \
+Jawafdehi, a civic accountability archive of Nepal's anti-corruption cases \
+investigated by the CIAA (अख्तियार दुरुपयोग अनुसन्धान आयोग) and tried at the \
+Special Court (विशेष अदालत).
+
+You are given the case's current title, its बिगो amount, key allegations, named \
+entities, and a snippet of the already-written case description. Produce up to two \
+fields in formal Nepali (देवनागरी; keep English technical/proper terms — "CR", \
+company names — as-is). Ground every word in the provided data: never invent \
+names, amounts, sections, dates, or outcomes.
+
+"""
+    + TITLE_RULES
+    + """
+
+SHORT_DESCRIPTION RULES (when asked for it):
+- A SINGLE punchy teaser, 1–2 sentences, ideally under 200 characters — the essence
+  (who/what/how much) at a glance.
+- Plain prose: no court number, no markdown, no headings, no bullets.
+- Neutral and factual, grounded in the provided data.
+
+OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose.
+Include only the requested key(s); set an unrequested key to null:
+{"title": "नेपाली शीर्षक (080-CR-0047)", "short_description": "एक-वाक्य सारांश"}
+"""
+)
+
+USER_PROMPT = """\
+{request_note}
+
+Current title: {current_title}
+Special-court case number (MUST end any regenerated title): {court_number}
+Bigo (बिगो), NPR: {bigo}
+
+KEY ALLEGATIONS:
+{key_allegations}
+
+NAMED ENTITIES (accused / related / location):
+{entities}
+
+DESCRIPTION (snippet — the factual basis for both fields):
+{description}
+
+Return ONLY the JSON object described in the system prompt.
+"""
+
+
+def build_parser():
+    ap = argparse.ArgumentParser(
+        description="Write case listing-card fields (title + short_description) "
+                    "via LLM, DB-free over the Jawafdehi HTTP API.",
+        epilog="This is the only script that patches Case.title.",
+    )
+    add_common_args(ap)
+    # The donor's choices were ("title", "short", "both"). `short` is spelled out
+    # here so the flag value matches the field name it writes -- `--only short`
+    # patching `short_description` is one more thing a reader has to hold in
+    # their head while auditing which field a run touched.
+    ap.add_argument(
+        "--only", choices=(TITLE_FIELD, SHORT_FIELD, "both"), default="both",
+        help="Which card field(s) to (re)generate (default: both). "
+             "`--only title` is the replacement for the donor's enrich_title.py.")
+    return ap
+
+
+def _snippet(detail):
+    """The description text fed to the prompt, or '(none)'."""
+    return (detail.get("description") or "").strip()[:DESCRIPTION_SNIPPET_BUDGET] \
+        or "(none)"
+
+
+def _build_prompt(detail, number, need_title, need_short):
+    wanted = [f for f, need in ((TITLE_FIELD, need_title), (SHORT_FIELD, need_short))
+              if need]
+    request_note = (
+        "Produce the title AND the short_description."
+        if len(wanted) == 2
+        else f"Only the {wanted[0]} is needed; set the other key to null."
+    )
+    return USER_PROMPT.format(
+        request_note=request_note,
+        current_title=detail.get("title") or "",
+        court_number=number or "(unknown)",
+        bigo=format_bigo(detail.get("bigo")),
+        key_allegations=format_list(detail.get("key_allegations")),
+        entities=format_entities(detail.get("entities")),
+        description=_snippet(detail),
+    )
+
+
+def _generate(detail, number, need_title, need_short, invoke_text, usage):
+    """One cheap-tier call producing whichever fields were asked for.
+
+    Returns the parsed dict, or None. Accepts an object carrying EITHER key --
+    a run asking only for a title gets `{"title": ..., "short_description":
+    null}`, so demanding both would reject every single-field reply.
+    """
+    response_text = invoke_text(
+        system=SYSTEM_PROMPT,
+        content=_build_prompt(detail, number, need_title, need_short),
+        max_tokens=CARD_MAX_TOKENS,
+        tier=tier_for("card"),
+        usage=usage,
+    )
+    result = parse_object_response(
+        response_text,
+        predicate=lambda o: TITLE_FIELD in o or SHORT_FIELD in o,
+    )
+    if result is None:
+        log.warning("No card JSON object found in the LLM response")
+    return result
+
+
+def vet_title(candidate, number):
+    """(title, rejection_reason). Exactly one of the two is set.
+
+    Every reason a title can be refused, in one place, so the dry-run preview
+    and the write path cannot disagree about what is publishable. Over-length is
+    a rejection, never a trim -- see deviation 4.
+    """
+    title = (candidate or "").strip()
+    if not title:
+        return None, "LLM returned no title"
+    issue = validate_title(title, number)
+    if issue:
+        return None, issue
+    if title_has_headcount(title):
+        return None, "contains a defendant headcount"
+    if len(title) > MAX_TITLE_CHARS:
+        return None, (
+            f"too long: {len(title)} > {MAX_TITLE_CHARS} chars "
+            "(CasePatchSerializer max_length); not truncating a headline")
+    return title, None
+
+
+def vet_short_description(candidate):
+    """(short_description, rejection_reason). Exactly one of the two is set.
+
+    An empty value is a rejection, not a write: `CaseListSerializer` ships this
+    field with no fallback to title or description (`cases/serializers.py:320`),
+    so writing "" renders a blank card on the public list.
+    """
+    short = (candidate or "").strip()
+    if not short:
+        return None, "LLM returned an empty short_description"
+    if len(short) > MAX_SHORT_DESCRIPTION_CHARS:
+        return None, f"too long: {len(short)} > {MAX_SHORT_DESCRIPTION_CHARS} chars"
+    return short, None
+
+
+@dataclass
+class _WriteContext:
+    """Everything `_vet_and_write` needs that is the same for both fields.
+
+    A dataclass rather than a closure inside `main()`: the two fields go through
+    identical vet -> record -> log -> maybe-PATCH machinery, and writing that
+    twice is how the title path and the short_description path drift until one
+    of them forgets to pass `if_match` or forgets a review row.
+    """
+    api: object
+    slug: str
+    dry_run: bool
+    etag: object
+    sources: list
+    report: object
+    review: object
+    logger: object
+    run_id: str
+    events_path: str
+
+
+def _vet_and_write(ctx, field, current, candidate, vet):
+    """Vet one generated field value and write it, or record why it was refused.
+
+    Returns the written value, or None when nothing was written -- a rejection,
+    a dry run, and a failed PATCH all return None, because in all three cases
+    the server still holds `current`.
+    """
+    def _record(status, note, generated):
+        ctx.report.record(ctx.slug, "card", status, f"{field}: {note}")
+        ctx.review.add(ReviewRow(
+            slug=ctx.slug, status=f"{status} ({field})", before=current,
+            generated=generated, sources=ctx.sources, note=note))
+
+    value, rejection = vet(candidate)
+    if rejection:
+        _record("rejected", rejection, (candidate or "").strip())
+        log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
+                  slug=ctx.slug, step=f"vet:{field}", status="rejected",
+                  detail=rejection, level=logging.WARNING)
+        return None
+
+    if ctx.dry_run:
+        _record("would-enrich", value, value)
+        log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
+                  slug=ctx.slug, step=f"write:{field}", status="would-enrich",
+                  detail=f"{field}={value}")
+        return None
+
+    try:
+        ctx.api.patch_field(ctx.slug, field, value, if_match=ctx.etag)
+    except Exception as exc:
+        _record("error", f"PATCH failed: {exc}", value)
+        log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
+                  slug=ctx.slug, step=f"write:{field}", status="error",
+                  detail=str(exc), level=logging.ERROR)
+        return None
+
+    _record("enriched", value, value)
+    log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
+              slug=ctx.slug, step=f"write:{field}", status="enriched",
+              detail=f"{field}={value}")
+    return value
+
+
+def build_api(args):
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
+    if args.api_token:
+        return CaseworkApi(
+            args.api_base_url, token=args.api_token,
+            allow_remote_writes=args.allow_remote_writes,
+        )
+    return CaseworkApi(
+        args.api_base_url,
+        basic=basic_auth_from_env(),
+        allow_remote_writes=args.allow_remote_writes,
+    )
+
+
+def main(argv=None):
+    """Main entry point."""
+    args = build_parser().parse_args(argv)
+
+    setup_logging(args.verbose)
+    logger, run_id, paths = configure_run_logging("card", verbose=args.verbose)
+    start_time = time.monotonic()
+
+    try:
+        bootstrap(args.provider, args.model)
+    except Exception as exc:
+        print(f"Bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    from llm.invoke import invoke_text
+    from llm.usage import UsageAccumulator, render_usage_table
+
+    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
+
+    # Local dev response cache (casework/common/llm_cache.py). Cheap tier, but
+    # this stage makes TWO calls per case (the adequacy judge, then the
+    # generation), so a re-run after a gate tweak still doubles the bill without
+    # it. --no-llm-cache forces fresh.
+    llm_cache = build_llm_cache(args)
+    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
+
+    api = build_api(args)
+    usage = UsageAccumulator()
+    report = RunReport()
+    # The review file names both fields: one run can write either or both, and a
+    # reviewer has to see which.
+    review = build_review_file(
+        args, stage="card", field_name=f"{TITLE_FIELD} + {SHORT_FIELD}", run_id=run_id)
+
+    all_cases = list(api.iter_cases())
+    cases = select_cases(
+        all_cases,
+        fiscal_year=args.fiscal_year,
+        slugs=args.slug,
+        court_cases=args.court_case,
+    )
+    if args.limit:
+        cases = cases[: args.limit]
+
+    total = len(cases)
+    log_run_header(
+        logger, stage="card", base_url=args.api_base_url, dry_run=args.dry_run,
+        provider=args.provider, model=args.model, n_selected=total,
+        run_id=run_id, paths=paths,
+    )
+    if total == 0:
+        print("No matching CIAA case(s) to process.", file=sys.stderr)
+        print_summary(report.summary(), args.dry_run, "Card enrichment")
+        print(f"review file: {review.write()}")
+        log_run_footer(
+            logger, stage="card", stats=report.summary(),
+            duration_s=time.monotonic() - start_time,
+        )
+        return report
+
+    print(f"Found {total} matching case(s). Target: {args.only}")
+    if args.force:
+        print("  --force: regenerating even fields that already pass their gate")
+    if args.dry_run:
+        print("  [DRY RUN] No changes will be saved.")
+
+    want_title = args.only in (TITLE_FIELD, "both")
+    want_short = args.only in (SHORT_FIELD, "both")
+
+    for idx, case in enumerate(cases, 1):
+        slug = case.get("slug") or "?"
+        log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                  step="start", status="start",
+                  detail=f"[{idx}/{total}] {(case.get('title') or '')[:80]}")
+
+        try:
+            detail, etag = api.get_case_with_etag(slug)
+        except Exception as exc:
+            # Donor-preserved fallback: a detail-fetch failure does not abort the
+            # case. Widened from the donor's bare `except` / `requests.HTTPError`
+            # because `CaseworkApi` is urllib-based.
+            detail, etag = case, None
+            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                      step="fetch", status="fallback", detail=str(exc),
+                      level=logging.WARNING)
+
+        current_title = detail.get("title") or ""
+        current_short = detail.get("short_description") or ""
+        number = court_number(detail)
+
+        unmet = unmet_prerequisites(STAGE, detail)
+        if unmet:
+            for reason in unmet:
+                report.record(slug, "card", "unmet", reason)
+            review.add(ReviewRow(slug=slug, status="unmet", before=current_title,
+                                 note="; ".join(unmet)))
+            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                      step="prereq", status="unmet", detail="; ".join(unmet),
+                      level=logging.WARNING)
+            continue
+
+        # ── decide what needs work ──
+        # No court number means no title can ever satisfy the format contract
+        # (it must END in that number), so regenerating would burn a call on a
+        # title guaranteed to be rejected. Donor-preserved.
+        need_title = False
+        if want_title:
+            if not number:
+                report.record(slug, "card", "unmet",
+                              "no special-court number; a title cannot satisfy "
+                              "the format contract")
+            else:
+                need_title = args.force or not title_is_acceptable(
+                    current_title, number)
+                if not need_title:
+                    report.record(slug, "card", "already",
+                                  f"title already valid: {current_title}")
+
+        need_short = False
+        short_reason = ""
+        if want_short:
+            if args.force:
+                need_short = True
+            else:
+                adequate, short_reason = judge_description_adequacy(
+                    current_short,
+                    kind="case card short description (one-line teaser)",
+                    invoke_text=invoke_text,
+                    usage=usage,
+                    context=f"title={current_title[:80]}",
+                )
+                need_short = not adequate
+                if adequate:
+                    report.record(slug, "card", "already",
+                                  f"short_description already adequate: {short_reason}")
+                log_event(logger, paths["events"], run_id=run_id, stage="card",
+                          slug=slug, step="judge",
+                          status="adequate" if adequate else "inadequate",
+                          detail=short_reason)
+
+        if not need_title and not need_short:
+            review.add(ReviewRow(slug=slug, status="already", before=current_title,
+                                 note="nothing to do (use --force)"))
+            continue
+
+        # Both fields derive from the description, falling back to allegations.
+        if not (detail.get("description") or "").strip() and not detail.get(
+                "key_allegations"):
+            reason = "no description or key_allegations to derive a card from"
+            report.record(slug, "card", "unmet", reason)
+            review.add(ReviewRow(slug=slug, status="unmet", before=current_title,
+                                 note=reason))
+            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                      step="source", status="unmet", detail=reason,
+                      level=logging.WARNING)
+            continue
+
+        try:
+            result = _generate(detail, number, need_title, need_short,
+                               invoke_text, usage)
+        except Exception as exc:
+            report.record(slug, "card", "error", f"LLM generation failed: {exc}")
+            review.add(ReviewRow(slug=slug, status="error", before=current_title,
+                                 note=f"LLM generation failed: {exc}"))
+            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                      step="generate", status="error", detail=str(exc),
+                      level=logging.ERROR)
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+            continue
+
+        if result is None:
+            report.record(slug, "card", "skipped", "LLM returned no parseable object")
+            review.add(ReviewRow(slug=slug, status="skipped", before=current_title,
+                                 note="LLM returned no parseable object"))
+            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                      step="generate", status="skipped",
+                      detail="no parseable object", level=logging.WARNING)
+            continue
+
+        # The description snippet IS the source for both fields, so it is what
+        # the review file shows. There is no material IRI: this stage fetches no
+        # document, and inventing one would misattribute the provenance.
+        fed = [("case description (no document fetched)", "", _snippet(detail))]
+
+        ctx = _WriteContext(
+            api=api, slug=slug, dry_run=args.dry_run, etag=etag, sources=fed,
+            report=report, review=review, logger=logger, run_id=run_id,
+            events_path=paths["events"],
+        )
+        if need_title:
+            _vet_and_write(ctx, TITLE_FIELD, current_title,
+                           result.get(TITLE_FIELD), lambda c: vet_title(c, number))
+        if need_short:
+            _vet_and_write(ctx, SHORT_FIELD, current_short,
+                           result.get(SHORT_FIELD), vet_short_description)
+
+    stats = report.summary()
+    print_summary(stats, args.dry_run, "Card enrichment")
+    unmet_reasons = report.unmet_reasons()
+    if unmet_reasons:
+        print("  unmet reasons:")
+        for reason, count in unmet_reasons.most_common():
+            print(f"    {count} x {reason}")
+
+    usage_summary = ""
+    if usage.calls > 0:
+        usage_summary = render_usage_table(
+            usage.as_dict()["by_provider"], title="card usage")
+        print()
+        print(usage_summary)
+
+    cache_summary = llm_cache.summary()
+    print(cache_summary)
+    print(f"review file: {review.write()}")
+
+    log_run_footer(
+        logger, stage="card", stats=stats,
+        duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+        cache_summary=cache_summary,
+    )
+
+    return report
+
+
+if __name__ == "__main__":
+    main()

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -191,6 +191,13 @@ allegation. A teaser that gives only the आरोप for a case that was alread
 is wrong by omission: readers take it as a live accusation. When the description \
 reports no verdict, say nothing about an outcome — do not guess, and do not write \
 "अनुसन्धान जारी" unless the description says so.
+- IF THE DEFENDANTS GOT DIFFERENT OUTCOMES, SAY SO. When the description reports \
+one defendant दोषी and another सफाई, a teaser naming only one of them is false \
+about the other — and a person a court CLEARED must never read as convicted. Name \
+the split plainly: "…एक प्रतिवादीलाई दोषी ठहर, अर्कोलाई सफाई" or \
+"…प्रधानाध्यापकलाई कैद, लेखा कर्मचारीलाई सफाई". Prefer naming who was cleared over \
+listing the sentence in full — the sentence is on the case page, the correction of \
+a false impression is not.
 
 OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose.
 Include only the requested key(s); set an unrequested key to null:

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -70,6 +70,17 @@ So over-length is reported and the case moves on. The `short_description` cap of
 320 is different in kind: the field is a `TextField` with no server limit, so that
 number is the donor's editorial judgement about a one-line card teaser, kept as-is.
 
+DEVIATION 5 -- `CARD_MAX_TOKENS` IS 4000, NOT THE DONOR'S 1000. Measured on the
+2026-08-04 local smoke run: one of two cases died with
+`API Error: Claude's response exceeded the 1000 output token maximum`, a hard
+provider failure rather than a truncated answer, so the case produced nothing at
+all. The cap has to cover the two fields' own limits (200 + 320 chars) in
+DEVANAGARI, which costs far more tokens per character than Latin text, plus
+whatever framing the provider wraps around the reply. The donor's 1000 was set
+against Latin-heavy expectations; it does not survive real Nepali output. 4000 is
+still half of `enrich_description`'s budget and cannot mask an over-length title,
+because `vet_title` rejects on characters, not tokens.
+
 Usage:
     uv run python -m casework.enrich_card --dry-run
     uv run python -m casework.enrich_card --slug case-0123
@@ -120,7 +131,11 @@ SHORT_FIELD = "short_description"
 # snippet budget; `enrich_title.py` used 2000, and the wider one wins per
 # deviation 1.
 DESCRIPTION_SNIPPET_BUDGET = 3000
-CARD_MAX_TOKENS = 1000
+# 4000, not the donor's 1000 -- see DEVIATION 5. A Devanagari title +
+# short_description does not fit in 1000 output tokens, and the provider turns an
+# over-budget reply into a hard error, so the case yields nothing rather than a
+# trimmed answer.
+CARD_MAX_TOKENS = 4000
 
 # `title` really is capped at 200 by CasePatchSerializer AND cases/models.py.
 # `short_description` is a TextField with no server cap -- 320 is the donor's
@@ -337,6 +352,27 @@ def _vet_and_write(ctx, field, current, candidate, vet):
                   slug=ctx.slug, step=f"write:{field}", status="error",
                   detail=str(exc), level=logging.ERROR)
         return None
+
+    # RE-READ THE ETAG BEFORE THE NEXT FIELD. This script is the only ported
+    # enricher that issues TWO PATCHes for one case, and the first one changes
+    # the case's ETag -- so reusing the ETag captured before it makes the second
+    # write fail `If-Match` with a 412. Measured on the 2026-08-04 local smoke
+    # run: `title` landed, `short_description` died with
+    # "HTTP Error 412: Precondition Failed" on BOTH cases, meaning the script
+    # could never write both fields in one pass. The dry run cannot see this --
+    # it reports `would-enrich` for both and looks perfect.
+    #
+    # A failed refresh clears the ETag rather than keeping the stale one: an
+    # unconditional second write is a smaller problem than a guaranteed 412,
+    # and the case was just read, so the race window is the width of one PATCH.
+    try:
+        _, ctx.etag = ctx.api.get_case_with_etag(ctx.slug)
+    except Exception as exc:  # noqa: BLE001 -- the write already succeeded.
+        ctx.etag = None
+        log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
+                  slug=ctx.slug, step=f"etag:{field}", status="stale",
+                  detail=f"could not re-read ETag after writing {field}: {exc}",
+                  level=logging.WARNING)
 
     _record("enriched", value, value)
     log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -104,6 +104,7 @@ Usage:
 
 import argparse
 import logging
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -179,6 +180,12 @@ SHORT_DESCRIPTION RULES (when asked for it):
   (who/what/how much) at a glance.
 - Plain prose: no court number, no markdown, no headings, no bullets.
 - Neutral and factual, grounded in the provided data.
+- STATE THE OUTCOME when the description reports one. If the case has been \
+decided — दोषी, सफाई, आंशिक सफाई, जरिवाना, कैद — say so, briefly, after the \
+allegation. A teaser that gives only the आरोप for a case that was already decided \
+is wrong by omission: readers take it as a live accusation. When the description \
+reports no verdict, say nothing about an outcome — do not guess, and do not write \
+"अनुसन्धान जारी" unless the description says so.
 
 OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose.
 Include only the requested key(s); set an unrequested key to null:
@@ -224,10 +231,69 @@ def build_parser():
     return ap
 
 
+#: The verdict SECTION heading (`### ग) विशेष अदालतको फैसलाको सार`, the contract
+#: in `casework/enrich_description.py`). Line-anchored and required to name
+#: फैसला, because a bare `ग)` is also a list marker and a table cell reference --
+#: `081-CR-0060` carries "(ग), (घ) र (ङ) मा उल्लिखित सम्पत्ति" in a table at
+#: offset 1,740, and matching that would splice a random table row in as the
+#: outcome.
+_OUTCOME_HEADING_RE = re.compile(r"^#{0,4}[ \t]*ग\)[^\n]*फैसला[^\n]*$", re.MULTILINE)
+
+#: Fallback locator. Only 11 of the published descriptions actually follow the
+#: heading contract -- most are hand-written prose with no headings at all -- so
+#: a heading-only search finds the outcome in a small minority of the cases that
+#: have one. These are the words a Nepali verdict is stated in.
+_OUTCOME_WORD_RE = re.compile(r"(फैसला|सफाई|सफाइ|दोषी|ठहर|जरिवाना|कैद)")
+
+#: How much of the snippet budget is reserved for the verdict passage.
+OUTCOME_SLICE_CHARS = 1200
+
+
+def _outcome_offset(text):
+    """Where the verdict passage starts, or None when the text states no outcome.
+
+    Prefers the section heading (a clean boundary) and falls back to the first
+    outcome word, backing up to its line start so the slice does not begin
+    mid-sentence.
+    """
+    match = _OUTCOME_HEADING_RE.search(text) or _OUTCOME_WORD_RE.search(text)
+    if match is None:
+        return None
+    return text.rfind("\n", 0, match.start()) + 1
+
+
 def _snippet(detail):
-    """The description text fed to the prompt, or '(none)'."""
-    return (detail.get("description") or "").strip()[:DESCRIPTION_SNIPPET_BUDGET] \
-        or "(none)"
+    """The description text fed to the prompt, or '(none)'.
+
+    A HEAD CLAMP ALONE LOSES THE OUTCOME. A description states the allegation
+    first and the verdict last, so the outcome is structurally late. Measured
+    across the published cases whose description exceeds this budget and states
+    an outcome at all: **34 of 52 state it only beyond 3,000 characters**. So a
+    plain head clamp hides the verdict from the teaser on about two thirds of
+    decided cases, and no prompt rule can recover it -- the model cannot state
+    what it was never shown. The 2026-08-04 evaluation caught exactly that on
+    `081-CR-0060`, an acquitted case (सफाई at offset 5,100) whose generated
+    teaser read as a live accusation.
+
+    So when an outcome exists outside the head, the snippet becomes
+    head + elision + the verdict passage, inside the same total budget.
+    """
+    text = (detail.get("description") or "").strip()
+    if not text:
+        return "(none)"
+    if len(text) <= DESCRIPTION_SNIPPET_BUDGET:
+        return text
+
+    offset = _outcome_offset(text)
+    head_budget = DESCRIPTION_SNIPPET_BUDGET - OUTCOME_SLICE_CHARS
+    # Nothing to rescue when the text states no outcome, or when the outcome
+    # already sits inside the head the plain clamp would have kept anyway.
+    if offset is None or offset < head_budget:
+        return text[:DESCRIPTION_SNIPPET_BUDGET]
+
+    head = text[:head_budget].rstrip()
+    outcome = text[offset:offset + OUTCOME_SLICE_CHARS].rstrip()
+    return f"{head}\n\n[…]\n\n{outcome}"
 
 
 def _build_prompt(detail, number, need_title, need_short):

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -243,67 +243,75 @@ def build_parser():
     return ap
 
 
-#: The verdict SECTION heading (`### ग) विशेष अदालतको फैसलाको सार`, the contract
-#: in `casework/enrich_description.py`). Line-anchored and required to name
-#: फैसला, because a bare `ग)` is also a list marker and a table cell reference --
-#: `081-CR-0060` carries "(ग), (घ) र (ङ) मा उल्लिखित सम्पत्ति" in a table at
-#: offset 1,740, and matching that would splice a random table row in as the
-#: outcome.
-_OUTCOME_HEADING_RE = re.compile(r"^#{0,4}[ \t]*ग\)[^\n]*फैसला[^\n]*$", re.MULTILINE)
-
-#: Fallback locator. Only 11 of the published descriptions actually follow the
-#: heading contract -- most are hand-written prose with no headings at all -- so
-#: a heading-only search finds the outcome in a small minority of the cases that
-#: have one. These are the words a Nepali verdict is stated in.
-_OUTCOME_WORD_RE = re.compile(r"(फैसला|सफाई|सफाइ|दोषी|ठहर|जरिवाना|कैद)")
+#: Words that state a RESULT -- what the court decided, not what anyone asked
+#: for. `फैसला` ("judgment") is deliberately ABSENT even though a verdict section
+#: is titled with it: it is also the word an appeal section uses to refer BACK to
+#: the judgment, so including it drags the locator past the verdict it exists to
+#: find. Measured over the corpus, `पुनरावेदन` appears after the last outcome
+#: word on 16 of the 83 descriptions long enough to need this path.
+_OUTCOME_WORD_RE = re.compile(r"(सफाई|सफाइ|दोषी|ठहर|जरिवाना|कैद)")
 
 #: How much of the description's OPENING the snippet keeps. The rest of the
 #: budget goes to the verdict.
 SNIPPET_HEAD_CHARS = 1800
 
-#: Ceiling on the whole snippet once a verdict has been spliced in. The verdict
-#: passage is read to the END of the description rather than clipped to a fixed
-#: width, so this is what stops a 13,617-character judgment summary from filling
-#: the prompt. See `_snippet` for the measurement behind 6000.
+#: Ceiling on the whole snippet once a verdict has been spliced in -- what stops
+#: a 13,617-character judgment summary from filling the prompt.
 SNIPPET_MAX_CHARS = 6000
 
+#: How far past the last outcome word the window runs, so the sentence stating
+#: the outcome is never cut off mid-clause.
+_OUTCOME_TRAILING_CHARS = 200
 
-def _outcome_offset(text):
-    """Where the verdict passage starts, or None when the text states no outcome.
 
-    Prefers the section heading (a clean boundary). Failing that, takes the LAST
-    outcome word, not the first, and backs up to its line start so the slice does
-    not begin mid-sentence.
+def _verdict_window(text):
+    """`(start, end)` of the verdict passage, or None when no outcome is stated.
 
-    LAST, NOT FIRST -- these words appear all over a description, not only in the
-    verdict. Section क) is specified to state the punishment SOUGHT (मागदावी),
-    which is written in exactly this vocabulary (कैद, जरिवाना), and narrative
-    reasoning uses ठहर freely. Measured over the 56 published descriptions longer
-    than the snippet budget, taking the first match produced two distinct
-    failures:
+    THE WINDOW ENDS AT THE LAST OUTCOME WORD AND GROWS BACKWARD. Every
+    start-somewhere-and-read-forward design loses verdicts, because no single
+    point reliably marks where the outcome discussion begins:
 
-      - No rescue at all when the first hit sits inside the head. One case's
-        first match is `ठहर` at offset 847, in a sentence about who bears a tax
-        liability; the real फैसला is at 5,275.
-      - A WRONG rescue when the first hit is past the head budget: another case
-        matches `दोषी` at 6,466, mid-narrative, and splices from there while the
-        actual ठहर sits at 26,224. That is the worse half -- the prompt rule says
-        STATE THE OUTCOME, so the model is handed unrelated prose and invited to
-        report it as the verdict.
+      - Read forward from the FIRST outcome word past the head, and a
+        mid-narrative hit hijacks the slice. One real case matches `दोषी` at
+        6,466 while the actual ठहर sits at 26,224.
+      - Read forward from the LAST outcome word, and a multi-defendant verdict
+        loses every defendant but the last one named.
+      - Read forward from the `ग)` section heading, and a long verdict
+        discussion is clipped before it finishes. Measured: preferring the
+        heading scores WORSE than ignoring it (51/54 vs 53/54 on carrying the
+        acquittal), which is why this function has no heading branch at all.
 
-    Scanning from the end fixes both: the rescue fires on 35 of the 45
-    non-heading cases instead of 29, and the passage it splices is the one the
-    document ends on, which is where a verdict structurally sits.
+    Ending the window at the last outcome word and filling the budget backward
+    dominates all three, because the outcome discussion is contiguous and ends
+    where the last outcome word is. Measured over the 83 descriptions longer than
+    the snippet budget, on whether the passage the model actually receives
+    contains the court's granted acquittal:
+
+        plain head clamp        2/54       (and 7/76 on the last outcome stated)
+        read forward from last  42/54      (62/76)
+        this function           53/54      (76/76)
+
+    The one remaining miss is a false one -- `सफाइ दिने अवसर` ("an opportunity to
+    be heard") is a due-process phrase, not a verdict.
     """
-    heading = _OUTCOME_HEADING_RE.search(text)
-    if heading is not None:
-        return text.rfind("\n", 0, heading.start()) + 1
-    last = None
-    for last in _OUTCOME_WORD_RE.finditer(text):
-        pass
-    if last is None:
+    matches = [m for m in _OUTCOME_WORD_RE.finditer(text)
+               if m.start() >= SNIPPET_HEAD_CHARS]
+    if not matches:
         return None
-    return text.rfind("\n", 0, last.start()) + 1
+    end = min(len(text), matches[-1].end() + _OUTCOME_TRAILING_CHARS)
+    start = max(SNIPPET_HEAD_CHARS, end - (SNIPPET_MAX_CHARS - SNIPPET_HEAD_CHARS))
+    # Align to a line boundary so the passage does not open mid-sentence, moving
+    # FORWARD. Backing up to the PREVIOUS line start is the obvious reading and
+    # is wrong: it grows the window by up to a whole line, which put 50 of the 83
+    # real snippets over `SNIPPET_MAX_CHARS` (the worst 6,998). Moving forward
+    # can only shrink it, so the ceiling holds. A text with no newline at all
+    # simply keeps the computed start -- `find` returning -1 must not be read as
+    # a boundary, which is the trap on the other side of this.
+    if start > SNIPPET_HEAD_CHARS:
+        line_start = text.find("\n", start)
+        if 0 <= line_start < end:
+            start = line_start + 1
+    return start, end
 
 
 def _snippet(detail):
@@ -322,24 +330,18 @@ def _snippet(detail):
     So when an outcome exists outside the head, the snippet becomes
     head + elision + the verdict passage.
 
-    THE VERDICT PASSAGE IS READ TO THE END, NOT CLIPPED TO A FIXED WIDTH. It used
-    to take a flat 1,200 characters, and that silently truncated the verdict on
-    **21 of the 52** published descriptions long enough to need this path. The
-    failure is worst exactly where it matters most: a multi-defendant case states
-    one outcome per defendant, so a clipped slice keeps the first (usually a
-    conviction) and drops the rest. Reproduced twice on `078-CR-0103`, where the
-    verdict section runs 1,835 characters and राकेशमान श्रेष्ठ's सफाई sits 172
-    characters past where a 1,200-char slice ended -- the model was shown the
-    conviction, never the acquittal, and wrote a teaser that reads as though both
-    defendants were convicted.
+    A MULTI-DEFENDANT VERDICT IS THE CASE THAT MUST NOT BE CLIPPED. Such a case
+    states one outcome per defendant, so any slice that ends early keeps the
+    first (usually a conviction) and drops the rest. Reproduced twice on
+    `078-CR-0103`, where राकेशमान श्रेष्ठ's सफाई sat past where the slice ended --
+    the model was shown the conviction, never the acquittal, and wrote a teaser
+    reading as though both defendants were convicted. `_verdict_window` exists to
+    make that structurally hard; see its docstring for the measurement.
 
-    Why a ceiling instead of no limit: the median verdict section is only 794
-    characters, so most cases send LESS than the old fixed slice and the typical
-    snippet gets smaller, not bigger. The tail is what needs room -- three in four
-    are under 3,337 characters, but the longest is 13,617. `SNIPPET_MAX_CHARS`
-    covers the realistic tail without letting one outlier judgment dominate the
-    prompt. Input tokens are the cheap half of this stage; the output cap
-    (`CARD_MAX_TOKENS`) is unchanged and is what actually bounds cost.
+    Why a ceiling instead of no limit: three in four verdict passages are under
+    3,337 characters, but the longest is 13,617, and one outlier judgment must
+    not dominate the prompt. Input tokens are the cheap half of this stage; the
+    output cap (`CARD_MAX_TOKENS`) is what actually bounds cost.
     """
     text = (detail.get("description") or "").strip()
     if not text:
@@ -347,15 +349,15 @@ def _snippet(detail):
     if len(text) <= DESCRIPTION_SNIPPET_BUDGET:
         return text
 
-    offset = _outcome_offset(text)
-    # Nothing to rescue when the text states no outcome, or when the outcome
-    # already sits inside the head the plain clamp would have kept anyway.
-    if offset is None or offset < SNIPPET_HEAD_CHARS:
+    window = _verdict_window(text)
+    # Nothing to rescue when the text states no outcome past the head -- an
+    # outcome inside the head is already kept by the plain clamp.
+    if window is None:
         return text[:DESCRIPTION_SNIPPET_BUDGET]
 
+    start, end = window
     head = text[:SNIPPET_HEAD_CHARS].rstrip()
-    outcome = text[offset:offset + (SNIPPET_MAX_CHARS - SNIPPET_HEAD_CHARS)].rstrip()
-    return f"{head}\n\n[…]\n\n{outcome}"
+    return f"{head}\n\n[…]\n\n{text[start:end].strip()}"
 
 
 def _build_prompt(detail, number, need_title, need_short):

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -517,15 +517,6 @@ def main(argv=None):
     from llm.invoke import invoke_text
     from llm.usage import UsageAccumulator, render_usage_table
 
-    from casework.common.llm_cache import build_llm_cache, wrap_invoke_text
-
-    # Local dev response cache (casework/common/llm_cache.py). Cheap tier, but
-    # this stage makes TWO calls per case (the adequacy judge, then the
-    # generation), so a re-run after a gate tweak still doubles the bill without
-    # it. --no-llm-cache forces fresh.
-    llm_cache = build_llm_cache(args)
-    invoke_text = wrap_invoke_text(invoke_text, llm_cache)
-
     api = build_api(args)
     usage = UsageAccumulator()
     report = RunReport()
@@ -723,14 +714,11 @@ def main(argv=None):
         print()
         print(usage_summary)
 
-    cache_summary = llm_cache.summary()
-    print(cache_summary)
     print(f"review file: {review.write()}")
 
     log_run_footer(
         logger, stage="card", stats=stats,
         duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
-        cache_summary=cache_summary,
     )
 
     return report

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -22,9 +22,14 @@ titles end in the case number in parens, which is the format contract). Both
 fields render on the public case list, so wrong here is wrong on the front page.
 
 Fetches NO source documents. Both fields derive from the `description` already on
-the case (falling back to `key_allegations`), which is what makes the stage cheap
-and what makes the single-owner split affordable: `order_stages` runs
-`description` first and this picks up what it wrote, no charge sheet re-fetched.
+the case, which is what makes the stage cheap and what makes the single-owner
+split affordable: `order_stages` runs `description` first and this picks up what
+it wrote, no charge sheet re-fetched. `key_allegations` and the entity list go
+into the prompt as supporting context, NOT as a fallback source -- the donor
+treated them as one, but `STAGES["card"].requires_fields` declares
+`("description",)`, so `unmet_prerequisites` reports any case with a blank
+description as unmet before generation is ever reached. A description is a hard
+prerequisite here, not a preference.
 
 Ported from two donors at commit `0321a85`: `casework/enrich_card.py` (425 lines)
 and `casework/enrich_title.py` (283 lines). Six deliberate deviations:
@@ -252,14 +257,39 @@ OUTCOME_SLICE_CHARS = 1200
 def _outcome_offset(text):
     """Where the verdict passage starts, or None when the text states no outcome.
 
-    Prefers the section heading (a clean boundary) and falls back to the first
-    outcome word, backing up to its line start so the slice does not begin
-    mid-sentence.
+    Prefers the section heading (a clean boundary). Failing that, takes the LAST
+    outcome word, not the first, and backs up to its line start so the slice does
+    not begin mid-sentence.
+
+    LAST, NOT FIRST -- these words appear all over a description, not only in the
+    verdict. Section क) is specified to state the punishment SOUGHT (मागदावी),
+    which is written in exactly this vocabulary (कैद, जरिवाना), and narrative
+    reasoning uses ठहर freely. Measured over the 56 published descriptions longer
+    than the snippet budget, taking the first match produced two distinct
+    failures:
+
+      - No rescue at all when the first hit sits inside the head. One case's
+        first match is `ठहर` at offset 847, in a sentence about who bears a tax
+        liability; the real फैसला is at 5,275.
+      - A WRONG rescue when the first hit is past the head budget: another case
+        matches `दोषी` at 6,466, mid-narrative, and splices from there while the
+        actual ठहर sits at 26,224. That is the worse half -- the prompt rule says
+        STATE THE OUTCOME, so the model is handed unrelated prose and invited to
+        report it as the verdict.
+
+    Scanning from the end fixes both: the rescue fires on 35 of the 45
+    non-heading cases instead of 29, and the passage it splices is the one the
+    document ends on, which is where a verdict structurally sits.
     """
-    match = _OUTCOME_HEADING_RE.search(text) or _OUTCOME_WORD_RE.search(text)
-    if match is None:
+    heading = _OUTCOME_HEADING_RE.search(text)
+    if heading is not None:
+        return text.rfind("\n", 0, heading.start()) + 1
+    last = None
+    for last in _OUTCOME_WORD_RE.finditer(text):
+        pass
+    if last is None:
         return None
-    return text.rfind("\n", 0, match.start()) + 1
+    return text.rfind("\n", 0, last.start()) + 1
 
 
 def _snippet(detail):
@@ -322,6 +352,26 @@ def _build_prompt(detail, number, need_title, need_short):
     )
 
 
+def _carries_a_field(obj):
+    """True when the object holds a NON-BLANK STRING on at least one card field.
+
+    Key presence is not enough, and this is the whole point. The system prompt
+    tells the model to "set an unrequested key to null", so
+    `{"title": null, "short_description": null}` is a shape the prompt itself
+    invites -- and a presence test (`TITLE_FIELD in o`) accepts it, which stops
+    `parse_object_response`'s scan on an object carrying nothing. The run then
+    reports two rejections ("LLM returned an empty ...") for a response whose
+    REAL object may have been the next `{` along, behind a preamble.
+
+    Matches the contract `casework/common/titles.py::parse_title` documents for
+    the same reason.
+    """
+    return any(
+        isinstance(obj.get(field), str) and obj.get(field).strip()
+        for field in (TITLE_FIELD, SHORT_FIELD)
+    )
+
+
 def _generate(detail, number, need_title, need_short, invoke_text, usage):
     """One cheap-tier call producing whichever fields were asked for.
 
@@ -338,7 +388,7 @@ def _generate(detail, number, need_title, need_short, invoke_text, usage):
     )
     result = parse_object_response(
         response_text,
-        predicate=lambda o: TITLE_FIELD in o or SHORT_FIELD in o,
+        predicate=_carries_a_field,
     )
     if result is None:
         log.warning("No card JSON object found in the LLM response")
@@ -569,23 +619,47 @@ def main(argv=None):
         try:
             detail, etag = api.get_case_with_etag(slug)
         except Exception as exc:
-            # Donor-preserved fallback: a detail-fetch failure does not abort the
-            # case. Widened from the donor's bare `except` / `requests.HTTPError`
-            # because `CaseworkApi` is urllib-based.
-            detail, etag = case, None
+            # NOT the donor's fall-back-to-the-list-payload. This stage must skip.
+            #
+            # The donor (and `enrich_description`) continue on `detail = case`,
+            # and for description that is safe by accident: its
+            # `requires_materials` gate trips on the list payload's unresolved
+            # `associatedMedia`, so the case is reported unmet and never
+            # generated. `STAGES["card"]` declares NO `requires_materials` -- it
+            # reads no document -- so nothing would stop the run here.
+            #
+            # What would happen instead is the bad case: `CaseSerializer` is the
+            # list serializer's child (`cases/serializers.py:312`), so the list
+            # payload carries `title`, `short_description` AND `description`.
+            # Card would generate a headline from a page-cached description and
+            # then PATCH with `if_match=None`, because the failed fetch is
+            # exactly what left `etag` unset -- an unconditional write that
+            # silently clobbers whatever a caseworker changed in between. A
+            # skipped case costs one re-run; a clobbered edit is unrecoverable.
+            report.record(slug, "card", "error", f"detail fetch failed: {exc}")
+            review.add(ReviewRow(slug=slug, status="error",
+                                 before=case.get("title") or "",
+                                 note=f"detail fetch failed: {exc}"))
             log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
-                      step="fetch", status="fallback", detail=str(exc),
-                      level=logging.WARNING)
+                      step="fetch", status="error", detail=str(exc),
+                      level=logging.ERROR)
+            continue
 
         current_title = detail.get("title") or ""
         current_short = detail.get("short_description") or ""
+        # Whole-case rows (unmet / already / error / skipped) concern both fields
+        # or neither, so the "Before" column has to reflect what the RUN is about.
+        # Reporting `current_title` unconditionally showed a reviewer the headline
+        # in every row of an `--only short_description` run -- the one field that
+        # run could not touch.
+        current_for_review = current_title if want_title else current_short
         number = court_number(detail)
 
         unmet = unmet_prerequisites(STAGE, detail)
         if unmet:
             for reason in unmet:
                 report.record(slug, "card", "unmet", reason)
-            review.add(ReviewRow(slug=slug, status="unmet", before=current_title,
+            review.add(ReviewRow(slug=slug, status="unmet", before=current_for_review,
                                  note="; ".join(unmet)))
             log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
                       step="prereq", status="unmet", detail="; ".join(unmet),
@@ -632,28 +706,21 @@ def main(argv=None):
                           detail=short_reason)
 
         if not need_title and not need_short:
-            review.add(ReviewRow(slug=slug, status="already", before=current_title,
+            review.add(ReviewRow(slug=slug, status="already", before=current_for_review,
                                  note="nothing to do (use --force)"))
             continue
 
-        # Both fields derive from the description, falling back to allegations.
-        if not (detail.get("description") or "").strip() and not detail.get(
-                "key_allegations"):
-            reason = "no description or key_allegations to derive a card from"
-            report.record(slug, "card", "unmet", reason)
-            review.add(ReviewRow(slug=slug, status="unmet", before=current_title,
-                                 note=reason))
-            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
-                      step="source", status="unmet", detail=reason,
-                      level=logging.WARNING)
-            continue
+        # No blank-description guard here on purpose: `unmet_prerequisites` above
+        # already reported and skipped every such case, because
+        # `STAGES["card"].requires_fields` is `("description",)`. A second check
+        # would be unreachable code that reads like a live safety net.
 
         try:
             result = _generate(detail, number, need_title, need_short,
                                invoke_text, usage)
         except Exception as exc:
             report.record(slug, "card", "error", f"LLM generation failed: {exc}")
-            review.add(ReviewRow(slug=slug, status="error", before=current_title,
+            review.add(ReviewRow(slug=slug, status="error", before=current_for_review,
                                  note=f"LLM generation failed: {exc}"))
             log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
                       step="generate", status="error", detail=str(exc),
@@ -666,7 +733,7 @@ def main(argv=None):
 
         if result is None:
             report.record(slug, "card", "skipped", "LLM returned no parseable object")
-            review.add(ReviewRow(slug=slug, status="skipped", before=current_title,
+            review.add(ReviewRow(slug=slug, status="skipped", before=current_for_review,
                                  note="LLM returned no parseable object"))
             log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
                       step="generate", status="skipped",

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -250,8 +250,15 @@ _OUTCOME_HEADING_RE = re.compile(r"^#{0,4}[ \t]*ग\)[^\n]*फैसला[^\n]*
 #: have one. These are the words a Nepali verdict is stated in.
 _OUTCOME_WORD_RE = re.compile(r"(फैसला|सफाई|सफाइ|दोषी|ठहर|जरिवाना|कैद)")
 
-#: How much of the snippet budget is reserved for the verdict passage.
-OUTCOME_SLICE_CHARS = 1200
+#: How much of the description's OPENING the snippet keeps. The rest of the
+#: budget goes to the verdict.
+SNIPPET_HEAD_CHARS = 1800
+
+#: Ceiling on the whole snippet once a verdict has been spliced in. The verdict
+#: passage is read to the END of the description rather than clipped to a fixed
+#: width, so this is what stops a 13,617-character judgment summary from filling
+#: the prompt. See `_snippet` for the measurement behind 6000.
+SNIPPET_MAX_CHARS = 6000
 
 
 def _outcome_offset(text):
@@ -306,7 +313,26 @@ def _snippet(detail):
     teaser read as a live accusation.
 
     So when an outcome exists outside the head, the snippet becomes
-    head + elision + the verdict passage, inside the same total budget.
+    head + elision + the verdict passage.
+
+    THE VERDICT PASSAGE IS READ TO THE END, NOT CLIPPED TO A FIXED WIDTH. It used
+    to take a flat 1,200 characters, and that silently truncated the verdict on
+    **21 of the 52** published descriptions long enough to need this path. The
+    failure is worst exactly where it matters most: a multi-defendant case states
+    one outcome per defendant, so a clipped slice keeps the first (usually a
+    conviction) and drops the rest. Reproduced twice on `078-CR-0103`, where the
+    verdict section runs 1,835 characters and राकेशमान श्रेष्ठ's सफाई sits 172
+    characters past where a 1,200-char slice ended -- the model was shown the
+    conviction, never the acquittal, and wrote a teaser that reads as though both
+    defendants were convicted.
+
+    Why a ceiling instead of no limit: the median verdict section is only 794
+    characters, so most cases send LESS than the old fixed slice and the typical
+    snippet gets smaller, not bigger. The tail is what needs room -- three in four
+    are under 3,337 characters, but the longest is 13,617. `SNIPPET_MAX_CHARS`
+    covers the realistic tail without letting one outlier judgment dominate the
+    prompt. Input tokens are the cheap half of this stage; the output cap
+    (`CARD_MAX_TOKENS`) is unchanged and is what actually bounds cost.
     """
     text = (detail.get("description") or "").strip()
     if not text:
@@ -315,14 +341,13 @@ def _snippet(detail):
         return text
 
     offset = _outcome_offset(text)
-    head_budget = DESCRIPTION_SNIPPET_BUDGET - OUTCOME_SLICE_CHARS
     # Nothing to rescue when the text states no outcome, or when the outcome
     # already sits inside the head the plain clamp would have kept anyway.
-    if offset is None or offset < head_budget:
+    if offset is None or offset < SNIPPET_HEAD_CHARS:
         return text[:DESCRIPTION_SNIPPET_BUDGET]
 
-    head = text[:head_budget].rstrip()
-    outcome = text[offset:offset + OUTCOME_SLICE_CHARS].rstrip()
+    head = text[:SNIPPET_HEAD_CHARS].rstrip()
+    outcome = text[offset:offset + (SNIPPET_MAX_CHARS - SNIPPET_HEAD_CHARS)].rstrip()
     return f"{head}\n\n[…]\n\n{outcome}"
 
 

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -61,7 +61,7 @@ DEVIATION 3 -- NO LIST-LEVEL `skip_field`. The card donor selected cases with
 assumption that "nothing populates it today, so virtually every card is
 processed". That assumption is now false, and expensively so: 2,666 cases carry a
 populated template stub, so a field-presence skip would skip every single case
-this script exists to fix. Selection is `select_cases` plus per-case gates, and
+this script exists to fix. Selection is `select_for_run` plus per-case gates, and
 the short_description gate is the content-based adequacy judge
 (`casework/common/judge.py`), which is what can tell a 120-character grammatical
 Nepali stub from a real teaser.
@@ -131,7 +131,7 @@ from casework.common.llm import bootstrap, tier_for
 from casework.common.parse import parse_object_response
 from casework.common.pipeline import STAGES, RunReport, unmet_prerequisites
 from casework.common.review import ReviewRow, build_review_file
-from casework.common.select import court_number, select_cases
+from casework.common.select import court_number, select_for_run
 from casework.common.titles import (
     TITLE_RULES,
     title_has_headcount,
@@ -608,14 +608,11 @@ def main(argv=None):
         args, stage="card", field_name=f"{TITLE_FIELD} + {SHORT_FIELD}", run_id=run_id)
 
     all_cases = list(api.iter_cases())
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    # `select_for_run` is the one selection path every enricher shares (#410): it
+    # applies the --batch-csv allowlist, then the other selectors, then --limit --
+    # and it slices --limit in BATCH order, which a local `cases[:limit]` cannot
+    # do because the API's iteration order is not the CSV's.
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -129,7 +129,12 @@ from casework.common.format import format_bigo, format_entities, format_list
 from casework.common.judge import judge_description_adequacy
 from casework.common.llm import bootstrap, tier_for
 from casework.common.parse import parse_object_response
-from casework.common.pipeline import STAGES, RunReport, unmet_prerequisites
+from casework.common.pipeline import (
+    STAGES,
+    SUBSTANTIAL_DESCRIPTION_CHARS,
+    RunReport,
+    unmet_prerequisites,
+)
 from casework.common.review import ReviewRow, build_review_file
 from casework.common.select import court_number, select_for_run
 from casework.common.titles import (
@@ -162,6 +167,21 @@ CARD_MAX_TOKENS = 4000
 # editorial limit for a one-line teaser. See deviation 4.
 MAX_TITLE_CHARS = 200
 MAX_SHORT_DESCRIPTION_CHARS = 320
+
+#: The literal placeholders in the OUTPUT FORMAT example below. Named constants
+#: so the prompt and the vetting gate cannot drift apart.
+#:
+#: WHY THIS IS A WRITE GATE AND NOT A CURIOSITY. A cheap-tier model that echoes
+#: the example instead of answering it produces an object that passes every other
+#: check. `vet_title` catches the title half only by accident -- the example's
+#: case number never matches the case's own, so `validate_title` rejects it --
+#: but `short_description` has no format contract to violate, so nothing stopped
+#: "एक-वाक्य सारांश" ("one-sentence summary") from being PATCHed onto a public
+#: case card. Deviation 2 argues the cheap tier is safe here because "the two
+#: write gates are also unusually strong"; that was true of `title` and false of
+#: `short_description`.
+_TITLE_PLACEHOLDER = "नेपाली शीर्षक (080-CR-0047)"
+_SHORT_PLACEHOLDER = "एक-वाक्य सारांश"
 
 SYSTEM_PROMPT = (
     """\
@@ -201,8 +221,9 @@ a false impression is not.
 
 OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose.
 Include only the requested key(s); set an unrequested key to null:
-{"title": "नेपाली शीर्षक (080-CR-0047)", "short_description": "एक-वाक्य सारांश"}
 """
+    + f'{{"title": "{_TITLE_PLACEHOLDER}", '
+      f'"short_description": "{_SHORT_PLACEHOLDER}"}}\n'
 )
 
 USER_PROMPT = """\
@@ -457,10 +478,17 @@ def vet_short_description(candidate):
     An empty value is a rejection, not a write: `CaseListSerializer` ships this
     field with no fallback to title or description (`cases/serializers.py:320`),
     so writing "" renders a blank card on the public list.
+
+    The placeholder check is the only content gate this field has -- unlike
+    `title`, it has no format contract for `validate_title` to enforce. See
+    `_SHORT_PLACEHOLDER`.
     """
     short = (candidate or "").strip()
     if not short:
         return None, "LLM returned an empty short_description"
+    if _SHORT_PLACEHOLDER in short:
+        return None, ("echoed the OUTPUT FORMAT placeholder "
+                      f"({_SHORT_PLACEHOLDER!r}) instead of answering")
     if len(short) > MAX_SHORT_DESCRIPTION_CHARS:
         return None, f"too long: {len(short)} > {MAX_SHORT_DESCRIPTION_CHARS} chars"
     return short, None
@@ -687,6 +715,23 @@ def main(argv=None):
         number = court_number(detail)
 
         unmet = unmet_prerequisites(STAGE, detail)
+        # THE EMPTINESS TEST IS NOT ENOUGH, so the substance check belongs here --
+        # before the adequacy judge below, which is itself an LLM call and would
+        # otherwise be billed for a case that cannot be carded.
+        #
+        # `unmet_prerequisites` rejects `description` only when it is `None`, `""`,
+        # `[]` or `{}`. A whitespace-only description passes it and reaches the
+        # prompt as `DESCRIPTION: (none)`; a one-line template stub reaches it as
+        # the entire factual basis for a headline TITLE_RULES asks to name the
+        # principal accused with a quantifiable hook. Either way the model is asked
+        # for facts it was never given. An earlier comment here claimed a second
+        # check would be unreachable code -- that was wrong, and being wrong is the
+        # reason no guard existed.
+        substance = len((detail.get("description") or "").strip())
+        if not unmet and substance < SUBSTANTIAL_DESCRIPTION_CHARS:
+            unmet = [f"description is only {substance} chars, under the "
+                     f"{SUBSTANTIAL_DESCRIPTION_CHARS}-char threshold the "
+                     "description stage itself uses for a real description"]
         if unmet:
             for reason in unmet:
                 report.record(slug, "card", "unmet", reason)
@@ -740,11 +785,6 @@ def main(argv=None):
             review.add(ReviewRow(slug=slug, status="already", before=current_for_review,
                                  note="nothing to do (use --force)"))
             continue
-
-        # No blank-description guard here on purpose: `unmet_prerequisites` above
-        # already reported and skipped every such case, because
-        # `STAGES["card"].requires_fields` is `("description",)`. A second check
-        # would be unreachable code that reads like a live safety net.
 
         try:
             result = _generate(detail, number, need_title, need_short,

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -205,6 +205,20 @@ SHORT_DESCRIPTION RULES (when asked for it):
   (who/what/how much) at a glance.
 - Plain prose: no court number, no markdown, no headings, no bullets.
 - Neutral and factual, grounded in the provided data.
+- NEVER COMPRESS A SENTENCE OR AN AMOUNT INTO A DIFFERENT NUMBER. Copy every \
+duration, quantity and money figure in the form the description states it. \
+"२ वर्ष ६ महिना" is TWO AND A HALF YEARS; writing it "२.६ वर्ष" invents a number \
+the court never imposed and misstates a real person's prison sentence. If a figure \
+does not fit the character budget, drop it and keep the words — a shorter teaser is \
+always better than a wrong number. Never convert units, never round, never merge \
+two figures into a total.
+- DO NOT RELABEL WHAT MONEY WAS FOR. When a total is made of distinct components \
+— construction funds plus a double salary, say — do not attribute the whole sum to \
+one of them. Either name the component you are quoting or use the case's बिगो as \
+given, unlabelled.
+- ONE DIGIT SCRIPT PER FIELD. Nepali prose takes Devanagari numerals \
+(२०८०, रु. ३०,४२,३७८). A case number keeps its own form — "078-CR-0103", never \
+"07८-CR-0103". Mixing the two scripts inside one number is always an error.
 - STATE THE OUTCOME when the description reports one. If the case has been \
 decided — दोषी, सफाई, आंशिक सफाई, जरिवाना, कैद — say so, briefly, after the \
 allegation. A teaser that gives only the आरोप for a case that was already decided \

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -241,7 +241,14 @@ def _build_prompt(detail, number, need_title, need_short):
     return USER_PROMPT.format(
         request_note=request_note,
         current_title=detail.get("title") or "",
-        court_number=number or "(unknown)",
+        # UPPERCASED. The model copies this string into the title verbatim, and
+        # `court_number()` reads it off the canonical IRI, which is lowercase
+        # (`.../courtcase/special/081-cr-0060`). Feeding the lowercase form
+        # produced public headlines ending in `(081-cr-0060)` on 2 of 5 cases in
+        # the 2026-08-04 evaluation, against 50 of 50 PUBLISHED titles that use
+        # `(081-CR-0060)`. `validate_title` compares case-insensitively, so
+        # nothing rejected it -- the only fix is to hand the model the right form.
+        court_number=(number or "").upper() or "(unknown)",
         bigo=format_bigo(detail.get("bigo")),
         key_allegations=format_list(detail.get("key_allegations")),
         entities=format_entities(detail.get("entities")),
@@ -383,7 +390,7 @@ def _write_fields(ctx, accepted):
     a reachable state.
     """
     if not accepted:
-        return []
+        return
 
     if ctx.dry_run:
         for field, current, value in accepted:
@@ -391,7 +398,7 @@ def _write_fields(ctx, accepted):
             log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id,
                       stage="card", slug=ctx.slug, step=f"write:{field}",
                       status="would-enrich", detail=f"{field}={value}")
-        return []
+        return
 
     try:
         ctx.api.patch_fields(
@@ -404,14 +411,13 @@ def _write_fields(ctx, accepted):
             log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id,
                       stage="card", slug=ctx.slug, step=f"write:{field}",
                       status="error", detail=str(exc), level=logging.ERROR)
-        return []
+        return
 
     for field, current, value in accepted:
         _record(ctx, field, current, "enriched", value, value)
         log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
                   slug=ctx.slug, step=f"write:{field}", status="enriched",
                   detail=f"{field}={value}")
-    return [f for f, _, _ in accepted]
 
 
 def build_api(args):

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -27,7 +27,7 @@ and what makes the single-owner split affordable: `order_stages` runs
 `description` first and this picks up what it wrote, no charge sheet re-fetched.
 
 Ported from two donors at commit `0321a85`: `casework/enrich_card.py` (425 lines)
-and `casework/enrich_title.py` (283 lines). Four deliberate deviations:
+and `casework/enrich_title.py` (283 lines). Six deliberate deviations:
 
 DEVIATION 1 -- `enrich_title.py` IS NOT PORTED AS ITS OWN SCRIPT. It becomes
 `--only title`. The donor needed a separate script because `enrich_description`
@@ -80,6 +80,20 @@ whatever framing the provider wraps around the reply. The donor's 1000 was set
 against Latin-heavy expectations; it does not survive real Nepali output. 4000 is
 still half of `enrich_description`'s budget and cannot mask an over-length title,
 because `vet_title` rejects on characters, not tokens.
+
+DEVIATION 6 -- BOTH FIELDS GO IN ONE PATCH, NOT ONE PATCH EACH. The donor wrote
+each field with its own request. That cannot work against a server enforcing
+`If-Match`: the first PATCH changes the case's ETag, so the second one -- still
+carrying the ETag read at the top of the case -- fails with 412 every time. The
+2026-08-04 smoke run wrote `title` and lost `short_description` to
+"HTTP Error 412: Precondition Failed" on every case, so the script could never
+finish a card. No dry run can catch it; a dry run issues no PATCH and reports
+`would-enrich` for both fields. `_write_fields` now sends one multi-op document
+(`CaseworkApi.patch_fields`), which also makes the write atomic: a half-written
+card -- new headline, stale teaser -- is no longer reachable. Per-field
+INDEPENDENCE is unchanged and lives where it always belonged, in vetting: a title
+that fails `vet_title` is simply left out of the op list, and the teaser still
+lands.
 
 Usage:
     uv run python -m casework.enrich_card --dry-run
@@ -299,10 +313,13 @@ def vet_short_description(candidate):
 class _WriteContext:
     """Everything `_vet_and_write` needs that is the same for both fields.
 
-    A dataclass rather than a closure inside `main()`: the two fields go through
-    identical vet -> record -> log -> maybe-PATCH machinery, and writing that
-    twice is how the title path and the short_description path drift until one
-    of them forgets to pass `if_match` or forgets a review row.
+    A dataclass rather than a closure inside `main()`: both fields go through
+    identical vet -> record -> log machinery, and writing that twice is how the
+    title path and the short_description path drift until one of them forgets a
+    review row.
+
+    `etag` is read once per case and never rewritten -- the single multi-op PATCH
+    in `_write_fields` is the only write, so there is nothing to refresh.
     """
     api: object
     slug: str
@@ -316,69 +333,85 @@ class _WriteContext:
     events_path: str
 
 
-def _vet_and_write(ctx, field, current, candidate, vet):
-    """Vet one generated field value and write it, or record why it was refused.
+def _record(ctx, field, current, status, note, generated):
+    """One report row + one review row for one field's outcome.
 
-    Returns the written value, or None when nothing was written -- a rejection,
-    a dry run, and a failed PATCH all return None, because in all three cases
-    the server still holds `current`.
+    Shared by the vet and the write halves so a rejection and a successful write
+    cannot drift into describing themselves differently.
     """
-    def _record(status, note, generated):
-        ctx.report.record(ctx.slug, "card", status, f"{field}: {note}")
-        ctx.review.add(ReviewRow(
-            slug=ctx.slug, status=f"{status} ({field})", before=current,
-            generated=generated, sources=ctx.sources, note=note))
+    ctx.report.record(ctx.slug, "card", status, f"{field}: {note}")
+    ctx.review.add(ReviewRow(
+        slug=ctx.slug, status=f"{status} ({field})", before=current,
+        generated=generated, sources=ctx.sources, note=note))
 
+
+def _vet_field(ctx, field, current, candidate, vet):
+    """Vet one generated value. Returns it, or None when it was refused.
+
+    Vetting is deliberately separate from writing: a bad headline must not cost
+    the case its teaser, and that independence lives HERE, before any request is
+    made -- not in the number of PATCHes issued.
+    """
     value, rejection = vet(candidate)
     if rejection:
-        _record("rejected", rejection, (candidate or "").strip())
+        _record(ctx, field, current, "rejected", rejection,
+                (candidate or "").strip())
         log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
                   slug=ctx.slug, step=f"vet:{field}", status="rejected",
                   detail=rejection, level=logging.WARNING)
         return None
+    return value
+
+
+def _write_fields(ctx, accepted):
+    """Write every field that passed vetting in ONE conditional PATCH.
+
+    `accepted` is `[(field, current, value)]`.
+
+    WHY ONE REQUEST AND NOT ONE PER FIELD. A PATCH changes the case's ETag, so a
+    second request carrying the ETag read at the top of the case fails `If-Match`
+    with a 412 -- always. This script shipped as two `patch_field` calls and could
+    therefore never write both `title` and `short_description` in one pass: the
+    2026-08-04 smoke run wrote the title and took
+    "HTTP Error 412: Precondition Failed" on the teaser for every case. A dry run
+    cannot see it, because it issues no PATCH at all and reports `would-enrich`
+    for both.
+
+    Sending both ops in one request removes that failure rather than handling it,
+    and buys atomicity: the server applies the whole array against a single
+    snapshot, so a half-written card -- new headline, stale teaser -- stops being
+    a reachable state.
+    """
+    if not accepted:
+        return []
 
     if ctx.dry_run:
-        _record("would-enrich", value, value)
-        log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
-                  slug=ctx.slug, step=f"write:{field}", status="would-enrich",
-                  detail=f"{field}={value}")
-        return None
+        for field, current, value in accepted:
+            _record(ctx, field, current, "would-enrich", value, value)
+            log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id,
+                      stage="card", slug=ctx.slug, step=f"write:{field}",
+                      status="would-enrich", detail=f"{field}={value}")
+        return []
 
     try:
-        ctx.api.patch_field(ctx.slug, field, value, if_match=ctx.etag)
+        ctx.api.patch_fields(
+            ctx.slug, [(f, v) for f, _, v in accepted], if_match=ctx.etag)
     except Exception as exc:
-        _record("error", f"PATCH failed: {exc}", value)
-        log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
-                  slug=ctx.slug, step=f"write:{field}", status="error",
-                  detail=str(exc), level=logging.ERROR)
-        return None
+        # The write is atomic, so the failure is too: every field is reported
+        # failed, because the server holds `current` for all of them.
+        for field, current, value in accepted:
+            _record(ctx, field, current, "error", f"PATCH failed: {exc}", value)
+            log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id,
+                      stage="card", slug=ctx.slug, step=f"write:{field}",
+                      status="error", detail=str(exc), level=logging.ERROR)
+        return []
 
-    # RE-READ THE ETAG BEFORE THE NEXT FIELD. This script is the only ported
-    # enricher that issues TWO PATCHes for one case, and the first one changes
-    # the case's ETag -- so reusing the ETag captured before it makes the second
-    # write fail `If-Match` with a 412. Measured on the 2026-08-04 local smoke
-    # run: `title` landed, `short_description` died with
-    # "HTTP Error 412: Precondition Failed" on BOTH cases, meaning the script
-    # could never write both fields in one pass. The dry run cannot see this --
-    # it reports `would-enrich` for both and looks perfect.
-    #
-    # A failed refresh clears the ETag rather than keeping the stale one: an
-    # unconditional second write is a smaller problem than a guaranteed 412,
-    # and the case was just read, so the race window is the width of one PATCH.
-    try:
-        _, ctx.etag = ctx.api.get_case_with_etag(ctx.slug)
-    except Exception as exc:  # noqa: BLE001 -- the write already succeeded.
-        ctx.etag = None
+    for field, current, value in accepted:
+        _record(ctx, field, current, "enriched", value, value)
         log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
-                  slug=ctx.slug, step=f"etag:{field}", status="stale",
-                  detail=f"could not re-read ETag after writing {field}: {exc}",
-                  level=logging.WARNING)
-
-    _record("enriched", value, value)
-    log_event(ctx.logger, ctx.events_path, run_id=ctx.run_id, stage="card",
-              slug=ctx.slug, step=f"write:{field}", status="enriched",
-              detail=f"{field}={value}")
-    return value
+                  slug=ctx.slug, step=f"write:{field}", status="enriched",
+                  detail=f"{field}={value}")
+    return [f for f, _, _ in accepted]
 
 
 def build_api(args):
@@ -587,12 +620,21 @@ def main(argv=None):
             report=report, review=review, logger=logger, run_id=run_id,
             events_path=paths["events"],
         )
+        # Vet first, write once. Each field can still be refused on its own --
+        # what it cannot do any more is cost the other field a 412.
+        accepted = []
         if need_title:
-            _vet_and_write(ctx, TITLE_FIELD, current_title,
-                           result.get(TITLE_FIELD), lambda c: vet_title(c, number))
+            value = _vet_field(ctx, TITLE_FIELD, current_title,
+                               result.get(TITLE_FIELD),
+                               lambda c: vet_title(c, number))
+            if value is not None:
+                accepted.append((TITLE_FIELD, current_title, value))
         if need_short:
-            _vet_and_write(ctx, SHORT_FIELD, current_short,
-                           result.get(SHORT_FIELD), vet_short_description)
+            value = _vet_field(ctx, SHORT_FIELD, current_short,
+                               result.get(SHORT_FIELD), vet_short_description)
+            if value is not None:
+                accepted.append((SHORT_FIELD, current_short, value))
+        _write_fields(ctx, accepted)
 
     stats = report.summary()
     print_summary(stats, args.dry_run, "Card enrichment")

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -236,7 +236,10 @@ Bigo (बिगो), NPR: {bigo}
 KEY ALLEGATIONS:
 {key_allegations}
 
-NAMED ENTITIES (accused / related / location):
+NAMED ENTITIES (accused / related / location). A `फैसला:` label on an entity is
+that person's own outcome — use it to get a split verdict right. Any other trailing
+text is an INTERNAL caseworker note: read it for context, never quote or paraphrase
+it, and never treat it as a published fact.
 {entities}
 
 DESCRIPTION (snippet — the factual basis for both fields):
@@ -407,8 +410,8 @@ def _build_prompt(detail, number, need_title, need_short):
     )
 
 
-def _carries_a_field(obj):
-    """True when the object holds a NON-BLANK STRING on at least one card field.
+def _carries_a_field(obj, wanted=(TITLE_FIELD, SHORT_FIELD)):
+    """True when the object holds a NON-BLANK STRING on a field this run WANTS.
 
     Key presence is not enough, and this is the whole point. The system prompt
     tells the model to "set an unrequested key to null", so
@@ -418,21 +421,28 @@ def _carries_a_field(obj):
     reports two rejections ("LLM returned an empty ...") for a response whose
     REAL object may have been the next `{` along, behind a preamble.
 
-    Matches the contract `casework/common/titles.py::parse_title` documents for
-    the same reason.
+    `wanted` IS NOT DECORATION. Checking both fields unconditionally reopens the
+    same hole one field over: on an `--only title` run,
+    `{"title": null, "short_description": "..."}` satisfies "carries a field",
+    the scan stops there, and the title is then rejected at vetting ("LLM
+    returned no title") while the object that actually had one -- behind a
+    preamble the model added -- is never looked at. The predicate has to ask about
+    the fields the run can write, not about the union of both.
     """
     return any(
         isinstance(obj.get(field), str) and obj.get(field).strip()
-        for field in (TITLE_FIELD, SHORT_FIELD)
+        for field in wanted
     )
 
 
 def _generate(detail, number, need_title, need_short, invoke_text, usage):
     """One cheap-tier call producing whichever fields were asked for.
 
-    Returns the parsed dict, or None. Accepts an object carrying EITHER key --
-    a run asking only for a title gets `{"title": ..., "short_description":
-    null}`, so demanding both would reject every single-field reply.
+    Returns the parsed dict, or None. Accepts an object carrying any field this
+    run ASKED FOR -- a run wanting only a title gets `{"title": ...,
+    "short_description": null}`, so demanding both would reject every single-field
+    reply, and accepting either would let a null title through on an
+    `--only title` run. See `_carries_a_field`.
     """
     response_text = invoke_text(
         system=SYSTEM_PROMPT,
@@ -441,10 +451,26 @@ def _generate(detail, number, need_title, need_short, invoke_text, usage):
         tier=tier_for("card"),
         usage=usage,
     )
+    wanted = tuple(f for f, need in ((TITLE_FIELD, need_title),
+                                    (SHORT_FIELD, need_short)) if need)
+    # TWO PASSES, NARROW THEN BROAD. The narrow pass skips an object that carries
+    # only the field this run cannot write -- otherwise an `--only title` run
+    # accepts `{"title": null, "short_description": "..."}`, stops scanning, and
+    # reports "LLM returned no title" while the object that HAD one, behind a
+    # preamble, is never looked at.
+    #
+    # The broad pass exists so narrowing does not cost error precision. When the
+    # model's real answer carries the wanted field but leaves it BLANK, the narrow
+    # pass rejects it and, alone, would report "no card JSON object found" -- true
+    # of the predicate, misleading to an operator whose model actually returned an
+    # empty teaser. Falling back lets vetting name the real problem. Both passes
+    # are pure string work; neither costs an LLM call.
     result = parse_object_response(
         response_text,
-        predicate=_carries_a_field,
+        predicate=lambda obj: _carries_a_field(obj, wanted),
     )
+    if result is None:
+        result = parse_object_response(response_text, predicate=_carries_a_field)
     if result is None:
         log.warning("No card JSON object found in the LLM response")
     return result
@@ -701,6 +727,26 @@ def main(argv=None):
                                  note=f"detail fetch failed: {exc}"))
             log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
                       step="fetch", status="error", detail=str(exc),
+                      level=logging.ERROR)
+            continue
+
+        # A 200 THAT CARRIES NO ETag IS THE SAME HOLE AS A FAILED FETCH. The
+        # reasoning above guards the exception route, but `if_match` is only sent
+        # when it is truthy (`common/api.py`) and the server only checks it when
+        # present -- so a response that simply lacks the header (a proxy stripping
+        # it, a non-`retrieve` path) also produces an unconditional write, with no
+        # log line saying so. `cases/api_views.py` does set it today, which makes
+        # this latent rather than live; it is one check to close, and the argument
+        # above applies unchanged: a skipped case costs one re-run, a clobbered
+        # caseworker edit is unrecoverable.
+        if not etag:
+            reason = ("case detail returned no ETag; refusing to write "
+                      "unconditionally (would clobber a concurrent edit)")
+            report.record(slug, "card", "error", reason)
+            review.add(ReviewRow(slug=slug, status="error",
+                                 before=detail.get("title") or "", note=reason))
+            log_event(logger, paths["events"], run_id=run_id, stage="card", slug=slug,
+                      step="fetch", status="error", detail=reason,
                       level=logging.ERROR)
             continue
 

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -224,7 +224,11 @@ KEY ALLEGATIONS (already curated for this case):
 FACTUAL TIMELINE (already curated; dates are reliable — use for section ग etc.):
 {timeline}
 
-NAMED ENTITIES (accused / related / location):
+NAMED ENTITIES (accused / related / location). A `फैसला:` label on an entity is
+that person's own outcome — it is the authoritative per-defendant answer for
+section ग, so prefer it over inferring the split from the source prose. Any other
+trailing text is an INTERNAL caseworker note: read it for context, never quote or
+paraphrase it, and never treat it as a published fact.
 {entities}
 
 SOURCE DOCUMENTS (press release, charge sheet, verdict — the factual basis for
@@ -467,6 +471,7 @@ def main(argv=None):
         # matters more here than anywhere else -- a 412 means re-read and retry,
         # where an unconditional write would silently clobber the other writer.
         etag = None
+        fetch_ok = True
         try:
             detail, etag = api.get_case_with_etag(slug)
         except Exception as exc:
@@ -474,10 +479,29 @@ def main(argv=None):
             # case. The LIST-shaped payload still yields a well-formed "unmet"
             # reason below (unresolved material), never a crash. Widened from the
             # donor's `requests.HTTPError` because `CaseworkApi` is urllib-based.
+            fetch_ok = False
             detail = case
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="fetch", status="fallback", detail=str(exc),
                       level=logging.WARNING)
+
+        # A SUCCESSFUL FETCH THAT CARRIES NO ETag IS AN UNCONDITIONAL WRITE.
+        # `if_match` is sent only when truthy and the server checks it only when
+        # present, so a 200 missing the header (a proxy stripping it, a
+        # non-`retrieve` path) writes without a precondition and logs nothing about
+        # it. Scoped to `fetch_ok` so the donor fallback above is untouched: that
+        # path is meant to reach the unmet-material gate and report from there.
+        if fetch_ok and not etag:
+            reason = ("case detail returned no ETag; refusing to write "
+                      "unconditionally (would clobber a concurrent edit)")
+            report.record(slug, "description", "error", reason)
+            review.add(ReviewRow(slug=slug, status="error",
+                                 before=(detail.get("description") or "").strip(),
+                                 note=reason))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="fetch", status="error", detail=reason,
+                      level=logging.ERROR)
+            continue
 
         before = (detail.get("description") or "").strip()
 
@@ -587,6 +611,25 @@ def main(argv=None):
                                  note=source_note))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="write", status="would-enrich", detail=detail_msg)
+            continue
+
+        # THE BACKSTOP FOR THE FALLBACK ROUTE. The fetch-time guard above is
+        # scoped to a successful fetch, which leaves the donor fallback
+        # (`detail = case`, `etag = None`) able to reach a write. Today the
+        # unmet-material gate stops it, because a LIST payload carries
+        # `material: null` -- but that is an accident of the list serializer, not
+        # a precondition, and it is the same "safe by accident" reasoning
+        # `enrich_card` refuses to rely on. One check, at the only write.
+        if not etag:
+            reason = ("no ETag for this case; refusing an unconditional write "
+                      "(would clobber a concurrent edit)")
+            report.record(slug, "description", "error", reason)
+            review.add(ReviewRow(slug=slug, status="error", before=before,
+                                 generated=description, sources=fed,
+                                 note="; ".join(filter(None, (reason, source_note)))))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="write", status="error", detail=reason,
+                      level=logging.ERROR)
             continue
 
         try:

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -270,6 +270,35 @@ def _ordered_sources(chunks):
     return sorted(chunks, key=key)
 
 
+def _allocate_budget(sizes, budget):
+    """Chars each source may spend, max-min fair. Returns a list parallel to `sizes`.
+
+    WHY NOT GREEDY. The previous version walked the sources in PRIORITY order and
+    gave each one whatever was left, so one huge document consumed the whole
+    budget and every later source was dropped outright. Measured on
+    `081-CR-0138`: a 529,947-char charge sheet took all 60,000 and the case's
+    4,185-char press release -- 7% of the budget, and the most concise account of
+    the case that exists -- was dropped entirely. The model saw 11% of one
+    document and nothing of the other.
+
+    Allocating smallest-first fixes that without a magic reserve: each source
+    claims an equal share of what remains, and a source smaller than its share
+    returns the surplus to the pool for the larger ones. Small documents are
+    therefore never starved, and the big ones still absorb everything left over
+    -- with two sources and a 60,000 budget the press release takes its 4,185 and
+    the charge sheet gets the remaining 55,815.
+    """
+    allowance = [0] * len(sizes)
+    remaining = budget
+    # Ascending, so the smallest claims first and its surplus flows upward.
+    for n, i in enumerate(sorted(range(len(sizes)), key=lambda i: sizes[i])):
+        left = len(sizes) - n
+        take = min(sizes[i], remaining // left)
+        allowance[i] = take
+        remaining -= take
+    return allowance
+
+
 def _assemble_source_text(chunks, invoke_text, usage):
     """Build the source-document block within SOURCE_TEXT_BUDGET.
 
@@ -296,15 +325,15 @@ def _assemble_source_text(chunks, invoke_text, usage):
         prepared.append((mtype, iri, text))
 
     parts, fed = [], []
-    remaining = SOURCE_TEXT_BUDGET
-    for label, iri, text in prepared:
-        if remaining <= 0:
+    allowance = _allocate_budget([len(text) for _, _, text in prepared],
+                                SOURCE_TEXT_BUDGET)
+    for i, (label, iri, text) in enumerate(prepared):
+        if allowance[i] <= 0:
             log.warning("Source budget spent; dropped a %s source", label)
-            break
-        chunk = _clamp(text, remaining, label)
+            continue
+        chunk = _clamp(text, allowance[i], label)
         parts.append(f"[{label}]\n{chunk}")
         fed.append((label, iri, chunk))
-        remaining -= len(chunk)
     return "\n\n---\n\n".join(parts), fed
 
 

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -80,6 +80,7 @@ from casework.common.cli import (
     print_summary,
     setup_logging,
 )
+from casework.common.format import format_bigo, format_entities, format_list
 from casework.common.llm import bootstrap, tier_for
 from casework.common.materials import source_chunks
 from casework.common.parse import parse_object_response
@@ -254,37 +255,6 @@ def _clamp(text: str, limit: int, label: str = "source") -> str:
     return sent
 
 
-def _format_bigo(value) -> str:
-    """Donor-verbatim बिगो display string."""
-    return f"रु {value:,}" if value else "उल्लेख छैन"
-
-
-def _format_list(items) -> str:
-    """Numbered Nepali-friendly rendering of a case's string list field."""
-    entries = [str(i).strip() for i in (items or []) if str(i or "").strip()]
-    if not entries:
-        return "(none)"
-    return "\n".join(f"{n}. {e}" for n, e in enumerate(entries, 1))
-
-
-def _format_entities(entities) -> str:
-    """One line per linked entity: role, name, IRI.
-
-    The payload is a list of `{entity_iri, role, ...}` dicts (see
-    `cases/serializers.py`); a non-dict entry is skipped rather than crashing
-    prompt assembly.
-    """
-    lines = []
-    for e in entities or []:
-        if not isinstance(e, dict):
-            continue
-        role = e.get("role") or "?"
-        iri = e.get("entity_iri") or ""
-        name = e.get("name") or e.get("label") or iri.rsplit("/", 1)[-1]
-        lines.append(f"- [{role}] {name} ({iri})" if iri else f"- [{role}] {name}")
-    return "\n".join(lines) or "(none)"
-
-
 def _ordered_sources(chunks):
     """Sort `source_chunks` triples into `DESCRIPTION_SOURCE_ORDER`.
 
@@ -343,11 +313,11 @@ def _generate_description(detail, court_number, source_text, invoke_text, usage)
     prompt = EXTRACTION_USER_PROMPT.format(
         case_title=detail.get("title") or "",
         court_number=court_number or "(unknown)",
-        bigo=_format_bigo(detail.get("bigo")),
+        bigo=format_bigo(detail.get("bigo")),
         court_cases=", ".join(detail.get("court_cases") or []) or "(none)",
-        key_allegations=_format_list(detail.get("key_allegations")),
+        key_allegations=format_list(detail.get("key_allegations")),
         timeline=json.dumps(detail.get("timeline") or [], ensure_ascii=False),
-        entities=_format_entities(detail.get("entities")),
+        entities=format_entities(detail.get("entities")),
         source_text=source_text,
     )
     response_text = invoke_text(

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python
+"""Write the public case narrative `Case.description` via LLM (DB-free). LOCAL WRITES ONLY.
+
+Ported from the deleted `casework/enrich_description.py` (recovered at donor commit
+`0321a85`, 619 lines). Reads a case's charge sheet, CIAA press release and Special
+Court verdict entirely over the Jawafdehi HTTP API and asks the premium LLM tier for
+the अभियोगदावी / बयान / फैसला structure of https://github.com/Jawafdehi/JawafdehiAPI/issues/199.
+Never touches the database directly -- writes go through `CaseworkApi.patch_field`,
+which this project's binding constraint restricts to loopback (`127.0.0.1:48010`).
+
+It is the field production is emptiest on: 188 of 3,003 cases carry a description.
+
+ONE FIELD. This script writes `description` and NOTHING else -- see the three
+deliberate deviations from the donor below.
+
+DEVIATION 1 -- THE DONOR'S TITLE PASS IS DROPPED. The donor regenerated
+`Case.title` in the same LLM call, gated by `--skip-title`, because it had the
+source documents in hand and the title came free. `title` now has exactly one
+owner, `casework/enrich_card.py`. So `--skip-title`, the `TITLE_RULES` import from
+`casework/common/titles.py`, `validate_title`, `title_has_headcount` and the
+`"title"` key in the response contract are all gone, and `STAGES["description"]
+.provides` is `("description",)` alone. What that buys: one prompt holding the
+title rules instead of two, one answer to "why does this case have this title",
+and a title that can be regenerated without re-fetching charge sheets. What it
+costs: one extra cheap LLM call per case, since `enrich_card` reads the
+`description` this script just wrote. `test_never_writes_title` pins it.
+
+DEVIATION 2 -- `invoke_text`, NOT the donor's `invoke_with_tools` +
+`convert_date` tool. Two reasons, in order of weight:
+  1. The donor passed the tool but never told the model it existed. Compare
+     `enrich_timeline.py`'s `EXTRACTION_SYSTEM_PROMPT`, which spends a 12-line
+     "DATE CONVERSION TOOL (MANDATORY)" block on it, against the donor's
+     description prompt, which mentions dates only under QUALITY RULES and never
+     names the tool. An unadvertised tool in a prose-generation call is a
+     tool-loop the model has no reason to enter.
+  2. This stage emits prose, not structured dates. Every date reaching it is
+     already converted -- the FACTUAL TIMELINE block carries `date` (AD) and
+     `date_bs` written by `enrich_timeline`, which DID use the tool -- or is
+     copied verbatim from a source document, where the correct behaviour is to
+     leave the BS date exactly as written.
+A single-turn call is also the cheaper shape: `invoke_with_tools` bills every
+turn of the loop, and this is the most expensive call in the casework pipeline.
+The safety pairing for removing the tool is one added QUALITY RULE forbidding the
+model from converting dates itself; without it, dropping the tool would invite
+exactly the silent BS<->AD arithmetic error the tool existed to prevent.
+
+DEVIATION 3 -- THE DONOR'S NGM SECTION IS NOT PORTED. The donor fetched
+`GET /ngm/court_case/{special:NNN-CR-NNNN}` and formatted it as a prompt block.
+That path is doubly dead and `casework/enrich_timeline.py` documents the
+measurements: the colon-prefixed `special:` reference it scans for matches 0 of
+109 real `court_cases` entries (they are full IRIs), and the endpoint itself was
+removed in the 2026-07-01 hard cut of `config/urls.py`. `enrich_timeline` kept its
+copy dead-but-intact for a port-vs-donor A/B that this task has no part in;
+porting an unreachable HTTP call a second time would add a code path no run can
+enter. Prompt-identical on current data either way: the donor's `{ngm_section}`
+renders to the empty string whenever the fetch returns None, which is always.
+
+Usage:
+    uv run python -m casework.enrich_description --dry-run
+    uv run python -m casework.enrich_description --slug case-0123
+    uv run python -m casework.enrich_description --limit 3 --verbose
+    uv run python -m casework.enrich_description --apply
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from typing import Optional
+
+from casework.common.api import CaseworkApi
+from casework.common.cli import (
+    add_common_args,
+    basic_auth_from_env,
+    configure_run_logging,
+    log_event,
+    log_run_footer,
+    log_run_header,
+    print_summary,
+    setup_logging,
+)
+from casework.common.llm import bootstrap, tier_for
+from casework.common.materials import source_chunks
+from casework.common.parse import parse_object_response
+from casework.common.pipeline import (
+    COURT_TYPES,
+    PRESS_TYPES,
+    STAGES,
+    RunReport,
+    unmet_prerequisites,
+)
+from casework.common.review import ReviewRow, build_review_file
+from casework.common.select import court_number, select_cases
+
+# `summarize_verdict` and its four donor-pinned constants are imported from the
+# timeline enricher rather than re-copied. The donor kept them in the shared
+# `casework/common.py`; on `main` they landed in `enrich_timeline.py` only
+# because that was the sole enricher in their porting task's scope, and
+# `tests/casework/test_enrich_timeline.py` now asserts each constant against
+# the donor source. A second copy here would be four more numbers free to
+# drift from that pin. Their proper home is `casework/common/`; moving them is
+# a separate change, not this port's business.
+from casework.enrich_timeline import (
+    VERDICT_SUMMARY_TARGET,
+    VERDICT_SUMMARY_TRIGGER,
+    summarize_verdict,
+)
+
+log = logging.getLogger("casework.enrich_description")
+
+STAGE = STAGES["description"]
+
+# Source types ordered by usefulness for the description, richest first --
+# the donor's `DESCRIPTION_SOURCE_TYPES` mapped onto the current material
+# vocabulary (`casework/common/pipeline.py`). The donor's AG_ABHIYOG_PATRA is
+# today's `charge_sheet` and it stays first: it is the prosecution claim
+# verbatim, which is what section क is. The verdict comes last because it is
+# also the one that gets summarised rather than passed through whole.
+DESCRIPTION_SOURCE_ORDER = ("charge_sheet", "ciaa_press_release", "press_release",
+                            "court_order")
+
+# The donor read this from `CASEWORK_SOURCE_TEXT_BUDGET` via an `env_int()`
+# helper that lived in the deleted `casework/common.py` and was never
+# re-created in the common package -- same treatment as every sibling
+# enricher (see `enrich_allegations.py`'s identical note). Fixed at the
+# donor's own default.
+SOURCE_TEXT_BUDGET = 60000
+DESCRIPTION_MAX_TOKENS = 8000
+
+# Donor-verbatim idempotency threshold (`_has_substantial_description`): a
+# description shorter than this is a stub, not a description. Content-based on
+# purpose -- an emptiness test would treat a one-line template stub as done.
+SUBSTANTIAL_DESCRIPTION_CHARS = 600
+
+EXTRACTION_SYSTEM_PROMPT = """\
+You are a Nepali legal analyst writing the public case summary (description) for \
+Jawafdehi, a civic accountability archive of Nepal's anti-corruption cases. The \
+case was investigated by the CIAA (अख्तियार दुरुपयोग अनुसन्धान आयोग) and tried at \
+the Special Court (विशेष अदालत).
+
+You will be given the case's key allegations, factual timeline, bigo (बिगो) \
+amount, named entities, and the full text of the source documents (CIAA press \
+release, charge sheet/अभियोगपत्र, and Special Court verdict/फैसला). Write a \
+faithful, well-structured Markdown description.
+
+LANGUAGE: Write in formal Nepali (देवनागरी), matching the register of the court \
+and government source documents. Keep technical, proper, and forensic terms in \
+their original form (English where the source uses English — e.g. "CR", \
+"Common Authorship", company names, "forensic") rather than forcing a translation.
+
+STRUCTURE — use these Markdown sections, in this order, but ONLY include a \
+section when the sources actually support it (omit sections with no grounding; \
+never invent content to fill one):
+
+### क) अभियोगदावीको सार
+The prosecution's claim: the core facts, how they breach the law (cite the
+ऐन/दफा when the sources state them), the evidence the CIAA relied on, the persons
+involved, the बिगो, and the punishment sought. When the CIAA lays out distinct
+grounds/findings, present them as a numbered list (**१.** … **२.** …). When there
+are multiple defendants with per-person amounts or demands, present them as a
+Markdown table (प्रतिवादी | भूमिका/अभियोग | बिगो | मागदावी).
+
+### ख) प्रतिवादीको बयानको सार
+For EACH defendant, summarise their statement (बयान) before the authorised
+authority or the court in at least ~100 words: whether they admit (स्वीकार) or
+deny (इन्कार) the allegation and their reasoning. With several defendants, use a
+Markdown table (क्र.सं | प्रतिवादी | भूमिका | बयानको सार).
+
+### ग) विशेष अदालतको फैसलाको सार
+The verdict: the judgment date, the bench (इजलास / न्यायाधीशहरू), and the outcome
+for each defendant (दोषी / सफाई), with the बिगो/sentence and the court's key
+reasoning. Do NOT include procedural or registry orders — the appeal म्याद
+(e.g. "३५ दिनभित्र पुनरावेदन गर्न"), धरौटी सदर/फिर्ता, लगत कायम, and similar routine
+"अन्य आदेश" are court-procedure, not the substantive फैसला; leave them out. A
+विशेष अदालत ruling does NOT set precedent, so do not call its reasoning a नजिर here.
+
+### घ) पुनरावेदनको सार
+Only if the sources or a supreme-court reference show an appeal was ACTUALLY
+filed: the grounds and legal basis of the appeal and who filed it. The routine
+appeal म्याद granted in the verdict (e.g. "३५ दिनभित्र पुनरावेदन गर्न जाने") is NOT
+an appeal — do not emit this section for it; OMIT the section entirely unless an
+appeal was really lodged.
+
+### ङ) सर्वोच्च अदालतको फैसलाको सार
+Only if a Supreme Court judgment is in the sources: date, bench, and final
+outcome.
+
+### च) नजिरको सार
+Include ONLY when a सर्वोच्च अदालत (Supreme Court) judgment in the sources
+establishes a legal principle — ideally one published in the Nepal Kanoon Patrika
+(नेपाल कानून पत्रिका). A विशेष अदालत (Special Court) decision is NEVER a precedent;
+if no qualifying Supreme Court principle is in the sources, OMIT this section
+entirely. State only the key principle.
+
+QUALITY RULES:
+- Ground every sentence in the provided sources/case data. Do NOT fabricate
+  names, amounts, section numbers, dates, benches, or outcomes. If the verdict is
+  not in the sources, write section ग only to the extent the timeline/NGM data
+  supports (e.g. "मिति … मा फैसला भएको") and omit unknown specifics.
+- Prefer specifics from the documents (exact बिगो, दफा, र.नं./नि.नं., dates,
+  named officials) over vague phrasing.
+- Use the बिगो figure provided in the case data as the headline amount.
+- DATES: write every date exactly as its source states it — a BS date stays in
+  BS, as written. Do NOT convert between BS (Bikram Sambat) and AD yourself.
+  Such a conversion done in your head is wrong by days or months often enough
+  that the converted date is a fabricated fact. The FACTUAL TIMELINE below
+  already carries both the AD date and the BS date where you need the pair.
+- This is an official public record drawn from government/court documents; do not
+  soften, editorialise, or add commentary. Neutral, factual tone only.
+
+OUTPUT FORMAT — return ONLY a single JSON object, no markdown fences, no prose:
+{"description": "### क) …\\n…"}
+"""
+
+EXTRACTION_USER_PROMPT = """\
+Write the Jawafdehi case description for the following CIAA Special Court case.
+
+Case title: {case_title}
+Special-court case number: {court_number}
+Bigo (बिगो), NPR: {bigo}
+Court case references: {court_cases}
+
+KEY ALLEGATIONS (already curated for this case):
+{key_allegations}
+
+FACTUAL TIMELINE (already curated; dates are reliable — use for section ग etc.):
+{timeline}
+
+NAMED ENTITIES (accused / related / location):
+{entities}
+
+SOURCE DOCUMENTS (press release, charge sheet, verdict — the factual basis for
+the description; quote specifics from here):
+
+{source_text}
+
+Return ONLY the JSON object described in the system prompt.
+"""
+
+
+def _clamp(text: str, limit: int, label: str = "source") -> str:
+    """Truncate `text` to `limit` chars (<=0 = no limit) and PRINT total vs sent,
+    matching the convention every sibling enricher already follows (an operator
+    can see how much of each source actually reached the model). Kept local, as
+    in `enrich_allegations.py` / `enrich_timeline.py` / `enrich_missing_bigo.py`
+    -- consolidating the four copies into `casework/common/` is a separate
+    change that would touch three enrichers this port has no reason to edit."""
+    text = text or ""
+    total = len(text)
+    sent = text if (limit <= 0 or total <= limit) else text[:limit]
+    note = "" if len(sent) == total else f"  (capped at {limit:,})"
+    print(f"    {label}: {total:,} total chars, sent {len(sent):,}{note}")
+    return sent
+
+
+def _format_bigo(value) -> str:
+    """Donor-verbatim बिगो display string."""
+    return f"रु {value:,}" if value else "उल्लेख छैन"
+
+
+def _format_list(items) -> str:
+    """Numbered Nepali-friendly rendering of a case's string list field."""
+    entries = [str(i).strip() for i in (items or []) if str(i or "").strip()]
+    if not entries:
+        return "(none)"
+    return "\n".join(f"{n}. {e}" for n, e in enumerate(entries, 1))
+
+
+def _format_entities(entities) -> str:
+    """One line per linked entity: role, name, IRI.
+
+    The payload is a list of `{entity_iri, role, ...}` dicts (see
+    `cases/serializers.py`); a non-dict entry is skipped rather than crashing
+    prompt assembly.
+    """
+    lines = []
+    for e in entities or []:
+        if not isinstance(e, dict):
+            continue
+        role = e.get("role") or "?"
+        iri = e.get("entity_iri") or ""
+        name = e.get("name") or e.get("label") or iri.rsplit("/", 1)[-1]
+        lines.append(f"- [{role}] {name} ({iri})" if iri else f"- [{role}] {name}")
+    return "\n".join(lines) or "(none)"
+
+
+def _ordered_sources(chunks):
+    """Sort `source_chunks` triples into `DESCRIPTION_SOURCE_ORDER`.
+
+    A material type outside that list keeps its original relative position at
+    the end rather than being dropped -- an unexpected type is still evidence.
+    """
+    def key(item):
+        mtype = item[0]
+        return (DESCRIPTION_SOURCE_ORDER.index(mtype)
+                if mtype in DESCRIPTION_SOURCE_ORDER
+                else len(DESCRIPTION_SOURCE_ORDER))
+
+    return sorted(chunks, key=key)
+
+
+def _assemble_source_text(chunks, invoke_text, usage):
+    """Build the source-document block within SOURCE_TEXT_BUDGET.
+
+    Returns `(prompt_block, fed_sources)` where `fed_sources` is the
+    `[(label, material_iri, text)]` actually sent to the model -- the review
+    file prints those, so it must reflect the post-summarisation,
+    post-truncation reality rather than what was fetched.
+
+    A long verdict is SUMMARISED rather than head-truncated: the ठहर sits at
+    the end of a फैसला, so a head clamp is exactly the truncation that drops
+    the outcome section ग exists to report.
+    """
+    prepared = []
+    for mtype, iri, text in _ordered_sources(chunks):
+        if mtype in COURT_TYPES and len(text) > VERDICT_SUMMARY_TRIGGER:
+            summary = summarize_verdict(text, invoke_text, usage)
+            if summary:
+                log.info("Verdict summarised: %d -> %d chars", len(text), len(summary))
+                prepared.append((f"{mtype} (फैसला सारांश)", iri, summary))
+                continue
+            # Summary failed -- fall back to the donor's truncated head.
+            prepared.append((mtype, iri, text[:VERDICT_SUMMARY_TARGET]))
+            continue
+        prepared.append((mtype, iri, text))
+
+    parts, fed = [], []
+    remaining = SOURCE_TEXT_BUDGET
+    for label, iri, text in prepared:
+        if remaining <= 0:
+            log.warning("Source budget spent; dropped a %s source", label)
+            break
+        chunk = _clamp(text, remaining, label)
+        parts.append(f"[{label}]\n{chunk}")
+        fed.append((label, iri, chunk))
+        remaining -= len(chunk)
+    return "\n\n---\n\n".join(parts), fed
+
+
+def _generate_description(detail, court_number, source_text, invoke_text, usage):
+    """One premium-tier call. Returns the description string, or None."""
+    prompt = EXTRACTION_USER_PROMPT.format(
+        case_title=detail.get("title") or "",
+        court_number=court_number or "(unknown)",
+        bigo=_format_bigo(detail.get("bigo")),
+        court_cases=", ".join(detail.get("court_cases") or []) or "(none)",
+        key_allegations=_format_list(detail.get("key_allegations")),
+        timeline=json.dumps(detail.get("timeline") or [], ensure_ascii=False),
+        entities=_format_entities(detail.get("entities")),
+        source_text=source_text,
+    )
+    response_text = invoke_text(
+        system=EXTRACTION_SYSTEM_PROMPT,
+        content=prompt,
+        max_tokens=DESCRIPTION_MAX_TOKENS,
+        tier=tier_for("description"),
+        usage=usage,
+    )
+    return _parse_description_response(response_text)
+
+
+def _parse_description_response(response_text: str) -> Optional[str]:
+    """Pull `description` out of the JSON object reply.
+
+    A `title` key in the reply is IGNORED, not written -- see deviation 1. The
+    model can still emit one (the OUTPUT FORMAT block does not ask for it, but
+    models volunteer keys); silently dropping it here is what makes the
+    single-owner rule hold even against a chatty response.
+    """
+    obj = parse_object_response(response_text, "description")
+    if obj is None:
+        log.warning("No JSON object with a description found in the LLM response")
+        return None
+    description = (obj.get("description") or "").strip()
+    return description or None
+
+
+def _has_substantial_description(case: dict) -> bool:
+    """Donor-verbatim: a description at/over the threshold counts as done."""
+    return len((case.get("description") or "").strip()) >= SUBSTANTIAL_DESCRIPTION_CHARS
+
+
+def build_api(args):
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
+    if args.api_token:
+        return CaseworkApi(
+            args.api_base_url, token=args.api_token,
+            allow_remote_writes=args.allow_remote_writes,
+        )
+    return CaseworkApi(
+        args.api_base_url,
+        basic=basic_auth_from_env(),
+        allow_remote_writes=args.allow_remote_writes,
+    )
+
+
+def main(argv=None):
+    """Main entry point."""
+    ap = argparse.ArgumentParser(
+        description="Write CIAA Special Court case descriptions via LLM (DB-free).",
+        epilog="Reads/writes cases entirely over the Jawafdehi HTTP API.",
+    )
+    add_common_args(ap)
+    args = ap.parse_args(argv)
+
+    setup_logging(args.verbose)
+    logger, run_id, paths = configure_run_logging("description", verbose=args.verbose)
+    start_time = time.monotonic()
+
+    # Bootstrap Django + LLM (MUST come before importing llm.invoke)
+    try:
+        bootstrap(args.provider, args.model)
+    except Exception as exc:
+        print(f"Bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    from llm.invoke import invoke_text
+    from llm.usage import UsageAccumulator, render_usage_table
+
+    api = build_api(args)
+    usage = UsageAccumulator()
+    report = RunReport()
+    review = build_review_file(
+        args, stage="description", field_name="description", run_id=run_id)
+
+    all_cases = list(api.iter_cases())
+    cases = select_cases(
+        all_cases,
+        fiscal_year=args.fiscal_year,
+        slugs=args.slug,
+        court_cases=args.court_case,
+    )
+    if args.limit:
+        cases = cases[: args.limit]
+
+    total = len(cases)
+    log_run_header(
+        logger, stage="description", base_url=args.api_base_url, dry_run=args.dry_run,
+        provider=args.provider, model=args.model, n_selected=total,
+        run_id=run_id, paths=paths,
+    )
+    if total == 0:
+        print("No matching CIAA case(s) to process.", file=sys.stderr)
+        print_summary(report.summary(), args.dry_run, "Description generation")
+        print(f"review file: {review.write()}")
+        log_run_footer(
+            logger, stage="description", stats=report.summary(),
+            duration_s=time.monotonic() - start_time,
+        )
+        return report
+
+    print(f"Found {total} matching case(s).")
+    if args.force:
+        print("  --force: re-generating even for populated cases")
+    if args.dry_run:
+        print("  [DRY RUN] No changes will be saved.")
+
+    for idx, case in enumerate(cases, 1):
+        slug = case.get("slug") or "?"
+        title = case.get("title") or ""
+        log_event(logger, paths["events"], run_id=run_id, stage="description", slug=slug,
+                  step="start", status="start", detail=f"[{idx}/{total}] {title[:80]}")
+
+        # `get_case_with_etag` in place of `get_case`: the ETag is echoed back as
+        # `If-Match` on the PATCH below. A description is the most expensive
+        # output in the pipeline, so losing it to a concurrent caseworker edit
+        # matters more here than anywhere else -- a 412 means re-read and retry,
+        # where an unconditional write would silently clobber the other writer.
+        etag = None
+        try:
+            detail, etag = api.get_case_with_etag(slug)
+        except Exception as exc:
+            # Donor-preserved fallback: a detail-fetch failure does not abort the
+            # case. The LIST-shaped payload still yields a well-formed "unmet"
+            # reason below (unresolved material), never a crash. Widened from the
+            # donor's `requests.HTTPError` because `CaseworkApi` is urllib-based.
+            detail = case
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="fetch", status="fallback", detail=str(exc),
+                      level=logging.WARNING)
+
+        before = (detail.get("description") or "").strip()
+
+        if _has_substantial_description(detail) and not args.force:
+            reason = f"description already {len(before):,} chars"
+            report.record(slug, "description", "already", reason)
+            review.add(ReviewRow(slug=slug, status="already", before=before, note=reason))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="idempotency", status="already", detail=reason)
+            continue
+
+        unmet = unmet_prerequisites(STAGE, detail)
+        if unmet:
+            for reason in unmet:
+                report.record(slug, "description", "unmet", reason)
+            review.add(ReviewRow(slug=slug, status="unmet", before=before,
+                                 note="; ".join(unmet)))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="prereq", status="unmet", detail="; ".join(unmet),
+                      level=logging.WARNING)
+            continue
+
+        chunks, text_unmet = source_chunks(detail, types=PRESS_TYPES + COURT_TYPES)
+        if not chunks:
+            reasons = text_unmet or ["no press-release or court-order source text"]
+            for reason in reasons:
+                report.record(slug, "description", "unmet", reason)
+            review.add(ReviewRow(slug=slug, status="unmet", before=before,
+                                 note="; ".join(reasons)))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="source", status="unmet",
+                      detail="; ".join(reasons), level=logging.WARNING)
+            continue
+
+        log_event(logger, paths["events"], run_id=run_id, stage="description", slug=slug,
+                  step="source", status="ok",
+                  detail=f"{len(chunks)} source(s): "
+                         + ", ".join(f"{t}({len(x):,})" for t, _, x in chunks))
+
+        try:
+            source_block, fed = _assemble_source_text(chunks, invoke_text, usage)
+        except Exception as exc:
+            report.record(slug, "description", "error", f"source assembly failed: {exc}")
+            review.add(ReviewRow(slug=slug, status="error", before=before,
+                                 note=f"source assembly failed: {exc}"))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="assemble", status="error", detail=str(exc),
+                      level=logging.ERROR)
+            continue
+
+        try:
+            description = _generate_description(
+                detail=detail,
+                court_number=court_number(detail),
+                source_text=source_block,
+                invoke_text=invoke_text,
+                usage=usage,
+            )
+        except Exception as exc:
+            report.record(slug, "description", "error", f"LLM generation failed: {exc}")
+            review.add(ReviewRow(slug=slug, status="error", before=before, sources=fed,
+                                 note=f"LLM generation failed: {exc}"))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="generate", status="error", detail=str(exc),
+                      level=logging.ERROR)
+            if args.verbose:
+                import traceback
+
+                traceback.print_exc()
+            continue
+
+        if not description:
+            report.record(slug, "description", "skipped", "LLM returned no description")
+            review.add(ReviewRow(slug=slug, status="skipped", before=before, sources=fed,
+                                 note="LLM returned no description"))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="generate", status="skipped",
+                      detail="LLM returned no description", level=logging.WARNING)
+            continue
+
+        detail_msg = f"description={len(description):,} chars"
+        log_event(logger, paths["events"], run_id=run_id, stage="description", slug=slug,
+                  step="generate", status="ok", detail=detail_msg)
+
+        if args.dry_run:
+            report.record(slug, "description", "would-enrich", detail_msg)
+            review.add(ReviewRow(slug=slug, status="would-enrich", before=before,
+                                 generated=description, sources=fed))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="write", status="would-enrich", detail=detail_msg)
+            continue
+
+        try:
+            api.patch_field(slug, "description", description, if_match=etag)
+            report.record(slug, "description", "enriched", detail_msg)
+            review.add(ReviewRow(slug=slug, status="enriched", before=before,
+                                 generated=description, sources=fed))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="write", status="enriched", detail=detail_msg)
+        except Exception as exc:
+            report.record(slug, "description", "error", f"PATCH failed: {exc}")
+            review.add(ReviewRow(slug=slug, status="error", before=before,
+                                 generated=description, sources=fed,
+                                 note=f"PATCH failed: {exc}"))
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="write", status="error", detail=str(exc),
+                      level=logging.ERROR)
+
+    stats = report.summary()
+    print_summary(stats, args.dry_run, "Description generation")
+    unmet_reasons = report.unmet_reasons()
+    if unmet_reasons:
+        print("  unmet reasons:")
+        for reason, count in unmet_reasons.most_common():
+            print(f"    {count} x {reason}")
+
+    usage_summary = ""
+    if usage.calls > 0:
+        usage_summary = render_usage_table(
+            usage.as_dict()["by_provider"], title="description usage")
+        print()
+        print(usage_summary)
+
+    print(f"review file: {review.write()}")
+
+    log_run_footer(
+        logger, stage="description", stats=stats,
+        duration_s=time.monotonic() - start_time, usage_summary=usage_summary,
+    )
+
+    return report
+
+
+if __name__ == "__main__":
+    main()

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -88,6 +88,7 @@ from casework.common.pipeline import (
     COURT_TYPES,
     PRESS_TYPES,
     STAGES,
+    SUBSTANTIAL_DESCRIPTION_CHARS,
     RunReport,
     unmet_prerequisites,
 )
@@ -128,11 +129,6 @@ DESCRIPTION_SOURCE_ORDER = ("charge_sheet", "ciaa_press_release", "press_release
 # donor's own default.
 SOURCE_TEXT_BUDGET = 60000
 DESCRIPTION_MAX_TOKENS = 8000
-
-# Donor-verbatim idempotency threshold (`_has_substantial_description`): a
-# description shorter than this is a stub, not a description. Content-based on
-# purpose -- an emptiness test would treat a one-line template stub as done.
-SUBSTANTIAL_DESCRIPTION_CHARS = 600
 
 EXTRACTION_SYSTEM_PROMPT = """\
 You are a Nepali legal analyst writing the public case summary (description) for \
@@ -341,7 +337,14 @@ def _generate_description(detail, court_number, source_text, invoke_text, usage)
     """One premium-tier call. Returns the description string, or None."""
     prompt = EXTRACTION_USER_PROMPT.format(
         case_title=detail.get("title") or "",
-        court_number=court_number or "(unknown)",
+        # UPPERCASED. `select.court_number()` reads the number off the canonical
+        # IRI, which is lowercase (`.../courtcase/special/081-cr-0091`), and the
+        # prompt tells the model to prefer specifics from the context over vague
+        # phrasing -- so the lowercase form lands verbatim in public prose. Fixed
+        # for the card on evidence (`081-cr-0060` shipped in 2 of 5 titles in the
+        # 2026-08-04 evaluation, against 50/50 uppercase in PUBLISHED titles);
+        # this is the same defect on the same input, one stage earlier.
+        court_number=(court_number or "").upper() or "(unknown)",
         bigo=format_bigo(detail.get("bigo")),
         court_cases=", ".join(detail.get("court_cases") or []) or "(none)",
         key_allegations=format_list(detail.get("key_allegations")),
@@ -509,6 +512,22 @@ def main(argv=None):
                       detail="; ".join(reasons), level=logging.WARNING)
             continue
 
+        # A PARTIAL FETCH FAILURE MUST BE VISIBLE. `text_unmet` was previously
+        # consumed only when NOTHING fetched, so a case whose charge sheet
+        # succeeded and whose court order 500'd generated a full public narrative
+        # from the prosecution claim alone -- silently omitting that the defendant
+        # was acquitted. Nothing in the review file said a verdict source existed
+        # and was lost, so the human reviewer could not catch it either. This is
+        # the one stage where the lost source can BE the outcome.
+        source_note = ""
+        if text_unmet:
+            source_note = "SOURCE MISSING — " + "; ".join(text_unmet)
+            for reason in text_unmet:
+                report.record(slug, "description", "partial", reason)
+            log_event(logger, paths["events"], run_id=run_id, stage="description",
+                      slug=slug, step="source", status="partial",
+                      detail="; ".join(text_unmet), level=logging.WARNING)
+
         log_event(logger, paths["events"], run_id=run_id, stage="description", slug=slug,
                   step="source", status="ok",
                   detail=f"{len(chunks)} source(s): "
@@ -536,7 +555,8 @@ def main(argv=None):
         except Exception as exc:
             report.record(slug, "description", "error", f"LLM generation failed: {exc}")
             review.add(ReviewRow(slug=slug, status="error", before=before, sources=fed,
-                                 note=f"LLM generation failed: {exc}"))
+                                 note="; ".join(filter(None, (
+                                     f"LLM generation failed: {exc}", source_note)))))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="generate", status="error", detail=str(exc),
                       level=logging.ERROR)
@@ -549,7 +569,8 @@ def main(argv=None):
         if not description:
             report.record(slug, "description", "skipped", "LLM returned no description")
             review.add(ReviewRow(slug=slug, status="skipped", before=before, sources=fed,
-                                 note="LLM returned no description"))
+                                 note="; ".join(filter(None, (
+                                     "LLM returned no description", source_note)))))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="generate", status="skipped",
                       detail="LLM returned no description", level=logging.WARNING)
@@ -562,7 +583,8 @@ def main(argv=None):
         if args.dry_run:
             report.record(slug, "description", "would-enrich", detail_msg)
             review.add(ReviewRow(slug=slug, status="would-enrich", before=before,
-                                 generated=description, sources=fed))
+                                 generated=description, sources=fed,
+                                 note=source_note))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="write", status="would-enrich", detail=detail_msg)
             continue
@@ -571,14 +593,16 @@ def main(argv=None):
             api.patch_field(slug, "description", description, if_match=etag)
             report.record(slug, "description", "enriched", detail_msg)
             review.add(ReviewRow(slug=slug, status="enriched", before=before,
-                                 generated=description, sources=fed))
+                                 generated=description, sources=fed,
+                                 note=source_note))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="write", status="enriched", detail=detail_msg)
         except Exception as exc:
             report.record(slug, "description", "error", f"PATCH failed: {exc}")
             review.add(ReviewRow(slug=slug, status="error", before=before,
                                  generated=description, sources=fed,
-                                 note=f"PATCH failed: {exc}"))
+                                 note="; ".join(filter(None, (
+                                     f"PATCH failed: {exc}", source_note)))))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="write", status="error", detail=str(exc),
                       level=logging.ERROR)

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -92,7 +92,7 @@ from casework.common.pipeline import (
     unmet_prerequisites,
 )
 from casework.common.review import ReviewRow, build_review_file
-from casework.common.select import court_number, select_cases
+from casework.common.select import court_number, select_for_run
 
 # `summarize_verdict` and its four donor-pinned constants are imported from the
 # timeline enricher rather than re-copied. The donor kept them in the shared
@@ -424,14 +424,11 @@ def main(argv=None):
         args, stage="description", field_name="description", run_id=run_id)
 
     all_cases = list(api.iter_cases())
-    cases = select_cases(
-        all_cases,
-        fiscal_year=args.fiscal_year,
-        slugs=args.slug,
-        court_cases=args.court_case,
-    )
-    if args.limit:
-        cases = cases[: args.limit]
+    # `select_for_run` is the one selection path every enricher shares (#410): it
+    # applies the --batch-csv allowlist, then the other selectors, then --limit --
+    # and it slices --limit in BATCH order, which a local `cases[:limit]` cannot
+    # do because the API's iteration order is not the CSV's.
+    cases = select_for_run(all_cases, args)
 
     total = len(cases)
     log_run_header(

--- a/tests/casework/conftest.py
+++ b/tests/casework/conftest.py
@@ -17,3 +17,15 @@ def _isolate_casework_run_logs(monkeypatch, tmp_path):
     for itself.
     """
     monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_review_files(monkeypatch, tmp_path):
+    """Enricher `main()`s write a human review file on EVERY run, dry runs
+    included (`casework/common/review.py`), defaulting to
+    `<repo>/work/reviews/`. Same reason as the two fixtures above: without
+    this, every test that drives `main()` end to end drops a Markdown file
+    full of fixture Nepali into that real directory. A test that wants to read
+    its own review file back finds it under this `tmp_path`.
+    """
+    monkeypatch.setenv("CASEWORK_REVIEW_DIR", str(tmp_path / "reviews"))

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -6,7 +6,11 @@ import urllib.request
 
 import pytest
 
-from casework.common.api import CaseworkApi, build_replace_patch
+from casework.common.api import (
+    CaseworkApi,
+    build_replace_ops,
+    build_replace_patch,
+)
 
 
 def test_build_replace_patch_is_a_list_of_ops():
@@ -21,6 +25,70 @@ def test_build_replace_patch_handles_list_paths():
     assert build_replace_patch("evidence", items) == [
         {"op": "replace", "path": "/evidence", "value": items}
     ]
+
+
+def test_build_replace_ops_puts_every_field_in_one_document():
+    """One document, several ops -- the shape that makes a multi-field write
+    atomic under a single `If-Match`."""
+    ops = build_replace_ops([("title", "शीर्षक"), ("short_description", "सार")])
+    assert ops == [
+        {"op": "replace", "path": "/title", "value": "शीर्षक"},
+        {"op": "replace", "path": "/short_description", "value": "सार"},
+    ]
+
+
+def test_build_replace_ops_preserves_the_order_it_was_given():
+    fields = ["a", "b", "c", "d"]
+    ops = build_replace_ops((f, f.upper()) for f in fields)
+    assert [op["path"] for op in ops] == ["/a", "/b", "/c", "/d"]
+
+
+def test_build_replace_ops_on_nothing_is_an_empty_document():
+    """A caller whose every field failed validation must send no ops, not an
+    empty patch the server has to reason about."""
+    assert build_replace_ops([]) == []
+
+
+def test_patch_fields_makes_no_request_when_there_is_nothing_to_write(monkeypatch):
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+
+    def boom(*a, **kw):
+        raise AssertionError("patch_fields must not issue a request for no ops")
+
+    monkeypatch.setattr(api, "_request", boom)
+    assert api.patch_fields("case-x", []) == {}
+
+
+def test_patch_fields_sends_one_conditional_request_for_both_fields(monkeypatch):
+    """The regression this helper exists for: two `patch_field` calls take a 412
+    on the second, because the first one moved the ETag."""
+    seen = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b"{}"
+
+    def fake_request(method, url, data=None, headers=None, timeout=None):
+        seen.setdefault("calls", []).append(method)
+        seen["data"] = json.loads(data.decode())
+        seen["headers"] = headers
+        return _Resp()
+
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    monkeypatch.setattr(api, "_request", fake_request)
+    api.patch_fields(
+        "case-x", [("title", "शीर्षक"), ("short_description", "सार")],
+        if_match='W/"etag-1"')
+
+    assert seen["calls"] == ["PATCH"], "one request, not one per field"
+    assert [op["path"] for op in seen["data"]] == ["/title", "/short_description"]
+    assert seen["headers"]["If-Match"] == 'W/"etag-1"'
 
 
 def test_patch_uses_plain_application_json(monkeypatch):

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -59,6 +59,15 @@ def test_patch_fields_makes_no_request_when_there_is_nothing_to_write(monkeypatc
     assert api.patch_fields("case-x", []) == {}
 
 
+@pytest.mark.parametrize("path", ["evidence", "entities"])
+def test_patch_fields_refuses_the_whole_list_paths(path):
+    """`replace_list` documents the merge-first contract for these; letting them
+    through here would perform the same destructive replace without it."""
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    with pytest.raises(ValueError, match="whole-list path"):
+        api.patch_fields("case-x", [("title", "शीर्षक"), (path, [])])
+
+
 def test_patch_fields_sends_one_conditional_request_for_both_fields(monkeypatch):
     """The regression this helper exists for: two `patch_field` calls take a 412
     on the second, because the first one moved the ETag."""

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -295,6 +295,33 @@ def test_configure_run_logging_uses_env_var_for_default_log_dir(monkeypatch, tmp
         _cleanup_logger(stage)
 
 
+def test_api_token_defaults_to_the_environment(monkeypatch):
+    """`basic_auth_from_env`'s error text tells operators to set
+    JAWAFDEHI_API_TOKEN, and the documented production invocation exports it.
+    Without this default, following that instruction failed with the very
+    message that gave it."""
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "eyJ-token")
+    parser = argparse.ArgumentParser()
+    add_common_args(parser)
+    assert parser.parse_args([]).api_token == "eyJ-token"
+
+
+def test_an_explicit_api_token_flag_wins_over_the_environment(monkeypatch):
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "from-env")
+    parser = argparse.ArgumentParser()
+    add_common_args(parser)
+    assert parser.parse_args(["--api-token", "from-flag"]).api_token == "from-flag"
+
+
+def test_api_token_is_empty_when_unset(monkeypatch):
+    """Empty, not None -- `build_api` branches on truthiness to fall back to
+    local Basic auth."""
+    monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+    parser = argparse.ArgumentParser()
+    add_common_args(parser)
+    assert parser.parse_args([]).api_token == ""
+
+
 def test_configure_run_logging_falls_back_to_repo_root_work_dir(monkeypatch, tmp_path):
     import casework.common.cli as cli_module
 

--- a/tests/casework/test_cli.py
+++ b/tests/casework/test_cli.py
@@ -78,6 +78,26 @@ def test_model_default_is_empty_not_haiku():
     assert _parse([]).model == ""
 
 
+def test_the_model_help_lists_the_tiers_the_registry_actually_holds():
+    """Review finding 11. The help text used to name the premium stages by hand,
+    and went stale the moment `description` and `card` were registered -- it
+    promised "premium stages (bigo, timeline, allegations, entities)" to an
+    operator reading `--help` to find out what a run would cost.
+
+    Deriving it from `llm.TIERS` is what stops that recurring.
+    """
+    import argparse
+
+    from casework.common.llm import TIERS
+
+    parser = add_common_args(argparse.ArgumentParser())
+    help_text = parser.format_help()
+    for stage, tier in TIERS.items():
+        assert stage in help_text, f"{stage} is registered but absent from --model help"
+    assert "description" in help_text and "card" in help_text
+    assert "premium stages (bigo, timeline, allegations, entities)" not in help_text
+
+
 def test_provider_default_is_claude_cli():
     assert _parse([]).provider == "claude_cli"
 

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1365,3 +1365,34 @@ class TestTheParsePredicateAsksAboutTheFieldsTheRunCanWrite:
                            BASE_ARGV + ["--only", "short_description", "--apply"])
         assert api.patched == []
         assert any(r["status"] == "rejected" for r in report.rows)
+
+
+class TestTheOutputAccuracyRulesTheSmokeRunsFound:
+    """Three defects observed in real generated teasers, each a wrong FACT about
+    a named person rather than a code path. Pinned so a prompt edit cannot drop
+    them silently.
+    """
+
+    def test_a_sentence_may_not_be_compressed_into_a_different_number(self):
+        """Observed: the court imposed `२ वर्ष ६ महिना` (2.5 years) and the model
+        wrote `२.६ वर्ष` -- concatenating the digits into a number the court never
+        imposed, misstating a real person's prison sentence in public text."""
+        assert "२ वर्ष ६ महिना" in ec.SYSTEM_PROMPT
+        assert "२.६ वर्ष" in ec.SYSTEM_PROMPT, "the wrong form must be shown as wrong"
+        assert "NEVER COMPRESS" in ec.SYSTEM_PROMPT
+        assert "never round" in ec.SYSTEM_PROMPT
+
+    def test_a_total_may_not_be_relabelled_as_one_of_its_parts(self):
+        """Observed: रु. ३०,४२,३७८ described as construction money when it
+        included रु. ९२,३७८ of double salary."""
+        assert "DO NOT RELABEL WHAT MONEY WAS FOR" in ec.SYSTEM_PROMPT
+
+    def test_the_digit_script_may_not_be_mixed(self):
+        """Observed: `07८-CR-0103` -- Latin 0, 7 then Devanagari ८."""
+        assert "ONE DIGIT SCRIPT PER FIELD" in ec.SYSTEM_PROMPT
+        assert "07८-CR-0103" in ec.SYSTEM_PROMPT
+
+    def test_the_budget_loses_to_correctness(self):
+        """A shorter teaser beats a wrong number -- the rule has to say which
+        gives way, or the 200-char guidance silently wins."""
+        assert "a shorter teaser is" in ec.SYSTEM_PROMPT

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1297,3 +1297,71 @@ class TestAStubDescriptionCannotGroundACard:
         _run_main(monkeypatch, api, stub, BASE_ARGV + ["--apply"])
         assert stub.calls, "an 861-char description is a real one"
         assert api.patched
+
+
+class TestAMissingETagIsNotAFreePass:
+    """Review finding 10. `if_match` is sent only when truthy and the server
+    checks it only when present, so `etag=None` is an UNCONDITIONAL write.
+
+    The exception route was already guarded with exactly this argument. A 200 that
+    simply lacks the header -- a proxy stripping it, a non-`retrieve` path --
+    produced the same unconditional write with no log line. Latent today, since
+    `cases/api_views.py` does set it.
+    """
+
+    def test_no_etag_means_no_write(self, monkeypatch):
+        stub = _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)")
+        api = _StubApi([CASE_STUB_BOTH], etag="")
+        report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--apply"])
+        assert api.patched == [], "a write with no precondition can clobber an edit"
+        assert any("no ETag" in r["reason"] for r in report.rows)
+
+    def test_no_etag_costs_no_llm_call(self, monkeypatch):
+        stub = _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)")
+        _run_main(monkeypatch, _StubApi([CASE_STUB_BOTH], etag=""), stub,
+                  BASE_ARGV + ["--apply"])
+        assert stub.calls == []
+
+    def test_a_present_etag_still_writes(self, monkeypatch):
+        api = _StubApi([CASE_STUB_BOTH], etag='W/"etag-1"')
+        _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+                  BASE_ARGV + ["--apply"])
+        assert api.patched, "the guard must not block the normal case"
+
+
+class TestTheParsePredicateAsksAboutTheFieldsTheRunCanWrite:
+    """Review finding 9. `_carries_a_field` checked the UNION of both fields."""
+
+    def test_only_title_skips_an_object_carrying_only_the_other_field(self):
+        """`{"title": null, "short_description": "..."}` used to be accepted on an
+        `--only title` run, stopping the scan, so the object that actually had a
+        title -- behind a preamble -- was never looked at."""
+        decoy = {"title": None, "short_description": "कुनै सारांश।"}
+        assert ec._carries_a_field(decoy) is True, "the union test accepts it"
+        assert ec._carries_a_field(decoy, (ec.TITLE_FIELD,)) is False
+
+    def test_the_real_object_behind_a_preamble_is_found(self, monkeypatch):
+        """The end-to-end shape of the bug: a decoy object first, the answer
+        second, on a title-only run."""
+        good = "काठमाडौं ठेक्का घोटाला (076-CR-0182)"
+
+        def stub(**kw):
+            return (
+                'यहाँ नतिजा छ:\n'
+                '{"title": null, "short_description": "कुनै सारांश।"}\n'
+                f'{{"title": "{good}", "short_description": null}}'
+            )
+
+        stub.calls = []
+        api = _StubApi([CASE_STUB_BOTH])
+        _run_main(monkeypatch, api, stub, BASE_ARGV + ["--only", "title", "--apply"])
+        assert [(f, v) for _, f, v, _ in api.patched] == [("title", good)]
+
+    def test_a_blank_wanted_field_still_reports_precisely(self, monkeypatch):
+        """The broad second pass. Narrowing alone would report "no card JSON
+        object found" for a model that really did return an empty teaser."""
+        api = _StubApi([CASE_STUB_BOTH])
+        report = _run_main(monkeypatch, api, _llm(short="   "),
+                           BASE_ARGV + ["--only", "short_description", "--apply"])
+        assert api.patched == []
+        assert any(r["status"] == "rejected" for r in report.rows)

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1130,3 +1130,18 @@ class TestTheSplitVerdictRule:
         """The split rule must not weaken the no-guessing rule beside it."""
         assert "do not guess" in ec.SYSTEM_PROMPT
         assert "अनुसन्धान जारी" in ec.SYSTEM_PROMPT
+
+
+def test_batch_csv_reaches_selection(monkeypatch, tmp_path):
+    """`--batch-csv` selects through `select_for_run` (#410), not a local slice.
+
+    Pins the wiring, not the loader: `tests/casework/test_select_batch_csv.py`
+    owns the parsing. What this asserts is that THIS enricher routes selection
+    through the shared path, so a batch file restricts the run here the same way
+    it does on the five enrichers already on main.
+    """
+    csv = tmp_path / "batch.csv"
+    csv.write_text("slug\n076-cr-0182-nope\n", encoding="utf-8")
+    args = build_parser().parse_args(["--batch-csv", str(csv)])
+    assert args.batch_csv == str(csv)
+    assert "select_for_run" in Path(ec.__file__).read_text(encoding="utf-8")

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -371,10 +371,24 @@ DETAIL = {
 
 
 class TestPromptAssembly:
+    def test_the_court_number_reaches_the_model_uppercased(self):
+        """All 50 PUBLISHED titles carrying a case number use `(081-CR-0060)`.
+
+        `court_number()` reads the lowercase canonical IRI, and the model copies
+        whatever it is given, so the lowercase form shipped `(081-cr-0060)` on 2
+        of 5 cases in the 2026-08-04 evaluation. `validate_title` compares
+        case-insensitively and cannot catch it.
+        """
+        prompt = _build_prompt(DETAIL, "081-cr-0091", True, True)
+        assert "081-CR-0091" in prompt
+        assert "081-cr-0091" not in prompt
+
     def test_the_prompt_carries_every_context_block(self):
         content = _build_prompt(DETAIL, "081-cr-0091", True, True)
         assert STUB_TITLE in content
-        assert "081-cr-0091" in content
+        # Uppercased on the way in -- see
+        # test_the_court_number_reaches_the_model_uppercased.
+        assert "081-CR-0091" in content
         assert "330,000,000" in content
         assert "ठेक्कामा मिलेमतो" in content
         assert "[accused] कमल राज गौतम" in content

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -396,6 +396,36 @@ class TestSnippetKeepsTheOutcome:
         assert "सफाई" in snippet
         assert "[…]" in snippet
 
+    def test_an_early_outcome_word_does_not_hijack_the_slice(self):
+        """Finding 1. The vocabulary scan takes the LAST match, not the first.
+
+        Section क) states the punishment SOUGHT (मागदावी) in this exact
+        vocabulary, and narrative reasoning uses ठहर freely. Measured on a real
+        case: first match `दोषी` at offset 6,466 in a sentence about
+        investigating officials, actual ठहर at 26,224. Taking the first match
+        spliced 6,466 onward and handed the model unrelated prose under a prompt
+        rule that says STATE THE OUTCOME.
+        """
+        text = ("क) मागदावी: कैद र जरिवाना माग गरिएको। " * 200
+                + "\nविशेष अदालतले प्रतिवादीलाई सफाई दिएको ठहर।")
+        snippet = _snippet(dict(DETAIL, description=text))
+        assert "सफाई दिएको ठहर।" in snippet, (
+            "the real outcome sits at the end; a first-match scan misses it")
+        assert "[…]" in snippet
+
+    def test_the_offset_is_the_last_outcome_word_not_the_first(self):
+        text = "कैद माग।\n" + ("पूरक विवरण। " * 50) + "\nअन्ततः सफाई भएको।"
+        offset = ec._outcome_offset(text)
+        assert offset > text.index("कैद माग।"), "must not stop at the first hit"
+        assert text[offset:].startswith("अन्ततः सफाई भएको।")
+
+    def test_the_heading_still_wins_over_the_vocabulary_scan(self):
+        """A clean section boundary beats a bare word anywhere in the text."""
+        text = ("कैद माग।\n### ग) विशेष अदालतको फैसलाको सार\nसफाई भएको।\n"
+                "थप टिप्पणीमा जरिवाना शब्द पछि आउँछ।")
+        offset = ec._outcome_offset(text)
+        assert text[offset:].startswith("### ग) विशेष अदालतको फैसला")
+
     def test_a_table_cell_reference_is_not_mistaken_for_the_heading(self):
         """`081-CR-0060` carries "(ग), (घ) र (ङ) मा उल्लिखित सम्पत्ति" in a table
         at offset 1,740. Splicing from there would present a table row as the
@@ -991,3 +1021,54 @@ def test_add_common_args_is_wired():
     assert args.limit == 3
     assert args.force is True
     assert isinstance(build_parser(), argparse.ArgumentParser)
+
+
+class TestPredicateRejectsAnAllNullObject:
+    """Finding 4. Key PRESENCE is not a usable field.
+
+    The system prompt tells the model to "set an unrequested key to null", so
+    `{"title": null, "short_description": null}` is a shape the prompt invites.
+    A presence test accepted it, stopping `parse_object_response`'s scan on an
+    object carrying nothing -- while the real object may have been the next `{`.
+    """
+
+    def test_an_all_null_object_is_not_a_usable_field(self):
+        assert ec._carries_a_field({"title": None, "short_description": None}) is False
+
+    def test_a_blank_string_is_not_a_usable_field(self):
+        assert ec._carries_a_field({"title": "   ", "short_description": ""}) is False
+
+    def test_one_populated_field_is_enough(self):
+        """`--only title` legitimately nulls the other key."""
+        assert ec._carries_a_field({"title": "शीर्षक (081-CR-0091)",
+                                    "short_description": None}) is True
+        assert ec._carries_a_field({"title": None,
+                                    "short_description": "सारांश।"}) is True
+
+    def test_the_scan_walks_past_an_all_null_object_to_the_real_one(self):
+        """The behaviour the predicate exists for, end to end."""
+        response = (
+            '{"title": null, "short_description": null}\n'
+            '{"title": "असली शीर्षक (081-CR-0091)", "short_description": "असली सार।"}'
+        )
+        obj = ec.parse_object_response(response, predicate=ec._carries_a_field)
+        assert obj["title"] == "असली शीर्षक (081-CR-0091)"
+
+
+def test_a_failed_detail_fetch_skips_the_case_and_never_writes(monkeypatch):
+    """Finding 2. A fetch failure must not fall back to the LIST payload.
+
+    `CaseSerializer` is the list serializer's child, so the list payload carries
+    `title`, `short_description` AND `description` -- and `STAGES["card"]`
+    declares no `requires_materials`, so nothing else would stop the run. The old
+    fallback generated from a page-cached description and PATCHed with
+    `if_match=None`, because the failed fetch is what left the ETag unset.
+    """
+    class _FetchFails(_StubApi):
+        def get_case_with_etag(self, slug):
+            raise RuntimeError("HTTP Error 502: Bad Gateway")
+
+    api = _FetchFails([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+              ["--apply", "--allow-remote-writes"])
+    assert api.requests == [], "no PATCH may be attempted without a fresh ETag"

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -370,6 +370,64 @@ DETAIL = {
 }
 
 
+class TestSnippetKeepsTheOutcome:
+    """The teaser cannot state a verdict the snippet clamped away.
+
+    A description states the allegation first and the verdict last. Measured on
+    the published cases whose description exceeds the 3,000-char budget and
+    states an outcome: 34 of 52 state it ONLY beyond 3,000. `081-CR-0060` is the
+    case that surfaced it -- acquitted, सफाई at offset 5,100, and the generated
+    teaser read as a live accusation.
+    """
+
+    def _long(self, tail):
+        return dict(DETAIL, description=("क) अभियोगदावी। " * 400) + tail)
+
+    def test_a_late_outcome_is_spliced_in(self):
+        snippet = _snippet(self._long("\n### ग) विशेष अदालतको फैसलाको सार\nसफाई भएको।"))
+        assert "सफाई भएको।" in snippet
+        assert "[…]" in snippet, "the elision has to be visible to the model"
+        assert len(snippet) <= ec.DESCRIPTION_SNIPPET_BUDGET + 16
+
+    def test_a_headingless_outcome_is_still_found(self):
+        """Only 11 published descriptions use the ### ग) heading; most are plain
+        prose, so the vocabulary fallback carries the real load."""
+        snippet = _snippet(self._long("\nविशेष अदालतले प्रतिवादीलाई सफाई दिएको।"))
+        assert "सफाई" in snippet
+        assert "[…]" in snippet
+
+    def test_a_table_cell_reference_is_not_mistaken_for_the_heading(self):
+        """`081-CR-0060` carries "(ग), (घ) र (ङ) मा उल्लिखित सम्पत्ति" in a table
+        at offset 1,740. Splicing from there would present a table row as the
+        verdict."""
+        detail = dict(DETAIL, description=(
+            "क) सुरु। तालिका (ग), (घ) र (ङ) मा उल्लिखित सम्पत्ति। "
+            + ("भरण। " * 900)))
+        snippet = _snippet(detail)
+        assert "[…]" not in snippet, "no outcome exists, so nothing to splice"
+        assert len(snippet) == ec.DESCRIPTION_SNIPPET_BUDGET
+
+    def test_an_outcome_already_in_the_head_is_left_alone(self):
+        detail = dict(DETAIL, description="सफाई भएको। " + ("पछि। " * 900))
+        snippet = _snippet(detail)
+        assert "सफाई" in snippet
+        assert "[…]" not in snippet, "a plain clamp already keeps it"
+
+    def test_a_long_description_with_no_outcome_is_plainly_clamped(self):
+        snippet = _snippet(self._long("कुनै फैसला उल्लेख नभएको।".replace("फैसला", "निर्णय")))
+        assert "[…]" not in snippet
+        assert len(snippet) == ec.DESCRIPTION_SNIPPET_BUDGET
+
+    def test_a_short_description_is_returned_whole(self):
+        detail = dict(DETAIL, description="छोटो विवरण। सफाई भएको।")
+        assert _snippet(detail) == "छोटो विवरण। सफाई भएको।"
+
+    def test_the_prompt_requires_the_outcome_when_one_exists(self):
+        assert "STATE THE OUTCOME" in ec.SYSTEM_PROMPT
+        assert "सफाई" in ec.SYSTEM_PROMPT
+        assert "do not guess" in ec.SYSTEM_PROMPT
+
+
 class TestPromptAssembly:
     def test_the_court_number_reaches_the_model_uppercased(self):
         """All 50 PUBLISHED titles carrying a case number use `(081-CR-0060)`.

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -373,11 +373,15 @@ DETAIL = {
 class TestSnippetKeepsTheOutcome:
     """The teaser cannot state a verdict the snippet clamped away.
 
-    A description states the allegation first and the verdict last. Measured on
-    the published cases whose description exceeds the 3,000-char budget and
-    states an outcome: 34 of 52 state it ONLY beyond 3,000. `081-CR-0060` is the
-    case that surfaced it -- acquitted, सफाई at offset 5,100, and the generated
-    teaser read as a live accusation.
+    A description states the allegation first and the verdict last. Measured over
+    the 83 descriptions longer than the 3,000-char budget, on whether the passage
+    the model actually receives contains the court's granted acquittal:
+
+        plain head clamp   2/54
+        `_verdict_window` 53/54
+
+    `081-CR-0060` is the case that surfaced it -- acquitted, सफाई at offset 5,100,
+    and the generated teaser read as a live accusation.
     """
 
     def _long(self, tail):
@@ -390,20 +394,17 @@ class TestSnippetKeepsTheOutcome:
         assert len(snippet) <= ec.DESCRIPTION_SNIPPET_BUDGET + 16
 
     def test_a_headingless_outcome_is_still_found(self):
-        """Only 11 published descriptions use the ### ग) heading; most are plain
-        prose, so the vocabulary fallback carries the real load."""
+        """Only 28 of the 83 long descriptions carry the ### ग) heading; most are
+        plain prose, so the vocabulary scan carries the real load."""
         snippet = _snippet(self._long("\nविशेष अदालतले प्रतिवादीलाई सफाई दिएको।"))
         assert "सफाई" in snippet
         assert "[…]" in snippet
 
-    def test_a_long_verdict_is_read_to_the_end_not_clipped(self):
-        """The whole verdict section reaches the model, not a fixed 1,200 chars.
-
-        A flat slice clipped the verdict on 21 of the 52 long published
-        descriptions, and worst where it matters: a multi-defendant case states
-        one outcome PER defendant, so a clipped slice keeps the conviction and
-        drops the acquittal. `078-CR-0103` reproduced it twice -- सफाई sat 172
-        characters past where the old slice ended.
+    def test_a_multi_defendant_verdict_keeps_every_outcome(self):
+        """A multi-defendant case states one outcome PER defendant, so any slice
+        that ends early keeps the conviction and drops the acquittal.
+        `078-CR-0103` reproduced it twice -- सफाई sat 172 characters past where a
+        fixed 1,200-char slice ended.
         """
         verdict = ("\n### ग) विशेष अदालतको फैसलाको सार\n"
                    + ("अदालतले प्रतिवादीलाई दोषी ठहर गरेको। " * 40)
@@ -421,9 +422,15 @@ class TestSnippetKeepsTheOutcome:
         snippet = _snippet(dict(DETAIL, description=text))
         assert len(snippet) <= ec.SNIPPET_MAX_CHARS + 16
 
-    def test_a_short_verdict_makes_the_snippet_SMALLER_than_the_old_flat_slice(self):
-        """The median verdict section is 794 chars, so the common case now sends
-        LESS than the old fixed 1,200 -- this change is not a cost increase."""
+    def test_a_short_verdict_does_not_pad_the_snippet_to_the_ceiling(self):
+        """Filling the budget backward stops at a line boundary, so a one-line
+        verdict sends one line -- not 4,200 characters of the preceding narrative.
+
+        Be honest about the cost: across the 83 real long descriptions the
+        average snippet is 5,119 chars against 3,159 under the old locator. That
+        is the price of carrying the verdict, and it is input tokens on the cheap
+        tier; the output cap (`CARD_MAX_TOKENS`) is what bounds spend.
+        """
         text = ("क) अभियोगदावी। " * 400) + "\nफैसला: सफाई दिएको।"
         assert len(_snippet(dict(DETAIL, description=text))) < 3000
 
@@ -444,20 +451,75 @@ class TestSnippetKeepsTheOutcome:
             "the real outcome sits at the end; a first-match scan misses it")
         assert "[…]" in snippet
 
-    def test_the_offset_is_the_last_outcome_word_not_the_first(self):
-        text = "कैद माग।\n" + ("पूरक विवरण। " * 50) + "\nअन्ततः सफाई भएको।"
-        offset = ec._outcome_offset(text)
-        assert offset > text.index("कैद माग।"), "must not stop at the first hit"
-        assert text[offset:].startswith("अन्ततः सफाई भएको।")
+    def test_the_window_ENDS_at_the_last_outcome_word(self):
+        """The window is anchored to the END of the outcome discussion and fills
+        the budget backward, so every defendant named before the last one still
+        reaches the model."""
+        text = ("क) अभियोगदावी। " * 400
+                + "\nपहिलो प्रतिवादीलाई दोषी ठहर। दोस्रोलाई सफाई भएको।")
+        start, end = ec._verdict_window(text)
+        assert end >= text.rindex("सफाई"), "the window must reach the last outcome"
+        assert start <= text.index("दोषी"), (
+            "and must extend back far enough to keep the first defendant")
 
-    def test_the_heading_still_wins_over_the_vocabulary_scan(self):
-        """A clean section boundary beats a bare word anywhere in the text."""
-        text = ("कैद माग।\n### ग) विशेष अदालतको फैसलाको सार\nसफाई भएको।\n"
-                "थप टिप्पणीमा जरिवाना शब्द पछि आउँछ।")
-        offset = ec._outcome_offset(text)
-        assert text[offset:].startswith("### ग) विशेष अदालतको फैसला")
+    def test_an_appeal_section_after_the_verdict_does_not_steal_the_window(self):
+        """Review finding 1. `फैसला` is how an appeal section refers BACK to the
+        judgment, so a locator that treats it as an outcome word lands past the
+        verdict. On the corpus, `पुनरावेदन` follows the last outcome word on 16
+        of the 83 long descriptions.
 
-    def test_a_table_cell_reference_is_not_mistaken_for_the_heading(self):
+        Before this fix the snippet contained the appeal sentence and NOT the
+        acquittal -- worse than no rescue at all, because the plain clamp would
+        have kept it.
+        """
+        text = ("क) अभियोगदावी।\n" * 130
+                + "विशेष अदालतले राकेशमान श्रेष्ठलाई सफाई दिएको।\n"
+                + "ख) प्रमाणको विवेचना गरिएको।\n" * 250
+                + "घ) पुनरावेदनको सार: उक्त फैसलाउपर पुनरावेदन गरेको।")
+        snippet = _snippet(dict(DETAIL, description=text))
+        assert "सफाई" in snippet, "the acquittal is the whole point of the rescue"
+        assert "फैसला" not in ec._OUTCOME_WORD_RE.pattern, (
+            "फैसला in the vocabulary is what caused this")
+
+    def test_a_single_paragraph_verdict_is_still_rescued(self):
+        """Review finding 2. A description with no newline at all used to cancel
+        the rescue silently: the old locator backed up to the previous line start,
+        `rfind` returned -1, `+ 1` made that offset 0, and offset 0 reads as "the
+        outcome is already in the head". The module's own docstring says most
+        descriptions are hand-written prose."""
+        text = ("क) अभियोगदावीमा भ्रष्टाचारको आरोप छ। " * 200
+                + "विशेष अदालतले प्रतिवादी राकेशमान श्रेष्ठलाई सफाई दिएको।")
+        assert "\n" not in text
+        snippet = _snippet(dict(DETAIL, description=text))
+        assert "[…]" in snippet, "the rescue must fire"
+        assert "सफाई" in snippet
+
+    def test_the_ceiling_survives_line_alignment(self):
+        """Aligning the window start to a line boundary must move FORWARD.
+
+        Backing up to the previous line start is the obvious reading and grows
+        the window by up to a whole line -- it put 50 of the 83 real snippets over
+        the ceiling, the worst at 6,998 chars.
+        """
+        # One 900-char line, then the verdict, so a backward alignment would
+        # overshoot by the full line length.
+        text = ("क) " + "अभियोगदावीको विस्तृत विवरण। " * 200 + "\n"
+                + "अ" * 900 + " अन्ततः प्रतिवादीलाई सफाई दिएको।")
+        snippet = _snippet(dict(DETAIL, description=text))
+        assert len(snippet) <= ec.SNIPPET_MAX_CHARS + 16, (
+            f"snippet is {len(snippet)}, ceiling is {ec.SNIPPET_MAX_CHARS}")
+
+    def test_the_ceg_heading_is_deliberately_not_preferred(self):
+        """Measured: preferring the `ग)` heading and reading forward from it
+        scores WORSE than ignoring it (51/54 vs 53/54 on carrying the court's
+        granted acquittal), because a long verdict discussion gets clipped before
+        it finishes. Only 28 of the 83 long descriptions carry the heading at all.
+        """
+        assert not hasattr(ec, "_OUTCOME_HEADING_RE"), (
+            "the heading branch was removed on evidence; re-adding it needs new "
+            "evidence, not intuition about clean boundaries")
+
+    def test_a_table_cell_reference_is_not_mistaken_for_a_verdict(self):
         """`081-CR-0060` carries "(ग), (घ) र (ङ) मा उल्लिखित सम्पत्ति" in a table
         at offset 1,740. Splicing from there would present a table row as the
         verdict."""

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1103,3 +1103,30 @@ def test_a_failed_detail_fetch_skips_the_case_and_never_writes(monkeypatch):
     _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
               ["--apply", "--allow-remote-writes"])
     assert api.requests == [], "no PATCH may be attempted without a fresh ETag"
+
+
+class TestTheSplitVerdictRule:
+    """The teaser must not convict a defendant the court cleared.
+
+    Measured on production: 1,250 of 3,003 cases (42%) name co-defendants in the
+    title, and 10 of the 35 published descriptions that state a decision state
+    BOTH दोषी and सफाई -- roughly three in ten decided cases hand different
+    outcomes to different people. `078-CR-0103` is the case that surfaced it: the
+    model was shown the acquittal (after `SNIPPET_MAX_CHARS` widened the window)
+    and still wrote a teaser naming only the conviction, because the prompt asked
+    it to "state the outcome", singular.
+    """
+
+    def test_the_prompt_demands_the_split_be_named(self):
+        assert "DIFFERENT OUTCOMES" in ec.SYSTEM_PROMPT
+        assert "सफाई" in ec.SYSTEM_PROMPT
+
+    def test_the_rule_names_the_harm_not_just_the_format(self):
+        """A rule the model can follow mechanically without understanding why
+        gets dropped under length pressure. This one says who is hurt."""
+        assert "CLEARED must never read as convicted" in ec.SYSTEM_PROMPT
+
+    def test_the_outcome_rules_still_forbid_inventing_a_verdict(self):
+        """The split rule must not weaken the no-guessing rule beside it."""
+        assert "do not guess" in ec.SYSTEM_PROMPT
+        assert "अनुसन्धान जारी" in ec.SYSTEM_PROMPT

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -467,6 +467,7 @@ class _StubApi:
         self._cases = {c["slug"]: dict(c) for c in cases}
         self._etag = etag
         self.patched = []
+        self.requests = []
 
     def iter_cases(self, params=None, timeout=60):
         yield from self._cases.values()
@@ -477,6 +478,22 @@ class _StubApi:
     def patch_field(self, slug, field, value, timeout=60, if_match=None):
         self.patched.append((slug, field, value, if_match))
         self._cases[slug][field] = value
+        return {}
+
+    def patch_fields(self, slug, pairs, timeout=60, if_match=None):
+        """One request, several fields -- what `enrich_card` actually calls.
+
+        `patched` still gets one entry per field so the assertions here read the
+        same as before; `requests` counts the HTTP calls, which is what tells a
+        multi-op write apart from a loop.
+        """
+        pairs = list(pairs)
+        if not pairs:
+            return {}
+        self.requests.append((slug, [f for f, _ in pairs], if_match))
+        for field, value in pairs:
+            self.patched.append((slug, field, value, if_match))
+            self._cases[slug][field] = value
         return {}
 
 
@@ -497,12 +514,21 @@ class _EtagEnforcingApi(_StubApi):
         super().__init__(cases)
         self._version = 1
 
-    def patch_field(self, slug, field, value, timeout=60, if_match=None):
+    def _bump(self, if_match):
         if if_match is not None and if_match != self._etag:
             raise RuntimeError("HTTP Error 412: Precondition Failed")
         self._version += 1
         self._etag = f'W/"etag-{self._version}"'
+
+    def patch_field(self, slug, field, value, timeout=60, if_match=None):
+        self._bump(if_match)
         return super().patch_field(slug, field, value, timeout, if_match)
+
+    def patch_fields(self, slug, pairs, timeout=60, if_match=None):
+        pairs = list(pairs)
+        if pairs:
+            self._bump(if_match)
+        return super().patch_fields(slug, pairs, timeout, if_match)
 
 
 class _FakeUsage:
@@ -695,46 +721,61 @@ def test_a_rejected_title_does_not_block_the_short_description(monkeypatch):
     assert [f for _, f, _, _ in api.patched] == ["short_description"]
 
 
-def test_both_fields_land_when_the_server_enforces_if_match(monkeypatch):
-    """Regression: the second field write must not carry the first one's ETag.
+def test_both_fields_land_in_one_patch_when_the_server_enforces_if_match(monkeypatch):
+    """DEVIATION 6, and the regression test for the bug that motivated it.
 
-    Found by the 2026-08-04 local smoke run, invisible to every other test here
-    and to any dry run — the dry run reports `would-enrich` twice and looks
-    perfect, because it never issues a PATCH at all.
+    The donor shape -- one PATCH per field -- took a 412 on the second write for
+    every case, because the first write had already changed the ETag. Asserting
+    ONE request is the point: a passing "both fields are present" check would
+    also pass for a two-request version that refreshes the ETag in between, and
+    that version is the one that cannot be atomic.
+
+    Invisible to any dry run, which issues no PATCH and reports `would-enrich`
+    for both fields.
     """
     api = _EtagEnforcingApi([CASE_STUB_BOTH])
     report = _run_main(monkeypatch, api, _llm(title=MATCHING_TITLE),
                        BASE_ARGV + ["--apply"])
 
-    assert [f for _, f, _, _ in api.patched] == ["title", "short_description"]
+    assert len(api.requests) == 1, "both fields must go in ONE conditional PATCH"
+    slug, fields, if_match = api.requests[0]
+    assert fields == ["title", "short_description"]
+    assert if_match, "the write must stay conditional"
     assert not [r for r in report.rows if r["status"] == "error"]
-
-    first_etag = api.patched[0][3]
-    second_etag = api.patched[1][3]
-    assert first_etag and second_etag, "both writes must send an If-Match"
-    assert first_etag != second_etag, (
-        "the second PATCH reused the first PATCH's ETag — a guaranteed 412"
-    )
+    assert api._cases[slug]["title"] == MATCHING_TITLE
 
 
-def test_a_failed_etag_refresh_does_not_block_the_second_write(monkeypatch):
-    """The write already succeeded, so a refresh failure must not lose the other
-    field. The ETag is cleared and the second write goes unconditional."""
+def test_a_rejected_title_leaves_the_teaser_in_a_single_op_patch(monkeypatch):
+    """Per-field independence survives the merge into one request.
+
+    It lives in vetting, not in the number of PATCHes: a title that fails
+    `vet_title` is left out of the op list and the teaser still lands.
+    """
     api = _EtagEnforcingApi([CASE_STUB_BOTH])
-    calls = {"n": 0}
-    real_get = api.get_case_with_etag
+    _run_main(monkeypatch, api, _llm(title="शीर्षक without a number"),
+              BASE_ARGV + ["--apply"])
 
-    def flaky(slug, timeout=60):
-        calls["n"] += 1
-        if calls["n"] > 1:          # the post-write refresh
-            raise RuntimeError("connection reset")
-        return real_get(slug, timeout)
+    assert len(api.requests) == 1
+    assert api.requests[0][1] == ["short_description"]
 
-    api.get_case_with_etag = flaky
-    _run_main(monkeypatch, api, _llm(title=MATCHING_TITLE), BASE_ARGV + ["--apply"])
 
-    assert [f for _, f, _, _ in api.patched] == ["title", "short_description"]
-    assert api.patched[1][3] is None, "second write should be unconditional"
+def test_a_failed_patch_reports_every_field_as_failed(monkeypatch):
+    """The write is atomic, so the failure has to be reported that way.
+
+    Reporting one field written and one failed would describe a state the server
+    never held.
+    """
+    class _FailingApi(_EtagEnforcingApi):
+        def patch_fields(self, slug, pairs, timeout=60, if_match=None):
+            raise RuntimeError("HTTP Error 500: Internal Server Error")
+
+    api = _FailingApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api, _llm(title=MATCHING_TITLE),
+                       BASE_ARGV + ["--apply"])
+
+    assert api.patched == []
+    errors = [r for r in report.rows if r["status"] == "error"]
+    assert len(errors) == 2, "both fields are unwritten, so both are errors"
 
 
 def test_an_unparseable_reply_is_skipped_not_written(monkeypatch):
@@ -759,18 +800,31 @@ def test_an_llm_exception_is_recorded_as_error(monkeypatch):
 
 
 def test_a_patch_failure_is_recorded_and_the_run_continues(monkeypatch):
-    class _FailingApi(_StubApi):
-        def patch_field(self, slug, field, value, timeout=60, if_match=None):
-            if field == "title":
-                raise RuntimeError("412 stale")
-            return super().patch_field(slug, field, value, timeout, if_match)
+    """One case's failed write must not end the batch.
 
-    api = _FailingApi([CASE_STUB_BOTH])
+    This used to assert that a failed `title` write let `short_description`
+    through. DEVIATION 6 removed that: the two fields share one atomic PATCH, so
+    a failure loses both (see
+    `test_a_failed_patch_reports_every_field_as_failed`). What still has to hold
+    -- and what the original test was really protecting -- is that the RUN keeps
+    going to the next case.
+    """
+    class _FailingApi(_StubApi):
+        def patch_fields(self, slug, pairs, timeout=60, if_match=None):
+            if slug == "case-stub-both":
+                raise RuntimeError("412 stale")
+            return super().patch_fields(slug, pairs, timeout, if_match)
+
+    api = _FailingApi([CASE_STUB_BOTH, CASE_GOOD_TITLE])
     report = _run_main(monkeypatch, api,
                        _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
                        BASE_ARGV + ["--apply"])
-    assert [f for _, f, _, _ in api.patched] == ["short_description"]
+
     assert any("412 stale" in r["reason"] for r in report.rows)
+    written = {s for s, _, _, _ in api.patched}
+    assert "case-stub-both" not in written, "the failed write must not be recorded"
+    assert "case-good-title" in written, (
+        "the other case must still be written after this one failed")
 
 
 # --------------------------------------------------------------------------

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -987,8 +987,7 @@ def test_build_api_refuses_a_remote_write_by_default():
 def test_add_common_args_is_wired():
     """Sanity: the shared flags this script relies on all parse."""
     args = build_parser().parse_args(
-        ["--limit", "3", "--force", "--no-llm-cache", "--verbose"])
+        ["--limit", "3", "--force", "--verbose"])
     assert args.limit == 3
     assert args.force is True
-    assert args.llm_cache is False
     assert isinstance(build_parser(), argparse.ArgumentParser)

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1207,3 +1207,93 @@ def test_batch_csv_reaches_selection(monkeypatch, tmp_path):
     args = build_parser().parse_args(["--batch-csv", str(csv)])
     assert args.batch_csv == str(csv)
     assert "select_for_run" in Path(ec.__file__).read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# code-review findings
+# --------------------------------------------------------------------------
+
+
+class TestThePlaceholderIsNotAWritableAnswer:
+    """Review finding 4. The OUTPUT FORMAT example is a string the model can
+    echo, and `short_description` had no content gate to stop it.
+
+    `vet_title` catches the title half only by accident -- the example's case
+    number never matches the case's own, so `validate_title` rejects it. But
+    `short_description` has no format contract to violate, so "एक-वाक्य सारांश"
+    ("one-sentence summary") passed vetting and would render on a public card.
+    Deviation 2 justifies the cheap tier by "the two write gates are also
+    unusually strong here"; that was true of one field and false of the other.
+    """
+
+    def test_the_short_placeholder_is_rejected(self):
+        short, reason = vet_short_description(ec._SHORT_PLACEHOLDER)
+        assert short is None
+        assert "placeholder" in reason
+
+    def test_the_placeholder_is_rejected_inside_a_longer_reply(self):
+        short, reason = vet_short_description(f"{ec._SHORT_PLACEHOLDER}: ठेक्का प्रकरण।")
+        assert short is None
+
+    def test_the_prompt_and_the_gate_cannot_drift(self):
+        """The prompt is BUILT from the constant the gate checks, so an edit to
+        the example cannot leave the gate guarding a string nobody sends."""
+        assert ec._SHORT_PLACEHOLDER in ec.SYSTEM_PROMPT
+        assert ec._TITLE_PLACEHOLDER in ec.SYSTEM_PROMPT
+
+    def test_an_echoed_placeholder_is_never_written(self, monkeypatch):
+        api = _StubApi([CASE_STUB_BOTH])
+        _run_main(monkeypatch, api,
+                  _llm(title=ec._TITLE_PLACEHOLDER, short=ec._SHORT_PLACEHOLDER),
+                  BASE_ARGV + ["--apply"])
+        assert api.patched == [], "echoing the example must write nothing at all"
+
+
+class TestAStubDescriptionCannotGroundACard:
+    """Review finding 5. `unmet_prerequisites` is an emptiness test, so it
+    rejected only `None`/`""`/`[]`/`{}`.
+
+    A whitespace-only description passed it and reached the prompt as
+    `DESCRIPTION: (none)`; a one-line template stub reached it as the entire
+    factual basis for a headline TITLE_RULES asks to name the principal accused
+    with a quantifiable hook. A comment in `main()` asserted a second check would
+    be unreachable code -- that was wrong, and being wrong is why no guard
+    existed.
+    """
+
+    def test_the_emptiness_test_alone_lets_whitespace_through(self):
+        """Pins WHY the extra guard is needed, not just that it exists."""
+        from casework.common.pipeline import STAGES, unmet_prerequisites
+
+        assert unmet_prerequisites(STAGES["card"], {"description": "   \n  "}) == []
+
+    def test_a_whitespace_only_description_generates_nothing(self, monkeypatch):
+        stub = _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)")
+        api = _StubApi([dict(CASE_STUB_BOTH, description="   \n  ")])
+        _run_main(monkeypatch, api, stub, BASE_ARGV + ["--apply"])
+        assert stub.calls == [], "no LLM call may be billed on an empty basis"
+        assert api.patched == []
+
+    def test_a_template_stub_description_generates_nothing(self, monkeypatch):
+        stub = _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)")
+        api = _StubApi([dict(CASE_STUB_BOTH,
+                             description="यो मुद्दाको विवरण अद्यावधिक हुँदैछ।")])
+        _run_main(monkeypatch, api, stub, BASE_ARGV + ["--apply"])
+        assert stub.calls == []
+        assert api.patched == []
+
+    def test_the_threshold_is_the_description_stage_s_own(self):
+        """One number, one home. When only `enrich_description` held it, the two
+        stages disagreed on what "written" means."""
+        from casework.common import pipeline
+
+        assert ec.SUBSTANTIAL_DESCRIPTION_CHARS is pipeline.SUBSTANTIAL_DESCRIPTION_CHARS
+        assert ec.SUBSTANTIAL_DESCRIPTION_CHARS == 600
+
+    def test_a_real_description_still_passes(self, monkeypatch):
+        """The guard must not swallow the normal case."""
+        stub = _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)")
+        api = _StubApi([CASE_STUB_BOTH])
+        _run_main(monkeypatch, api, stub, BASE_ARGV + ["--apply"])
+        assert stub.calls, "an 861-char description is a real one"
+        assert api.patched

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -49,6 +49,11 @@ STUB_SHORT = (
 )
 GOOD_TITLE = "काठमाडौं महानगरपालिका ठेक्का घोटाला: रु ३३ करोड हिनामिना (081-CR-0091)"
 
+# A title whose court number matches CASE_STUB_BOTH. `GOOD_TITLE` names
+# 081-CR-0091, so `vet_title` rightly rejects it for a 076-CR-0182 case --
+# use this whenever a test needs the title write to actually land.
+MATCHING_TITLE = "काठमाडौं ठेक्का घोटाला: रु ३३ करोड हिनामिना (076-CR-0182)"
+
 
 def _donor_source(name) -> str:
     proc = subprocess.run(
@@ -185,9 +190,17 @@ class TestDonorDeviations:
         assert "DESCRIPTION_SNIPPET_BUDGET = 2000" in donor_title
         assert ec.DESCRIPTION_SNIPPET_BUDGET == 3000
 
-    def test_max_tokens_matches_the_donors(self, donor_card):
+    def test_max_tokens_deliberately_exceeds_the_donors(self, donor_card):
+        """DEVIATION 5, pinned both ways.
+
+        The donor's 1000 killed a real case on the 2026-08-04 local smoke run:
+        `API Error: Claude's response exceeded the 1000 output token maximum`.
+        The provider raises rather than truncating, so the case produced nothing
+        at all. Devanagari costs far more tokens per character than Latin, and
+        the two fields' own caps (200 + 320 chars) have to fit.
+        """
         assert "max_tokens=1000" in donor_card
-        assert ec.CARD_MAX_TOKENS == 1000
+        assert ec.CARD_MAX_TOKENS == 4000
 
 
 # --------------------------------------------------------------------------
@@ -388,7 +401,7 @@ class TestPromptAssembly:
         assert _snippet(dict(DETAIL, description="")) == "(none)"
 
 
-def test_generate_uses_the_cheap_tier_and_1000_max_tokens():
+def test_generate_uses_the_cheap_tier_and_the_card_token_budget():
     seen = {}
 
     def stub(**kw):
@@ -398,7 +411,7 @@ def test_generate_uses_the_cheap_tier_and_1000_max_tokens():
     result = _generate(DETAIL, "081-CR-0091", True, True, stub, usage=None)
     assert result["title"] == GOOD_TITLE
     assert seen["tier"] == "cheap"
-    assert seen["max_tokens"] == 1000
+    assert seen["max_tokens"] == ec.CARD_MAX_TOKENS
     assert seen["system"] == ec.SYSTEM_PROMPT
 
 
@@ -465,6 +478,31 @@ class _StubApi:
         self.patched.append((slug, field, value, if_match))
         self._cases[slug][field] = value
         return {}
+
+
+class _EtagEnforcingApi(_StubApi):
+    """`_StubApi` with the server's actual optimistic-concurrency semantics.
+
+    Every successful write mints a NEW ETag, and a PATCH carrying a stale
+    `If-Match` is refused — which is what `/api/cases/{slug}/` does. `_StubApi`
+    returns one constant ETag and ignores `If-Match` altogether, and that is
+    precisely why a full green suite coexisted with a script that could never
+    write both of its fields: the 2026-08-04 local smoke run wrote `title`, then
+    took `HTTP Error 412: Precondition Failed` on `short_description` for every
+    case. Any future two-PATCH enricher should be tested against this, not the
+    permissive double.
+    """
+
+    def __init__(self, cases):
+        super().__init__(cases)
+        self._version = 1
+
+    def patch_field(self, slug, field, value, timeout=60, if_match=None):
+        if if_match is not None and if_match != self._etag:
+            raise RuntimeError("HTTP Error 412: Precondition Failed")
+        self._version += 1
+        self._etag = f'W/"etag-{self._version}"'
+        return super().patch_field(slug, field, value, timeout, if_match)
 
 
 class _FakeUsage:
@@ -655,6 +693,48 @@ def test_a_rejected_title_does_not_block_the_short_description(monkeypatch):
     _run_main(monkeypatch, api, _llm(title="शीर्षक without a number"),
               BASE_ARGV + ["--apply"])
     assert [f for _, f, _, _ in api.patched] == ["short_description"]
+
+
+def test_both_fields_land_when_the_server_enforces_if_match(monkeypatch):
+    """Regression: the second field write must not carry the first one's ETag.
+
+    Found by the 2026-08-04 local smoke run, invisible to every other test here
+    and to any dry run — the dry run reports `would-enrich` twice and looks
+    perfect, because it never issues a PATCH at all.
+    """
+    api = _EtagEnforcingApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api, _llm(title=MATCHING_TITLE),
+                       BASE_ARGV + ["--apply"])
+
+    assert [f for _, f, _, _ in api.patched] == ["title", "short_description"]
+    assert not [r for r in report.rows if r["status"] == "error"]
+
+    first_etag = api.patched[0][3]
+    second_etag = api.patched[1][3]
+    assert first_etag and second_etag, "both writes must send an If-Match"
+    assert first_etag != second_etag, (
+        "the second PATCH reused the first PATCH's ETag — a guaranteed 412"
+    )
+
+
+def test_a_failed_etag_refresh_does_not_block_the_second_write(monkeypatch):
+    """The write already succeeded, so a refresh failure must not lose the other
+    field. The ETag is cleared and the second write goes unconditional."""
+    api = _EtagEnforcingApi([CASE_STUB_BOTH])
+    calls = {"n": 0}
+    real_get = api.get_case_with_etag
+
+    def flaky(slug, timeout=60):
+        calls["n"] += 1
+        if calls["n"] > 1:          # the post-write refresh
+            raise RuntimeError("connection reset")
+        return real_get(slug, timeout)
+
+    api.get_case_with_etag = flaky
+    _run_main(monkeypatch, api, _llm(title=MATCHING_TITLE), BASE_ARGV + ["--apply"])
+
+    assert [f for _, f, _, _ in api.patched] == ["title", "short_description"]
+    assert api.patched[1][3] is None, "second write should be unconditional"
 
 
 def test_an_unparseable_reply_is_skipped_not_written(monkeypatch):

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -396,6 +396,37 @@ class TestSnippetKeepsTheOutcome:
         assert "सफाई" in snippet
         assert "[…]" in snippet
 
+    def test_a_long_verdict_is_read_to_the_end_not_clipped(self):
+        """The whole verdict section reaches the model, not a fixed 1,200 chars.
+
+        A flat slice clipped the verdict on 21 of the 52 long published
+        descriptions, and worst where it matters: a multi-defendant case states
+        one outcome PER defendant, so a clipped slice keeps the conviction and
+        drops the acquittal. `078-CR-0103` reproduced it twice -- सफाई sat 172
+        characters past where the old slice ended.
+        """
+        verdict = ("\n### ग) विशेष अदालतको फैसलाको सार\n"
+                   + ("अदालतले प्रतिवादीलाई दोषी ठहर गरेको। " * 40)
+                   + "\nदोस्रो प्रतिवादीलाई सफाई दिएको।")
+        snippet = _snippet(dict(DETAIL, description=("क) अभियोगदावी। " * 400) + verdict))
+        assert "दोषी ठहर" in snippet, "the conviction must survive"
+        assert "सफाई दिएको।" in snippet, (
+            "the ACQUITTAL is the half a fixed-width slice used to drop")
+        assert len(snippet) <= ec.SNIPPET_MAX_CHARS + 16
+
+    def test_the_ceiling_still_bounds_a_runaway_verdict(self):
+        """The longest published verdict section is 13,617 chars; one outlier
+        judgment must not fill the whole prompt."""
+        text = ("क) अभियोगदावी। " * 400) + "\nफैसला: " + ("दोषी ठहर गरेको। " * 2000)
+        snippet = _snippet(dict(DETAIL, description=text))
+        assert len(snippet) <= ec.SNIPPET_MAX_CHARS + 16
+
+    def test_a_short_verdict_makes_the_snippet_SMALLER_than_the_old_flat_slice(self):
+        """The median verdict section is 794 chars, so the common case now sends
+        LESS than the old fixed 1,200 -- this change is not a cost increase."""
+        text = ("क) अभियोगदावी। " * 400) + "\nफैसला: सफाई दिएको।"
+        assert len(_snippet(dict(DETAIL, description=text))) < 3000
+
     def test_an_early_outcome_word_does_not_hijack_the_slice(self):
         """Finding 1. The vocabulary scan takes the LAST match, not the first.
 

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1,0 +1,788 @@
+"""Tests for the DB-free standalone card enricher (casework/enrich_card.py).
+
+`enrich_card.py` writes `Case.title` and `Case.short_description` from the
+`description` already on the case. It fetches no source documents, and it is the
+SOLE writer of `title` on `main`.
+
+The two things worth the most test weight here:
+
+1. THE TEMPLATE STUB. 2,666 of 2,918 DRAFT cases carry a `short_description`
+   that is 120-odd characters of grammatical Nepali naming a real case and a
+   real defendant. Anything that treats "populated" as "done" skips every case
+   this script exists to fix, which is why the donor's list-level
+   `skip_field="short_description"` had to go and why the gate is a content
+   judge. `test_the_real_template_stub_is_classified_as_a_placeholder` uses the
+   verbatim production string.
+
+2. `--only title` MUST NOT TOUCH THE DESCRIPTION. That path replaces the title
+   pass stripped out of `enrich_description`, and its whole reason to exist is
+   fixing a title on a case whose description is already good.
+"""
+import argparse
+import ast
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from casework import enrich_card as ec
+from casework.enrich_card import (
+    _build_prompt,
+    _generate,
+    _snippet,
+    build_parser,
+    vet_short_description,
+    vet_title,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DONOR_COMMIT = "0321a85"
+
+# The verbatim production template, from the brief. Both fields, one real case.
+STUB_TITLE = "CIAA Special Court Case 076-CR-0182: बिनोद कुमार भूजेल समेत ५"
+STUB_SHORT = (
+    "अख्तियार दुरुपयोग अनुसन्धान आयोगले विशेष अदालतमा दायर गरेको मुद्दा "
+    "076-CR-0182, प्रतिवादी: बिनोद कुमार भूजेल समेत ५।"
+)
+GOOD_TITLE = "काठमाडौं महानगरपालिका ठेक्का घोटाला: रु ३३ करोड हिनामिना (081-CR-0091)"
+
+
+def _donor_source(name) -> str:
+    proc = subprocess.run(
+        ["git", "show", f"{DONOR_COMMIT}:casework/{name}"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        pytest.skip(
+            f"donor commit {DONOR_COMMIT} not in local history "
+            "(shallow clone?); fidelity check needs full git history")
+    return proc.stdout
+
+
+@pytest.fixture(scope="module")
+def donor_card():
+    return _donor_source("enrich_card.py")
+
+
+@pytest.fixture(scope="module")
+def donor_title():
+    return _donor_source("enrich_title.py")
+
+
+def _shipped_source():
+    return Path(ec.__file__).read_text(encoding="utf-8")
+
+
+def _imports_name(path, name):
+    """True when `path` really imports `name`.
+
+    An AST check, not a text grep: `enrich_description.py`'s docstring MENTIONS
+    `TITLE_RULES` on purpose -- it explains that the title pass was dropped --
+    and a grep would read that explanation as a violation of the rule it exists
+    to document.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and any(a.name == name for a in node.names)
+        for node in ast.walk(tree)
+    )
+
+
+def _identifiers(source):
+    names = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.keyword) and node.arg:
+            names.add(node.arg)
+        elif isinstance(node, ast.alias):
+            names.add(node.asname or node.name.split(".")[-1])
+    return names
+
+
+class TestDonorDeviations:
+    """The four deliberate deviations, pinned in both directions."""
+
+    def test_enrich_title_folds_in_as_only_title(self, donor_title):
+        """Deviation 1. The donor file exists and is deliberately not ported."""
+        assert "enrich_title.py" in _shipped_source(), (
+            "the docstring must say why enrich_title.py was not ported, or the "
+            "next reader ports it again")
+        assert "def main" in donor_title
+        choices = build_parser().parse_args(["--only", "title"])
+        assert choices.only == "title"
+
+    def test_the_wider_enrich_title_input_set_wins(self, donor_card, donor_title):
+        """Deviation 1. `enrich_title` fed `entities`; the card donor did not.
+
+        Named accused are exactly what a headline needs, so the wider set is
+        taken -- asserted against the donors rather than trusted from prose.
+        """
+        assert "format_entities" in donor_title
+        assert "format_entities" not in donor_card
+        assert "NAMED ENTITIES" in ec.USER_PROMPT
+
+    def test_shared_title_rules_are_used_not_restated(self, donor_card):
+        """Deviation 1. The card donor restated the rules inline; this imports.
+
+        Two copies of a public-headline contract is two places a rule changes
+        and one place it silently does not.
+        """
+        from casework.common.titles import TITLE_RULES
+
+        assert "TITLE_RULES" not in donor_card       # the donor restated them
+        assert TITLE_RULES in ec.SYSTEM_PROMPT       # this port imports them
+        assert "NEVER put a defendant HEADCOUNT" in ec.SYSTEM_PROMPT
+
+    def test_titles_module_has_exactly_one_importer(self):
+        """The single-owner rule, enforced across the whole package.
+
+        This is the assertion that actually keeps `title` single-owner: a future
+        enricher importing TITLE_RULES fails here rather than being noticed in
+        review.
+        """
+        importers = sorted(
+            p.name for p in (REPO_ROOT / "casework").rglob("*.py")
+            if p.name != "titles.py" and _imports_name(p, "TITLE_RULES")
+        )
+        assert importers == ["enrich_card.py"], importers
+
+    def test_the_two_donors_disagreed_on_tier_and_cheap_wins(
+        self, donor_card, donor_title
+    ):
+        """Deviation 2, pinned against both donor sources."""
+        from casework.common.llm import tier_for
+
+        assert 'tier="cheap"' in donor_card
+        assert 'tier="premium"' in donor_title
+        assert tier_for("card") == "cheap"
+
+    def test_no_list_level_skip_field_survives(self, donor_card):
+        """Deviation 3. `skip_field="short_description"` would skip all 2,666."""
+        assert 'skip_field="short_description"' in donor_card
+        ids = _identifiers(_shipped_source())
+        assert "skip_field" not in ids
+        assert "get_target_cases" not in ids
+
+    def test_the_donor_had_no_title_length_check(self, donor_card, donor_title):
+        """Deviation 4. Neither donor checked `max_length=200`."""
+        assert "MAX_TITLE_CHARS" not in donor_card
+        assert "MAX_TITLE_CHARS" not in donor_title
+        assert ec.MAX_TITLE_CHARS == 200
+
+    def test_short_description_cap_matches_the_donor(self, donor_card):
+        assert "MAX_SHORT_DESCRIPTION_CHARS = 320" in donor_card
+        assert ec.MAX_SHORT_DESCRIPTION_CHARS == 320
+
+    def test_snippet_budget_takes_the_wider_donor_value(self, donor_card, donor_title):
+        assert "DESCRIPTION_SNIPPET_BUDGET = 3000" in donor_card
+        assert "DESCRIPTION_SNIPPET_BUDGET = 2000" in donor_title
+        assert ec.DESCRIPTION_SNIPPET_BUDGET == 3000
+
+    def test_max_tokens_matches_the_donors(self, donor_card):
+        assert "max_tokens=1000" in donor_card
+        assert ec.CARD_MAX_TOKENS == 1000
+
+
+# --------------------------------------------------------------------------
+# stage + tier registration
+# --------------------------------------------------------------------------
+
+
+def test_stage_reads_no_material_but_hard_gates_on_description():
+    """`requires_stages` only ORDERS -- it never checks. So the description
+    dependency has to be in `requires_fields` as well, or a card gets built
+    from an empty description whenever the stage runs on its own."""
+    from casework.common.pipeline import STAGES
+
+    stage = STAGES["card"]
+    assert stage.requires_materials == ()
+    assert stage.requires_fields == ("description",)
+    assert stage.requires_stages == ("description",)
+
+
+def test_stage_provides_both_card_fields():
+    from casework.common.pipeline import STAGES
+
+    assert STAGES["card"].provides == ("title", "short_description")
+
+
+def test_card_orders_after_description():
+    from casework.common.pipeline import order_stages
+
+    assert order_stages(["card", "description"]) == ["description", "card"]
+
+
+def test_an_empty_description_is_an_unmet_prerequisite():
+    from casework.common.pipeline import STAGES, unmet_prerequisites
+
+    unmet = unmet_prerequisites(STAGES["card"], {"description": ""})
+    assert unmet == ["required field description is empty"]
+
+
+# --------------------------------------------------------------------------
+# the template stub -- the gate that matters most
+# --------------------------------------------------------------------------
+
+
+def test_the_real_template_stub_is_classified_as_a_placeholder():
+    """The production stub, verbatim, must reach the model rather than being
+    short-circuited as "populated, therefore fine".
+
+    It is 120-odd characters of grammatical Nepali naming a real case and a
+    real defendant, so it passes every cheap heuristic -- non-empty, long
+    enough, well-formed. Only a content judgement catches it, which is why the
+    gate spends a cheap LLM call instead of measuring a length.
+    """
+    from casework.common.judge import _JUDGE_MIN_CHARS, judge_description_adequacy
+
+    assert len(STUB_SHORT) > _JUDGE_MIN_CHARS, (
+        "the stub is long enough to clear the no-call floor -- if it weren't, "
+        "this test would be passing for the wrong reason")
+
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"adequate": False, "reason": "generic boilerplate"})
+
+    adequate, reason = judge_description_adequacy(
+        STUB_SHORT, kind="case card short description", invoke_text=stub)
+    assert adequate is False
+    assert "boilerplate" in reason
+    # The judge must actually have seen the stub text.
+    assert STUB_SHORT in seen["content"]
+    assert seen["tier"] == "cheap"
+
+
+def test_the_template_title_fails_the_format_contract():
+    """The stub title carries the case number but does not END in it in parens,
+    so `title_is_acceptable` refuses it and the case is regenerated."""
+    from casework.common.titles import title_is_acceptable
+
+    assert not title_is_acceptable(STUB_TITLE, "076-CR-0182")
+    assert title_is_acceptable(GOOD_TITLE, "081-CR-0091")
+
+
+# --------------------------------------------------------------------------
+# vet_title / vet_short_description
+# --------------------------------------------------------------------------
+
+
+class TestVetTitle:
+    def test_a_good_title_passes(self):
+        assert vet_title(GOOD_TITLE, "081-CR-0091") == (GOOD_TITLE, None)
+
+    def test_whitespace_is_stripped(self):
+        assert vet_title(f"  {GOOD_TITLE}  ", "081-CR-0091")[0] == GOOD_TITLE
+
+    def test_an_empty_title_is_rejected(self):
+        assert vet_title("", "081-CR-0091") == (None, "LLM returned no title")
+        assert vet_title(None, "081-CR-0091")[0] is None
+
+    def test_a_title_missing_the_case_number_is_rejected(self):
+        value, reason = vet_title("काठमाडौं ठेक्का घोटाला", "081-CR-0091")
+        assert value is None
+        assert "no court case number" in reason
+
+    def test_a_title_with_a_headcount_is_rejected(self):
+        value, reason = vet_title(
+            "काठमाडौं ठेक्कामा ५ जना प्रतिवादी (081-CR-0091)", "081-CR-0091")
+        assert value is None
+        assert "headcount" in reason
+
+    def test_an_over_length_title_is_rejected_not_truncated(self):
+        """Deviation 4. A trimmed headline looks deliberate and loses the case
+        number the contract requires at the END."""
+        long_title = "क" * 200 + " (081-CR-0091)"
+        value, reason = vet_title(long_title, "081-CR-0091")
+        assert value is None
+        assert "too long" in reason
+        assert "not truncating" in reason
+
+    def test_a_title_at_exactly_the_limit_is_accepted(self):
+        suffix = " (081-CR-0091)"
+        exact = "क" * (ec.MAX_TITLE_CHARS - len(suffix)) + suffix
+        assert len(exact) == ec.MAX_TITLE_CHARS
+        assert vet_title(exact, "081-CR-0091") == (exact, None)
+
+
+class TestVetShortDescription:
+    def test_a_good_teaser_passes(self):
+        text = "काठमाडौं महानगरपालिकाको ठेक्कामा रु ३३ करोड हिनामिना भएको आरोप।"
+        assert vet_short_description(text) == (text, None)
+
+    def test_an_empty_value_is_rejected_never_written(self):
+        """`CaseListSerializer` ships this field with no fallback to title or
+        description, so writing "" renders a blank card on the public list."""
+        value, reason = vet_short_description("   ")
+        assert value is None
+        assert "empty" in reason
+
+    def test_none_is_rejected(self):
+        assert vet_short_description(None)[0] is None
+
+    def test_an_over_length_teaser_is_rejected(self):
+        value, reason = vet_short_description("क" * 321)
+        assert value is None
+        assert "too long" in reason
+
+    def test_exactly_the_cap_is_accepted(self):
+        text = "क" * ec.MAX_SHORT_DESCRIPTION_CHARS
+        assert vet_short_description(text) == (text, None)
+
+
+# --------------------------------------------------------------------------
+# prompt assembly
+# --------------------------------------------------------------------------
+
+DETAIL = {
+    "slug": "case-081-cr-0091",
+    "title": STUB_TITLE,
+    "short_description": STUB_SHORT,
+    "description": "### क) अभियोगदावीको सार\nकाठमाडौं महानगरपालिकाको ठेक्कामा मिलेमतो।",
+    "bigo": 330000000,
+    "court_cases": ["https://jawafdehi.org/courtcase/special/081-cr-0091"],
+    "key_allegations": ["ठेक्कामा मिलेमतो गरी सार्वजनिक सम्पत्ति हानि पुर्‍याएको।"],
+    "entities": [
+        {"nes_id": "person/kamal-raj-gautam", "display_name": "कमल राज गौतम",
+         "entity_type": "person", "type": "accused", "outcome": "", "notes": ""},
+    ],
+}
+
+
+class TestPromptAssembly:
+    def test_the_prompt_carries_every_context_block(self):
+        content = _build_prompt(DETAIL, "081-cr-0091", True, True)
+        assert STUB_TITLE in content
+        assert "081-cr-0091" in content
+        assert "330,000,000" in content
+        assert "ठेक्कामा मिलेमतो" in content
+        assert "[accused] कमल राज गौतम" in content
+        assert "अभियोगदावीको सार" in content
+
+    def test_asking_for_both_says_so(self):
+        content = _build_prompt(DETAIL, "081-cr-0091", True, True)
+        assert "Produce the title AND the short_description." in content
+
+    def test_asking_for_one_tells_the_model_to_null_the_other(self):
+        content = _build_prompt(DETAIL, "081-cr-0091", True, False)
+        assert "Only the title is needed" in content
+        content = _build_prompt(DETAIL, "081-cr-0091", False, True)
+        assert "Only the short_description is needed" in content
+
+    def test_a_missing_court_number_renders_as_unknown(self):
+        assert "(unknown)" in _build_prompt(DETAIL, "", True, False)
+
+    def test_the_description_snippet_is_capped(self):
+        detail = dict(DETAIL, description="क" * 5000)
+        assert len(_snippet(detail)) == ec.DESCRIPTION_SNIPPET_BUDGET
+
+    def test_no_description_renders_as_none(self):
+        assert _snippet(dict(DETAIL, description="")) == "(none)"
+
+
+def test_generate_uses_the_cheap_tier_and_1000_max_tokens():
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"title": GOOD_TITLE, "short_description": "सार।"})
+
+    result = _generate(DETAIL, "081-CR-0091", True, True, stub, usage=None)
+    assert result["title"] == GOOD_TITLE
+    assert seen["tier"] == "cheap"
+    assert seen["max_tokens"] == 1000
+    assert seen["system"] == ec.SYSTEM_PROMPT
+
+
+def test_generate_accepts_a_reply_carrying_only_one_key():
+    """A `--only title` run gets `{"title": ..., "short_description": null}`.
+    Demanding both keys would reject every single-field reply."""
+    body = json.dumps({"title": GOOD_TITLE, "short_description": None})
+    result = _generate(DETAIL, "081-CR-0091", True, False,
+                       lambda **kw: body, usage=None)
+    assert result["title"] == GOOD_TITLE
+
+
+def test_generate_returns_none_for_an_object_with_neither_key():
+    assert _generate(DETAIL, "081-CR-0091", True, True,
+                     lambda **kw: '{"other": 1}', usage=None) is None
+
+
+def test_generate_returns_none_for_unparseable_text():
+    assert _generate(DETAIL, "081-CR-0091", True, True,
+                     lambda **kw: "sorry, no", usage=None) is None
+
+
+# --------------------------------------------------------------------------
+# main() -- integration over a stubbed API + LLM
+# --------------------------------------------------------------------------
+
+CASE_STUB_BOTH = {
+    "slug": "case-stub-both",
+    "title": STUB_TITLE,
+    "short_description": STUB_SHORT,
+    "state": "DRAFT",
+    "description": "### क) अभियोगदावीको सार\n" + "काठमाडौंको ठेक्कामा मिलेमतो। " * 30,
+    "bigo": 330000000,
+    "court_cases": ["https://jawafdehi.org/courtcase/special/076-cr-0182"],
+    "key_allegations": ["ठेक्कामा मिलेमतो गरेको।"],
+    "entities": [],
+}
+
+CASE_GOOD_TITLE = dict(
+    CASE_STUB_BOTH, slug="case-good-title", title=GOOD_TITLE,
+    court_cases=["https://jawafdehi.org/courtcase/special/081-cr-0091"],
+)
+
+CASE_NO_DESCRIPTION = dict(
+    CASE_STUB_BOTH, slug="case-no-description", description="", key_allegations=[])
+
+CASE_NO_COURT_NUMBER = dict(
+    CASE_STUB_BOTH, slug="case-no-court-number", court_cases=[])
+
+
+class _StubApi:
+    def __init__(self, cases, etag='W/"etag-1"'):
+        self._cases = {c["slug"]: dict(c) for c in cases}
+        self._etag = etag
+        self.patched = []
+
+    def iter_cases(self, params=None, timeout=60):
+        yield from self._cases.values()
+
+    def get_case_with_etag(self, slug, timeout=60):
+        return self._cases[slug], self._etag
+
+    def patch_field(self, slug, field, value, timeout=60, if_match=None):
+        self.patched.append((slug, field, value, if_match))
+        self._cases[slug][field] = value
+        return {}
+
+
+class _FakeUsage:
+    def __init__(self):
+        self.calls = 0
+
+    def as_dict(self):
+        return {"by_provider": []}
+
+
+def _llm(*, title=GOOD_TITLE, short="काठमाडौं ठेक्कामा रु ३३ करोड हिनामिना भएको आरोप।",
+         adequate=False):
+    """One stub serving both call sites.
+
+    `main()` makes TWO kinds of call per case -- the adequacy judge, then the
+    generation -- and they are told apart by the judge's system prompt, not by
+    call order: a `--only title` run never calls the judge at all, so ordering
+    would make the stub silently answer the wrong question.
+    """
+    calls = []
+
+    def stub(**kw):
+        calls.append(kw)
+        if "data-quality reviewer" in kw.get("system", ""):
+            return json.dumps({"adequate": adequate, "reason": "stub verdict"})
+        payload = {}
+        if title is not None:
+            payload["title"] = title
+        if short is not None:
+            payload["short_description"] = short
+        return json.dumps(payload)
+
+    stub.calls = calls
+    return stub
+
+
+def _run_main(monkeypatch, api, invoke_text_stub, argv):
+    monkeypatch.setattr(ec, "build_api", lambda args: api)
+    monkeypatch.setattr(ec, "bootstrap", lambda *a, **k: None)
+
+    fake_llm_invoke = types.ModuleType("llm.invoke")
+    fake_llm_invoke.invoke_text = invoke_text_stub
+
+    fake_llm_usage = types.ModuleType("llm.usage")
+    fake_llm_usage.UsageAccumulator = _FakeUsage
+    fake_llm_usage.render_usage_table = lambda by_provider, title=None: ""
+
+    monkeypatch.setitem(sys.modules, "llm.invoke", fake_llm_invoke)
+    monkeypatch.setitem(sys.modules, "llm.usage", fake_llm_usage)
+
+    return ec.main(argv)
+
+
+BASE_ARGV = ["--api-base-url", "http://127.0.0.1:48010"]
+
+
+def test_both_fields_are_written_on_a_template_stub_case(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+              BASE_ARGV + ["--apply"])
+    fields = [f for _, f, _, _ in api.patched]
+    assert sorted(fields) == ["short_description", "title"]
+    assert all(etag == 'W/"etag-1"' for *_, etag in api.patched)
+
+
+def test_only_title_writes_the_title_alone(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+              BASE_ARGV + ["--only", "title", "--apply"])
+    assert [f for _, f, _, _ in api.patched] == ["title"]
+
+
+def test_only_title_leaves_the_description_untouched(monkeypatch):
+    """The standalone-title path the stripped description pass used to cover.
+
+    A case with a good description must come out with that description
+    byte-identical -- this script fetches no documents and must never write
+    that field.
+    """
+    before = CASE_STUB_BOTH["description"]
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+              BASE_ARGV + ["--only", "title", "--apply"])
+    assert api._cases["case-stub-both"]["description"] == before
+    assert "description" not in {f for _, f, _, _ in api.patched}
+
+
+def test_only_title_never_calls_the_adequacy_judge(monkeypatch):
+    """The judge is a real LLM call. A title-only run must not pay for it."""
+    api = _StubApi([CASE_STUB_BOTH])
+    stub = _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)")
+    _run_main(monkeypatch, api, stub, BASE_ARGV + ["--only", "title", "--dry-run"])
+    assert not any("data-quality reviewer" in c.get("system", "") for c in stub.calls)
+
+
+def test_only_short_description_writes_that_field_alone(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(), BASE_ARGV +
+              ["--only", "short_description", "--apply"])
+    assert [f for _, f, _, _ in api.patched] == ["short_description"]
+
+
+def test_a_good_title_is_left_alone(monkeypatch):
+    """`title_is_acceptable` passes, so no title call and no title write."""
+    api = _StubApi([CASE_GOOD_TITLE])
+    report = _run_main(monkeypatch, api, _llm(adequate=True),
+                       BASE_ARGV + ["--only", "title", "--apply"])
+    assert api.patched == []
+    assert {r["status"] for r in report.rows} == {"already"}
+
+
+def test_an_adequate_short_description_is_left_alone(monkeypatch):
+    api = _StubApi([CASE_GOOD_TITLE])
+    report = _run_main(monkeypatch, api, _llm(adequate=True),
+                       BASE_ARGV + ["--only", "short_description", "--apply"])
+    assert api.patched == []
+    assert {r["status"] for r in report.rows} == {"already"}
+
+
+def test_force_overrides_both_gates(monkeypatch):
+    """Both fields are already fine, so only --force reaches the model."""
+    api = _StubApi([CASE_GOOD_TITLE])
+    _run_main(monkeypatch, api, _llm(adequate=True),
+              BASE_ARGV + ["--force", "--apply"])
+    assert sorted(f for _, f, _, _ in api.patched) == ["short_description", "title"]
+
+
+def test_force_skips_the_adequacy_judge_entirely(monkeypatch):
+    """--force means regenerate, so asking the judge would be a wasted call."""
+    api = _StubApi([CASE_GOOD_TITLE])
+    stub = _llm(adequate=True)
+    _run_main(monkeypatch, api, stub, BASE_ARGV + ["--force", "--dry-run"])
+    assert not any("data-quality reviewer" in c.get("system", "") for c in stub.calls)
+
+
+def test_dry_run_writes_nothing(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api,
+                       _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+                       BASE_ARGV + ["--dry-run"])
+    assert api.patched == []
+    assert any(r["status"] == "would-enrich" for r in report.rows)
+
+
+def test_an_over_length_title_is_reported_and_not_written(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    report = _run_main(
+        monkeypatch, api, _llm(title="क" * 250 + " (076-CR-0182)"),
+        BASE_ARGV + ["--only", "title", "--apply"],
+    )
+    assert api.patched == []
+    rejected = [r for r in report.rows if r["status"] == "rejected"]
+    assert rejected and "too long" in rejected[0]["reason"]
+
+
+def test_an_empty_short_description_is_never_patched(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api, _llm(short="   "),
+                       BASE_ARGV + ["--only", "short_description", "--apply"])
+    assert api.patched == []
+    assert any(r["status"] == "rejected" for r in report.rows)
+
+
+def test_a_case_without_a_description_is_unmet(monkeypatch):
+    api = _StubApi([CASE_NO_DESCRIPTION])
+    stub = _llm()
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--dry-run"])
+    assert {r["status"] for r in report.rows} == {"unmet"}
+    assert api.patched == []
+    assert stub.calls == [], "an unmet prerequisite must cost zero LLM calls"
+
+
+def test_a_case_without_a_court_number_skips_the_title(monkeypatch):
+    """No court number means no title can satisfy the format contract, so
+    regenerating would burn a call on a guaranteed rejection."""
+    api = _StubApi([CASE_NO_COURT_NUMBER])
+    report = _run_main(monkeypatch, api, _llm(),
+                       BASE_ARGV + ["--only", "title", "--dry-run"])
+    assert api.patched == []
+    reasons = [r["reason"] for r in report.rows if r["status"] == "unmet"]
+    assert any("special-court number" in r for r in reasons)
+
+
+def test_a_rejected_title_does_not_block_the_short_description(monkeypatch):
+    """The two fields are independent writes. One bad headline must not cost the
+    case its card teaser."""
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="शीर्षक without a number"),
+              BASE_ARGV + ["--apply"])
+    assert [f for _, f, _, _ in api.patched] == ["short_description"]
+
+
+def test_an_unparseable_reply_is_skipped_not_written(monkeypatch):
+    api = _StubApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api, lambda **kw: "no json here",
+                       BASE_ARGV + ["--apply"])
+    assert api.patched == []
+    assert any(r["status"] == "skipped" for r in report.rows)
+
+
+def test_an_llm_exception_is_recorded_as_error(monkeypatch):
+    def boom(**kw):
+        if "data-quality reviewer" in kw.get("system", ""):
+            return json.dumps({"adequate": False, "reason": "stub"})
+        raise RuntimeError("provider exploded")
+
+    api = _StubApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api, boom, BASE_ARGV + ["--apply"])
+    assert api.patched == []
+    errors = [r for r in report.rows if r["status"] == "error"]
+    assert errors and "provider exploded" in errors[0]["reason"]
+
+
+def test_a_patch_failure_is_recorded_and_the_run_continues(monkeypatch):
+    class _FailingApi(_StubApi):
+        def patch_field(self, slug, field, value, timeout=60, if_match=None):
+            if field == "title":
+                raise RuntimeError("412 stale")
+            return super().patch_field(slug, field, value, timeout, if_match)
+
+    api = _FailingApi([CASE_STUB_BOTH])
+    report = _run_main(monkeypatch, api,
+                       _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+                       BASE_ARGV + ["--apply"])
+    assert [f for _, f, _, _ in api.patched] == ["short_description"]
+    assert any("412 stale" in r["reason"] for r in report.rows)
+
+
+# --------------------------------------------------------------------------
+# the review file
+# --------------------------------------------------------------------------
+
+
+def _review_file(tmp_path):
+    files = sorted((tmp_path / "reviews").glob("*.md"))
+    assert files, "every run must write exactly one review file"
+    return files[-1]
+
+
+def test_the_review_file_shows_the_stub_before_and_the_headline_after(
+    monkeypatch, tmp_path
+):
+    api = _StubApi([CASE_STUB_BOTH])
+    new_title = "काठमाडौं ठेक्का घोटाला (076-CR-0182)"
+    _run_main(monkeypatch, api, _llm(title=new_title), BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert STUB_TITLE in text          # before
+    assert new_title in text           # generated
+    assert "DRY RUN" in text
+    assert "title + short_description" in text
+
+
+def test_the_review_file_names_the_description_as_the_source_not_a_material(
+    monkeypatch, tmp_path
+):
+    """This stage fetches no document. Printing a material IRI beside the
+    generated headline would misattribute where it came from."""
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+              BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "case description (no document fetched)" in text
+    assert "jawafdehi.org/material/" not in text
+
+
+def test_the_review_file_records_a_rejection_with_its_reason(monkeypatch, tmp_path):
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="क" * 250 + " (076-CR-0182)"),
+              BASE_ARGV + ["--only", "title", "--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "rejected (title)" in text
+    assert "too long" in text
+
+
+def test_the_review_file_keeps_devanagari_unescaped(monkeypatch, tmp_path):
+    api = _StubApi([CASE_STUB_BOTH])
+    _run_main(monkeypatch, api, _llm(title="काठमाडौं ठेक्का घोटाला (076-CR-0182)"),
+              BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "काठमाडौं" in text
+    assert "\\u0915" not in text
+
+
+# --------------------------------------------------------------------------
+# guard wiring
+# --------------------------------------------------------------------------
+
+
+def test_dry_run_is_the_default():
+    assert build_parser().parse_args([]).dry_run is True
+    assert build_parser().parse_args(["--apply"]).dry_run is False
+
+
+def test_only_defaults_to_both():
+    assert build_parser().parse_args([]).only == "both"
+
+
+def test_only_rejects_an_unknown_field():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--only", "description"])
+
+
+def test_build_api_refuses_a_remote_write_by_default():
+    class _Args:
+        api_base_url = "https://api.jawafdehi.org"
+        api_token = "tok"
+        allow_remote_writes = False
+
+    api = ec.build_api(_Args())
+    with pytest.raises(RuntimeError, match="refusing to write"):
+        api.patch_field("case-x", "title", GOOD_TITLE)
+
+
+def test_add_common_args_is_wired():
+    """Sanity: the shared flags this script relies on all parse."""
+    args = build_parser().parse_args(
+        ["--limit", "3", "--force", "--no-llm-cache", "--verbose"])
+    assert args.limit == 3
+    assert args.force is True
+    assert args.llm_cache is False
+    assert isinstance(build_parser(), argparse.ArgumentParser)

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -1004,3 +1004,17 @@ def test_build_api_refuses_a_remote_write_by_default(monkeypatch):
     api = ed.build_api(_Args())
     with pytest.raises(RuntimeError, match="refusing to write"):
         api.patch_field("case-ready", "description", "विवरण।")
+
+
+def test_batch_csv_reaches_selection(tmp_path):
+    """`--batch-csv` selects through the shared `select_for_run` path (#410)."""
+    import argparse
+
+    from casework.common.cli import add_common_args
+
+    csv = tmp_path / "batch.csv"
+    csv.write_text("slug\ncase-078-cr-0103-x\n", encoding="utf-8")
+    args = add_common_args(argparse.ArgumentParser()).parse_args(
+        ["--batch-csv", str(csv)])
+    assert args.batch_csv == str(csv)
+    assert "select_for_run" in _shipped_source()

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -205,9 +205,8 @@ class TestDonorDeviations:
     def test_donor_used_a_tool_loop_and_this_port_uses_plain_invoke_text(
         self, donor_source
     ):
-        # Deviation 2. The cache cannot key a multi-turn tool loop
-        # (casework/common/llm_cache.py), so the port's most expensive call
-        # would be the one call never served from disk.
+        # Deviation 2. The donor advertised the tool nowhere in its prompt, and
+        # a tool loop bills every turn -- on the pipeline's most expensive call.
         assert "invoke_with_tools" in donor_source
         assert "convert_date_tool" in donor_source
         ids = _identifiers(_shipped_source())

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -1,0 +1,969 @@
+"""Tests for the DB-free standalone description enricher (casework/enrich_description.py).
+
+`enrich_description.py` writes the long public Nepali narrative `Case.description`
+from a case's charge sheet, press release and Special Court verdict, at the
+premium tier, and writes ONE field.
+
+WHY THERE IS NO BYTE-EQUALITY PROMPT PIN HERE. Every other ported enricher's
+test file asserts its prompts are byte-identical to the donor at `0321a85`.
+This port's prompts DELIBERATELY diverge -- the title pass is gone, the
+`convert_date` tool is gone, and one dates QUALITY RULE is added (see the
+module docstring's three numbered deviations). A byte-equality assertion would
+therefore have to be deleted or weakened, which is exactly how a real drift
+later slips through unnoticed.
+
+So `TestDonorDeviations` pins the DIVERGENCE instead, in both directions: each
+intended edit is asserted present, and the donor's untouched section
+structure -- the क) … च) block that carries every instruction about what the
+public record may contain -- is asserted to have survived verbatim. A clause
+lost from that block changes what gets published about named people, with no
+other test failing.
+"""
+import ast
+import json
+import logging
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from casework import enrich_description as ed
+from casework.enrich_description import (
+    _assemble_source_text,
+    _format_bigo,
+    _format_entities,
+    _format_list,
+    _generate_description,
+    _has_substantial_description,
+    _ordered_sources,
+    _parse_description_response,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DONOR_COMMIT = "0321a85"
+
+
+def _donor_source() -> str:
+    proc = subprocess.run(
+        ["git", "show", f"{DONOR_COMMIT}:casework/enrich_description.py"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        pytest.skip(
+            f"donor commit {DONOR_COMMIT} not in local history "
+            "(shallow clone?); fidelity check needs full git history")
+    return proc.stdout
+
+
+def _donor_system_prompt() -> str:
+    """The donor's EXTRACTION_SYSTEM_PROMPT, read out of the donor source.
+
+    It is a BinOp (a string literal, plus the TITLE_RULES name, plus another
+    string literal), so `ast.literal_eval` on the whole node fails -- only the
+    string literals are evaluable. Joining just those reproduces the donor
+    prompt with the `TITLE_RULES` name replaced by nothing, which is exactly
+    the comparison this file wants: the donor's own non-title text.
+
+    Collected left-to-right by explicit recursion, NOT `ast.walk`: walk is
+    breadth-first, so on `((A + name) + B)` it yields B before A and the
+    reassembled prompt comes out with its tail on top.
+    """
+    tree = ast.parse(_donor_source())
+    for node in tree.body:
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
+            continue
+        target = node.targets[0]
+        if not (isinstance(target, ast.Name) and target.id == "EXTRACTION_SYSTEM_PROMPT"):
+            continue
+        parts = []
+        _collect_str_literals(node.value, parts)
+        return "".join(parts)
+    pytest.fail("donor has no EXTRACTION_SYSTEM_PROMPT assignment")
+
+
+def _collect_str_literals(node, out):
+    """Append every string literal under `node`, in source order."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        out.append(node.value)
+    elif isinstance(node, ast.BinOp):
+        _collect_str_literals(node.left, out)
+        _collect_str_literals(node.right, out)
+
+
+def _shipped_source():
+    return Path(ed.__file__).read_text(encoding="utf-8")
+
+
+def _identifiers(source):
+    """Every name the code actually references.
+
+    An identifier check, not a substring search: the module docstring names
+    `TITLE_RULES` and `invoke_with_tools` on purpose (it explains why they are
+    gone), so grepping the file text for them can only ever fail.
+    """
+    names = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.arg):
+            names.add(node.arg)
+        elif isinstance(node, ast.keyword) and node.arg:
+            names.add(node.arg)
+        elif isinstance(node, ast.alias):
+            names.add(node.asname or node.name.split(".")[-1])
+    return names
+
+
+def _docstring_nodes(tree):
+    out = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                                 ast.ClassDef)):
+            continue
+        body = getattr(node, "body", None) or []
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            out.add(id(body[0].value))
+    return out
+
+
+def _string_literals(source):
+    """Every string literal EXCEPT docstrings -- i.e. the ones that reach the
+    model or the network."""
+    tree = ast.parse(source)
+    skip = _docstring_nodes(tree)
+    return {n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and id(n) not in skip}
+
+
+@pytest.fixture(scope="module")
+def donor_source():
+    return _donor_source()
+
+
+@pytest.fixture(scope="module")
+def donor_system_prompt():
+    return _donor_system_prompt()
+
+
+class TestDonorDeviations:
+    """The three deliberate deviations, pinned in both directions."""
+
+    def test_donor_section_structure_survives_verbatim(self, donor_system_prompt):
+        """The क) … च) instruction block is the part that must NOT drift.
+
+        Sliced from the donor's own prompt text at runtime, not transcribed
+        here -- a transcription would drift silently alongside the code it is
+        supposed to be guarding.
+        """
+        start = donor_system_prompt.index("### क) अभियोगदावीको सार")
+        end = donor_system_prompt.index("QUALITY RULES:")
+        donor_block = donor_system_prompt[start:end]
+        assert donor_block.strip()
+        assert donor_block in ed.EXTRACTION_SYSTEM_PROMPT
+
+    def test_donor_quality_rules_survive_verbatim(self, donor_system_prompt):
+        """Every donor QUALITY RULE bullet is still present.
+
+        Checked bullet by bullet rather than as one block, because this port
+        INSERTS a dates bullet into the middle of that list -- a whole-block
+        substring check would fail on the insertion and tell us nothing about
+        whether a donor bullet went missing.
+        """
+        start = donor_system_prompt.index("QUALITY RULES:")
+        end = donor_system_prompt.index("OUTPUT FORMAT")
+        donor_rules = donor_system_prompt[start:end]
+        # Split on the bullet marker at line starts; keep non-trivial ones.
+        bullets = [b.strip() for b in donor_rules.split("\n- ") if len(b.strip()) > 40]
+        assert len(bullets) >= 4
+        for bullet in bullets[1:]:  # bullets[0] is the "QUALITY RULES:" header
+            assert bullet in ed.EXTRACTION_SYSTEM_PROMPT, bullet[:60]
+
+    def test_donor_regenerated_the_title_and_this_port_never_mentions_it(
+        self, donor_source, donor_system_prompt
+    ):
+        # Deviation 1. The donor's own source proves the behaviour existed...
+        assert "--skip-title" in donor_source
+        assert "TITLE_RULES" in donor_source
+        assert 'patch_field(case_slug, "title"' in donor_source
+        # ...and none of it survives here, in prompt or code.
+        ids = _identifiers(_shipped_source())
+        assert "skip_title" not in ids
+        assert "TITLE_RULES" not in ids
+        assert "validate_title" not in ids
+        assert "title_has_headcount" not in ids
+        assert "titles" not in {
+            n.split(".")[-1] for n in _imported_modules(_shipped_source())
+        }, "enrich_description must not import casework.common.titles"
+        assert "TITLE RULES" not in ed.EXTRACTION_SYSTEM_PROMPT
+        assert '"title"' not in ed.EXTRACTION_SYSTEM_PROMPT
+
+    def test_donor_used_a_tool_loop_and_this_port_uses_plain_invoke_text(
+        self, donor_source
+    ):
+        # Deviation 2. The cache cannot key a multi-turn tool loop
+        # (casework/common/llm_cache.py), so the port's most expensive call
+        # would be the one call never served from disk.
+        assert "invoke_with_tools" in donor_source
+        assert "convert_date_tool" in donor_source
+        ids = _identifiers(_shipped_source())
+        assert "invoke_with_tools" not in ids
+        assert "convert_date_tool" not in ids
+        assert "tools" not in ids
+
+    def test_dropping_the_tool_is_paired_with_a_no_self_conversion_rule(
+        self, donor_system_prompt
+    ):
+        """The safety half of deviation 2.
+
+        Removing the date tool without forbidding mental conversion would
+        invite the BS<->AD arithmetic error the tool existed to prevent, so the
+        rule is not optional decoration -- it is the reason the removal is safe.
+        """
+        assert "DATES:" in ed.EXTRACTION_SYSTEM_PROMPT
+        assert "Do NOT convert between BS" in ed.EXTRACTION_SYSTEM_PROMPT
+        # And it is genuinely an addition, not something the donor already had.
+        assert "Do NOT convert between BS" not in donor_system_prompt
+
+    def test_donor_ngm_fetch_is_not_ported(self, donor_source):
+        # Deviation 3: the endpoint was removed in the 2026-07-01 cut and the
+        # colon-prefixed ref it needs matches 0 of 109 real court_cases
+        # entries (measured in casework/enrich_timeline.py).
+        assert "/ngm/court_case/" in donor_source
+        assert not [s for s in _string_literals(_shipped_source())
+                    if "/ngm/court_case/" in s]
+        assert "{ngm_section}" not in ed.EXTRACTION_USER_PROMPT
+
+    def test_source_budget_matches_the_donor_default(self, donor_source):
+        # Donor: SOURCE_TEXT_BUDGET = env_int("CASEWORK_SOURCE_TEXT_BUDGET", 60000)
+        assert 'env_int("CASEWORK_SOURCE_TEXT_BUDGET", 60000)' in donor_source
+        assert ed.SOURCE_TEXT_BUDGET == 60000
+
+    def test_substantial_threshold_matches_the_donor(self, donor_source):
+        assert ">= 600" in donor_source
+        assert ed.SUBSTANTIAL_DESCRIPTION_CHARS == 600
+
+    def test_max_tokens_matches_the_donor(self, donor_source):
+        assert "max_tokens=8000" in donor_source
+        assert ed.DESCRIPTION_MAX_TOKENS == 8000
+
+
+def _imported_modules(source):
+    """Every module name imported by `source`, for the "must not import" pin."""
+    names = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            names.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+            names.update(f"{node.module}.{a.name}" for a in node.names)
+    return names
+
+
+# --------------------------------------------------------------------------
+# stage + tier registration
+# --------------------------------------------------------------------------
+
+
+def test_stage_is_registered_with_both_material_families():
+    from casework.common.pipeline import COURT_TYPES, PRESS_TYPES, STAGES
+
+    stage = STAGES["description"]
+    assert set(stage.requires_materials) == set(PRESS_TYPES + COURT_TYPES)
+    assert stage.requires_stages == ("convert",)
+
+
+def test_stage_provides_description_only():
+    """`title` must NOT appear in `provides`.
+
+    `provides` feeds "already enriched, skip it" idempotency checks, so
+    naming a field this stage never writes makes a case look title-complete
+    that this stage never touched -- the phantom-entry defect documented on
+    STAGES["allegations"].
+    """
+    from casework.common.pipeline import STAGES
+
+    assert STAGES["description"].provides == ("description",)
+
+
+def test_tier_is_premium():
+    from casework.common.llm import tier_for
+
+    assert tier_for("description") == "premium"
+
+
+# --------------------------------------------------------------------------
+# _parse_description_response
+# --------------------------------------------------------------------------
+
+
+class TestParseDescriptionResponse:
+    def test_parses_the_object(self):
+        body = json.dumps({"description": "### क) अभियोगदावीको सार\nविवरण।"})
+        assert _parse_description_response(body) == "### क) अभियोगदावीको सार\nविवरण।"
+
+    def test_a_volunteered_title_key_is_ignored_not_returned(self):
+        """The single-owner rule has to hold against a chatty model.
+
+        The OUTPUT FORMAT block no longer asks for a title, but models
+        volunteer keys. Returning only the string is what makes it impossible
+        for a stray `"title"` to reach a PATCH.
+        """
+        body = json.dumps({"title": "नयाँ शीर्षक (081-CR-0091)", "description": "विवरण।"})
+        assert _parse_description_response(body) == "विवरण।"
+
+    def test_fenced_json_is_parsed(self):
+        body = 'यहाँ छ:\n```json\n{"description": "विवरण।"}\n```\n'
+        assert _parse_description_response(body) == "विवरण।"
+
+    def test_a_leading_unrelated_object_does_not_stop_the_scan(self):
+        """Donor behaviour: every `{` is tried, not just the first.
+
+        A reply that opens with an unrelated object (a preamble, an echoed
+        tool argument) returns None under a `text.find("{")` parser.
+        """
+        body = '{"note": "thinking"} then: {"description": "असली विवरण।"}'
+        assert _parse_description_response(body) == "असली विवरण।"
+
+    def test_returns_none_when_the_key_is_absent(self):
+        assert _parse_description_response('{"other": "value"}') is None
+
+    def test_returns_none_for_a_blank_description(self):
+        assert _parse_description_response(json.dumps({"description": "   "})) is None
+
+    def test_returns_none_for_unparseable_text(self):
+        assert _parse_description_response("not json at all") is None
+
+    def test_returns_none_for_empty_input(self):
+        assert _parse_description_response("") is None
+
+
+# --------------------------------------------------------------------------
+# prompt-context formatters
+# --------------------------------------------------------------------------
+
+
+class TestFormatters:
+    def test_bigo_formats_with_thousands_separators(self):
+        assert _format_bigo(10403941) == "रु 10,403,941"
+
+    def test_bigo_missing_says_so_in_nepali(self):
+        assert _format_bigo(None) == "उल्लेख छैन"
+        assert _format_bigo(0) == "उल्लेख छैन"
+
+    def test_list_is_numbered_and_drops_blanks(self):
+        assert _format_list(["पहिलो", "  ", "", "दोस्रो"]) == "1. पहिलो\n2. दोस्रो"
+
+    def test_empty_list_says_none(self):
+        assert _format_list([]) == "(none)"
+        assert _format_list(None) == "(none)"
+
+    def test_entities_render_role_name_and_iri(self):
+        out = _format_entities([
+            {"role": "ACCUSED", "name": "कमल राज गौतम",
+             "entity_iri": "https://jawafdehi.org/entity/person/kamal-raj-gautam"},
+        ])
+        assert "[ACCUSED] कमल राज गौतम" in out
+        assert "entity/person/kamal-raj-gautam" in out
+
+    def test_entities_fall_back_to_the_iri_tail_when_unnamed(self):
+        out = _format_entities([
+            {"role": "RELATED",
+             "entity_iri": "https://jawafdehi.org/entity/org/padma-company"},
+        ])
+        assert "padma-company" in out
+
+    def test_a_non_dict_entity_entry_is_skipped_not_crashed(self):
+        out = _format_entities(["गलत", None, {"role": "ACCUSED", "name": "राम"}])
+        assert out == "- [ACCUSED] राम"
+
+
+# --------------------------------------------------------------------------
+# _ordered_sources
+# --------------------------------------------------------------------------
+
+
+class TestOrderedSources:
+    def test_charge_sheet_comes_before_press_release_and_verdict(self):
+        chunks = [
+            ("court_order", "iri-c", "फैसला"),
+            ("press_release", "iri-p", "विज्ञप्ति"),
+            ("charge_sheet", "iri-a", "अभियोगपत्र"),
+        ]
+        assert [t for t, _, _ in _ordered_sources(chunks)] == [
+            "charge_sheet", "press_release", "court_order"]
+
+    def test_an_unknown_type_is_kept_at_the_end_not_dropped(self):
+        """An unexpected material type is still evidence.
+
+        Dropping it would silently shrink the factual basis of a public
+        narrative, which is the failure mode this whole port guards against.
+        """
+        chunks = [("mystery_type", "iri-m", "अज्ञात"), ("charge_sheet", "iri-a", "अ")]
+        ordered = _ordered_sources(chunks)
+        assert [t for t, _, _ in ordered] == ["charge_sheet", "mystery_type"]
+        assert len(ordered) == 2
+
+    def test_order_is_stable_within_one_type(self):
+        chunks = [("press_release", "iri-1", "एक"), ("press_release", "iri-2", "दुई")]
+        assert [i for _, i, _ in _ordered_sources(chunks)] == ["iri-1", "iri-2"]
+
+
+# --------------------------------------------------------------------------
+# _assemble_source_text
+# --------------------------------------------------------------------------
+
+
+class TestAssembleSourceText:
+    def test_a_long_verdict_is_summarised_not_head_truncated(self):
+        """A फैसला's ठहर sits at the END, so a head clamp drops the outcome
+        that section ग exists to report."""
+        long_verdict = "फ" * (ed.VERDICT_SUMMARY_TRIGGER + 500)
+        calls = []
+
+        def stub(**kw):
+            calls.append(kw)
+            return "फैसलाको सारांश: प्रतिवादी दोषी ठहर।"
+
+        block, fed = _assemble_source_text(
+            [("court_order", "iri-c", long_verdict)], stub, usage=None)
+        assert calls, "the summariser must have been called"
+        assert "फैसलाको सारांश" in block
+        assert "फैसला सारांश" in fed[0][0]  # the label says it was summarised
+        assert len(fed[0][2]) < len(long_verdict)
+
+    def test_a_failed_summariser_falls_back_to_the_donor_head_clamp(self):
+        long_verdict = "फ" * (ed.VERDICT_SUMMARY_TRIGGER + 500)
+
+        block, fed = _assemble_source_text(
+            [("court_order", "iri-c", long_verdict)],
+            lambda **kw: "",  # falsy -> summarize_verdict returns None
+            usage=None,
+        )
+        assert len(fed[0][2]) == ed.VERDICT_SUMMARY_TARGET
+        assert fed[0][0] == "court_order"  # not labelled as a summary
+        assert block
+
+    def test_a_short_verdict_passes_through_whole(self):
+        short = "छोटो फैसला।"
+        calls = []
+
+        def stub(**kw):
+            calls.append(kw)
+            return "should not be called"
+
+        _, fed = _assemble_source_text(
+            [("court_order", "iri-c", short)], stub, usage=None)
+        assert calls == []
+        assert fed == [("court_order", "iri-c", short)]
+
+    def test_the_budget_caps_what_is_fed_and_fed_reflects_it(self, monkeypatch):
+        """`fed` is what the review file prints, so it must be the
+        post-truncation reality, not what was fetched."""
+        monkeypatch.setattr(ed, "SOURCE_TEXT_BUDGET", 100)
+        _, fed = _assemble_source_text(
+            [("charge_sheet", "iri-a", "अ" * 500)], lambda **kw: "", usage=None)
+        assert len(fed[0][2]) == 100
+
+    def test_a_source_beyond_the_budget_is_dropped_with_a_warning(self, monkeypatch, caplog):
+        monkeypatch.setattr(ed, "SOURCE_TEXT_BUDGET", 10)
+        with caplog.at_level(logging.WARNING, logger="casework.enrich_description"):
+            _, fed = _assemble_source_text(
+                [("charge_sheet", "iri-a", "अ" * 10),
+                 ("press_release", "iri-p", "प" * 10)],
+                lambda **kw: "", usage=None,
+            )
+        assert [t for t, _, _ in fed] == ["charge_sheet"]
+        assert "budget spent" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# _generate_description -- tier / max_tokens / prompt-content pins
+# --------------------------------------------------------------------------
+
+
+DETAIL_FOR_PROMPT = {
+    "slug": "case-081-cr-0091",
+    "title": "काठमाडौं महानगरपालिका ठेक्का अनियमितता",
+    "bigo": 10403941,
+    "court_cases": ["https://jawafdehi.org/courtcase/special/081-cr-0091"],
+    "key_allegations": ["ठेक्कामा मिलेमतो गरी सार्वजनिक सम्पत्ति हानि पुर्‍याएको।"],
+    "timeline": [{"date": "2024-05-01", "date_bs": "2081-01-19", "title": "उजुरी दर्ता"}],
+    "entities": [
+        {"role": "ACCUSED", "name": "कमल राज गौतम",
+         "entity_iri": "https://jawafdehi.org/entity/person/kamal-raj-gautam"},
+    ],
+}
+
+
+def test_generate_uses_premium_tier_and_8000_max_tokens():
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"description": "विवरण।"})
+
+    result = _generate_description(
+        detail=DETAIL_FOR_PROMPT, court_number="081-cr-0091",
+        source_text="स्रोत पाठ", invoke_text=stub, usage=None,
+    )
+    assert result == "विवरण।"
+    assert seen["tier"] == "premium"
+    assert seen["max_tokens"] == 8000
+    assert seen["system"] == ed.EXTRACTION_SYSTEM_PROMPT
+    # No tool loop -- deviation 2. `tools=` would make the call uncacheable.
+    assert "tools" not in seen
+
+
+def test_generate_prompt_carries_every_context_block():
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"description": "विवरण।"})
+
+    _generate_description(
+        detail=DETAIL_FOR_PROMPT, court_number="081-cr-0091",
+        source_text="अभियोगपत्रको पाठ", invoke_text=stub, usage=None,
+    )
+    content = seen["content"]
+    assert "काठमाडौं महानगरपालिका ठेक्का अनियमितता" in content
+    assert "रु 10,403,941" in content
+    assert "081-cr-0091" in content
+    assert "ठेक्कामा मिलेमतो" in content
+    assert "कमल राज गौतम" in content
+    assert "अभियोगपत्रको पाठ" in content
+
+
+def test_generate_prompt_keeps_the_timeline_in_devanagari():
+    """`json.dumps(..., ensure_ascii=False)`: a timeline serialised as
+    `\\u0909...` is unreadable to the model's Nepali register and to anyone
+    reading the review file."""
+    seen = {}
+    _generate_description(
+        detail=DETAIL_FOR_PROMPT, court_number="081-cr-0091", source_text="x",
+        invoke_text=lambda **kw: seen.update(kw) or json.dumps({"description": "व।"}),
+        usage=None,
+    )
+    assert "उजुरी दर्ता" in seen["content"]
+    assert "\\u0909" not in seen["content"]
+
+
+# --------------------------------------------------------------------------
+# _has_substantial_description
+# --------------------------------------------------------------------------
+
+
+class TestHasSubstantialDescription:
+    def test_a_long_description_counts_as_done(self):
+        assert _has_substantial_description({"description": "क" * 600})
+
+    def test_one_char_short_of_the_threshold_does_not(self):
+        assert not _has_substantial_description({"description": "क" * 599})
+
+    def test_a_template_stub_does_not_count(self):
+        """The threshold is content-based on purpose: an emptiness test would
+        treat a one-line stub as a finished public narrative."""
+        assert not _has_substantial_description(
+            {"description": "यो मुद्दाको विवरण अद्यावधिक हुँदैछ।"})
+
+    def test_missing_and_whitespace_are_both_empty(self):
+        assert not _has_substantial_description({})
+        assert not _has_substantial_description({"description": "   \n  "})
+
+
+# --------------------------------------------------------------------------
+# main() -- integration over a stubbed API + LLM
+# --------------------------------------------------------------------------
+
+_PRESS_MD = "https://x/press.md"
+_COURT_MD = "https://x/court.md"
+
+CASE_READY = {
+    "slug": "case-ready",
+    "title": "काठमाडौं महानगरपालिका ठेक्का अनियमितता",
+    "state": "DRAFT",
+    "bigo": 10403941,
+    "description": "",
+    "court_cases": ["https://jawafdehi.org/courtcase/special/081-cr-0091"],
+    "key_allegations": ["ठेक्कामा मिलेमतो गरेको।"],
+    "timeline": [],
+    "entities": [],
+    "evidence": [
+        {"material_iri": "https://jawafdehi.org/material/ciaa/12345",
+         "additional_details": "",
+         "material": {"material_type": "press_release",
+                      "urls": [{"link": _PRESS_MD, "role": "MARKDOWN"}]}},
+        {"material_iri": "https://jawafdehi.org/material/court/special.081-cr-0091",
+         "additional_details": "",
+         "material": {"material_type": "court_order",
+                      "urls": [{"link": _COURT_MD, "role": "MARKDOWN"}]}},
+    ],
+}
+
+CASE_UNCONVERTED = dict(
+    CASE_READY, slug="case-unconverted",
+    evidence=[{"material_iri": "https://jawafdehi.org/material/ciaa/99",
+               "additional_details": "",
+               "material": {"material_type": "press_release",
+                            "urls": [{"link": "https://x/99.pdf", "role": "RAW"}]}}],
+)
+
+CASE_ALREADY = dict(CASE_READY, slug="case-already", description="क" * 900)
+
+# A template stub title plus a stub description: the case a title-writing
+# regression would visibly damage.
+CASE_STUB_TITLE = dict(
+    CASE_READY, slug="case-stub-title",
+    title="विशेष अदालत मुद्दा 081-CR-0091",
+    description="विवरण अद्यावधिक हुँदैछ।",
+)
+
+
+class _StubApi:
+    """Mirrors `CaseworkApi`'s surface for the calls `main()` makes."""
+
+    def __init__(self, cases, etag="W/\"abc123\"", fail_detail_for=()):
+        self._cases = {c["slug"]: dict(c) for c in cases}
+        self._etag = etag
+        self._fail_detail_for = set(fail_detail_for)
+        self.patched = []
+
+    def iter_cases(self, params=None, timeout=60):
+        yield from self._cases.values()
+
+    def get_case_with_etag(self, slug, timeout=60):
+        if slug in self._fail_detail_for:
+            raise RuntimeError(f"simulated detail-fetch failure for {slug}")
+        return self._cases[slug], self._etag
+
+    def patch_field(self, slug, field, value, timeout=60, if_match=None):
+        self.patched.append((slug, field, value, if_match))
+        self._cases[slug][field] = value
+        return {}
+
+
+class _FakeUsage:
+    def __init__(self):
+        self.calls = 0
+
+    def as_dict(self):
+        return {"by_provider": []}
+
+
+@pytest.fixture
+def patched_fetch_markdown(monkeypatch):
+    import casework.common.materials as m
+
+    def fake_fetch(link, timeout=60):
+        return {
+            _PRESS_MD: "अख्तियारले काठमाडौं महानगरपालिकाको ठेक्कामा भ्रष्टाचार भएको जनाएको।",
+            _COURT_MD: "विशेष अदालतले प्रतिवादीलाई दोषी ठहर गरेको।",
+        }.get(link, "")
+
+    monkeypatch.setattr(m, "fetch_markdown", fake_fetch)
+
+
+def _run_main(monkeypatch, api, invoke_text_stub, argv):
+    """Drive `main()` end to end with a stubbed API and LLM.
+
+    `invoke_text` / `UsageAccumulator` are imported INSIDE `main()` (after
+    bootstrap), so they are faked through `sys.modules` rather than
+    `monkeypatch.setattr(ed, ...)` -- same approach as every sibling test file.
+    """
+    monkeypatch.setattr(ed, "build_api", lambda args: api)
+    monkeypatch.setattr(ed, "bootstrap", lambda *a, **k: None)
+
+    fake_llm_invoke = types.ModuleType("llm.invoke")
+    fake_llm_invoke.invoke_text = invoke_text_stub
+
+    fake_llm_usage = types.ModuleType("llm.usage")
+    fake_llm_usage.UsageAccumulator = _FakeUsage
+    fake_llm_usage.render_usage_table = lambda by_provider, title=None: ""
+
+    monkeypatch.setitem(sys.modules, "llm.invoke", fake_llm_invoke)
+    monkeypatch.setitem(sys.modules, "llm.usage", fake_llm_usage)
+
+    return ed.main(argv)
+
+
+def _tracking_stub(description="### क) अभियोगदावीको सार\nठेक्कामा भ्रष्टाचार भएको।"):
+    """Records invocations. An "LLM must not be called" assertion has to check
+    `stub.calls == []` rather than rely on a raise: `main()` swallows
+    exceptions from the generate step as an `error` status, so a raising stub
+    would be counted, not surfaced."""
+    calls = []
+
+    def stub(**kw):
+        calls.append(kw)
+        return json.dumps({"description": description})
+
+    stub.calls = calls
+    return stub
+
+
+BASE_ARGV = ["--api-base-url", "http://127.0.0.1:48010"]
+
+
+def test_unmet_prerequisite_is_recorded_not_silently_skipped(
+    monkeypatch, patched_fetch_markdown
+):
+    api = _StubApi([CASE_UNCONVERTED])
+    stub = _tracking_stub()
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--dry-run"])
+    assert report.rows[0]["status"] == "unmet"
+    assert report.rows[0]["reason"]
+    assert stub.calls == []
+    assert api.patched == []
+
+
+def test_an_already_described_case_is_skipped_without_calling_the_llm(
+    monkeypatch, patched_fetch_markdown
+):
+    api = _StubApi([CASE_ALREADY])
+    stub = _tracking_stub()
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--dry-run"])
+    assert report.rows[0]["status"] == "already"
+    assert stub.calls == []
+    assert api.patched == []
+
+
+def test_force_regenerates_an_already_described_case(monkeypatch, patched_fetch_markdown):
+    api = _StubApi([CASE_ALREADY])
+    report = _run_main(
+        monkeypatch, api, _tracking_stub("नयाँ विवरण।"),
+        BASE_ARGV + ["--force", "--apply"],
+    )
+    assert report.rows[0]["status"] == "enriched"
+    assert [(s, f, v) for s, f, v, _ in api.patched] == [
+        ("case-already", "description", "नयाँ विवरण।")]
+
+
+def test_dry_run_generates_but_does_not_patch(monkeypatch, patched_fetch_markdown):
+    api = _StubApi([CASE_READY])
+    stub = _tracking_stub()
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--dry-run"])
+    assert report.rows[0]["status"] == "would-enrich"
+    assert api.patched == []
+    assert stub.calls, "a dry run still makes the LLM call -- that is why it bills"
+
+
+def test_apply_patches_description_with_the_etag_as_if_match(
+    monkeypatch, patched_fetch_markdown
+):
+    api = _StubApi([CASE_READY], etag='W/"etag-42"')
+    report = _run_main(
+        monkeypatch, api, _tracking_stub("विवरण।"), BASE_ARGV + ["--apply"])
+    assert report.rows[0]["status"] == "enriched"
+    assert api.patched == [("case-ready", "description", "विवरण।", 'W/"etag-42"')]
+
+
+def test_never_writes_title(monkeypatch, patched_fetch_markdown):
+    """The single-owner rule, end to end.
+
+    The model is made to volunteer a title (as the donor's prompt asked it to)
+    over a case whose title is a template stub -- exactly the case a
+    title-writing regression would damage. The stub title must come back
+    byte-identical and `title` must never appear in a PATCH.
+    """
+    before_title = CASE_STUB_TITLE["title"]
+
+    def stub(**kw):
+        return json.dumps({
+            "title": "काठमाडौं ठेक्का घोटाला: भ्रष्टाचार मुद्दा (081-CR-0091)",
+            "description": "### क) अभियोगदावीको सार\nविवरण।",
+        })
+
+    api = _StubApi([CASE_STUB_TITLE])
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--force", "--apply"])
+
+    assert report.rows[0]["status"] == "enriched"
+    assert {field for _, field, _, _ in api.patched} == {"description"}
+    assert api._cases["case-stub-title"]["title"] == before_title
+
+
+def test_llm_returning_no_description_is_skipped_not_enriched(
+    monkeypatch, patched_fetch_markdown
+):
+    api = _StubApi([CASE_READY])
+    report = _run_main(
+        monkeypatch, api, lambda **kw: json.dumps({"other": "no description key"}),
+        BASE_ARGV + ["--dry-run"],
+    )
+    assert report.rows[0]["status"] == "skipped"
+    assert api.patched == []
+
+
+def test_a_malformed_llm_response_is_skipped_not_written(
+    monkeypatch, patched_fetch_markdown
+):
+    api = _StubApi([CASE_READY])
+    report = _run_main(
+        monkeypatch, api, lambda **kw: "sorry, I can't help with that",
+        BASE_ARGV + ["--apply"],
+    )
+    assert report.rows[0]["status"] == "skipped"
+    assert api.patched == []
+
+
+def test_an_llm_exception_is_recorded_as_error_not_a_crash(
+    monkeypatch, patched_fetch_markdown
+):
+    def boom(**kw):
+        raise RuntimeError("provider exploded")
+
+    api = _StubApi([CASE_READY])
+    report = _run_main(monkeypatch, api, boom, BASE_ARGV + ["--apply"])
+    assert report.rows[0]["status"] == "error"
+    assert "provider exploded" in report.rows[0]["reason"]
+    assert api.patched == []
+
+
+def test_a_detail_fetch_failure_falls_back_and_reports_unmet(
+    monkeypatch, patched_fetch_markdown
+):
+    """Donor-preserved: a failed detail fetch does not abort the case.
+
+    The LIST-shaped fallback never resolves `material`, so it must surface as
+    a well-formed unmet reason -- never a crash, never a fabricated success.
+    """
+    list_shaped = dict(CASE_READY, evidence=[
+        {"material_iri": "https://jawafdehi.org/material/ciaa/12345",
+         "material": None}])
+    api = _StubApi([list_shaped], fail_detail_for=["case-ready"])
+    stub = _tracking_stub()
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--dry-run"])
+    assert {r["status"] for r in report.rows} == {"unmet"}
+    assert any("UNRESOLVED" in r["reason"] for r in report.rows)
+    assert stub.calls == []
+
+
+# --------------------------------------------------------------------------
+# the review file -- the accuracy deliverable
+# --------------------------------------------------------------------------
+
+
+def _review_file(tmp_path):
+    files = sorted((tmp_path / "reviews").glob("*.md"))
+    assert files, "every run must write exactly one review file"
+    return files[-1]
+
+
+def test_a_dry_run_writes_a_review_file(monkeypatch, patched_fetch_markdown, tmp_path):
+    """The dry run is the read-only path, so it is where accuracy is judged.
+    A review file that only appeared on --apply would mean output could never
+    be checked without first writing it somewhere."""
+    api = _StubApi([CASE_READY])
+    _run_main(monkeypatch, api, _tracking_stub("### क) सार\nठेक्का विवरण।"),
+              BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "DRY RUN" in text
+    assert "case-ready" in text
+
+
+def test_the_review_file_carries_before_generated_and_the_source_iri(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    api = _StubApi([CASE_STUB_TITLE])
+    _run_main(monkeypatch, api, _tracking_stub("नयाँ लामो विवरण।"),
+              BASE_ARGV + ["--force", "--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "विवरण अद्यावधिक हुँदैछ।" in text          # before
+    assert "नयाँ लामो विवरण।" in text                  # generated
+    assert "https://jawafdehi.org/material/ciaa/12345" in text   # source IRI
+    assert "अख्तियारले काठमाडौं" in text               # the passage fed to the model
+
+
+def test_the_review_file_keeps_devanagari_unescaped(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    api = _StubApi([CASE_READY])
+    _run_main(monkeypatch, api, _tracking_stub("देवनागरी विवरण।"),
+              BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "देवनागरी विवरण।" in text
+    assert "\\u0926" not in text
+
+
+def test_unmet_and_already_cases_still_get_a_row(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """One row per case means the file is a complete account of the run.
+    A case missing from it reads as "not selected", not "could not run"."""
+    api = _StubApi([CASE_UNCONVERTED, CASE_ALREADY])
+    _run_main(monkeypatch, api, _tracking_stub(), BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "case-unconverted" in text
+    assert "case-already" in text
+    assert "unmet" in text
+    assert "already" in text
+
+
+def test_the_review_file_labels_its_excerpts_as_fed_not_quoted(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """A completion does not report which sentences it drew on. Calling the
+    excerpt "the passage the model quoted" would be a fabricated provenance
+    claim in the one artefact whose job is checking for fabrication."""
+    api = _StubApi([CASE_READY])
+    _run_main(monkeypatch, api, _tracking_stub(), BASE_ARGV + ["--dry-run"])
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "Sources fed to the model" in text
+    assert "FED" in text
+
+
+def test_a_run_selecting_nothing_still_writes_a_review_file(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    api = _StubApi([])
+    _run_main(monkeypatch, api, _tracking_stub(), BASE_ARGV + ["--dry-run"])
+    assert _review_file(tmp_path).read_text(encoding="utf-8")
+
+
+def test_review_file_flag_overrides_the_default_location(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """`--review-file` is how a run drops its file into the meta-repo task
+    directory the work belongs to."""
+    target = tmp_path / "task-dir" / "description-review.md"
+    api = _StubApi([CASE_READY])
+    _run_main(monkeypatch, api, _tracking_stub("विवरण।"),
+              BASE_ARGV + ["--dry-run", "--review-file", str(target)])
+    assert "विवरण।" in target.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# guard wiring
+# --------------------------------------------------------------------------
+
+
+def test_dry_run_is_the_default_and_apply_opts_in():
+    import argparse
+
+    from casework.common.cli import add_common_args
+
+    ap = add_common_args(argparse.ArgumentParser())
+    assert ap.parse_args([]).dry_run is True
+    assert ap.parse_args(["--apply"]).dry_run is False
+
+
+def test_build_api_refuses_a_remote_write_by_default(monkeypatch):
+    """`CaseworkApi` must still refuse a PATCH to production. This port does
+    nothing to that guard and must not be able to."""
+    monkeypatch.setenv("CASEWORK_API_USER", "caseworker")
+    monkeypatch.setenv("CASEWORK_API_PASSWORD", "caseworker")
+
+    class _Args:
+        api_base_url = "https://api.jawafdehi.org"
+        api_token = "tok"
+        allow_remote_writes = False
+
+    api = ed.build_api(_Args())
+    with pytest.raises(RuntimeError, match="refusing to write"):
+        api.patch_field("case-ready", "description", "विवरण।")

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -31,6 +31,7 @@ import pytest
 
 from casework import enrich_description as ed
 from casework.enrich_description import (
+    _allocate_budget,
     _assemble_source_text,
     _generate_description,
     _has_substantial_description,
@@ -447,16 +448,71 @@ class TestAssembleSourceText:
             [("charge_sheet", "iri-a", "अ" * 500)], lambda **kw: "", usage=None)
         assert len(fed[0][2]) == 100
 
-    def test_a_source_beyond_the_budget_is_dropped_with_a_warning(self, monkeypatch, caplog):
+    def test_a_tight_budget_now_truncates_both_sources_instead_of_dropping_one(
+        self, monkeypatch
+    ):
+        """Changed contract. The greedy version gave the whole budget to the
+        first source in PRIORITY order and dropped the rest; on `081-CR-0138`
+        that dropped the case's only press release so a charge sheet could take
+        all 60,000. Both sources now appear, each truncated to a fair share."""
         monkeypatch.setattr(ed, "SOURCE_TEXT_BUDGET", 10)
+        _, fed = _assemble_source_text(
+            [("charge_sheet", "iri-a", "अ" * 10),
+             ("press_release", "iri-p", "प" * 10)],
+            lambda **kw: "", usage=None,
+        )
+        assert [t for t, _, _ in fed] == ["charge_sheet", "press_release"]
+        assert [len(text) for _, _, text in fed] == [5, 5]
+
+    def test_a_source_with_no_allowance_left_is_dropped_with_a_warning(
+        self, monkeypatch, caplog
+    ):
+        """Still reachable, but only when there are more sources than budget."""
+        monkeypatch.setattr(ed, "SOURCE_TEXT_BUDGET", 1)
         with caplog.at_level(logging.WARNING, logger="casework.enrich_description"):
             _, fed = _assemble_source_text(
                 [("charge_sheet", "iri-a", "अ" * 10),
                  ("press_release", "iri-p", "प" * 10)],
                 lambda **kw: "", usage=None,
             )
-        assert [t for t, _, _ in fed] == ["charge_sheet"]
+        assert len(fed) == 1
         assert "budget spent" in caplog.text
+
+    def test_a_small_source_is_never_starved_by_a_huge_one(self, monkeypatch):
+        """The regression, at the real sizes from `081-CR-0138`: a 529,947-char
+        charge sheet used to consume all 60,000 and drop the 4,185-char press
+        release -- 7% of the budget, and the most concise account of the case."""
+        _, fed = _assemble_source_text(
+            [("press_release", "iri-p", "प" * 4185),
+             ("charge_sheet", "iri-a", "अ" * 529947)],
+            lambda **kw: "", usage=None,
+        )
+        got = {label: len(text) for label, _, text in fed}
+        assert got["press_release"] == 4185, "the small source must arrive whole"
+        assert got["charge_sheet"] == 55815
+        assert sum(got.values()) == ed.SOURCE_TEXT_BUDGET
+
+
+class TestAllocateBudget:
+    def test_the_small_source_takes_what_it_needs_and_the_rest_flows_up(self):
+        assert _allocate_budget([4185, 529947], 60000) == [4185, 55815]
+
+    def test_several_small_sources_all_survive_two_huge_ones(self):
+        assert _allocate_budget([500, 800, 1200, 400000, 300000, 2000], 60000) == \
+            [500, 800, 1200, 27750, 27750, 2000]
+
+    def test_sources_that_all_fit_are_untouched(self):
+        assert _allocate_budget([100, 200, 300], 60000) == [100, 200, 300]
+
+    def test_equal_sources_split_evenly(self):
+        assert _allocate_budget([1000, 1000, 1000], 300) == [100, 100, 100]
+
+    def test_no_sources_is_no_allocation(self):
+        assert _allocate_budget([], 60000) == []
+
+    def test_the_allocation_never_exceeds_the_budget(self):
+        for sizes in ([10] * 7, [1, 999999], [50000, 50000], [0, 100]):
+            assert sum(_allocate_budget(sizes, 60000)) <= 60000
 
 
 # --------------------------------------------------------------------------

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -32,9 +32,6 @@ import pytest
 from casework import enrich_description as ed
 from casework.enrich_description import (
     _assemble_source_text,
-    _format_bigo,
-    _format_entities,
-    _format_list,
     _generate_description,
     _has_substantial_description,
     _ordered_sources,
@@ -344,44 +341,23 @@ class TestParseDescriptionResponse:
         assert _parse_description_response("") is None
 
 
-# --------------------------------------------------------------------------
-# prompt-context formatters
-# --------------------------------------------------------------------------
-
-
-class TestFormatters:
-    def test_bigo_formats_with_thousands_separators(self):
-        assert _format_bigo(10403941) == "रु 10,403,941"
-
-    def test_bigo_missing_says_so_in_nepali(self):
-        assert _format_bigo(None) == "उल्लेख छैन"
-        assert _format_bigo(0) == "उल्लेख छैन"
-
-    def test_list_is_numbered_and_drops_blanks(self):
-        assert _format_list(["पहिलो", "  ", "", "दोस्रो"]) == "1. पहिलो\n2. दोस्रो"
-
-    def test_empty_list_says_none(self):
-        assert _format_list([]) == "(none)"
-        assert _format_list(None) == "(none)"
-
-    def test_entities_render_role_name_and_iri(self):
-        out = _format_entities([
-            {"role": "ACCUSED", "name": "कमल राज गौतम",
-             "entity_iri": "https://jawafdehi.org/entity/person/kamal-raj-gautam"},
-        ])
-        assert "[ACCUSED] कमल राज गौतम" in out
-        assert "entity/person/kamal-raj-gautam" in out
-
-    def test_entities_fall_back_to_the_iri_tail_when_unnamed(self):
-        out = _format_entities([
-            {"role": "RELATED",
-             "entity_iri": "https://jawafdehi.org/entity/org/padma-company"},
-        ])
-        assert "padma-company" in out
-
-    def test_a_non_dict_entity_entry_is_skipped_not_crashed(self):
-        out = _format_entities(["गलत", None, {"role": "ACCUSED", "name": "राम"}])
-        assert out == "- [ACCUSED] राम"
+def test_prompt_context_comes_from_the_shared_formatters(donor_source):
+    """The donor imported `format_bigo` / `format_list` / `format_entities` from
+    the shared `casework/common.py` -- the very same functions `enrich_card` and
+    `enrich_title` used. A private per-enricher copy is a fork, and this one
+    forked wrong: the first draft of this port read `role` / `entity_iri` /
+    `name` off each entity, none of which exist on the live payload
+    (`{nes_id, display_name, entity_type, type, outcome, notes}`, built by
+    `nes_resolver.build_entity_binds`). Every entity rendered as a blank bullet
+    and the model lost every name in the case, with no test failing.
+    """
+    for name in ("format_bigo", "format_list", "format_entities"):
+        assert name in donor_source, f"donor must import {name}"
+    imported = _imported_modules(_shipped_source())
+    assert "casework.common.format" in imported
+    ids = _identifiers(_shipped_source())
+    for private in ("_format_bigo", "_format_list", "_format_entities"):
+        assert private not in ids, f"{private} must not be a private copy"
 
 
 # --------------------------------------------------------------------------
@@ -495,9 +471,14 @@ DETAIL_FOR_PROMPT = {
     "court_cases": ["https://jawafdehi.org/courtcase/special/081-cr-0091"],
     "key_allegations": ["ठेक्कामा मिलेमतो गरी सार्वजनिक सम्पत्ति हानि पुर्‍याएको।"],
     "timeline": [{"date": "2024-05-01", "date_bs": "2081-01-19", "title": "उजुरी दर्ता"}],
+    # The LIVE entity payload shape: nes_id / display_name / entity_type /
+    # type (the RELATIONSHIP type) / outcome / notes, per
+    # cases/services/nes_resolver.py::build_entity_binds. There is no `role`
+    # and no `entity_iri` key on a case's entities.
     "entities": [
-        {"role": "ACCUSED", "name": "कमल राज गौतम",
-         "entity_iri": "https://jawafdehi.org/entity/person/kamal-raj-gautam"},
+        {"nes_id": "person/kamal-raj-gautam", "display_name": "कमल राज गौतम",
+         "entity_type": "person", "type": "accused", "outcome": "",
+         "notes": "तत्कालीन प्रमुख"},
     ],
 }
 
@@ -534,10 +515,11 @@ def test_generate_prompt_carries_every_context_block():
     )
     content = seen["content"]
     assert "काठमाडौं महानगरपालिका ठेक्का अनियमितता" in content
-    assert "रु 10,403,941" in content
+    assert "10,403,941" in content
     assert "081-cr-0091" in content
     assert "ठेक्कामा मिलेमतो" in content
-    assert "कमल राज गौतम" in content
+    assert "[accused] कमल राज गौतम" in content
+    assert "तत्कालीन प्रमुख" in content
     assert "अभियोगपत्रको पाठ" in content
 
 

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -571,7 +571,10 @@ def test_generate_prompt_carries_every_context_block():
     content = seen["content"]
     assert "काठमाडौं महानगरपालिका ठेक्का अनियमितता" in content
     assert "10,403,941" in content
-    assert "081-cr-0091" in content
+    assert "Special-court case number: 081-CR-0091" in content, (
+        "the number is presented UPPERCASE. Asserting the bare lowercase string "
+        "instead passed for the wrong reason -- it also appears in the raw "
+        "court_cases IRI block, so the assertion held either way")
     assert "ठेक्कामा मिलेमतो" in content
     assert "[accused] कमल राज गौतम" in content
     assert "तत्कालीन प्रमुख" in content
@@ -1018,3 +1021,57 @@ def test_batch_csv_reaches_selection(tmp_path):
         ["--batch-csv", str(csv)])
     assert args.batch_csv == str(csv)
     assert "select_for_run" in _shipped_source()
+
+
+# --------------------------------------------------------------------------
+# code-review findings
+# --------------------------------------------------------------------------
+
+
+def test_a_partly_failed_source_fetch_is_reported_not_swallowed(monkeypatch, tmp_path):
+    """Review finding 3. `text_unmet` used to be consumed ONLY when nothing
+    fetched at all.
+
+    So a case whose charge sheet fetched and whose court order 500'd generated a
+    full public narrative from the prosecution claim alone -- silently omitting
+    that the defendant was acquitted -- and the review file listed only the
+    source that succeeded. The human reviewer had no way to see that a verdict
+    source existed and was lost. This is the one stage where the missing source
+    can BE the outcome.
+    """
+    import casework.common.materials as m
+
+    def half_broken(link, timeout=60):
+        if link == _COURT_MD:
+            raise RuntimeError("502 Bad Gateway")
+        return "अख्तियारले काठमाडौं महानगरपालिकाको ठेक्कामा भ्रष्टाचार भएको जनाएको।"
+
+    monkeypatch.setattr(m, "fetch_markdown", half_broken)
+    stub = _tracking_stub("### क) अभियोगदावीको सार\nठेक्कामा भ्रष्टाचार भएको।")
+    api = _StubApi([CASE_READY])
+    _run_main(monkeypatch, api, stub, BASE_ARGV + ["--dry-run"])
+
+    assert stub.calls, "the surviving source still generates -- this is not a skip"
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "SOURCE MISSING" in text, (
+        "the reviewer signs off on this file; a lost verdict source must appear in it")
+    assert "court_order" in text
+    assert "502 Bad Gateway" in text
+
+
+def test_the_court_number_reaches_the_model_uppercase(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """Review finding 6. `select.court_number()` reads the number off the
+    canonical IRI, which is lowercase, and the prompt tells the model to prefer
+    specifics from the context -- so `मुद्दा 081-cr-0091` lands in public prose.
+
+    Fixed for the card on evidence (2 of 5 titles shipped lowercase in the
+    2026-08-04 evaluation, against 50/50 uppercase in PUBLISHED titles); this is
+    the same defect one stage earlier.
+    """
+    stub = _tracking_stub("### क) सार\nठेक्का विवरण।")
+    _run_main(monkeypatch, _StubApi([CASE_READY]), stub, BASE_ARGV + ["--dry-run"])
+    content = stub.calls[0]["content"]
+    assert "Special-court case number: 081-CR-0091" in content
+    assert "case number: 081-cr-0091" not in content

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -1075,3 +1075,51 @@ def test_the_court_number_reaches_the_model_uppercase(
     content = stub.calls[0]["content"]
     assert "Special-court case number: 081-CR-0091" in content
     assert "case number: 081-cr-0091" not in content
+
+
+def test_a_successful_fetch_with_no_etag_refuses_to_write(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """Review finding 10, description side. A 200 missing the ETag header writes
+    with no precondition -- and a description is the most expensive output in the
+    pipeline, so losing someone else's edit to it matters most here."""
+    stub = _tracking_stub("### क) सार\nठेक्का विवरण।")
+    api = _StubApi([CASE_READY], etag="")
+    report = _run_main(monkeypatch, api, stub, BASE_ARGV + ["--apply"])
+    assert api.patched == []
+    assert stub.calls == [], "and it must not pay for the premium call first"
+    assert any("no ETag" in r["reason"] for r in report.rows)
+
+
+def test_the_donor_fallback_route_still_cannot_write_unconditionally(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """The fetch-time guard is scoped to a SUCCESSFUL fetch, so it deliberately
+    leaves the donor fallback (`detail = case`, `etag = None`) alone -- that path
+    is meant to report from the unmet-material gate.
+
+    But the gate only stops it because a LIST payload carries `material: null`,
+    which is an accident of the serializer rather than a precondition. So the
+    write itself is guarded too. This drives the fallback with a detail-shaped
+    payload -- the case the material gate does NOT catch -- and asserts nothing is
+    written.
+    """
+    api = _StubApi([CASE_READY], fail_detail_for=["case-ready"])
+    report = _run_main(monkeypatch, api, _tracking_stub("### क) सार\nठेक्का विवरण।"),
+                       BASE_ARGV + ["--apply"])
+    assert api.patched == []
+    assert any("no ETag" in r["reason"] for r in report.rows)
+
+
+def test_a_dry_run_is_not_blocked_by_a_missing_etag(
+    monkeypatch, patched_fetch_markdown, tmp_path
+):
+    """The write guard sits after the dry-run branch, so the read-only path still
+    produces its accuracy artefact. Blocking it would mean a fetch quirk could
+    stop output ever being reviewed."""
+    api = _StubApi([CASE_READY], fail_detail_for=["case-ready"])
+    _run_main(monkeypatch, api, _tracking_stub("### क) सार\nठेक्का विवरण।"),
+              BASE_ARGV + ["--dry-run"])
+    assert api.patched == []
+    text = _review_file(tmp_path).read_text(encoding="utf-8")
+    assert "ठेक्का विवरण।" in text

--- a/tests/casework/test_format.py
+++ b/tests/casework/test_format.py
@@ -1,0 +1,132 @@
+"""Tests for the shared prompt-context formatters (casework/common/format.py).
+
+These read the LIVE payload shape, and getting that wrong is a silent failure:
+a formatter reading keys that do not exist returns a tidy list of blank bullets,
+the prompt looks well-formed, and the model simply never learns any name in the
+case. So the entity tests assert against the shape
+`cases/services/nes_resolver.py::build_entity_binds` actually produces, and one
+test pins that shape by calling the real shaper.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from casework.common.format import format_bigo, format_entities, format_list
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DONOR_COMMIT = "0321a85"
+
+# The live shape: nes_id / display_name / entity_type / type / outcome / notes.
+# `type` is the RELATIONSHIP type -- that is what gets bracketed.
+LIVE_ENTITY = {
+    "nes_id": "person/kamal-raj-gautam",
+    "display_name": "कमल राज गौतम",
+    "entity_type": "person",
+    "type": "accused",
+    "outcome": "convicted",
+    "notes": "तत्कालीन प्रमुख जिल्ला अधिकारी",
+}
+
+
+class TestFormatBigo:
+    def test_thousands_separated(self):
+        assert format_bigo(330000000) == "330,000,000"
+
+    def test_a_numeric_string_is_accepted(self):
+        assert format_bigo("10403941") == "10,403,941"
+
+    def test_none_and_zero_and_junk_are_all_unknown(self):
+        assert format_bigo(None) == "(unknown)"
+        assert format_bigo(0) == "(unknown)"
+        assert format_bigo("") == "(unknown)"
+        assert format_bigo("अज्ञात") == "(unknown)"
+
+    def test_a_negative_bigo_is_unknown_not_negative(self):
+        """A negative disputed amount is data corruption, not a fact to print
+        into a public-facing prompt."""
+        assert format_bigo(-500) == "(unknown)"
+
+
+class TestFormatList:
+    def test_bullets(self):
+        assert format_list(["पहिलो", "दोस्रो"]) == "- पहिलो\n- दोस्रो"
+
+    def test_empty_and_none(self):
+        assert format_list([]) == "(none provided)"
+        assert format_list(None) == "(none provided)"
+
+
+class TestFormatEntities:
+    def test_the_relationship_type_and_display_name_are_rendered(self):
+        out = format_entities([LIVE_ENTITY])
+        assert out.startswith("- [accused] कमल राज गौतम")
+
+    def test_notes_are_appended_when_present(self):
+        assert "तत्कालीन प्रमुख जिल्ला अधिकारी" in format_entities([LIVE_ENTITY])
+
+    def test_blank_notes_add_no_dash(self):
+        out = format_entities([dict(LIVE_ENTITY, notes="")])
+        assert out == "- [accused] कमल राज गौतम"
+
+    def test_an_unresolved_entity_still_gets_a_line(self):
+        """`build_entity_binds` sets display_name to None when NES cannot
+        resolve the id. That must render as a line with a visible relationship
+        type, not vanish -- a dropped accused is a dropped fact."""
+        out = format_entities([
+            {"nes_id": "person/unknown", "display_name": None,
+             "entity_type": None, "type": "accused", "notes": ""},
+        ])
+        assert out == "- [accused] "
+
+    def test_a_non_dict_entry_is_skipped_not_crashed(self):
+        out = format_entities(["गलत", None, dict(LIVE_ENTITY, notes="")])
+        assert out == "- [accused] कमल राज गौतम"
+
+    def test_only_malformed_entries_falls_back_to_none_provided(self):
+        assert format_entities(["गलत", 42]) == "(none provided)"
+
+    def test_empty_and_none(self):
+        assert format_entities([]) == "(none provided)"
+        assert format_entities(None) == "(none provided)"
+
+    def test_the_keys_read_are_the_keys_the_real_shaper_emits(self):
+        """The pin that catches a payload-shape drift.
+
+        Calls `build_entity_binds` itself rather than trusting this file's
+        fixture, so a rename in `nes_resolver` fails here instead of quietly
+        turning every entity line blank.
+        """
+        from cases.services.nes_resolver import build_entity_binds
+
+        class _Rel:
+            nes_id = "person/kamal-raj-gautam"
+            relationship_type = "accused"
+            outcome = "convicted"
+            notes = "तत्कालीन प्रमुख"
+
+        binds = build_entity_binds(
+            [_Rel()],
+            {"person/kamal-raj-gautam": {"display_name": "कमल राज गौतम",
+                                         "entity_type": "person"}},
+            include_notes=True,
+        )
+        assert format_entities(binds) == "- [accused] कमल राज गौतम — तत्कालीन प्रमुख"
+
+
+def test_the_donors_all_shared_these_three_functions():
+    """Why they live in `common/` rather than in one enricher.
+
+    All three donor scripts imported the same three names from the shared
+    `casework/common.py`. A per-enricher copy is a fork, and a forked formatter
+    means two prompts that disagree about what a missing बिगो looks like.
+    """
+    for donor in ("enrich_description.py", "enrich_card.py", "enrich_title.py"):
+        proc = subprocess.run(
+            ["git", "show", f"{DONOR_COMMIT}:casework/{donor}"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            pytest.skip(f"donor commit {DONOR_COMMIT} not in local history")
+        assert "format_bigo" in proc.stdout, donor
+        assert "format_list" in proc.stdout, donor

--- a/tests/casework/test_format.py
+++ b/tests/casework/test_format.py
@@ -66,8 +66,24 @@ class TestFormatEntities:
         assert "तत्कालीन प्रमुख जिल्ला अधिकारी" in format_entities([LIVE_ENTITY])
 
     def test_blank_notes_add_no_dash(self):
-        out = format_entities([dict(LIVE_ENTITY, notes="")])
+        out = format_entities([dict(LIVE_ENTITY, notes="", outcome="")])
         assert out == "- [accused] कमल राज गौतम"
+
+    def test_the_per_entity_outcome_reaches_the_prompt(self):
+        """The structured answer to "who was convicted and who was cleared".
+
+        Both prompts require a per-defendant outcome -- `enrich_description`'s
+        section ग and `enrich_card`'s split-verdict teaser rule -- and dropping
+        this key forced both models to re-derive the split from prose, which is
+        what produced the misreported verdicts.
+        """
+        out = format_entities([dict(LIVE_ENTITY, notes="", outcome="सफाई")])
+        assert out == "- [accused] कमल राज गौतम — फैसला: सफाई"
+
+    def test_a_blank_outcome_adds_no_label(self):
+        for blank in ("", "   ", None):
+            out = format_entities([dict(LIVE_ENTITY, notes="", outcome=blank)])
+            assert out == "- [accused] कमल राज गौतम", f"outcome={blank!r}"
 
     def test_an_unresolved_entity_still_gets_a_line(self):
         """`build_entity_binds` sets display_name to None when NES cannot
@@ -80,7 +96,7 @@ class TestFormatEntities:
         assert out == "- [accused] "
 
     def test_a_non_dict_entry_is_skipped_not_crashed(self):
-        out = format_entities(["गलत", None, dict(LIVE_ENTITY, notes="")])
+        out = format_entities(["गलत", None, dict(LIVE_ENTITY, notes="", outcome="")])
         assert out == "- [accused] कमल राज गौतम"
 
     def test_only_malformed_entries_falls_back_to_none_provided(self):
@@ -111,7 +127,8 @@ class TestFormatEntities:
                                          "entity_type": "person"}},
             include_notes=True,
         )
-        assert format_entities(binds) == "- [accused] कमल राज गौतम — तत्कालीन प्रमुख"
+        assert format_entities(binds) == (
+            "- [accused] कमल राज गौतम — फैसला: convicted — तत्कालीन प्रमुख")
 
 
 def test_the_donors_all_shared_these_three_functions():

--- a/tests/casework/test_judge.py
+++ b/tests/casework/test_judge.py
@@ -103,7 +103,7 @@ class TestVerdictHandling:
         judge_description_adequacy(
             REAL_TEASER, kind="teaser", invoke_text=_stub({"adequate": True}, calls))
         assert calls[0]["tier"] == "cheap"
-        assert calls[0]["max_tokens"] == 300
+        assert calls[0]["max_tokens"] == 2000
 
     def test_the_tier_is_overridable(self):
         calls = []

--- a/tests/casework/test_judge.py
+++ b/tests/casework/test_judge.py
@@ -1,0 +1,189 @@
+"""Tests for the adequacy judge (casework/common/judge.py).
+
+The judge decides whether a field value is real or a template stub. Two
+properties carry all the weight:
+
+- It FAILS TOWARD REGENERATING. Every failure mode -- a dead provider, an
+  unparseable verdict, a truncated reply -- must return `adequate=False`. The
+  opposite default silently keeps template text on the public case list.
+- It spends no LLM call on text that cannot possibly be adequate.
+"""
+import json
+
+import pytest
+
+from casework.common.judge import (
+    _JUDGE_MIN_CHARS,
+    _parse_judge_verdict,
+    judge_description_adequacy,
+)
+
+REAL_TEASER = "काठमाडौं महानगरपालिकाको ठेक्कामा रु ३३ करोड हिनामिना भएको आरोप।"
+
+
+def _stub(payload, calls=None):
+    def stub(**kw):
+        if calls is not None:
+            calls.append(kw)
+        return payload if isinstance(payload, str) else json.dumps(payload)
+    return stub
+
+
+class TestNoCallShortCircuit:
+    def test_blank_text_is_inadequate_without_an_llm_call(self):
+        calls = []
+        adequate, reason = judge_description_adequacy(
+            "", kind="teaser", invoke_text=_stub({"adequate": True}, calls))
+        assert adequate is False
+        assert "blank or too short" in reason
+        assert calls == []
+
+    def test_none_is_inadequate_without_a_call(self):
+        calls = []
+        adequate, _ = judge_description_adequacy(
+            None, kind="teaser", invoke_text=_stub({"adequate": True}, calls))
+        assert adequate is False
+        assert calls == []
+
+    def test_text_under_the_floor_is_inadequate_without_a_call(self):
+        calls = []
+        adequate, _ = judge_description_adequacy(
+            "क" * (_JUDGE_MIN_CHARS - 1), kind="teaser",
+            invoke_text=_stub({"adequate": True}, calls))
+        assert adequate is False
+        assert calls == []
+
+    def test_text_at_the_floor_does_reach_the_model(self):
+        calls = []
+        judge_description_adequacy(
+            "क" * _JUDGE_MIN_CHARS, kind="teaser",
+            invoke_text=_stub({"adequate": True, "reason": "ok"}, calls))
+        assert len(calls) == 1
+
+
+class TestVerdictHandling:
+    def test_an_adequate_verdict_is_returned_with_its_reason(self):
+        adequate, reason = judge_description_adequacy(
+            REAL_TEASER, kind="teaser",
+            invoke_text=_stub({"adequate": True, "reason": "names an amount"}))
+        assert adequate is True
+        assert reason == "names an amount"
+
+    def test_an_inadequate_verdict_is_returned(self):
+        adequate, reason = judge_description_adequacy(
+            REAL_TEASER, kind="teaser",
+            invoke_text=_stub({"adequate": False, "reason": "boilerplate"}))
+        assert adequate is False
+        assert reason == "boilerplate"
+
+    def test_a_missing_reason_gets_a_placeholder_not_a_blank(self):
+        _, reason = judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=_stub({"adequate": True}))
+        assert reason == "(no reason given)"
+
+    def test_the_prompt_carries_the_field_kind_and_the_context(self):
+        calls = []
+        judge_description_adequacy(
+            REAL_TEASER, kind="case card short description",
+            invoke_text=_stub({"adequate": True}, calls),
+            context="title=काठमाडौं ठेक्का")
+        content = calls[0]["content"]
+        assert "case card short description" in content
+        assert "काठमाडौं ठेक्का" in content
+        assert REAL_TEASER in content
+
+    def test_the_context_line_is_omitted_when_empty(self):
+        calls = []
+        judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=_stub({"adequate": True}, calls))
+        assert "CONTEXT:" not in calls[0]["content"]
+
+    def test_the_cheap_tier_is_the_default(self):
+        calls = []
+        judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=_stub({"adequate": True}, calls))
+        assert calls[0]["tier"] == "cheap"
+        assert calls[0]["max_tokens"] == 300
+
+    def test_the_tier_is_overridable(self):
+        calls = []
+        judge_description_adequacy(
+            REAL_TEASER, kind="teaser",
+            invoke_text=_stub({"adequate": True}, calls), tier="premium")
+        assert calls[0]["tier"] == "premium"
+
+
+class TestFailsTowardRegenerating:
+    """Every failure mode returns adequate=False.
+
+    A needless regeneration costs one cheap call. Silently keeping a placeholder
+    ships template text to the public case list, where nothing distinguishes it
+    from real editorial output.
+    """
+
+    def test_a_failed_provider_call_is_inadequate(self):
+        def boom(**kw):
+            raise RuntimeError("provider down")
+
+        adequate, reason = judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=boom)
+        assert adequate is False
+        assert "judge call failed" in reason
+        assert "provider down" in reason
+
+    def test_an_unparseable_reply_is_inadequate(self):
+        adequate, reason = judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=_stub("I think it's fine!"))
+        assert adequate is False
+        assert "unparseable" in reason
+
+    def test_an_object_without_the_adequate_key_is_inadequate(self):
+        adequate, _ = judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=_stub({"verdict": "good"}))
+        assert adequate is False
+
+    def test_a_non_boolean_adequate_is_inadequate(self):
+        """`{"adequate": "yes"}` is not a verdict. Truthiness would read it as
+        adequate and keep a stub."""
+        adequate, _ = judge_description_adequacy(
+            REAL_TEASER, kind="teaser", invoke_text=_stub({"adequate": "yes"}))
+        assert adequate is False
+
+
+class TestParseJudgeVerdict:
+    def test_parses_a_plain_object(self):
+        assert _parse_judge_verdict(
+            '{"adequate": false, "reason": "stub"}') == (False, "stub")
+
+    def test_parses_a_fenced_object(self):
+        body = '```json\n{"adequate": true, "reason": "ok"}\n```'
+        assert _parse_judge_verdict(body) == (True, "ok")
+
+    def test_scans_past_a_near_miss_object(self):
+        """The `predicate` is what keeps the scan going.
+
+        A reply whose first object has a non-boolean `adequate` must not end the
+        search -- the real verdict may be the next one.
+        """
+        body = '{"adequate": "maybe"} then {"adequate": true, "reason": "ok"}'
+        assert _parse_judge_verdict(body) == (True, "ok")
+
+    def test_returns_none_when_no_boolean_verdict_exists(self):
+        assert _parse_judge_verdict('{"adequate": "yes"}') is None
+        assert _parse_judge_verdict("not json") is None
+        assert _parse_judge_verdict("") is None
+
+    @pytest.mark.parametrize("reason", [None, 42, "   "])
+    def test_a_junk_reason_becomes_the_placeholder(self, reason):
+        body = json.dumps({"adequate": True, "reason": reason})
+        assert _parse_judge_verdict(body) == (True, "(no reason given)")
+
+
+def test_the_system_prompt_names_placeholder_shapes_in_both_scripts():
+    """The judge has to recognise Nepali stubs, not only English ones -- the
+    2,666 production stubs are Devanagari."""
+    from casework.common.judge import _JUDGE_SYSTEM_PROMPT
+
+    assert "खाली" in _JUDGE_SYSTEM_PROMPT
+    assert "TODO" in _JUDGE_SYSTEM_PROMPT
+    assert "fits any case" in _JUDGE_SYSTEM_PROMPT

--- a/tests/casework/test_materials.py
+++ b/tests/casework/test_materials.py
@@ -5,7 +5,8 @@ import urllib.request
 from casework.common.api import BROWSER_UA
 from casework.common.materials import (
     court_order_ident, fetch_markdown, markdown_link, material_exists,
-    material_iri, materials_of_type, press_release_ident, raw_links, source_text,
+    material_iri, materials_of_type, press_release_ident, raw_links,
+    source_chunks, source_text, typed_materials,
 )
 
 CASE = {
@@ -38,6 +39,55 @@ def test_materials_of_type_filters():
     got = materials_of_type(CASE, ("press_release",))
     assert len(got) == 1
     assert got[0]["material_type"] == "press_release"
+
+
+def test_typed_materials_keeps_the_entry_level_material_iri():
+    """The IRI lives on the evidence ENTRY, not inside the resolved material
+    dict, so `materials_of_type` drops the only identifier a reviewer can use
+    to find the document again."""
+    got = typed_materials(CASE, ("press_release",))
+    assert got == [(
+        "press_release",
+        "https://jawafdehi.org/material/ciaa_press_release/1",
+        CASE["evidence"][0]["material"],
+    )]
+
+
+def test_typed_materials_selects_the_same_entries_as_materials_of_type():
+    assert [m for _, _, m in typed_materials(CASE)] == materials_of_type(CASE)
+
+
+def test_typed_materials_tolerates_a_missing_material_iri():
+    case = {"evidence": [{"material": {"material_type": "press_release", "urls": []}}]}
+    assert typed_materials(case) == [("press_release", "", case["evidence"][0]["material"])]
+
+
+def test_source_chunks_returns_type_iri_and_text(monkeypatch):
+    import casework.common.materials as m
+    monkeypatch.setattr(m, "fetch_markdown", lambda link, timeout=60: "प्रेस विज्ञप्ति पाठ")
+
+    chunks, unmet = source_chunks(CASE, types=("press_release",))
+    assert chunks == [(
+        "press_release",
+        "https://jawafdehi.org/material/ciaa_press_release/1",
+        "प्रेस विज्ञप्ति पाठ",
+    )]
+    assert unmet == []
+
+
+def test_source_text_is_the_join_of_source_chunks(monkeypatch):
+    """One implementation of the fetch and of the unmet wording, two shapes.
+    If these ever disagree, the typed and untyped callers are reading
+    different documents."""
+    import casework.common.materials as m
+    monkeypatch.setattr(
+        m, "fetch_markdown",
+        lambda link, timeout=60: {"https://x/pr.md": "पाठ एक"}.get(link, ""),
+    )
+    chunks, chunk_unmet = source_chunks(CASE)
+    text, text_unmet = source_text(CASE)
+    assert text == "\n\n".join(t for _, _, t in chunks)
+    assert text_unmet == chunk_unmet
 
 
 def test_source_text_reports_unmet_when_no_markdown(monkeypatch):

--- a/tests/casework/test_parse.py
+++ b/tests/casework/test_parse.py
@@ -1,4 +1,7 @@
-from casework.common.parse import balanced_object, is_valid_iso_date, parse_extraction_response
+from casework.common.parse import (
+    _strip_fence, balanced_object, is_valid_iso_date, parse_extraction_response,
+    parse_object_response,
+)
 
 
 def test_balanced_object_ignores_braces_inside_strings():
@@ -80,3 +83,56 @@ def test_is_valid_iso_date():
     assert not is_valid_iso_date("2024-13-01")
     assert not is_valid_iso_date("2081-01-15xx")
     assert not is_valid_iso_date(None)
+
+
+# --------------------------------------------------------------------------
+# parse_object_response -- the object-shaped reply (description enricher)
+# --------------------------------------------------------------------------
+
+
+def test_parse_object_response_returns_the_whole_dict():
+    body = '{"description": "### क) अभियोगदावीको सार", "title": "शीर्षक"}'
+    obj = parse_object_response(body, "description")
+    assert obj["description"] == "### क) अभियोगदावीको सार"
+    assert obj["title"] == "शीर्षक"
+
+
+def test_parse_object_response_scans_past_a_leading_unrelated_object():
+    """Every `{` is tried, not just `text.find("{")`.
+
+    A reply that opens with an unrelated object -- a preamble, an echoed tool
+    argument -- returns None under a first-brace-only parser, which is exactly
+    the donor bug this scan exists to avoid.
+    """
+    body = '{"thinking": "let me see"} \n\n {"description": "असली विवरण"}'
+    assert parse_object_response(body, "description") == {"description": "असली विवरण"}
+
+
+def test_parse_object_response_handles_a_fenced_block():
+    body = 'यहाँ छ:\n```json\n{"description": "विवरण"}\n```'
+    assert parse_object_response(body, "description") == {"description": "विवरण"}
+
+
+def test_parse_object_response_survives_a_brace_inside_a_quoted_value():
+    body = '{"description": "दफा ३ {क} अनुसार", "n": 1}'
+    assert parse_object_response(body, "description")["description"] == "दफा ३ {क} अनुसार"
+
+
+def test_parse_object_response_returns_none_when_the_key_is_absent():
+    assert parse_object_response('{"other": 1}', "description") is None
+
+
+def test_parse_object_response_returns_none_for_a_bare_array():
+    # A list is not an object; the description contract is an object.
+    assert parse_object_response('["विवरण"]', "description") is None
+
+
+def test_parse_object_response_returns_none_for_empty_and_none_input():
+    assert parse_object_response("", "description") is None
+    assert parse_object_response(None, "description") is None
+
+
+def test_strip_fence_leaves_text_without_a_closing_fence_alone():
+    # A truncated response must not have its whole body eaten by a half fence.
+    assert _strip_fence('```json\n{"description": "विवरण"}') == (
+        '```json\n{"description": "विवरण"}')

--- a/tests/casework/test_parse.py
+++ b/tests/casework/test_parse.py
@@ -1,6 +1,6 @@
 from casework.common.parse import (
-    _strip_fence, balanced_object, is_valid_iso_date, parse_extraction_response,
-    parse_object_response,
+    balanced_object, is_valid_iso_date, parse_extraction_response,
+    parse_object_response, strip_fence,
 )
 
 
@@ -134,5 +134,5 @@ def test_parse_object_response_returns_none_for_empty_and_none_input():
 
 def test_strip_fence_leaves_text_without_a_closing_fence_alone():
     # A truncated response must not have its whole body eaten by a half fence.
-    assert _strip_fence('```json\n{"description": "विवरण"}') == (
+    assert strip_fence('```json\n{"description": "विवरण"}') == (
         '```json\n{"description": "विवरण"}')

--- a/tests/casework/test_review.py
+++ b/tests/casework/test_review.py
@@ -1,0 +1,202 @@
+"""Tests for the human review file (casework/common/review.py).
+
+This file is the accuracy deliverable of every enricher run, so the things
+worth pinning are the ones that would quietly make it useless: escaped
+Devanagari, a case silently absent from it, a generated value's own Markdown
+headings swallowing the file structure, and any wording that would overclaim
+where a passage came from.
+"""
+import argparse
+
+import pytest
+
+from casework.common.cli import add_common_args
+from casework.common.review import (
+    EXCERPT_CHARS,
+    ReviewFile,
+    ReviewRow,
+    _quote,
+    build_review_file,
+    review_path,
+)
+
+
+def _file(tmp_path, **kw):
+    kw.setdefault("stage", "description")
+    kw.setdefault("field_name", "description")
+    kw.setdefault("path", tmp_path / "review.md")
+    return ReviewFile(**kw)
+
+
+def test_devanagari_is_written_unescaped(tmp_path):
+    """A review file full of `\\u0915` cannot be reviewed."""
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(slug="case-1", status="would-enrich",
+                     generated="ठेक्कामा भ्रष्टाचार भएको।"))
+    text = rf.write().read_text(encoding="utf-8")
+    assert "ठेक्कामा भ्रष्टाचार भएको।" in text
+    assert "\\u0920" not in text
+
+
+def test_every_row_appears_in_the_summary_table(tmp_path):
+    """A case missing from the file reads as "not selected", not "could not
+    run" -- so unmet and already-done cases get a row too."""
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(slug="case-unmet", status="unmet", note="no MARKDOWN role"))
+    rf.add(ReviewRow(slug="case-already", status="already", before="क" * 900))
+    rf.add(ReviewRow(slug="case-new", status="would-enrich", generated="नयाँ"))
+    text = rf.write().read_text(encoding="utf-8")
+    for slug in ("case-unmet", "case-already", "case-new"):
+        assert f"`{slug}`" in text
+    assert "no MARKDOWN role" in text
+
+
+def test_generated_markdown_headings_are_quoted_not_promoted(tmp_path):
+    """The generated value is itself Markdown (`### क) …`). Pasted raw, its
+    headings become headings of the review file and the per-case structure
+    collapses."""
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(slug="case-1", status="would-enrich",
+                     generated="### क) अभियोगदावीको सार\nविवरण।"))
+    text = rf.write().read_text(encoding="utf-8")
+    assert "> ### क) अभियोगदावीको सार" in text
+    assert "\n### क) अभियोगदावीको सार" not in text
+
+
+def test_a_source_records_its_material_iri(tmp_path):
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(
+        slug="case-1", status="would-enrich", generated="विवरण",
+        sources=[("press_release", "https://jawafdehi.org/material/ciaa/12345",
+                  "अख्तियारको विज्ञप्ति")],
+    ))
+    text = rf.write().read_text(encoding="utf-8")
+    assert "https://jawafdehi.org/material/ciaa/12345" in text
+    assert "अख्तियारको विज्ञप्ति" in text
+
+
+def test_a_long_source_is_excerpted_and_says_so(tmp_path):
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(
+        slug="case-1", status="would-enrich", generated="विवरण",
+        sources=[("court_order", "iri-c", "फ" * (EXCERPT_CHARS + 500))],
+    ))
+    text = rf.write().read_text(encoding="utf-8")
+    assert f"first {EXCERPT_CHARS:,}" in text
+    assert f"{EXCERPT_CHARS + 500:,} chars" in text
+
+
+def test_a_short_source_carries_no_truncation_note(tmp_path):
+    """A whole source must not be reported as an excerpt -- a reviewer who
+    thinks they are seeing a fragment will not treat a missing figure as a
+    real omission."""
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(slug="case-1", status="would-enrich", generated="विवरण",
+                     sources=[("press_release", "iri-p", "छोटो पाठ")]))
+    text = rf.write().read_text(encoding="utf-8")
+    assert "— excerpt, first" not in text
+    assert "(8 chars)" in text
+
+
+def test_sources_are_labelled_as_fed_to_the_model(tmp_path):
+    """A completion does not report which sentences it drew on. Presenting the
+    excerpt as the passage the model quoted would be a fabricated provenance
+    claim in the artefact whose whole job is checking for fabrication."""
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(slug="case-1", status="would-enrich", generated="विवरण",
+                     sources=[("press_release", "iri-p", "पाठ")]))
+    text = rf.write().read_text(encoding="utf-8")
+    assert "### Sources fed to the model" in text
+    assert "the text FED to the model, not a span the model reported quoting" in text
+
+
+def test_an_empty_before_value_is_shown_as_empty_not_blank(tmp_path):
+    """"(empty)" and "a value that rendered as nothing" must not look alike."""
+    rf = _file(tmp_path)
+    rf.add(ReviewRow(slug="case-1", status="would-enrich", before="", generated="नयाँ"))
+    text = rf.write().read_text(encoding="utf-8")
+    assert "_(empty)_" in text
+
+
+def test_dry_run_and_applied_are_visibly_different(tmp_path):
+    dry = _file(tmp_path, path=tmp_path / "dry.md", dry_run=True).render()
+    applied = _file(tmp_path, path=tmp_path / "applied.md", dry_run=False).render()
+    assert "DRY RUN" in dry
+    assert "nothing was written" in dry
+    assert "DRY RUN" not in applied
+    assert "APPLIED" in applied
+
+
+def test_write_creates_missing_parent_directories(tmp_path):
+    rf = _file(tmp_path, path=tmp_path / "a" / "b" / "review.md")
+    rf.add(ReviewRow(slug="case-1", status="would-enrich", generated="विवरण"))
+    assert rf.write().exists()
+
+
+def test_a_run_with_no_rows_still_renders(tmp_path):
+    text = _file(tmp_path).write().read_text(encoding="utf-8")
+    assert "Cases: 0" in text
+
+
+def test_quote_keeps_blank_lines_inside_the_quote(tmp_path):
+    """A blank line rendered as an unprefixed empty line ENDS the blockquote,
+    so the rest of a multi-paragraph description escapes it."""
+    assert _quote("क\n\nख") == "> क\n>\n> ख"
+
+
+def test_quote_of_blank_input_is_empty():
+    assert _quote("") == ""
+    assert _quote(None) == ""
+
+
+# --------------------------------------------------------------------------
+# review_path / build_review_file
+# --------------------------------------------------------------------------
+
+
+def test_review_path_prefers_an_explicit_override(tmp_path):
+    target = tmp_path / "task-dir" / "review.md"
+    assert review_path("description", "abc123", str(target)) == target
+
+
+def test_review_path_honours_the_env_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("CASEWORK_REVIEW_DIR", str(tmp_path / "reviews"))
+    path = review_path("description", "abc123")
+    assert path.parent == tmp_path / "reviews"
+    assert path.name.endswith("-description-abc123.md")
+
+
+def test_review_path_falls_back_to_the_repo_work_dir(monkeypatch):
+    monkeypatch.delenv("CASEWORK_REVIEW_DIR", raising=False)
+    path = review_path("description", "abc123")
+    # `work/` is gitignored, so the default can never commit generated prose.
+    assert path.parent.parts[-2:] == ("work", "reviews")
+
+
+def test_build_review_file_reads_the_cli_flags(tmp_path):
+    ap = add_common_args(argparse.ArgumentParser())
+    args = ap.parse_args([
+        "--api-base-url", "http://127.0.0.1:48010",
+        "--review-file", str(tmp_path / "out.md"),
+        "--provider", "claude_cli",
+    ])
+    rf = build_review_file(args, stage="description", field_name="description",
+                           run_id="r1")
+    assert rf.path == tmp_path / "out.md"
+    assert rf.dry_run is True          # --dry-run is the default
+    assert rf.base_url == "http://127.0.0.1:48010"
+    assert rf.provider == "claude_cli"
+
+
+def test_build_review_file_marks_apply_runs(tmp_path):
+    ap = add_common_args(argparse.ArgumentParser())
+    args = ap.parse_args(["--apply", "--review-file", str(tmp_path / "out.md")])
+    rf = build_review_file(args, stage="description", field_name="description",
+                           run_id="r1")
+    assert rf.dry_run is False
+
+
+@pytest.mark.parametrize("model,expected", [("", "(provider default)"), ("opus", "opus")])
+def test_the_header_names_the_model_or_says_it_defaulted(tmp_path, model, expected):
+    rf = _file(tmp_path, model=model, provider="claude_cli")
+    assert expected in rf.render()

--- a/tests/casework/test_review.py
+++ b/tests/casework/test_review.py
@@ -200,3 +200,32 @@ def test_build_review_file_marks_apply_runs(tmp_path):
 def test_the_header_names_the_model_or_says_it_defaulted(tmp_path, model, expected):
     rf = _file(tmp_path, model=model, provider="claude_cli")
     assert expected in rf.render()
+
+
+def test_a_directory_valued_override_gets_a_stamped_per_stage_name(tmp_path):
+    """Finding 6. Two stages pointed at one DIRECTORY must not collide.
+
+    The workflow that exposed this is the normal one: dry-run `description`, read
+    it, dry-run `card` against the same cases. Both runs were given the same
+    `--review-file`, and only the card's survived.
+    """
+    target = tmp_path / "reviews"
+    target.mkdir()
+    desc = review_path("description", "aaaa1111", override=str(target))
+    card = review_path("card", "bbbb2222", override=str(target))
+    assert desc.parent == target and card.parent == target
+    assert desc != card
+    assert desc.name.endswith("-description-aaaa1111.md")
+    assert card.name.endswith("-card-bbbb2222.md")
+
+
+def test_a_trailing_slash_is_a_directory_even_before_it_exists(tmp_path):
+    path = review_path("card", "cccc3333", override=f"{tmp_path / 'later'}/")
+    assert path.parent == tmp_path / "later"
+    assert path.name.endswith("-card-cccc3333.md")
+
+
+def test_a_file_valued_override_is_still_used_verbatim(tmp_path):
+    """Naming one file stays a deliberate act -- no stamp, no stage suffix."""
+    target = tmp_path / "exactly-this.md"
+    assert review_path("card", "dddd4444", override=str(target)) == target

--- a/tests/casework/test_titles.py
+++ b/tests/casework/test_titles.py
@@ -1,4 +1,7 @@
-from casework.common.titles import TITLE_RULES, title_has_headcount, validate_title
+from casework.common.titles import (
+    TITLE_RULES, parse_title, title_has_headcount, title_is_acceptable,
+    validate_title,
+)
 
 
 def test_accepts_title_with_trailing_court_number():
@@ -69,3 +72,103 @@ def test_court_number_itself_is_not_mistaken_for_headcount():
 
 def test_title_rules_is_shared_non_empty_text():
     assert isinstance(TITLE_RULES, str) and TITLE_RULES.strip()
+
+
+# --------------------------------------------------------------------------
+# title_is_acceptable -- one predicate behind both the skip gate and the write
+# gate. If they could disagree, a title good enough to skip could be one the
+# writer rejects, and the case would regenerate on every run forever.
+# --------------------------------------------------------------------------
+
+
+def test_title_is_acceptable_on_a_conforming_title():
+    assert title_is_acceptable("घूसखोरी प्रकरण (081-CR-0098)", "081-cr-0098")
+
+
+def test_title_is_not_acceptable_without_the_trailing_number():
+    assert not title_is_acceptable("घूसखोरी प्रकरण", "081-cr-0098")
+
+
+def test_title_is_not_acceptable_with_a_headcount():
+    assert not title_is_acceptable("घूसखोरीमा ५ जना (081-CR-0098)", "081-cr-0098")
+
+
+def test_a_missing_court_number_makes_every_title_unacceptable():
+    # The contract IS "ends in that number". With no number there is nothing to
+    # end in, so no title can conform -- and the card enricher uses exactly this
+    # to skip the case instead of burning a call on a guaranteed rejection.
+    assert not title_is_acceptable("घूसखोरी प्रकरण (081-CR-0098)", "")
+    assert not title_is_acceptable("घूसखोरी प्रकरण (081-CR-0098)", None)
+
+
+def test_a_blank_title_is_unacceptable():
+    assert not title_is_acceptable("", "081-cr-0098")
+    assert not title_is_acceptable(None, "081-cr-0098")
+
+
+def test_the_importer_template_title_is_unacceptable():
+    # The real production stub: it carries the case number but does not END in
+    # it in parens. 2,666 DRAFT cases look like this.
+    stub = "CIAA Special Court Case 076-CR-0182: बिनोद कुमार भूजेल समेत ५"
+    assert not title_is_acceptable(stub, "076-CR-0182")
+
+
+# --------------------------------------------------------------------------
+# parse_title
+# --------------------------------------------------------------------------
+
+
+def test_parse_title_reads_the_json_object():
+    assert parse_title('{"title": "घूसखोरी प्रकरण (081-CR-0098)"}') == (
+        "घूसखोरी प्रकरण (081-CR-0098)")
+
+
+def test_parse_title_strips_whitespace():
+    assert parse_title('{"title": "  घूसखोरी (081-CR-0098)  "}') == (
+        "घूसखोरी (081-CR-0098)")
+
+
+def test_parse_title_reads_a_fenced_object():
+    body = '```json\n{"title": "घूसखोरी प्रकरण (081-CR-0098)"}\n```'
+    assert parse_title(body) == "घूसखोरी प्रकरण (081-CR-0098)"
+
+
+def test_parse_title_scans_past_a_null_title():
+    # The card prompt TELLS the model to null an unrequested key, so a
+    # `{"title": null}` object is expected traffic, not a malformed reply. It
+    # must not be returned as a parse success.
+    body = '{"title": null} then {"title": "घूसखोरी (081-CR-0098)"}'
+    assert parse_title(body) == "घूसखोरी (081-CR-0098)"
+
+
+def test_parse_title_returns_none_for_a_null_title_alone():
+    assert parse_title('{"title": null, "short_description": "सार"}') is None
+
+
+def test_parse_title_returns_none_for_a_blank_title():
+    assert parse_title('{"title": "   "}') is None
+
+
+def test_parse_title_accepts_a_bare_single_line_title():
+    # A frugal model may emit the headline with no JSON wrapper.
+    assert parse_title("घूसखोरी प्रकरण (081-CR-0098)") == "घूसखोरी प्रकरण (081-CR-0098)"
+
+
+def test_parse_title_accepts_a_fenced_bare_title():
+    # Fences are stripped before the bare-line fallback, matching the donor.
+    assert parse_title("```\nघूसखोरी प्रकरण (081-CR-0098)\n```") == (
+        "घूसखोरी प्रकरण (081-CR-0098)")
+
+
+def test_parse_title_rejects_prose_without_a_court_number():
+    # A confirmation sentence must never be PATCHed as a public title.
+    assert parse_title("Sure, I've written the title for you.") is None
+
+
+def test_parse_title_rejects_a_multi_line_bare_response():
+    assert parse_title("घूसखोरी (081-CR-0098)\nthanks!") is None
+
+
+def test_parse_title_returns_none_for_empty_input():
+    assert parse_title("") is None
+    assert parse_title(None) is None


### PR DESCRIPTION
### **User description**
Ports two enrichers to the control-plane API: `enrich_description` (writes `Case.description`) and `enrich_card` (the sole writer of `Case.title`, plus `short_description`). Both are DB-free — every read and write goes over HTTP, and `CaseworkApi` refuses a non-loopback write unless `--allow-remote-writes` is passed.

Nothing here has been run against production. Every `--apply` in this branch targeted `127.0.0.1:48010`.

## What you get

| Script | Writes | Tier | Replaces |
|---|---|---|---|
| `casework/enrich_description.py` | `description` | premium | donor `enrich_description.py` |
| `casework/enrich_card.py` | `title`, `short_description` | cheap | donor `enrich_card.py` + `enrich_title.py` |

`enrich_title.py` folds in as `enrich_card --only title`, so `title` has exactly one writer. `test_titles_module_has_exactly_one_importer` fails if a second enricher ever imports `TITLE_RULES`.

Both scripts take the same flags as the merged enrichers — `--batch-csv`, `--limit`, `--slug`, `--model`, `--dry-run`/`--apply` — and select through the shared `select_for_run` from #410.

```bash
# dry run — makes every LLM call, writes nothing
DEBUG=True uv run python -m casework.enrich_description \
  --api-base-url https://api.jawafdehi.org \
  --batch-csv work/2026-08-03-Dry-run-bigo-enricher/batch-238.csv \
  --limit 10 --model haiku --verbose
```

## The verdict window, rewritten on measurement

A card teaser cannot state an outcome the prompt never showed it, and a description states the allegation first and the verdict last. So `_snippet` splices the verdict passage in beside the opening.

The first two attempts at locating that passage both lost verdicts. Measured over the 83 published descriptions longer than the snippet budget, on whether the passage the model receives contains the court's granted acquittal:

| Locator | Granted acquittal carried | Last outcome carried | Avg snippet |
|---|---|---|---|
| Plain head clamp | 2/54 | 7/76 | 3,000 |
| Read forward from the last outcome word | 42/54 | 62/76 | 3,159 |
| **This branch** — window ends at the last outcome word | **53/54** | **76/76** | 5,119 |

The one remaining miss is false: `सफाइ दिने अवसर` is a due-process phrase, not a verdict.

Two design points came from the data, not from intuition:

- **The `ग)` heading branch is deleted.** Preferring it scores worse (51/54), because reading *forward* from the heading clips a long verdict discussion. Only 28 of the 83 descriptions carry the heading at all.
- **Line alignment moves forward, not back.** Backing up to the previous line start grows the window by up to a whole line, which put 50 of the 83 snippets over `SNIPPET_MAX_CHARS`, the worst at 6,998.

Cost, stated plainly: the average snippet grows from 3,159 to 5,119 characters. That is input tokens on the cheap tier; `CARD_MAX_TOKENS` still bounds spend.

## Code-review findings fixed

A `/code-review` pass found ten. Each was reproduced against the code before being fixed.

| # | Finding | Why it mattered |
|---|---|---|
| 1 | `फैसला` in the outcome vocabulary | It is also how an appeal section refers *back* to the judgment. `पुनरावेदन` follows the last outcome word on 16 of 83 descriptions, so the snippet carried the appeal sentence instead of the acquittal — worse than no rescue at all |
| 2 | `rfind(...) + 1` returns 0 with no newline | Offset 0 reads as "the outcome is in the head" and cancelled the rescue on single-paragraph prose |
| 3 | `text_unmet` dropped when *some* sources fetched | A case whose court order 500'd generated a public narrative from the prosecution claim alone, and the review file showed only the source that worked |
| 4 | The OUTPUT FORMAT placeholder passed vetting | `एक-वाक्य सारांश` ("one-sentence summary") would have rendered on a public card. `vet_title` catches the title half only by accident |
| 5 | The card's description gate was an emptiness test | A whitespace-only description reached the prompt as `DESCRIPTION: (none)`; a template stub reached it as the whole factual basis for a headline |
| 6 | Court number reached the description model lowercase | Same defect already fixed for the card. The test meant to pin it asserted a string that also appears in the raw IRI, so it passed either way |
| 7 | `format_entities` dropped `outcome` | The structured per-defendant answer both prompts require was on the payload and unused, forcing both models to re-derive the split from prose |
| 8 | Internal entity notes fed to public-output prompts | Both prompts now label them internal, not publishable |
| 9 | `_carries_a_field` tested the union of both fields | An `--only title` run accepted `{"title": null, ...}` and stopped scanning |
| 10 | A missing ETag degraded to an unconditional write | `if_match` is sent only when truthy and checked only when present |

Finding 5 also removes a comment that claimed a second check would be unreachable code. It was wrong, and being wrong is why no guard existed.

## Three output-accuracy rules

These are wrong facts about named people that every test passed straight through. Each was found by a local smoke run and is now pinned.

1. **A sentence compressed into a different number.** The court imposed `२ बर्ष ६ महिना`; the model wrote `२.६ वर्ष` — a misstated prison sentence a reader cannot detect. The rule now says copy durations and amounts as the description states them, and that a shorter teaser beats a wrong number.
2. **A total relabelled as one of its parts.** रु. ३०,४२,३७८ described as construction money when it included रु. ९२,३७८ of double salary, which the description accounts for separately.
3. **Mixed digit scripts:** `07८-CR-0103` — Latin `0`, `7`, then Devanagari `८`.

## Verification

| Check | Result |
|---|---|
| Full suite | `3528 passed, 4 skipped`, exit 0 |
| casework suite | `961 passed` |
| `ruff check` / pre-commit | clean |
| `enrich_card` against `127.0.0.1:48010` | writes both fields in one PATCH |
| `enrich_description` dry run, same host | writes the review file, PATCHes nothing |

The card smoke run on the mirrored case `078-CR-0103` produced a 198-character teaser, with every figure checked against the source description:

```
श्रीपुर उच्च माध्यमिक विद्यालयको निर्माण कोषबाट रु. २९,५०,००० गैरकानूनी खचा गरेको
आरोपमा प्रधानाध्यापक बलराम श्रेष्ठलाई २ बर्ष ६ महिना कैद र रु. १४,६९,२४९ जरिवाना,
कर्मचारी राकेशमान श्रेष्ठलाई सफाई।
```

- `रु. २९,५०,०००` — the बिगो, and the निकासा for laboratory, building and toilet construction
- `२ बर्ष ६ महिना` — verbatim, including the source's `बर्ष` spelling
- `रु. १४,६९,२४९` — verbatim, and the description labels it `जरिवाना` itself
- `(078-CR-0103)` — all-ASCII, uppercase
- Both defendants named with their own outcome: the conviction **and** the acquittal

## Known open, for the reviewer

- **The description enricher's section coverage varies run to run.** The prompt does say to include a section only when the sources support it, but across four runs on the same case the output covered `क`, then `क ख ग`, then `ग` alone. One run emitted a `### ग) … (क्रमशः)` heading — "continued" — which is wrong in a standalone field. Worth a multi-case evaluation before any production run.
- **Whether internal caseworker notes belong in a public-output prompt at all** is a product decision (finding 8). This branch labels them; it does not remove them.
- `enrich_allegations.py` and `enrich_timeline.py` on `main` have finding 3's shape. Left alone to keep this diff scoped — description is the stage where the lost source can be the outcome.
- `casework/common/titles.py::parse_title` has no production caller. Documented rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add HTTP-only case enrichers

- Centralize card title ownership

- Add review, judge, formatting helpers

- Expand regression coverage heavily


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Case detail API"] -- "description, metadata" --> B["enrich_description"]
  B -- "writes description" --> C["Casework API"]
  C -- "card source" --> D["enrich_card"]
  D -- "atomic PATCH" --> E["title + short_description"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>enrich_card.py</strong><dd><code>Add DB-free card enricher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-92972ea4b06357e4d24ce1142c8d497fe2706e9aa7b8243f11026f5f77e259a5">+926/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_description.py</strong><dd><code>Add DB-free description enricher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-5ae987953d8c0a7283b3d17be907f84a93dc39867ed0658f68300fb2d721f2e4">+679/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>review.py</strong><dd><code>Add human review file builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-50b13ffb4901d71c88ddd5d529ab1398858855d5101d07d90609885f8149175f">+206/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>judge.py</strong><dd><code>Add adequacy judge helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-b4e7501e14d3049a829eb3b64394158f7954afe8ee3a2cbc6c48f33a15ac2506">+128/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>format.py</strong><dd><code>Add prompt formatting helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-a5719bea84b6ab04f321959e12549c4ae0fde1d34e79bd454f39fd229ac3cf87">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>titles.py</strong><dd><code>Refine title validation contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-8f9e4938d65825c8e5d6eb9cde129863bad9191560a8bccef22af067c3f5be73">+76/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>materials.py</strong><dd><code>Adjust material helper behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-20b825889b9cb5ba33e60c094787cbce4d1355c292eb96a5fdd8dee848afe7aa">+50/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.py</strong><dd><code>Add multi-field PATCH support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-543d520a75c6ab7cb169dc2e1d945691ed725d6ba3e177c282f2c9cbcd83b341">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli.py</strong><dd><code>Extend shared CLI utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-10d5ea401a4ba97c7ae79547175e565c3b7733fa1028b64dc098719fb7f8561d">+27/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>test_enrich_card.py</strong><dd><code>Cover card enricher behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-26c411973b810c922c00a3eb504211375a734a2e7cd32ff4d41eaaf10b1ef9eb">+1398/-0</a></td>

</tr>

<tr>
  <td><strong>conftest.py</strong><dd><code>Isolate generated review files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-4d76bb2281eed76dab46af0dd3acf771fec111df051e3e25a58c618d068050a0">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_enrich_description.py</strong><dd><code>Cover description enricher behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-6f603901804e5d04baea2759d4569cbd4ed32ef6fc630b70b8bfac080631c839">+1125/-0</a></td>

</tr>

<tr>
  <td><strong>test_review.py</strong><dd><code>Test review file output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-8a8da1da32a54135b22e65f3654198760ff2d3913273f98d577bb07e0ce47d68">+231/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_judge.py</strong><dd><code>Test adequacy judge helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-3bc807a824ce332c3f4bb7830afbb123dace67f264c21aecca79b67965c1b7d3">+189/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_format.py</strong><dd><code>Test prompt formatting helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-cfe38851c8160fa2a761f6617b2e973a34799e272e13be54a0dcf37fc93c0952">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_titles.py</strong><dd><code>Test title validation rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-a3850226e568e2c1888eb001fd98689a7b07a3ae43bff6f7e3cbc1489d7a6b01">+104/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_materials.py</strong><dd><code>Test material helper changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-ae00aa8ee830e42dc2527cf3eebcfd7764700c11e5748aa19a4337aebea0d946">+51/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_api.py</strong><dd><code>Test API write safeguards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-691498b1b6a7fd15b306238041c444e55a340b29288c4e271e5605cc5570e935">+78/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>llm.py</strong><dd><code>Register description and card tiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-a6ee919aab2153874e249c6c0d2a1617ef1e59b95a777094663078dfd06bcda3">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pipeline.py</strong><dd><code>Register new casework stages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-d5785940f298faaebfdb69119b32ab27cb7a0da4b2dac036bec608b92db51488">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>parse.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-7a1685c60b78541591ba224aef225d7ad6dd64516e9b925e31313eebd5375a3c">+65/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_cli.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-bc77ed5efdb1356557f26417ee31bc252a5f53f2af0444e1c966bc08a7c177cc">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_parse.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/418/files#diff-90f1d46931d0d3be234f195cd508901fbfbd6ac52bcd163f6abc6b775336296e">+57/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
