### PR TITLE
fix(llm,review): name an empty model result, and let job failures reach Sentry

### DIFF
--- a/llm/providers/cli.py
+++ b/llm/providers/cli.py
@@ -33,6 +33,36 @@ def _flatten(content):
     return "\n\n".join(b.get("text", "") for b in content)
 
 
+def _envelope_facts(data) -> str:
+    """The result envelope's own account of what happened, for an error message.
+
+    ``llm.exhaustion`` records that ``error_max_turns`` has two causes wanting
+    opposite remedies, that they are indistinguishable from the error text, and that
+    telling them apart "would need ``num_turns`` from the CLI's result envelope" —
+    which "no caller can currently reach", because :meth:`_finalize` returns
+    ``data["result"]`` and discards the rest.
+
+    This is the cheap half of closing that. It does not make the distinction
+    programmatically available, which would mean changing the provider's return
+    type; it puts the deciding numbers in the message a human or Sentry reads. A
+    call that died at ``num_turns=1`` with output tokens to spare was out of TURNS;
+    one that burned its whole budget was out of TOKENS. Both are visible here.
+
+    Kept to the envelope's own fields, with no derived judgement, so it cannot
+    itself become the next confidently-wrong diagnosis.
+    """
+    usage = data.get("usage") or {}
+    facts = {
+        "subtype": data.get("subtype"),
+        "num_turns": data.get("num_turns"),
+        "stop_reason": data.get("stop_reason"),
+        "duration_ms": data.get("duration_ms"),
+        "output_tokens": usage.get("output_tokens"),
+        "result_chars": len(data.get("result") or ""),
+    }
+    return "envelope: " + " ".join(f"{k}={v!r}" for k, v in facts.items() if v is not None)
+
+
 def _dominant_model(model_usage):
     """Pick the model that did the real work from claude -p's ``modelUsage`` map.
 
@@ -198,6 +228,7 @@ class ClaudeCliProvider(_CliProvider):
         if data.get("is_error") or "result" not in data:
             raise RuntimeError(
                 f"claude_cli error: {data.get('result', 'unknown error')}\n"
+                f"{_envelope_facts(data)}\n"
                 f"Payload: {out[-500:]}"
             )
         if usage is not None:
@@ -219,7 +250,25 @@ class ClaudeCliProvider(_CliProvider):
                 model=reported_model,
                 cost_usd=data.get("total_cost_usd", 0.0),
             )
-        return strip_code_fence(data["result"])
+        # An EMPTY result inside a SUCCESS envelope. Checked because it happens, and
+        # because the alternative is unreadable: `result: ""` satisfies every test
+        # above, this method returns "", and `llm.invoke.invoke_json` then fails two
+        # layers away as `json.JSONDecodeError: Expecting value: line 1 column 1
+        # (char 0)` — a message naming a column in a document that does not exist,
+        # raised from a call site that never mentions the model. Seen in production
+        # on 2026-08-04 (case_proposal.intent job 2876, which then succeeded on
+        # retry), where it cost a diagnosis rather than an outage.
+        #
+        # A plain retry is the right remedy and already happens, so this changes the
+        # MESSAGE, not the behaviour. `llm.exhaustion.is_exhaustion` deliberately
+        # does not match this: a larger budget cannot help a model that returned
+        # nothing at all, and escalating would pay four times over to find that out.
+        text = strip_code_fence(data.get("result") or "")
+        if not text.strip():
+            raise RuntimeError(
+                f"claude_cli: the model returned an empty result. {_envelope_facts(data)}"
+            )
+        return text
 
     def invoke_text(self, system, content, max_tokens, model_id, tier, usage=None):
         """Invoke claude -p --output-format json.

