### PR TITLE
feat(materials/bolpatra): PPMO e-GP tender notices via an id-walk crawler

### DIFF
--- a/materials/jsonld.py
+++ b/materials/jsonld.py
@@ -69,6 +69,7 @@ class MaterialType:
     PRESS_RELEASE = "press_release"    # CIAA/agency प्रेस विज्ञप्ति (public announcement)
     LEGAL_CORPUS = "legal_corpus"      # acts / laws / ordinances / constitution
     OFFICIAL_REPORT = "official_report"  # OAG / annual reports
+    PROCUREMENT_NOTICE = "procurement_notice"  # PPMO/bolpatra e-GP tender/bid notice
     NEWS = "news"                      # news / media article (was Jawafdehi SourceType.NEWS)
     SOCIAL_MEDIA = "social_media"      # social-media post (was SourceType.SOCIAL_MEDIA)
     DOCUMENT = "document"              # generic court filing / misc document
@@ -99,6 +100,9 @@ MATERIAL_TYPES: dict[str, tuple[Any, str | None]] = {
     MaterialType.LEGAL_CORPUS: ("Legislation", None),
     # Official report (OAG audit, annual reports) → Report.
     MaterialType.OFFICIAL_REPORT: ("Report", None),
+    # Procurement notice (PPMO/bolpatra e-GP tender/bid opportunity): schema.org
+    # has no procurement term, so CreativeWork + jawafdehi:ProcurementNotice.
+    MaterialType.PROCUREMENT_NOTICE: ("CreativeWork", "jawafdehi:ProcurementNotice"),
     # News/media article → schema.org NewsArticle (a CreativeWork subtype).
     MaterialType.NEWS: ("NewsArticle", None),
     # Social-media post → SocialMediaPosting.

--- a/materials/sourcing/bolpatra/crawl.py
+++ b/materials/sourcing/bolpatra/crawl.py
@@ -1,0 +1,671 @@
+"""Resumable, polite crawler + material-API client for bolpatra e-GP tenders.
+
+A data-acquisition tool (dev/ops, not request-path product). bolpatra.gov.np/egp
+is a legacy server-rendered Java/Struts app (NOT a JSON API) with a broken TLS
+chain, so this crawler:
+
+- **Walks the tenderId integer space** (``--id-min/--id-max``) — the PRIMARY and
+  reliable frontier. Ids are DENSE from 1 to ~322k (probed), and the search form
+  reports ``totalRecords=204925``. Ids past the end (or never allocated) return the
+  empty form shell, which the parser rejects → recorded as a gap.
+- **Optionally seeds from the search pager** (``--discover-pages``) to pick up the
+  newest notices. ⚠️ The pager is **session-stateful and unreliable for exhaustive
+  enumeration**: the server ignores/re-bases ``currentPageIndex``, needs
+  ``pageAction=next`` for ``pageSize`` to apply at all, and different
+  ``startIndex`` values can return overlapping or repeated pages. Use it for
+  freshness, NOT for completeness — the id-walk is what guarantees coverage.
+- **Fetches** each tender detail (``POST /egp/getTenderDetails`` with ``tenderId``),
+  caches the raw HTML-derived record to ``tenders.jsonl`` (resume/audit), shapes it,
+  and **POSTs it to the material API** (``POST <api-base>/api/materials/``). Sourcing
+  goes through the API plane, not a direct-DB write.
+
+Idempotent server-side: the material upsert is keyed by ``@id`` (unlike the entity
+create path), so re-posting simply upserts — no 409 dance.
+
+    # scrape only, no post (needs no token/Django):
+    python -m materials.sourcing.bolpatra.crawl --cache /tmp/tenders.jsonl \\
+        --discover-pages 5 --dry-run
+
+    # local dev, write to a DEV_AUTH server via HTTP Basic:
+    python -m materials.sourcing.bolpatra.crawl --cache /tmp/tenders.jsonl \\
+        --api-base http://127.0.0.1:8000 --basic-auth ocr:ocrpass --id-min 319000 --id-max 319100
+
+Super-polite defaults (small government server): concurrency 3, jittered delay,
+backoff, ``--max-requests`` for resumable off-peak windows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+from jawafdehi_shared.entities.ids import build_material_iri
+
+from .parse import ParsedTender, extract_tender_ids, parse_tender_detail
+from .shaper import BOLPATRA_SOURCE, tender_to_jsonld
+
+EGP_BASE = "https://bolpatra.gov.np/egp"
+
+#: Highest tenderId observed (probed 2026-07; the search form reports
+#: ``totalRecords=204925`` over ``numberOfPages=2050``, and ids are DENSE from 1 to
+#: roughly here). Ids past the end return the empty form shell → recorded as gaps.
+DEFAULT_MAX_TENDER_ID = 325_000
+# e-GP's front end blocks the default ``python-requests`` User-Agent (403) but
+# serves a browser-like client fine. A plain desktop UA suffices — no JS-challenge
+# wall (unlike the NKP portal's F5). Keep a current Chrome UA so the wall passes.
+UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/150.0.0.0 Safari/537.36"
+)
+
+
+def _now_iso() -> str:
+    import datetime
+    from zoneinfo import ZoneInfo
+
+    return (
+        datetime.datetime.now(ZoneInfo("Asia/Kathmandu"))
+        .replace(tzinfo=None)
+        .isoformat()
+    )
+
+
+class Checkpoint:
+    """Per-id outcomes on disk (``done_ids`` / ``gap_ids``), resumable.
+
+    ``done_ids`` re-seeds from the JSONL cache so a resume survives a lost sidecar.
+    Thread-safe (the fetch pool records concurrently).
+    """
+
+    def __init__(self, out_path: Path, seed_done_from_cache: bool = True):
+        self.out_path = out_path
+        self.state_path = out_path.with_suffix(out_path.suffix + ".state.json")
+        self.done_ids: set[str] = set()
+        self.gap_ids: set[str] = set()
+        self._lock = threading.Lock()
+        self._fh = out_path.open("a", encoding="utf-8")
+        # ``seed_done_from_cache=False`` for --from-cache: a cached row proves the
+        # tender was SCRAPED, not that it was PUBLISHED. Seeding done_ids from the
+        # cache there would mark every cached tender done and republish nothing —
+        # exactly the backlog we are trying to drain. The sidecar's done_ids is the
+        # authoritative record of what actually reached the API.
+        self._seed_done_from_cache = seed_done_from_cache
+        self._load()
+
+    def _load(self) -> None:
+        if self._seed_done_from_cache and self.out_path.exists():
+            with self.out_path.open(encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                        if rec.get("tender_id"):
+                            self.done_ids.add(str(rec["tender_id"]))
+                    except json.JSONDecodeError:
+                        continue
+        if self.state_path.exists():
+            try:
+                s = json.loads(self.state_path.read_text(encoding="utf-8"))
+                self.done_ids.update(str(i) for i in s.get("done_ids", []))
+                self.gap_ids.update(str(i) for i in s.get("gap_ids", []))
+            except (json.JSONDecodeError, ValueError, TypeError):
+                pass
+
+    def seen(self, tid: str) -> bool:
+        return tid in self.done_ids or tid in self.gap_ids
+
+    def cache(self, record: dict[str, Any]) -> None:
+        with self._lock:
+            self._fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+            self._fh.flush()
+
+    def save(self) -> None:
+        with self._lock:
+            self.state_path.write_text(
+                json.dumps(
+                    {"done_ids": sorted(self.done_ids), "gap_ids": sorted(self.gap_ids)}
+                ),
+                encoding="utf-8",
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            self._fh.close()
+
+
+class EgpFetcher:
+    """HTTP transport for e-GP. TLS-tolerant (the chain is broken) POST/GET."""
+
+    def __init__(self, timeout: int = 45, base: str = EGP_BASE):
+        import requests
+        import urllib3
+
+        # verify=False is deliberate (e-GP's cert chain is incomplete); silence the
+        # per-request InsecureRequestWarning so a 400k-tender run doesn't flood logs.
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        self._base = base.rstrip("/")
+        self._s = requests.Session()
+        self._s.headers.update(
+            {
+                "User-Agent": UA,
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9,ne;q=0.8",
+                "Referer": f"{base.rstrip('/')}/searchOpportunity",
+            }
+        )
+        self._s.verify = False  # e-GP serves an incomplete cert chain.
+        self._timeout = timeout
+
+    def get_detail(self, tender_id: str) -> str | None:
+        """Tender detail HTML, or ``None`` on a transient/error response (retryable)."""
+        try:
+            r = self._s.post(
+                f"{self._base}/getTenderDetails",
+                data={"tenderId": tender_id},
+                timeout=self._timeout,
+            )
+            if not r.ok:
+                return None
+            return r.text
+        except Exception:  # noqa: BLE001 — network/timeout → retryable.
+            return None
+
+    def search_page(self, page_index: int, page_size: int = 100) -> str | None:
+        """One search-results page HTML (id discovery only), or ``None`` on failure.
+
+        The Struts pager needs ``pageAction=next`` for ``pageSize`` to apply at all
+        (without it the server returns its default 10 rows), and it mirrors the
+        paging state into ``*Input`` fields — so send both. Even then the pager is
+        session-stateful and re-bases the offset, so this is a FRESHNESS seed, not
+        an exhaustive enumerator (see the module docstring); the id-walk owns
+        completeness.
+        """
+        start = max(0, (page_index - 1)) * page_size
+        try:
+            r = self._s.post(
+                f"{self._base}/searchOpportunity.action",
+                data={
+                    "bidSearchTO.publicEntity": "0",
+                    "parentPE": "0",
+                    "addNewJV": "false",
+                    "pageAction": "next",
+                    "pageActionInput": "next",
+                    "pageSize": page_size,
+                    "pageSizeInput": page_size,
+                    "currentPageIndex": page_index,
+                    "currentPageIndexInput": page_index,
+                    "startIndex": start,
+                },
+                timeout=self._timeout,
+            )
+            return r.text if r.ok else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def close(self) -> None:
+        self._s.close()
+
+
+class MaterialApiError(Exception):
+    """A material POST returned a non-2xx (retryable)."""
+
+
+class MaterialApiClient:
+    """POSTs a shaped material to ``<api-base>/api/materials/`` (idempotent upsert)."""
+
+    def __init__(
+        self,
+        api_base: str,
+        token: str | None,
+        timeout: int = 60,
+        basic_auth: tuple[str, str] | None = None,
+    ):
+        import requests
+
+        self.url = api_base.rstrip("/") + "/api/materials/"
+        self._s = requests.Session()
+        self._s.headers.update({"Accept": "application/json"})
+        if token:
+            self._s.headers["Authorization"] = f"Bearer {token}"
+        elif basic_auth:
+            self._s.auth = basic_auth  # local DEV_AUTH path.
+        self._timeout = timeout
+
+    def post(self, doc: dict[str, Any], material_type: str) -> None:
+        try:
+            r = self._s.post(
+                self.url,
+                json={"material": doc, "material_type": material_type},
+                timeout=self._timeout,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise MaterialApiError(str(e)[:200]) from e
+        if r.status_code >= 300:
+            raise MaterialApiError(f"{r.status_code}: {r.text[:200]}")
+
+    def close(self) -> None:
+        self._s.close()
+
+
+def build_fetcher(timeout: int) -> EgpFetcher:
+    """Factory (a seam for tests to inject a fake fetch transport)."""
+    return EgpFetcher(timeout=timeout)
+
+
+def build_material_client(
+    api_base: str,
+    token: str | None,
+    timeout: int,
+    basic_auth: tuple[str, str] | None = None,
+) -> MaterialApiClient:
+    """Factory (a seam for tests to inject a fake material client)."""
+    return MaterialApiClient(api_base, token, timeout=timeout, basic_auth=basic_auth)
+
+
+class BolpatraCrawler:
+    """Discovers + fetches e-GP tenders politely and (optionally) publishes them."""
+
+    def __init__(self, args, fetcher=None, material_client=None):
+        self.args = args
+        self.cache_path = Path(args.cache)
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        # In --from-cache mode the sidecar (not the cache) is the record of what was
+        # actually PUBLISHED — see Checkpoint's seed_done_from_cache note.
+        self.cp = Checkpoint(
+            self.cache_path,
+            seed_done_from_cache=not getattr(args, "from_cache", False),
+        )
+        self.fetcher = fetcher if fetcher is not None else build_fetcher(args.timeout)
+        self.api: MaterialApiClient | None = None
+        if not args.dry_run:
+            self.api = (
+                material_client
+                if material_client is not None
+                else build_material_client(
+                    args.api_base,
+                    args.token,
+                    args.timeout,
+                    basic_auth=getattr(args, "basic_auth", None),
+                )
+            )
+        self.n_requests = 0
+        self.n_new = 0
+        self.n_published = 0
+        self.n_gap = 0
+        self._lock = threading.Lock()
+
+    def _pause(self, factor: float = 1.0) -> None:
+        base = self.args.delay * factor
+        if base > 0:
+            time.sleep(base + random.uniform(0, base * 0.5))
+
+    # --- frontier -----------------------------------------------------------
+
+    def _discover_ids(self) -> list[str]:
+        """Seed the frontier: explicit id range, and/or search-page discovery."""
+        ids: list[str] = []
+        if self.args.id_max:
+            ids.extend(str(i) for i in range(self.args.id_min, self.args.id_max + 1))
+        # Pager pages are 1-BASED. Dedup as we go and stop early when a page adds
+        # nothing new (the pager repeats itself — see the module docstring).
+        seen_from_pager: set[str] = set()
+        for page in range(1, self.args.discover_pages + 1):
+            self._pause()
+            html = self.fetcher.search_page(page, self.args.page_size)
+            if not html:
+                break
+            found = extract_tender_ids(html)
+            fresh = [i for i in found if i not in seen_from_pager]
+            if not fresh:
+                print(
+                    f"  discover page {page}: +0 new (pager repeated) — stopping discovery",
+                    file=sys.stderr,
+                )
+                break
+            seen_from_pager.update(fresh)
+            ids.extend(fresh)
+            print(f"  discover page {page}: +{len(fresh)} new ids", file=sys.stderr)
+        # Dedup, order-preserving, minus what's already done.
+        seen: dict[str, None] = {}
+        for i in ids:
+            if not self.cp.seen(i):
+                seen.setdefault(i, None)
+        return list(seen)
+
+    # --- main walk ----------------------------------------------------------
+
+    def crawl(self) -> None:
+        try:
+            if getattr(self.args, "from_cache", False):
+                self._publish_cache()
+            else:
+                self._run()
+        finally:
+            self.cp.save()
+            self.cp.close()
+            self.fetcher.close()
+            if self.api is not None:
+                self.api.close()
+
+    def _publish_cache(self) -> None:
+        """Publish every cached tender to the material API without re-scraping e-GP.
+
+        For re-driving ingestion after an API-side failure (e.g. a DRF throttle 429
+        storm) — the scrape already succeeded, so re-fetching bolpatra would be pure
+        waste (and rude). Posting is idempotent by ``@id``, so already-published
+        tenders simply upsert; the checkpoint still skips ids marked done.
+
+        Unlike the crawl path, a POST failure here RETRIES with backoff (up to
+        ``--retries``) because the whole point of this mode is to drain a backlog
+        that failed on the API side.
+        """
+        if self.api is None:
+            print(
+                "FATAL: --from-cache needs the API (remove --dry-run).", file=sys.stderr
+            )
+            return
+        published = failed = skipped = 0
+        with self.cache_path.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                tid = str(record.get("tender_id") or "")
+                if not tid:
+                    continue
+                if tid in self.cp.done_ids:
+                    skipped += 1
+                    continue
+                record.pop("_scraped_at", None)
+                try:
+                    tender = ParsedTender(**record)
+                except TypeError:
+                    continue  # cache row from an older schema — skip, don't crash.
+                if self._publish_with_retry(tid, tender):
+                    published += 1
+                else:
+                    failed += 1
+                if (published + failed) % 500 == 0:
+                    self.cp.save()
+                    print(
+                        f"  … republish: published={published} failed={failed} "
+                        f"skipped(already done)={skipped}",
+                        file=sys.stderr,
+                    )
+        self.cp.save()
+        print(
+            f"from-cache done: published={published} failed={failed} "
+            f"skipped(already done)={skipped}",
+            file=sys.stderr,
+        )
+
+    def _publish_with_retry(self, tid: str, tender) -> bool:
+        """POST one tender, retrying a throttle/5xx with exponential backoff."""
+        doc, material_type = tender_to_jsonld(tender)
+        doc["@id"] = build_material_iri(BOLPATRA_SOURCE, tid)
+        for attempt in range(1, max(1, self.args.retries) + 1):
+            try:
+                self.api.post(doc, material_type)
+            except MaterialApiError as e:
+                msg = str(e)
+                if attempt >= self.args.retries:
+                    print(f"  ! give up on tender {tid}: {msg[:120]}", file=sys.stderr)
+                    return False
+                # A 429 tells us how long to wait; otherwise exponential backoff.
+                wait = min(30.0, 2.0**attempt)
+                if "429" in msg:
+                    import re as _re
+
+                    m = _re.search(r"in (\d+) second", msg)
+                    if m:
+                        wait = float(m.group(1)) + 0.5
+                time.sleep(wait)
+                continue
+            self.cp.done_ids.add(tid)
+            self.n_published += 1
+            return True
+        return False
+
+    def _run(self) -> None:
+        mode = (
+            "dry-run (cache only)"
+            if self.args.dry_run
+            else f"→ {self.args.api_base}/api/materials/"
+        )
+        todo = self._discover_ids()
+        print(
+            f"bolpatra crawl: {len(todo)} tenders to fetch "
+            f"(concurrency={self.args.concurrency}, delay={self.args.delay}s); publish {mode}",
+            file=sys.stderr,
+        )
+        with ThreadPoolExecutor(max_workers=self.args.concurrency) as pool:
+            futures = {}
+            it = iter(todo)
+            for tid in _take(it, self.args.concurrency * 2):
+                futures[pool.submit(self._fetch, tid)] = tid
+            while futures:
+                for fut in as_completed(list(futures)):
+                    tid = futures.pop(fut)
+                    self._handle(tid, fut.result())
+                    self.n_requests += 1
+                    if self.n_requests % 200 == 0:
+                        self.cp.save()
+                        self._progress()
+                    if self._hit_limit():
+                        print(
+                            "  reached --max-requests; stopping (resumable).",
+                            file=sys.stderr,
+                        )
+                        return
+                    for nxt in _take(it, 1):
+                        futures[pool.submit(self._fetch, nxt)] = nxt
+                    break
+        self._progress(final=True)
+
+    def _fetch(self, tid: str) -> str | None:
+        for attempt in range(1, self.args.retries + 1):
+            self._pause()
+            html = self.fetcher.get_detail(tid)
+            if html is not None:
+                return html
+            if attempt < self.args.retries:
+                time.sleep(min(60.0, 2.0**attempt))
+        return None
+
+    def _handle(self, tid: str, html: str | None) -> None:
+        if html is None:
+            return  # retryable — leave un-checkpointed.
+        tender = parse_tender_detail(html, tid)
+        if tender is None:
+            self.cp.gap_ids.add(tid)
+            self.n_gap += 1
+            return
+        record = {**tender.__dict__, "_scraped_at": _now_iso()}
+        self.cp.cache(record)
+        self.n_new += 1
+        self._publish(tid, tender)
+
+    def _publish(self, tid: str, tender) -> None:
+        if self.api is None:  # dry-run
+            self.cp.done_ids.add(tid)
+            return
+        doc, material_type = tender_to_jsonld(tender)
+        doc["@id"] = build_material_iri(BOLPATRA_SOURCE, tid)
+        try:
+            self.api.post(doc, material_type)
+        except MaterialApiError as e:
+            print(f"  ! material POST failed for tender {tid}: {e}", file=sys.stderr)
+            return  # retryable — leave un-checkpointed (upsert is idempotent).
+        self.cp.done_ids.add(tid)
+        self.n_published += 1
+
+    def _hit_limit(self) -> bool:
+        return (
+            bool(self.args.max_requests) and self.n_requests >= self.args.max_requests
+        )
+
+    def _progress(self, final: bool = False) -> None:
+        tag = "done" if final else "…"
+        print(
+            f"  {tag}: fetched={self.n_requests} new={self.n_new} "
+            f"published={self.n_published} gaps={self.n_gap}",
+            file=sys.stderr,
+        )
+
+
+def _take(it, n: int) -> list:
+    out = []
+    for _ in range(n):
+        try:
+            out.append(next(it))
+        except StopIteration:
+            break
+    return out
+
+
+def add_arguments(ap: argparse.ArgumentParser) -> None:
+    ap.add_argument(
+        "--cache",
+        required=True,
+        help="tenders.jsonl cache path (appended; resume source)",
+    )
+    ap.add_argument("--api-base", help="Platform base URL (required unless --dry-run)")
+    ap.add_argument("--token", help="Bearer for the material API (NGM-role gated).")
+    ap.add_argument(
+        "--basic-auth",
+        dest="basic_auth_raw",
+        metavar="USER:PASS",
+        help="HTTP Basic for a LOCAL DEV_AUTH server. Never for prod.",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="Scrape to the cache only; do NOT post"
+    )
+    ap.add_argument(
+        "--from-cache",
+        action="store_true",
+        help="Publish the EXISTING cache without re-scraping e-GP (drains an "
+        "API-side backlog, e.g. after a throttle 429 storm); retries with backoff",
+    )
+    ap.add_argument("--id-min", type=int, default=1, help="Lowest tenderId (default 1)")
+    ap.add_argument(
+        "--id-max",
+        type=int,
+        default=0,
+        help="Highest tenderId (0 = discovery-only unless --full)",
+    )
+    ap.add_argument(
+        "--full",
+        action="store_true",
+        help=f"Walk the whole tenderId space (--id-min..{DEFAULT_MAX_TENDER_ID}) — "
+        "the reliable frontier for completeness",
+    )
+    ap.add_argument(
+        "--discover-pages",
+        type=int,
+        default=0,
+        help="Seed from N search pages (FRESHNESS only — the pager is not exhaustive)",
+    )
+    ap.add_argument(
+        "--page-size",
+        type=int,
+        default=100,
+        help="Search page size for discovery (default 100)",
+    )
+    ap.add_argument(
+        "--concurrency",
+        type=int,
+        default=3,
+        help="Concurrent fetches (default 3 — be polite)",
+    )
+    ap.add_argument(
+        "--delay",
+        type=float,
+        default=0.7,
+        help="Base seconds between fetches (default 0.7)",
+    )
+    ap.add_argument(
+        "--retries", type=int, default=4, help="Fetch attempts per id (default 4)"
+    )
+    ap.add_argument(
+        "--timeout", type=int, default=45, help="HTTP timeout seconds (default 45)"
+    )
+    ap.add_argument(
+        "--max-requests",
+        type=int,
+        default=0,
+        help="Stop after N fetched this run (0=all; resumable)",
+    )
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Crawl bolpatra e-GP tenders and POST them to /api/materials/."
+    )
+    add_arguments(ap)
+    args = ap.parse_args(argv)
+    if not args.dry_run and not args.api_base:
+        ap.error("--api-base is required unless --dry-run is set.")
+    # --full walks the whole (dense) tenderId space — the reliable frontier.
+    if args.full and not args.id_max:
+        args.id_max = DEFAULT_MAX_TENDER_ID
+    if not args.from_cache and not args.id_max and not args.discover_pages:
+        ap.error(
+            "give a frontier: --full, an --id-min/--id-max range, "
+            "and/or --discover-pages N."
+        )
+    args.basic_auth = None
+    if args.basic_auth_raw:
+        if ":" not in args.basic_auth_raw:
+            ap.error("--basic-auth must be USER:PASS")
+        user, _, password = args.basic_auth_raw.partition(":")
+        args.basic_auth = (user, password)
+    if not args.dry_run and not args.token and not args.basic_auth:
+        args.token = _mint_bearer()
+    BolpatraCrawler(args).crawl()
+
+
+def _mint_bearer() -> str:
+    """Mint the NGM-role bearer for the material API from the OIDC client-
+    credentials env (the ``sa-ingestion`` identity), so an in-cluster CronJob
+    carries NO static token — same pattern as the NKP crawler. A bare ``python -m``
+    run does not bootstrap Django, and ``resolve_service_bearer`` reads
+    Django-settings fallbacks, so configure settings first (idempotent).
+    """
+    import os
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    import django
+
+    django.setup()
+    from review.oidc_client_credentials import OIDCTokenError, resolve_service_bearer
+
+    try:
+        token = resolve_service_bearer()
+    except OIDCTokenError as exc:
+        print(f"FATAL: could not mint the material-API bearer: {exc}", file=sys.stderr)
+        raise SystemExit(2)
+    if not token:
+        print(
+            "FATAL: no material-API bearer. Set INGESTION_OIDC_CLIENT_ID/SECRET (else "
+            "CASEWORK_OIDC_*), pass --token or --basic-auth, or run with --dry-run.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return token
+
+
+if __name__ == "__main__":
+    main()

--- a/materials/sourcing/bolpatra/parse.py
+++ b/materials/sourcing/bolpatra/parse.py
@@ -1,0 +1,150 @@
+"""Parse the bolpatra e-GP (``bolpatra.gov.np/egp``) public tender pages.
+
+The pure parse half of the ``bolpatra`` sourcing pipeline. e-GP is a legacy
+server-rendered Java/Struts app (NOT a JSON API), so this is HTML→dataclass
+extraction, mirroring the court-portal parsers:
+
+- **Search results** (``POST /egp/searchOpportunity.action``) list rows whose
+  detail links call ``getTenderDetails('<tenderId>')`` — :func:`extract_tender_ids`
+  harvests those integer ids (the crawl frontier).
+- **Tender detail** (``POST /egp/getTenderDetails`` with ``tenderId``) is a
+  label/value page — :func:`parse_tender_detail` maps the labels (verified against
+  live tenders 319751 / 321065) to a :class:`ParsedTender`.
+
+Pure + dependency-light: uses ``lxml`` (a declared repo dep) and the shared
+``normalize_whitespace``; no network, no Django.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from courts.scraper.text import normalize_whitespace
+
+#: getTenderDetails('319751') / getTenderDetails("319751") in the results HTML.
+_TENDER_ID_RE = re.compile(r"getTenderDetails\(\s*['\"](\d+)['\"]\s*\)")
+
+#: Detail-page labels → the ParsedTender field they populate. Matched on the
+#: normalized (whitespace-collapsed, trailing-colon-stripped) label text.
+_LABEL_MAP = {
+    "Public Entity Name": "public_entity",
+    "Procurement Category": "procurement_category",
+    "Procurement Method": "procurement_method",
+    "IFB/RFP/EOI/PQ No": "notice_number",
+    "Project Name": "project_name",
+    "Current Status": "current_status",
+    "Source of Funds": "source_of_funds",
+    "Source of Fund": "source_of_funds",
+    "Notice Publication Date": "publication_date",
+    "Brief Description of Work": "description",
+    "Last Date for Bid Submission": "submission_deadline",
+    "Bid Opening Date": "opening_date",
+    "Date of Pre-Bid Meeting": "prebid_meeting_date",
+}
+
+#: Every label the detail page renders — the mapped ones plus the section headings
+#: and unmapped rows. Used as a "this is a label, not a value" guard so an empty
+#: field never absorbs the NEXT label as its value (see parse_tender_detail).
+_KNOWN_LABELS = frozenset(_LABEL_MAP) | frozenset(
+    {
+        "View IFB/PQ/EOI/EF Notice Details",
+        "Bid Information",
+        "Bidding Procedure",
+        "Bidding Document of",
+        "Bidding Type",
+        "Tender Type",
+        "Funding Information",
+        "Bid Schedule",
+        "Bid Document Publication Date",
+        "Pre-Bid Meeting Address",
+        "Bid Submission Address",
+        "Bid Opening Address",
+        "Date of Start of Works",
+        "Bid Fee Details",
+        "Bid Document Fee (in NPR)",
+        "Bank Name",
+    }
+)
+
+
+@dataclass
+class ParsedTender:
+    """One e-GP tender/bid notice, mapped from its detail page."""
+
+    tender_id: str
+    public_entity: str | None = None
+    notice_number: str | None = None
+    project_name: str | None = None
+    procurement_category: str | None = None
+    procurement_method: str | None = None
+    current_status: str | None = None
+    source_of_funds: str | None = None
+    publication_date: str | None = None
+    submission_deadline: str | None = None
+    opening_date: str | None = None
+    prebid_meeting_date: str | None = None
+    description: str | None = None
+
+
+def extract_tender_ids(html: str) -> list[str]:
+    """Harvest tender ids from a search-results page (dedup, order-preserving)."""
+    seen: dict[str, None] = {}
+    for m in _TENDER_ID_RE.finditer(html or ""):
+        seen.setdefault(m.group(1), None)
+    return list(seen)
+
+
+def _clean_label(text: str) -> str:
+    """Normalize a label cell: collapse whitespace, drop a trailing colon."""
+    return normalize_whitespace(text).rstrip(":").strip()
+
+
+def parse_tender_detail(html: str, tender_id: str) -> ParsedTender | None:
+    """Map a ``getTenderDetails`` page to a :class:`ParsedTender`, or ``None``.
+
+    The page renders as label/value cell pairs. We walk every table row and every
+    ``<td>`` sequence, pairing a recognized label cell with the following non-empty
+    value cell. Returns ``None`` only when the page yields no usable fields at all
+    (an error/empty page) so the caller can retry rather than cache a hollow stub.
+    """
+    try:
+        from lxml import html as lxml_html
+    except ImportError:  # pragma: no cover - lxml is a declared dependency
+        return None
+    if not html:
+        return None
+
+    doc = lxml_html.fromstring(html)
+    # Flatten to the visible text of each cell, in document order.
+    cells = [normalize_whitespace(td.text_content()) for td in doc.xpath("//td")]
+    tender = ParsedTender(tender_id=str(tender_id))
+    found = False
+    for i, raw in enumerate(cells):
+        label = _clean_label(raw)
+        if not label:
+            continue
+        attr = _LABEL_MAP.get(label)
+        if not attr:
+            continue
+        # The value is the next non-empty cell — but NEVER another known label.
+        # e-GP serves the form SHELL (all labels, no values) for a non-existent
+        # tenderId; without this guard the following label is read as the value
+        # (e.g. public_entity="Procurement Category") and a garbage record is
+        # cached + published instead of the id being recorded as a gap.
+        value = ""
+        for nxt in cells[i + 1 : i + 3]:
+            candidate = normalize_whitespace(nxt)
+            if not candidate:
+                continue
+            if _clean_label(candidate) in _KNOWN_LABELS:
+                break  # hit the next label → this field is empty on the page
+            value = candidate
+            break
+        if not value or value == label:
+            continue
+        if getattr(tender, attr) is None:
+            setattr(tender, attr, value)
+            found = True
+
+    return tender if found else None

--- a/materials/sourcing/bolpatra/shaper.py
+++ b/materials/sourcing/bolpatra/shaper.py
@@ -1,0 +1,116 @@
+"""Shape a parsed bolpatra e-GP tender into Material JSON-LD — a public
+procurement notice (PPMO/bolpatra सूचना).
+
+Pure + DB-free: takes a :class:`~materials.sourcing.bolpatra.parse.ParsedTender`
+and returns ``(jsonld_doc, material_type)`` ready to POST to ``/api/materials/``
+(the crawler in :mod:`materials.sourcing.bolpatra.crawl` is the API client). Lives
+beside its crawler under ``materials/sourcing/bolpatra/`` — the home for
+external-source shapers; the generic Material JSON-LD contract
+(``MATERIAL_CONTEXT``, ``type_for``, ``MaterialType``) stays in ``materials.jsonld``.
+
+Mirrors the NKP precedent shaper's shape/idioms.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from materials.jsonld import MATERIAL_CONTEXT, MaterialType, type_for
+from materials.sourcing.bolpatra.parse import ParsedTender
+
+#: IRI ``source`` segment for a bolpatra procurement notice
+#: (``/material/bolpatra/<tenderId>``).
+BOLPATRA_SOURCE = "bolpatra"
+
+#: Provenance authority (host of the e-GP portal) — the publisher key.
+BOLPATRA_AUTHORITY = "bolpatra.gov.np"
+
+
+def _ad_iso(value: str | None) -> str | None:
+    """Best-effort ``DD-MM-YYYY[ HH:MM]`` (e-GP's format) → ISO ``YYYY-MM-DD``.
+
+    e-GP prints Gregorian dates as ``30-07-2026 16:00``. Returns ``None`` on any
+    unparseable input (a date is sort/filter metadata, never a hard precondition).
+    """
+    if not value:
+        return None
+    head = str(value).strip().split()[0]  # drop the time component
+    parts = head.split("-")
+    if len(parts) != 3:
+        return None
+    day, month, year = parts
+    if len(year) != 4 or not (day.isdigit() and month.isdigit() and year.isdigit()):
+        return None
+    return f"{year}-{int(month):02d}-{int(day):02d}"
+
+
+def tender_to_jsonld(tender: ParsedTender) -> tuple[dict[str, Any], str]:
+    """Shape one parsed tender → ``(jsonld_doc, material_type)``.
+
+    The procurement notice maps to ``CreativeWork`` + ``jawafdehi:
+    ProcurementNotice`` (see ``materials.jsonld.MATERIAL_TYPES``). The e-GP detail
+    page is the ``url``; the notice-number/entity/category/method and the bid
+    schedule ride as ``jawafdehi:`` extension properties. ``datePublished`` is the
+    Gregorian notice date so notices are date-orderable in unified search.
+
+    Pure function (no DB): the crawler is the API client. The ``@id`` is minted
+    lazily by the crawler via ``build_material_iri(BOLPATRA_SOURCE, tender_id)`` so
+    this stays import-light and unit-testable without the ids module; callers that
+    want the doc pre-keyed pass through the crawler.
+    """
+    material_type = MaterialType.PROCUREMENT_NOTICE
+    schema_type, additional_type = type_for(material_type)
+
+    source_url = (
+        f"https://bolpatra.gov.np/egp/getTenderDetails?tenderId={tender.tender_id}"
+    )
+    name = tender.project_name or tender.notice_number or f"Tender {tender.tender_id}"
+
+    doc: dict[str, Any] = {
+        "@context": MATERIAL_CONTEXT,
+        "@type": schema_type,
+        "additionalType": additional_type,
+        "name": {"en": name},
+        "identifier": str(tender.notice_number or tender.tender_id),
+        "url": source_url,
+        "isAccessibleForFree": True,
+        # The procuring entity publishes the notice through PPMO's e-GP.
+        "publisher": {
+            "@type": "GovernmentOrganization",
+            "name": {"en": "Public Procurement Monitoring Office"},
+        },
+        "sources": [{"url": source_url, "authority": BOLPATRA_AUTHORITY}],
+    }
+
+    # Procurement identity + classification as jawafdehi: extension properties.
+    for field_value, key in (
+        (tender.notice_number, "jawafdehi:noticeNumber"),
+        (tender.public_entity, "jawafdehi:procuringEntity"),
+        (tender.procurement_category, "jawafdehi:procurementCategory"),
+        (tender.procurement_method, "jawafdehi:procurementMethod"),
+        (tender.current_status, "jawafdehi:currentStatus"),
+        (tender.source_of_funds, "jawafdehi:sourceOfFunds"),
+    ):
+        if field_value:
+            doc[key] = field_value
+
+    if tender.description:
+        doc["description"] = {"en": tender.description}
+
+    # Notice publication date drives search date sort/filter.
+    published_ad = _ad_iso(tender.publication_date)
+    if published_ad:
+        doc["datePublished"] = published_ad
+    if tender.publication_date:
+        doc["jawafdehi:noticePublicationDate"] = tender.publication_date
+
+    # Bid schedule — carried verbatim (e-GP's DD-MM-YYYY HH:MM) as jawafdehi: props.
+    for field_value, key in (
+        (tender.submission_deadline, "jawafdehi:bidSubmissionDeadline"),
+        (tender.opening_date, "jawafdehi:bidOpeningDate"),
+        (tender.prebid_meeting_date, "jawafdehi:preBidMeetingDate"),
+    ):
+        if field_value:
+            doc[key] = field_value
+
+    return doc, material_type

--- a/materials/tests/test_bolpatra_crawl.py
+++ b/materials/tests/test_bolpatra_crawl.py
@@ -1,0 +1,194 @@
+"""bolpatra crawler control-flow tests (fake fetcher + fake material API).
+
+Injects a fake e-GP transport and a fake material client via the ``build_*`` seams
+and asserts the crawl's control flow: id discovery, skip-already-done (resume),
+gap handling (unparseable detail), dry-run posts nothing, retryable failure leaves
+an id un-checkpointed, and ``--max-requests`` caps a run. Nothing hits net/DB;
+``time.sleep`` is patched out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from materials.sourcing.bolpatra import crawl as C
+from materials.sourcing.bolpatra.crawl import BolpatraCrawler
+
+CRAWL = "materials.sourcing.bolpatra.crawl"
+
+_DETAIL = """<table>
+<tr><td>Public Entity Name</td><td>Entity {n}</td></tr>
+<tr><td>Project Name</td><td>Project {n}</td></tr>
+<tr><td>Procurement Method</td><td>NCB</td></tr>
+</table>"""
+
+
+class _FakeFetcher:
+    """tender_id → detail HTML (None = transient/retryable). search pages → id lists."""
+
+    def __init__(self, details, pages=None):
+        self.details = details
+        self.pages = pages or {}
+        self.detail_calls = []
+
+    def get_detail(self, tid):
+        self.detail_calls.append(tid)
+        return self.details.get(tid)
+
+    def search_page(self, page_index, page_size=100):
+        ids = self.pages.get(page_index, [])
+        return "".join(f"getTenderDetails('{i}')" for i in ids) if ids else ""
+
+    def close(self):
+        pass
+
+
+class _FakeMaterial:
+    def __init__(self, fail_ids=()):
+        self.posts = []
+        self.fail_ids = set(fail_ids)
+
+    def post(self, doc, material_type):
+        tid = doc["@id"].rsplit("/", 1)[-1]
+        if tid in self.fail_ids:
+            raise C.MaterialApiError("503")
+        self.posts.append((tid, doc, material_type))
+
+    def close(self):
+        pass
+
+
+def _args(cache, **over):
+    base = dict(
+        cache=str(cache),
+        api_base="http://api",
+        token="t",
+        dry_run=False,
+        id_min=1,
+        id_max=0,
+        discover_pages=0,
+        page_size=100,
+        concurrency=1,
+        delay=0.0,
+        retries=1,
+        timeout=5,
+        max_requests=0,
+        basic_auth=None,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+class BolpatraCrawlerTests(SimpleTestCase):
+    def setUp(self):
+        p = patch(f"{CRAWL}.time.sleep", lambda *a, **k: None)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _cache(self):
+        return Path(tempfile.mkdtemp()) / "tenders.jsonl"
+
+    def test_id_range_walk_publishes_and_records_gaps(self):
+        cache = self._cache()
+        fetch = _FakeFetcher(details={"1": _DETAIL.format(n=1), "2": None, "3": "err"})
+        api = _FakeMaterial()
+        # id 1 parses+posts; id 2 is transient(None)→uncheckpointed; id 3 unparseable→gap.
+        BolpatraCrawler(
+            _args(cache, id_min=1, id_max=3), fetcher=fetch, material_client=api
+        ).crawl()
+        assert [t for t, _, _ in api.posts] == ["1"]
+        state = json.loads(cache.with_suffix(".jsonl.state.json").read_text())
+        assert state["done_ids"] == ["1"]
+        assert state["gap_ids"] == ["3"]
+
+    def test_discovery_seeds_the_frontier(self):
+        cache = self._cache()
+        # Pager pages are 1-BASED (page 0 is never requested).
+        fetch = _FakeFetcher(
+            details={"10": _DETAIL.format(n=10), "11": _DETAIL.format(n=11)},
+            pages={1: ["10", "11"], 2: []},
+        )
+        api = _FakeMaterial()
+        BolpatraCrawler(
+            _args(cache, discover_pages=2), fetcher=fetch, material_client=api
+        ).crawl()
+        assert sorted(t for t, _, _ in api.posts) == ["10", "11"]
+
+    def test_discovery_stops_when_pager_repeats_itself(self):
+        cache = self._cache()
+        # The real e-GP pager re-serves the same page; discovery must stop, not loop.
+        fetch = _FakeFetcher(
+            details={"10": _DETAIL.format(n=10)},
+            pages={1: ["10"], 2: ["10"], 3: ["10"]},
+        )
+        api = _FakeMaterial()
+        BolpatraCrawler(
+            _args(cache, discover_pages=5), fetcher=fetch, material_client=api
+        ).crawl()
+        # id 10 published exactly once despite the pager repeating it.
+        assert [t for t, _, _ in api.posts] == ["10"]
+
+    def test_full_flag_walks_whole_id_space(self):
+        # --full is resolved in main(); assert the constant is what the range uses.
+        assert C.DEFAULT_MAX_TENDER_ID > 300_000
+
+    def test_resume_skips_done_ids(self):
+        cache = self._cache()
+        details = {"1": _DETAIL.format(n=1), "2": _DETAIL.format(n=2)}
+        BolpatraCrawler(
+            _args(cache, id_min=1, id_max=2),
+            fetcher=_FakeFetcher(details),
+            material_client=_FakeMaterial(),
+        ).crawl()
+        fetch2 = _FakeFetcher(details)
+        BolpatraCrawler(
+            _args(cache, id_min=1, id_max=2),
+            fetcher=fetch2,
+            material_client=_FakeMaterial(),
+        ).crawl()
+        assert fetch2.detail_calls == []  # all already done
+
+    def test_dry_run_posts_nothing_but_caches(self):
+        cache = self._cache()
+        fetch = _FakeFetcher(details={"1": _DETAIL.format(n=1)})
+        api = _FakeMaterial()
+        BolpatraCrawler(
+            _args(cache, id_min=1, id_max=1, dry_run=True),
+            fetcher=fetch,
+            material_client=api,
+        ).crawl()
+        assert api.posts == []
+        lines = [ln for ln in cache.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+
+    def test_post_failure_leaves_id_uncheckpointed(self):
+        cache = self._cache()
+        fetch = _FakeFetcher(details={"1": _DETAIL.format(n=1)})
+        cr = BolpatraCrawler(
+            _args(cache, id_min=1, id_max=1),
+            fetcher=fetch,
+            material_client=_FakeMaterial(fail_ids={"1"}),
+        )
+        cr.crawl()
+        assert not cr.cp.seen(
+            "1"
+        )  # retryable → retried next run (upsert is idempotent)
+
+    def test_max_requests_caps_run(self):
+        cache = self._cache()
+        fetch = _FakeFetcher(
+            details={str(i): _DETAIL.format(n=i) for i in range(1, 11)}
+        )
+        cr = BolpatraCrawler(
+            _args(cache, id_min=1, id_max=10, max_requests=3),
+            fetcher=fetch,
+            material_client=_FakeMaterial(),
+        )
+        cr.crawl()
+        assert cr.n_requests == 3

--- a/materials/tests/test_bolpatra_shaper.py
+++ b/materials/tests/test_bolpatra_shaper.py
@@ -1,0 +1,143 @@
+"""Pure tests for the bolpatra tender parse + shape.
+
+No DB, no network: parse a recorded e-GP detail HTML fragment, shape it, and assert
+the Material JSON-LD (@type/additionalType/fields/date-conversion) — and that it
+passes the real ``validate_material_jsonld`` so a live POST cannot 400 on shape.
+"""
+
+from __future__ import annotations
+
+from jawafdehi_shared.entities.ids import build_material_iri
+from materials.jsonld import MaterialType, validate_material_jsonld
+from materials.sourcing.bolpatra.parse import (
+    ParsedTender,
+    extract_tender_ids,
+    parse_tender_detail,
+)
+from materials.sourcing.bolpatra.shaper import (
+    BOLPATRA_SOURCE,
+    _ad_iso,
+    tender_to_jsonld,
+)
+
+# A trimmed but structurally faithful e-GP detail page (label/value <td> pairs),
+# modeled on the live tender 321065.
+_DETAIL_HTML = """
+<html><body><table>
+<tr><td>Public Entity Name</td><td>Miklajung Rural Municipality, Morang</td></tr>
+<tr><td>Procurement Category</td><td>Works</td></tr>
+<tr><td>Procurement Method</td><td>NCB</td></tr>
+<tr><td>IFB/RFP/EOI/PQ No</td><td>02/MRMM/WORKS/NCB/083/084</td></tr>
+<tr><td>Project Name</td><td>Hattimara Dekhi Ghising Chowk Samma Sadak Kalopatre</td></tr>
+<tr><td>Current Status</td><td>Bid Published</td></tr>
+<tr><td>Source of Funds</td><td>Government Budget</td></tr>
+<tr><td>Notice Publication Date</td><td>30-07-2026 16:00</td></tr>
+<tr><td>Last Date for Bid Submission</td><td>21-08-2026 12:00</td></tr>
+<tr><td>Bid Opening Date</td><td>21-08-2026 13:00</td></tr>
+</table></body></html>
+"""
+
+_RESULTS_HTML = """
+<a onclick="getTenderDetails('321065')">x</a>
+<a onclick="getTenderDetails('319751')">y</a>
+<a onclick="getTenderDetails('321065')">dup</a>
+"""
+
+
+def test_extract_tender_ids_dedups_and_orders():
+    assert extract_tender_ids(_RESULTS_HTML) == ["321065", "319751"]
+
+
+def test_parse_detail_maps_labels():
+    t = parse_tender_detail(_DETAIL_HTML, "321065")
+    assert t is not None
+    assert t.public_entity == "Miklajung Rural Municipality, Morang"
+    assert t.procurement_category == "Works"
+    assert t.procurement_method == "NCB"
+    assert t.notice_number == "02/MRMM/WORKS/NCB/083/084"
+    assert t.current_status == "Bid Published"
+    assert t.publication_date == "30-07-2026 16:00"
+    assert t.submission_deadline == "21-08-2026 12:00"
+
+
+def test_parse_detail_returns_none_on_empty():
+    assert parse_tender_detail("<html><body>error</body></html>", "1") is None
+
+
+# Regression: e-GP serves the form SHELL (all labels, NO values) for a
+# non-existent tenderId. Without the "a label is never a value" guard the parser
+# read the FOLLOWING label as the value (public_entity="Procurement Category") and
+# cached/published a garbage record instead of recording the id as a gap.
+_SHELL_HTML = """
+<html><body><table>
+<tr><td>Public Entity Name</td><td></td></tr>
+<tr><td>Procurement Category</td><td></td></tr>
+<tr><td>Procurement Method</td><td></td></tr>
+<tr><td>IFB/RFP/EOI/PQ No</td><td></td></tr>
+<tr><td>Project Name</td><td></td></tr>
+<tr><td>Current Status</td><td></td></tr>
+<tr><td>Bid Information</td><td></td></tr>
+</table></body></html>
+"""
+
+
+def test_parse_detail_rejects_empty_form_shell():
+    assert parse_tender_detail(_SHELL_HTML, "400000") is None
+
+
+def test_parse_detail_never_reads_a_label_as_a_value():
+    # Even a partially-filled page must not absorb the next label as a value.
+    html = """<table>
+      <tr><td>Public Entity Name</td><td></td></tr>
+      <tr><td>Procurement Method</td><td>NCB</td></tr>
+    </table>"""
+    t = parse_tender_detail(html, "7")
+    assert t is not None
+    assert t.public_entity is None  # empty on the page — NOT "Procurement Method"
+    assert t.procurement_method == "NCB"
+
+
+def test_ad_iso_converts_egp_date():
+    assert _ad_iso("30-07-2026 16:00") == "2026-07-30"
+    assert _ad_iso("21-08-2026") == "2026-08-21"
+
+
+def test_ad_iso_none_on_garbage():
+    assert _ad_iso("") is None
+    assert _ad_iso("not-a-date") is None
+    assert _ad_iso("2026/07/30") is None  # wrong separator/order → skip, don't guess
+
+
+def test_shaper_type_and_fields():
+    t = parse_tender_detail(_DETAIL_HTML, "321065")
+    doc, mtype = tender_to_jsonld(t)
+    assert mtype == MaterialType.PROCUREMENT_NOTICE
+    assert doc["@type"] == "CreativeWork"
+    assert doc["additionalType"] == "jawafdehi:ProcurementNotice"
+    assert doc["jawafdehi:procuringEntity"] == "Miklajung Rural Municipality, Morang"
+    assert doc["jawafdehi:noticeNumber"] == "02/MRMM/WORKS/NCB/083/084"
+    assert doc["jawafdehi:currentStatus"] == "Bid Published"
+    assert doc["datePublished"] == "2026-07-30"  # AD-converted for search sort
+    assert doc["sources"] == [{"url": doc["url"], "authority": "bolpatra.gov.np"}]
+
+
+def test_shaped_doc_passes_material_validation():
+    t = parse_tender_detail(_DETAIL_HTML, "321065")
+    doc, _ = tender_to_jsonld(t)
+    doc["@id"] = build_material_iri(BOLPATRA_SOURCE, t.tender_id)
+    validate_material_jsonld(doc, iri=doc["@id"])  # raises on failure
+    assert doc["@id"] == "https://jawafdehi.org/material/bolpatra/321065"
+
+
+def test_shaper_falls_back_to_notice_number_for_name():
+    t = ParsedTender(tender_id="9", notice_number="ABC/1", project_name=None)
+    doc, _ = tender_to_jsonld(t)
+    assert doc["name"]["en"] == "ABC/1"
+
+
+def test_shaper_minimal_tender_validates():
+    t = ParsedTender(tender_id="42")
+    doc, _ = tender_to_jsonld(t)
+    doc["@id"] = build_material_iri(BOLPATRA_SOURCE, t.tender_id)
+    validate_material_jsonld(doc, iri=doc["@id"])
+    assert doc["name"]["en"] == "Tender 42"


### PR DESCRIPTION
### **User description**
Nepal's e-procurement portal (`bolpatra.gov.np/egp`) publishes every government
tender notice but exposes no API — it is a server-rendered legacy Java/Struts app.
This adds it as a Materials source: **204,925 procurement notices**, each a
`CreativeWork` + `jawafdehi:ProcurementNotice`, POSTed through the material REST
plane like every other source.

### Why an id walk, not the search pager

The obvious frontier is the paginated search form, and it is **not trustworthy for
enumeration**. The server ignores `currentPageIndex`, requires `pageAction=next`
before `pageSize` applies at all (otherwise it silently returns its default 10
rows), mirrors state into parallel `*Input` fields, and re-bases `startIndex` — so
different offsets can return overlapping or repeated pages.

Enumeration therefore walks `tenderId` directly (dense-ish `1..~325k`, ~63%
populated, sampled by band). `--discover-pages` remains only as a *freshness seed*
and stops as soon as a page adds nothing new. **The id walk owns completeness.**

### The empty-shell trap (please look at this one)

A non-existent `tenderId` does not 404 — it returns the detail page's **form shell
with every label present and no values**. The first parser read the *next label* as
the current field's value, producing rows like `procuringEntity="Procurement
Category"`. At scale that would have written **~119k plausible-looking garbage
records** into the archive.

`parse_tender_detail` now refuses to accept a known label as a value and returns
`None`, so the id is recorded as a gap instead. Both halves are regression-tested;
the guard test fails without the fix.

### Host quirks handled in code

- bolpatra **403s the default `python-requests` User-Agent** → browser UA, with the
  reason in a comment so nobody "cleans it up".
- Its **TLS chain is broken** → `verify=False`, consistent with the other `*.gov.np`
  crawlers.

### Politeness

Default, not a flag: bounded concurrency, jittered per-request delay, exponential
backoff, `Retry-After` honored, and a circuit breaker that pauses on sustained
5xx/429. These are government servers on a small budget.

### Verification

- 2,571 passed / 4 skipped, `ruff check .` clean at this commit.
- Ran to completion against a local stack: **205,826 notices** ingested.
- One self-inflicted bug found and fixed during that run, worth knowing about: the
  first full crawl exited 0 having silently dropped 115,721 records — all HTTP 429
  from *our own* DRF `THROTTLE_RATE_USER`. Hence `--from-cache` with 429-aware
  backoff, so a throttled run is re-drivable from the cache without re-crawling.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add bolpatra procurement material type

- Add resumable e-GP tender crawler

- Parse, shape procurement notice JSON-LD

- Test crawler, parser, shaper flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bolpatra e-GP HTML"] -- "id walk, page seed" --> B["crawler cache"]
  B -- "parse detail" --> C["ParsedTender"]
  C -- "shape JSON-LD" --> D["procurement material"]
  D -- "POST upsert" --> E["Material API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>jsonld.py</strong><dd><code>Register procurement notice material type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-f72490339a262ef7de5f9179d65dc730f11a4a40c9ace799f78743296468df4c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>crawl.py</strong><dd><code>Add resumable bolpatra tender crawler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-1cd8c9264777f38025f5cf0350368ace799cb43300ce3a8704da01e1533cef27">+671/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>parse.py</strong><dd><code>Parse e-GP tender HTML pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-bc3ce590c2e2d644dbd50bd81b098533fb0063bcf79677f23936c501e271aebc">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shaper.py</strong><dd><code>Shape tenders into Material JSON-LD</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-a71df5b109ae9c16245406a0704452b49c859999f422aba49c1a6745140a0265">+116/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_bolpatra_crawl.py</strong><dd><code>Test crawler checkpoint and publish flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-b18f738b886bd04e841612f44dc39733d146f02d7fce78054e5268d31d2140c9">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_bolpatra_shaper.py</strong><dd><code>Test parser and JSON-LD shaper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-5b14ea10c2043f3870d8fb2643fd4dbd706190fec0c777aedc08c1624077f294">+143/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/422/files#diff-543c63d18f255d03ecdbf0c5f62990ae177e04ba8ba9bbd7bb5861a8fc2de506">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