--- a/llm/tests/test_cli_empty_result.py
+++ b/llm/tests/test_cli_empty_result.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""An empty result inside a SUCCESS envelope.
+
+`_finalize` validated that `result` EXISTS and never that it said anything. So
+`result: ""` passed every check, `invoke_text` returned "", and the failure surfaced
+two layers away in `llm.invoke.invoke_json` as::
+
+    json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
+
+— a message naming a column in a document that does not exist, raised from a call
+site that never mentions the model. Seen in production 2026-08-04 on
+`case_proposal.intent` job 2876, which then succeeded on retry.
+
+Retry was and remains the right remedy. These pin the MESSAGE, not the behaviour.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+from llm.providers.cli import ClaudeCliProvider
+
+
+def envelope(**overrides):
+    return json.dumps({"type": "result", "subtype": "success", "result": "{}", **overrides})
+
+
+def invoke(raw):
+    provider = ClaudeCliProvider()
+    with mock.patch.object(ClaudeCliProvider, "_run", return_value=raw):
+        return provider.invoke_text("sys", "content", 2000, "claude-opus-4-8", "premium")
+
+
+class TestAnEmptyResultIsNamed:
+    @pytest.mark.parametrize("empty", ["", "   ", "\n\n", "```\n```"])
+    def test_an_empty_result_raises_instead_of_returning_nothing(self, empty):
+        """Whitespace and an empty code fence count as empty: `strip_code_fence`
+        turns "```\\n```" into "", which reaches the JSON decoder identically."""
+        with pytest.raises(RuntimeError, match="empty result"):
+            invoke(envelope(result=empty))
+
+    def test_the_error_does_not_mention_a_json_column(self):
+        """The regression in words. The old failure said "line 1 column 1 (char 0)",
+        which sent two investigations looking at the prompt's JSON."""
+        with pytest.raises(RuntimeError) as caught:
+            invoke(envelope(result=""))
+        assert "column 1" not in str(caught.value)
+
+    def test_the_error_carries_the_envelopes_own_numbers(self):
+        """`llm.exhaustion` records that telling the two `error_max_turns` causes
+        apart "would need num_turns from the CLI's result envelope", which "no
+        caller can currently reach". This puts it in the message: a call that ended
+        at num_turns=1 with tokens to spare was out of TURNS, not tokens."""
+        with pytest.raises(RuntimeError) as caught:
+            invoke(envelope(result="", num_turns=1, duration_ms=812, usage={"output_tokens": 0}))
+
+        message = str(caught.value)
+        assert "num_turns=1" in message
+        assert "output_tokens=0" in message
+        assert "subtype='success'" in message
+
+    def test_a_normal_result_is_untouched(self):
+        assert invoke(envelope(result='{"ok": true}')) == '{"ok": true}'
+
+    def test_an_error_envelope_also_reports_the_numbers(self):
+        """The `is_error` branch is where a real `error_max_turns` lands, and it is
+        the case the num_turns question was actually asked about."""
+        raw = json.dumps(
+            {"type": "result", "subtype": "error_max_turns", "is_error": True,
+             "result": "Reached maximum number of turns (1)", "num_turns": 1}
+        )
+        with pytest.raises(RuntimeError) as caught:
+            invoke(raw)
+        assert "num_turns=1" in str(caught.value)
+        assert "subtype='error_max_turns'" in str(caught.value)
+
+
+class TestItStaysOutOfTheEscalationPath:
+    def test_an_empty_result_is_not_treated_as_exhaustion(self):
+        """A bigger budget cannot help a model that returned nothing, and
+        escalating pays roughly four times over to discover that. The retry that
+        recovered job 2876 was a plain one, which is correct."""
+        from llm.exhaustion import is_exhaustion
+
+        with pytest.raises(RuntimeError) as caught:
+            invoke(envelope(result=""))
+
+        assert not is_exhaustion(caught.value), (
+            "an empty result must not trigger the escalated-budget retry"
+        )
+
+    @override_settings(CLAUDE_CLI_MAX_TURNS=3)
+    def test_a_real_turn_exhaustion_still_is(self):
+        """The converse, so the test above cannot pass by `is_exhaustion` being
+        broken outright."""
+        from llm.exhaustion import is_exhaustion
+
+        raw = json.dumps(
+            {"type": "result", "subtype": "error_max_turns", "is_error": True,
+             "result": "Reached maximum number of turns (3)", "num_turns": 3}
+        )
+        with pytest.raises(RuntimeError) as caught:
+            invoke(raw)
+        assert is_exhaustion(caught.value)

--- a/review/management/commands/review_poller.py
+++ b/review/management/commands/review_poller.py
@@ -64,6 +64,38 @@ class PollerError(Exception):
     pass
 
 
+def _capture_job_failure(exc, *, job_id, kind, err) -> bool:
+    """Send one job failure to Sentry. Returns whether it was sent.
+
+    Best-effort by construction. A telemetry problem must never turn a reported job
+    failure into an unreported one, so every path returns rather than raises —
+    including the import, since ``sentry_sdk`` is a real dependency here but this
+    command also runs in environments that trim it.
+
+    Grouped by ``kind`` rather than by traceback. The interesting question is "is
+    ``case_proposal_intent`` failing?", not "how many distinct stack shapes did the
+    JSON decoder produce?" — and an LLM failure's traceback varies with the prompt
+    while the thing worth alerting on does not.
+    """
+    try:
+        import sentry_sdk
+    except Exception:  # noqa: BLE001 - telemetry must not break the worker
+        return False
+
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("job.kind", kind or "unknown")
+            scope.set_tag("component", "review_poller")
+            scope.set_context("job", {"id": job_id, "kind": kind})
+            # The queue's own record of the failure, which is what an operator
+            # would otherwise have to go to Postgres to read.
+            scope.set_extra("job_error", err[:4000])
+            scope.fingerprint = ["review_poller", "job_failed", kind or "unknown"]
+            return bool(sentry_sdk.capture_exception(exc))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 class Command(BaseCommand):
     help = "Consume jobs from the central queue, run them locally, submit results."
 
@@ -216,6 +248,17 @@ class Command(BaseCommand):
             import traceback
 
             err = f"{e}\n{traceback.format_exc()[:2000]}"
+            # Report to Sentry EXPLICITLY. This except block is why nothing else
+            # would: the exception is caught here and handed to the queue, so it
+            # never reaches the interpreter's excepthook, which is the only thing
+            # sentry_sdk hooks for a management command. Every LLM job failure this
+            # worker has ever had — including two rounds of misdiagnosed
+            # `error_max_turns` — was therefore visible only in `job.error` and in
+            # this pod's stdout, and stdout is 90 days of VictoriaLogs that nobody
+            # alerts on.
+            #
+            # A no-op when no DSN is configured, so this is safe in dev and CI.
+            _capture_job_failure(e, job_id=job_id, kind=kind, err=err)
             try:
                 # Transient errors are retryable; the queue re-queues with backoff
                 # up to the kind's max_attempts, else dead-letters.

--- a/tests/test_review_poller_sentry.py
+++ b/tests/test_review_poller_sentry.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Hippocratic-3.0
+"""Job failures reaching Sentry.
+
+They did not. `_process_job` catches every exception and hands it to the queue, so
+it never reaches the interpreter's excepthook — which is the only thing `sentry_sdk`
+hooks for a management command. Every LLM job failure this worker has had, including
+two rounds of misdiagnosed `error_max_turns`, existed only in `job.error` and in pod
+stdout.
+
+The pod also had no `SENTRY_DSN` at all, which is fixed in the infra repo. Both
+halves were needed: code that reports to a client that was never initialised is
+still silence.
+"""
+
+from unittest import mock
+
+import pytest
+
+from review.management.commands.review_poller import _capture_job_failure
+
+
+class TestItActuallyReports:
+    def test_the_exception_is_captured(self):
+        with mock.patch("sentry_sdk.capture_exception", return_value="evt-1") as cap:
+            sent = _capture_job_failure(
+                ValueError("boom"), job_id=2876, kind="case_proposal_intent", err="boom\ntb"
+            )
+        assert sent is True
+        assert isinstance(cap.call_args.args[0], ValueError)
+
+    def test_it_is_grouped_by_kind_not_by_traceback(self):
+        """The question worth alerting on is "is case_proposal_intent failing?", not
+        "how many distinct stack shapes did the JSON decoder produce?". An LLM
+        failure's traceback varies with the prompt; the thing to alert on does not.
+        """
+        scope = mock.MagicMock()
+        with mock.patch("sentry_sdk.new_scope") as new_scope:
+            new_scope.return_value.__enter__.return_value = scope
+            with mock.patch("sentry_sdk.capture_exception", return_value="e"):
+                _capture_job_failure(
+                    ValueError("boom"), job_id=1, kind="case_proposal_intent", err="e"
+                )
+
+        assert scope.fingerprint == ["review_poller", "job_failed", "case_proposal_intent"]
+        scope.set_tag.assert_any_call("job.kind", "case_proposal_intent")
+
+    def test_the_queues_own_error_text_rides_along(self):
+        """Otherwise an operator reading Sentry has to go to Postgres to find out
+        what the queue recorded."""
+        scope = mock.MagicMock()
+        with mock.patch("sentry_sdk.new_scope") as new_scope:
+            new_scope.return_value.__enter__.return_value = scope
+            with mock.patch("sentry_sdk.capture_exception", return_value="e"):
+                _capture_job_failure(ValueError("x"), job_id=1, kind="k", err="THE-ERROR-TEXT")
+
+        scope.set_extra.assert_any_call("job_error", "THE-ERROR-TEXT")
+
+    def test_a_missing_kind_still_groups_somewhere(self):
+        scope = mock.MagicMock()
+        with mock.patch("sentry_sdk.new_scope") as new_scope:
+            new_scope.return_value.__enter__.return_value = scope
+            with mock.patch("sentry_sdk.capture_exception", return_value="e"):
+                _capture_job_failure(ValueError("x"), job_id=1, kind=None, err="e")
+
+        assert scope.fingerprint == ["review_poller", "job_failed", "unknown"]
+
+
+class TestTelemetryNeverBreaksTheWorker:
+    """The failure this must not cause: a reported job failure becoming an
+    unreported one because the reporting itself broke."""
+
+    @pytest.mark.parametrize("boom", [RuntimeError("sentry down"), OSError("socket")])
+    def test_a_capture_failure_is_swallowed(self, boom):
+        with mock.patch("sentry_sdk.capture_exception", side_effect=boom):
+            assert _capture_job_failure(ValueError("x"), job_id=1, kind="k", err="e") is False
+
+    def test_a_scope_failure_is_swallowed(self):
+        with mock.patch("sentry_sdk.new_scope", side_effect=RuntimeError("no hub")):
+            assert _capture_job_failure(ValueError("x"), job_id=1, kind="k", err="e") is False
+
+    def test_no_dsn_configured_is_a_quiet_false(self):
+        """capture_exception returns None when the SDK has no client, which is the
+        state in dev and CI. Must not read as an error."""
+        with mock.patch("sentry_sdk.capture_exception", return_value=None):
+            assert _capture_job_failure(ValueError("x"), job_id=1, kind="k", err="e") is False
+
+
+class TestTheHandlerPathCallsIt:
+    def test_a_failing_handler_reports_before_submitting(self):
+        """Wired at the call site, not just available. The bug was never that the
+        helper was wrong — it was that nothing called anything."""
+        from review.management.commands.review_poller import Command
+
+        cmd = Command()
+        cmd._submit = mock.Mock()
+        cmd._report_stage = mock.Mock()
+        cmd.stdout = mock.MagicMock()
+        cmd.stderr = mock.MagicMock()
+
+        job = {"id": 99, "kind": "case_review", "payload": {}}
+        with mock.patch.dict(
+            "review.management.commands.review_poller.HANDLERS",
+            {"case_review": mock.Mock(side_effect=ValueError("kaboom"))},
+        ):
+            with mock.patch(
+                "review.management.commands.review_poller._capture_job_failure"
+            ) as capture:
+                cmd._process_job(job)
+
+        assert capture.called, "a failing job must reach Sentry"
+        assert capture.call_args.kwargs["job_id"] == 99
+        assert capture.call_args.kwargs["kind"] == "case_review"
+        # And the queue is still told, which is the pre-existing behaviour.
+        assert cmd._submit.call_args.args[1]["status"] == "failed"


### PR DESCRIPTION
### **User description**
Two findings from the first live docket run, where 1 of 3 intent jobs failed and then succeeded on retry.

## 1. An empty result inside a SUCCESS envelope

`ClaudeCliProvider._finalize` checked that `result` **exists** and never that it said anything:

```python
if data.get("is_error") or "result" not in data:   # passes for result: ""
    ...
return strip_code_fence(data["result"])            # returns ""
```

So the failure surfaced **two layers away** in `invoke_json`:

```
json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

A message naming a column in a document that does not exist, raised from a call site that never mentions the model. Production, 2026-08-04, `case_proposal.intent` job 2876.

**Retry was and remains the correct remedy** — attempt 2 succeeded in 23s — so this changes the *message*, not the behaviour. `is_exhaustion` still declines to match it, deliberately: a larger budget cannot help a model that returned nothing, and escalating would pay ~4× to discover that.

### It also closes something `llm/exhaustion.py` flagged as unreachable

That module says distinguishing the two `error_max_turns` causes *"would need `num_turns` from the CLI's result envelope"*, and that **"no caller can currently reach it"** — because `_finalize` returns `data["result"]` and discards the rest.

`_envelope_facts` now puts it in the error text, on both the empty-result and `is_error` paths:

```
claude_cli: the model returned an empty result. envelope: subtype='success' num_turns=1 duration_ms=812 output_tokens=0 result_chars=0
```

A call that ended at `num_turns=1` with output tokens to spare was out of **turns**; one that burned its budget was out of **tokens**. Envelope facts only, no derived judgement — so this cannot itself become the next confidently-wrong diagnosis. It does not make the distinction *programmatic* (that needs a return-type change); it makes it legible to a human and to Sentry.

## 2. Job failures were invisible to Sentry, and always had been

`_process_job` catches every exception and hands it to the queue — so it **never reaches the interpreter's excepthook**, which is the only thing `sentry_sdk` hooks for a management command. Nothing in this repo called `capture_exception` outside `search/views.py`.

**So every LLM job failure this worker has ever had — including two rounds of misdiagnosed `error_max_turns` that cost days — existed only in `job.error` in Postgres and in pod stdout.** That's 90 days of VictoriaLogs that nothing alerts on.

Now reported explicitly, **fingerprinted by job `kind` rather than by traceback**. The question worth alerting on is *"is `case_proposal_intent` failing?"*, not *"how many stack shapes did the JSON decoder produce?"* — an LLM failure's traceback varies with the prompt; the thing to alert on does not. The queue's own error text rides along as an extra, so an operator needn't go to Postgres to read it.

Every path is best-effort and returns rather than raises, **including the import**: a telemetry problem must never turn a reported job failure into an unreported one. Tests cover a capture failure, a scope failure, and the no-DSN case.

### The half that isn't in this PR

**The pod also had no `SENTRY_DSN` at all.** `config.settings` only calls `sentry_sdk.init` when a DSN is present, so this code alone would still have been silence:

```
platform-jobs-processor-env keys, before:
  CASEWORK_OIDC_CLIENT_ID, CASEWORK_OIDC_CLIENT_SECRET, CLAUDE_CODE_OAUTH_TOKEN, SECRET_KEY
```

Already done on the infra side: `SENTRY_DSN` / `SENTRY_ENVIRONMENT` / `SENTRY_TRACES_SAMPLE_RATE=0` added to the OpenBao item `jawafdehi/jawafdehi-product/jobs`, ESO resynced, verified present in the live Secret. Same DSN as the platform's — one project, so a failing job and a failing request land in one place. Traces off because this is a batch worker serving no requests.

The `bus-consumers` pod was **already** covered, for a different reason: structlog uses `stdlib.LoggerFactory`, so the runner's `logger.error(..., exc_info=...)` becomes an ERROR record that Sentry's `LoggingIntegration` captures, and that pod gets `platform-env` which does carry a DSN. Worth knowing, since it's why consumer failures were visible and job failures were not.

## Verification

- **749 tests pass** (`llm` / `case_proposals` / `courts` / `review` + the new module); `ruff check` clean.
- 10 new tests on the empty-result path, incl. whitespace and `` ```\n``` `` (which `strip_code_fence` reduces to empty), and both directions of the `is_exhaustion` boundary so the negative assertion can't pass by the classifier being broken outright.
- 9 on the Sentry path, including that the handler call site actually calls it — the bug was never a wrong helper, it was that nothing called anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Name empty Claude results

- Add envelope facts to errors

- Capture poller failures in Sentry

- Cover regressions with tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Claude CLI envelope"] -- "empty/error" --> B["RuntimeError with facts"]
  C["Review poller job"] -- "exception caught" --> D["Sentry capture"]
  B -- "covered by" --> E["Regression tests"]
  D -- "covered by" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Detect empty Claude CLI results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

llm/providers/cli.py

<ul><li>Add <code>_envelope_facts</code> helper<br> <li> Include envelope metadata in CLI errors<br> <li> Reject empty stripped model results<br> <li> Preserve normal non-empty result behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/419/files#diff-aff710dfc338c22800e99e14d443f4f141eaed2ef7a6c3b74249ea34e07b1a0f">+50/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>review_poller.py</strong><dd><code>Report poller job failures to Sentry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

review/management/commands/review_poller.py

<ul><li>Add <code>_capture_job_failure</code> Sentry helper<br> <li> Tag job kind, component, context<br> <li> Fingerprint failures by job kind<br> <li> Call capture before queue failure submit</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/419/files#diff-951e322f6bc2a05a837c1c3731f1f408d783f3d19ca88cf742bf93f618b34fa5">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cli_empty_result.py</strong><dd><code>Cover empty Claude result handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

llm/tests/test_cli_empty_result.py

<ul><li>Test blank, whitespace, empty-fence results<br> <li> Assert envelope numbers appear in errors<br> <li> Verify empty results avoid exhaustion escalation<br> <li> Confirm real turn exhaustion still escalates</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/419/files#diff-0cc683caa5e130c4efdcc3fcb688f854d8339e7e5d90a07fbd42b1d7bc6fa097">+106/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_review_poller_sentry.py</strong><dd><code>Cover poller Sentry failure reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_review_poller_sentry.py

<ul><li>Test exception capture path<br> <li> Verify grouping, tags, extras<br> <li> Ensure telemetry failures are swallowed<br> <li> Confirm <code>_process_job</code> calls reporter</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/419/files#diff-99bbd6a71720d1adf7b69975b9a10229f0667c095c0d3681cb8b1125d2d8bd26">+114/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when command-line responses are empty or contain only whitespace.
  * Empty responses no longer trigger unnecessary escalation handling.
  * Preserved normal response formatting while avoiding JSON-related error details.

* **Monitoring**
  * Added best-effort error reporting for review job processing failures.
  * Failures now include useful job context while remaining resilient if monitoring is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->