### PR TITLE
feat(proposals): a typed set_entity_outcome intent, so a verdict can move the accused

### DIFF
--- a/case_proposals/apply.py
+++ b/case_proposals/apply.py
@@ -17,7 +17,13 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from cases.caseworker_serializers import CasePatchSerializer, TimelineItemSerializer
-from cases.models import Case, CaseMaterialReference, validate_material_iri
+from cases.models import (
+    Case,
+    CaseMaterialReference,
+    RelationshipOutcome,
+    RelationshipType,
+    validate_material_iri,
+)
 
 from .models import SUPPORTED_INTENT_TYPES
 
@@ -109,6 +115,8 @@ def apply_intent(case, intent):
         result = _link_material(case, intent)
     elif itype == "raw_patch":
         result = _raw_patch(case, intent)
+    elif itype == "set_entity_outcome":
+        result = _set_entity_outcome(case, intent)
     else:
         # Every accepted type is applyable — the serializer and this dispatch share
         # one vocabulary, so there is no "staged but uncommittable" middle state.
@@ -194,3 +202,96 @@ def _raw_patch(case, intent):
     if updates:
         Case.objects.filter(pk=case.pk).update(updated_at=timezone.now(), **updates)
     return {"patched_fields": sorted(updates.keys())}
+
+
+# Terminal outcomes a proposal may set. ``charged`` is excluded on purpose: it is
+# the default a relationship already starts at, so "propose charged" is either a
+# no-op or a regression from a decided verdict back to undecided — and un-deciding
+# a case is not an enrichment, it is a correction that belongs in the admin with a
+# human looking at why.
+PROPOSABLE_OUTCOMES = frozenset(
+    {
+        RelationshipOutcome.CONVICTED,
+        RelationshipOutcome.ACQUITTED,
+        RelationshipOutcome.ABATED,
+    }
+)
+
+
+def _set_entity_outcome(case, intent):
+    """Set the verdict outcome on this case's ACCUSED entity relationships.
+
+    The one enrichment ``raw_patch`` cannot express, because ``entities`` is not a
+    Case scalar: it is a relationship guarded by the ``outcome_only_on_accused``
+    CHECK constraint. Resolving every ``nes_id`` against THIS case's own
+    relationships first is what makes that safe — a proposal cannot reach an
+    entity it was not already bound to, and cannot set an outcome on a
+    non-accused role (which the DB would reject with an IntegrityError, i.e. a
+    500 where a 400 belongs).
+
+    All-or-nothing by design. A verdict is one fact about every defendant, so a
+    partial application would leave the case asserting that some of the acquitted
+    are still merely charged — the exact defect this intent exists to remove.
+    """
+    outcomes = (intent or {}).get("outcomes")
+    if not isinstance(outcomes, list) or not outcomes:
+        raise ValidationError(
+            {"intent": "set_entity_outcome requires a non-empty `outcomes` list."}
+        )
+
+    # Only ACCUSED relationships are addressable; anything else is rejected below
+    # with the role named, rather than failing the CHECK constraint at write time.
+    by_nes_id = {rel.nes_id: rel for rel in case.entity_relationships.all()}
+    resolved = []
+    for item in outcomes:
+        if not isinstance(item, dict):
+            raise ValidationError({"intent": "each `outcomes` entry must be an object."})
+        nes_id, outcome = item.get("nes_id"), item.get("outcome")
+        if not nes_id or not outcome:
+            raise ValidationError(
+                {"intent": "each `outcomes` entry requires `nes_id` and `outcome`."}
+            )
+        if outcome not in PROPOSABLE_OUTCOMES:
+            raise ValidationError(
+                {
+                    "intent": (
+                        f"outcome '{outcome}' is not proposable. "
+                        f"Allowed: {sorted(PROPOSABLE_OUTCOMES)}."
+                    )
+                }
+            )
+        rel = by_nes_id.get(nes_id)
+        if rel is None:
+            raise ValidationError(
+                {"intent": f"'{nes_id}' is not an entity of case '{case.slug}'."}
+            )
+        if rel.relationship_type != RelationshipType.ACCUSED:
+            raise ValidationError(
+                {
+                    "intent": (
+                        f"'{nes_id}' is bound as '{rel.relationship_type}', not accused; "
+                        "an outcome is meaningful only for the accused role."
+                    )
+                }
+            )
+        resolved.append((rel, outcome))
+
+    changed = []
+    for rel, outcome in resolved:
+        if rel.outcome == outcome:
+            continue
+        previous = rel.outcome
+        rel.outcome = outcome
+        # ``save()`` (not ``queryset.update()``) so the model's own normalisation
+        # and ``full_clean()`` run, exactly as the admin edit path does. No
+        # ``update_fields``: this model has no ``updated_at``, and narrowing the
+        # write would skip nothing worth skipping on a single-column change.
+        rel.save()
+        changed.append({"nes_id": rel.nes_id, "from": previous, "to": outcome})
+
+    if changed:
+        # A relationship-only write never touches the Case row, so bump
+        # ``updated_at`` — the ETag/optimistic-concurrency basis — exactly like
+        # the relation-only PATCH path does.
+        Case.objects.filter(pk=case.pk).update(updated_at=timezone.now())
+    return {"outcomes_changed": changed, "unchanged": len(resolved) - len(changed)}

--- a/case_proposals/models.py
+++ b/case_proposals/models.py
@@ -21,7 +21,20 @@ class SignalSource(models.TextChoices):
 # was dropped: a Case has no legal-status field (only the editorial ``state``
 # workflow), so status facts belong in the timeline, and ``raw_patch`` is the
 # escape hatch for anything the typed intents don't cover. See case_proposals.apply.
-SUPPORTED_INTENT_TYPES = ("append_timeline_entry", "link_material", "raw_patch")
+#
+# ``set_entity_outcome`` is typed rather than left to ``raw_patch`` because
+# ``raw_patch`` deliberately cannot reach ``entities`` at all: an outcome write is
+# a relationship write guarded by the ``outcome_only_on_accused`` CHECK, so a
+# generic JSON patch over Case scalars is the wrong instrument. Without it the
+# single most consequential enrichment a verdict produces — moving an acquitted
+# defendant off ``charged`` — had no reviewable path, and the August 2026 docket
+# sweep found 71 such rows live on published cases.
+SUPPORTED_INTENT_TYPES = (
+    "append_timeline_entry",
+    "link_material",
+    "raw_patch",
+    "set_entity_outcome",
+)
 
 
 class CaseUpdateProposal(models.Model):

--- a/case_proposals/serializers.py
+++ b/case_proposals/serializers.py
@@ -26,6 +26,21 @@ def validate_intent_shape(intent):
     elif itype == "raw_patch":
         if not isinstance(intent.get("patch"), list) or not intent["patch"]:
             raise serializers.ValidationError("raw_patch requires a non-empty `patch` list.")
+    elif itype == "set_entity_outcome":
+        # A list, not a single pair: one verdict decides every defendant at once,
+        # so the reviewable unit is the whole disposition. Filing one proposal per
+        # defendant would invite a reviewer to approve half an acquittal and leave
+        # the case internally inconsistent.
+        outcomes = intent.get("outcomes")
+        if not isinstance(outcomes, list) or not outcomes:
+            raise serializers.ValidationError(
+                "set_entity_outcome requires a non-empty `outcomes` list."
+            )
+        for item in outcomes:
+            if not isinstance(item, dict) or not item.get("nes_id") or not item.get("outcome"):
+                raise serializers.ValidationError(
+                    "each set_entity_outcome entry requires `nes_id` and `outcome`."
+                )
     return intent
 
 

--- a/case_proposals/tests/test_set_entity_outcome.py
+++ b/case_proposals/tests/test_set_entity_outcome.py
@@ -1,0 +1,230 @@
+"""The ``set_entity_outcome`` intent: the one enrichment ``raw_patch`` cannot express.
+
+An August 2026 sweep of the published corpus found 71 accused rows still reading
+``charged`` on cases the Special Court had already decided — including a case where
+all 18 defendants had been acquitted, and one where the stored outcome was
+``acquitted`` for a defendant the court convicted. Both directions are factual
+errors on a public page about a named person, and neither had a reviewable fix:
+``raw_patch`` cannot reach ``entities`` at all.
+
+The negative tests here are the load-bearing ones. This intent writes a field the
+DB guards with a CHECK constraint, so "rejected with a 400" and "rejected with a
+500 IntegrityError" are very different outcomes, and only one of them is correct.
+"""
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from case_proposals.apply import apply_intent
+from cases.models import (
+    Case,
+    CaseEntityRelationship,
+    CaseType,
+    RelationshipOutcome,
+    RelationshipType,
+)
+
+ACCUSED_A = "https://jawafdehi.org/entity/person/sunil-paudel-a1b2c3"
+ACCUSED_B = "https://jawafdehi.org/entity/person/nim-bahadur-bali-d4e5f6"
+WITNESS = "https://jawafdehi.org/entity/person/a-witness-999999"
+STRANGER = "https://jawafdehi.org/entity/person/not-on-this-case-000000"
+
+
+def make_case(slug="ntc-081-cr-0111", title="NTC billing-system contract"):
+    return Case.objects.create(title=title, case_type=CaseType.CORRUPTION, slug=slug)
+
+
+def bind(case, nes_id, role=RelationshipType.ACCUSED, outcome=None):
+    return CaseEntityRelationship.objects.create(
+        case=case, nes_id=nes_id, relationship_type=role, outcome=outcome
+    )
+
+
+def outcome_intent(*pairs):
+    return {
+        "type": "set_entity_outcome",
+        "outcomes": [{"nes_id": nes_id, "outcome": outcome} for nes_id, outcome in pairs],
+    }
+
+
+@pytest.mark.django_db
+class TestTheAcquittedStopReadingAsCharged:
+    def test_a_full_acquittal_moves_every_accused_off_charged(self):
+        case = make_case()
+        a = bind(case, ACCUSED_A)
+        b = bind(case, ACCUSED_B)
+        assert a.outcome == RelationshipOutcome.CHARGED  # the model's default
+
+        result = apply_intent(
+            case,
+            outcome_intent(
+                (ACCUSED_A, RelationshipOutcome.ACQUITTED),
+                (ACCUSED_B, RelationshipOutcome.ACQUITTED),
+            ),
+        )
+
+        a.refresh_from_db()
+        b.refresh_from_db()
+        assert a.outcome == RelationshipOutcome.ACQUITTED
+        assert b.outcome == RelationshipOutcome.ACQUITTED
+        assert len(result["outcomes_changed"]) == 2
+
+    def test_a_partial_verdict_can_convict_one_and_acquit_another(self):
+        """``आंशिक ठहर`` is one fact with two different consequences per person."""
+        case = make_case()
+        a = bind(case, ACCUSED_A)
+        b = bind(case, ACCUSED_B)
+
+        apply_intent(
+            case,
+            outcome_intent(
+                (ACCUSED_A, RelationshipOutcome.CONVICTED),
+                (ACCUSED_B, RelationshipOutcome.ACQUITTED),
+            ),
+        )
+
+        a.refresh_from_db()
+        b.refresh_from_db()
+        assert a.outcome == RelationshipOutcome.CONVICTED
+        assert b.outcome == RelationshipOutcome.ACQUITTED
+
+    def test_it_corrects_the_inverse_error_too(self):
+        """Case 90's defect: stored ``acquitted`` for a defendant who was convicted."""
+        case = make_case()
+        rel = bind(case, ACCUSED_A, outcome=RelationshipOutcome.ACQUITTED)
+
+        apply_intent(case, outcome_intent((ACCUSED_A, RelationshipOutcome.CONVICTED)))
+
+        rel.refresh_from_db()
+        assert rel.outcome == RelationshipOutcome.CONVICTED
+
+    def test_reporting_distinguishes_changed_from_already_correct(self):
+        case = make_case()
+        bind(case, ACCUSED_A, outcome=RelationshipOutcome.ACQUITTED)
+        bind(case, ACCUSED_B)
+
+        result = apply_intent(
+            case,
+            outcome_intent(
+                (ACCUSED_A, RelationshipOutcome.ACQUITTED),  # already right
+                (ACCUSED_B, RelationshipOutcome.ACQUITTED),
+            ),
+        )
+
+        assert result["unchanged"] == 1
+        assert [c["nes_id"] for c in result["outcomes_changed"]] == [ACCUSED_B]
+        assert result["outcomes_changed"][0]["from"] == RelationshipOutcome.CHARGED
+
+
+@pytest.mark.django_db
+class TestItCannotReachWhatItWasNotGiven:
+    def test_an_entity_not_bound_to_this_case_is_a_400_not_a_silent_skip(self):
+        case = make_case()
+        bind(case, ACCUSED_A)
+
+        with pytest.raises(ValidationError) as exc:
+            apply_intent(case, outcome_intent((STRANGER, RelationshipOutcome.ACQUITTED)))
+        assert "not an entity of case" in str(exc.value)
+
+    def test_a_non_accused_role_is_rejected_with_the_role_named(self):
+        """The DB CHECK would raise IntegrityError (a 500); this must be a 400."""
+        case = make_case()
+        bind(case, WITNESS, role=RelationshipType.WITNESS)
+
+        with pytest.raises(ValidationError) as exc:
+            apply_intent(case, outcome_intent((WITNESS, RelationshipOutcome.ACQUITTED)))
+        assert "not accused" in str(exc.value)
+
+    def test_an_entity_on_a_DIFFERENT_case_stays_out_of_reach(self):
+        """Resolution is scoped to this case's own binds, not the whole table."""
+        theirs = make_case(slug="someone-elses-case", title="Another case")
+        bind(theirs, ACCUSED_A)
+        mine = make_case()
+        bind(mine, ACCUSED_B)
+
+        with pytest.raises(ValidationError):
+            apply_intent(mine, outcome_intent((ACCUSED_A, RelationshipOutcome.ACQUITTED)))
+
+        rel = CaseEntityRelationship.objects.get(case=theirs, nes_id=ACCUSED_A)
+        assert rel.outcome == RelationshipOutcome.CHARGED
+
+
+@pytest.mark.django_db
+class TestTheVocabularyIsNarrowerThanTheColumn:
+    def test_charged_is_not_proposable(self):
+        """Un-deciding a decided case is a correction for a human, not an enrichment."""
+        case = make_case()
+        bind(case, ACCUSED_A, outcome=RelationshipOutcome.ACQUITTED)
+
+        with pytest.raises(ValidationError) as exc:
+            apply_intent(case, outcome_intent((ACCUSED_A, RelationshipOutcome.CHARGED)))
+        assert "not proposable" in str(exc.value)
+
+    def test_an_invented_outcome_is_rejected(self):
+        case = make_case()
+        bind(case, ACCUSED_A)
+
+        with pytest.raises(ValidationError):
+            apply_intent(case, outcome_intent((ACCUSED_A, "exonerated")))
+
+    def test_abated_is_allowed(self):
+        case = make_case()
+        rel = bind(case, ACCUSED_A)
+
+        apply_intent(case, outcome_intent((ACCUSED_A, RelationshipOutcome.ABATED)))
+
+        rel.refresh_from_db()
+        assert rel.outcome == RelationshipOutcome.ABATED
+
+
+@pytest.mark.django_db
+class TestHalfAVerdictIsNeverApplied:
+    def test_one_bad_entry_rolls_back_the_whole_batch(self):
+        """Otherwise a case ends up asserting some of the acquitted are still charged."""
+        case = make_case()
+        good = bind(case, ACCUSED_A)
+
+        with pytest.raises(ValidationError):
+            apply_intent(
+                case,
+                outcome_intent(
+                    (ACCUSED_A, RelationshipOutcome.ACQUITTED),  # valid
+                    (STRANGER, RelationshipOutcome.ACQUITTED),  # not on this case
+                ),
+            )
+
+        good.refresh_from_db()
+        assert good.outcome == RelationshipOutcome.CHARGED, "the valid half must not persist"
+
+    def test_an_empty_outcomes_list_is_rejected(self):
+        case = make_case()
+        with pytest.raises(ValidationError):
+            apply_intent(case, {"type": "set_entity_outcome", "outcomes": []})
+
+    def test_a_malformed_entry_is_rejected(self):
+        case = make_case()
+        bind(case, ACCUSED_A)
+        with pytest.raises(ValidationError):
+            apply_intent(case, {"type": "set_entity_outcome", "outcomes": [{"nes_id": ACCUSED_A}]})
+
+
+@pytest.mark.django_db
+class TestTheCaseRowIsTouchedSoCachesInvalidate:
+    def test_updated_at_moves_on_a_relationship_only_write(self):
+        case = make_case()
+        bind(case, ACCUSED_A)
+        before = Case.objects.get(pk=case.pk).updated_at
+
+        apply_intent(case, outcome_intent((ACCUSED_A, RelationshipOutcome.ACQUITTED)))
+
+        assert Case.objects.get(pk=case.pk).updated_at > before
+
+    def test_updated_at_is_left_alone_when_nothing_changed(self):
+        case = make_case()
+        bind(case, ACCUSED_A, outcome=RelationshipOutcome.ACQUITTED)
+        before = Case.objects.get(pk=case.pk).updated_at
+
+        result = apply_intent(case, outcome_intent((ACCUSED_A, RelationshipOutcome.ACQUITTED)))
+
+        assert result["outcomes_changed"] == []
+        assert Case.objects.get(pk=case.pk).updated_at == before


### PR DESCRIPTION
### **User description**
## Why

An August 2026 sweep of the published case corpus verified every claim against our own docket rows. It found **71 accused rows still reading `charged` on cases the Special Court had already decided**, across 7 published cases — including one where all 18 defendants were acquitted, and one storing `acquitted` for a defendant the court convicted.

`CaseEntityRelationship` already states the standard being violated:

> terminal verdicts are set only from a primary court order — **an acquitted defendant must never render as accused.**

There was no reviewable path to fix any of it. `raw_patch` is restricted to Case scalars and deliberately excludes `entities`, so the single most consequential enrichment a verdict produces could only be applied by hand in the admin, one relationship at a time, with no provenance and no review trail.

## What

A fourth intent type, `set_entity_outcome`:

```json
{
  "type": "set_entity_outcome",
  "outcomes": [
    {"nes_id": "https://jawafdehi.org/entity/person/…", "outcome": "acquitted"},
    {"nes_id": "https://jawafdehi.org/entity/person/…", "outcome": "convicted"}
  ]
}
```

**A list, not a pair.** A verdict is one fact about every defendant. One proposal per accused would invite a reviewer to approve half an acquittal and leave the case asserting that some of the acquitted are still merely charged — the exact defect this removes. Application is all-or-nothing.

**Resolution is scoped to the case.** Every `nes_id` is matched against *this* case's own relationships before anything is written, so a proposal cannot reach an entity it was not already bound to, and cannot target a non-accused role. That last check is the point: the `outcome_only_on_accused` CHECK constraint would otherwise turn a bad intent into an `IntegrityError` — a 500 where a 400 belongs.

**`charged` is not proposable.** It is the default a relationship already starts at, so proposing it is either a no-op or a regression from a decided verdict back to undecided. Un-deciding a case is a correction for a human, not an enrichment.

Writes go through `rel.save()` rather than a queryset update, so the model's normalisation and `full_clean()` run exactly as the admin edit path does. The Case row's `updated_at` is bumped only when something actually changed, so the ETag basis moves for real writes and stays put for no-ops.

## Tests

15 new, weighted toward the negative cases — the unbound entity, the witness, the entity on someone else's case, the invented outcome, `charged`, and the half-batch rollback. **201 pass across `case_proposals` + `cases`.**

The 11 `case_events` failures on this branch are **pre-existing on `origin/main`** (verified by stashing this change and re-running — same 11); they need a live broker and are untouched here.

## Reviewer notes

- Is `abated` right to allow? It is a terminal outcome like the others, but unlike conviction/acquittal it is rarely stated plainly in a docket row, so in practice it will almost always come from a human.
- The 71 rows this unblocks still need a separate pass to actually correct — this PR only makes them *stageable*. That worklist is prepared separately, and the docket-confirmed verdicts are already filed as proposals #6–#14.
- Related: #420 fixes the upstream reason these verdicts were invisible in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `set_entity_outcome` intent

- Validate scoped accused outcomes

- Preserve atomic verdict application

- Cover outcome edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  proposal["Case proposal intent"]
  validate["Validate outcomes list"]
  resolve["Resolve case accused relationships"]
  save["Save relationship outcomes"]
  touch["Touch Case updated_at"]
  proposal -- "set_entity_outcome" --> validate
  validate -- "case-scoped" --> resolve
  resolve -- "allowed outcomes" --> save
  save -- "cache invalidation" --> touch
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.py</strong><dd><code>Apply case-scoped entity outcome changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/apply.py

<ul><li>Dispatches <code>set_entity_outcome</code>.<br> <li> Allows convicted, acquitted, abated only.<br> <li> Resolves <code>nes_id</code> inside current case.<br> <li> Saves relationships atomically; bumps <code>updated_at</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/425/files#diff-b074ae899405b133cf672df7e82b89a95644ac01cf28111216ff8e2040dee680">+102/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Register entity outcome proposal intent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/models.py

<ul><li>Adds <code>set_entity_outcome</code> to supported intents.<br> <li> Documents why <code>raw_patch</code> cannot cover relationships.<br> <li> Records published-case correction motivation.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/425/files#diff-eefb58f01026fc611dfe0753d827d3834f3bf58822387310e530b9c7c2255178">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Validate entity outcome intent shape</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/serializers.py

<ul><li>Validates non-empty <code>outcomes</code> list.<br> <li> Requires each entry include <code>nes_id</code>, <code>outcome</code>.<br> <li> Keeps verdict review unit batch-shaped.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/425/files#diff-a03c5760a1a0ec804104d2adbcecd20220c7752c46a342f59304217b911f1465">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_set_entity_outcome.py</strong><dd><code>Cover entity outcome proposal behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/tests/test_set_entity_outcome.py

<ul><li>Tests acquittal, conviction, abatement updates.<br> <li> Tests stranger, wrong-role, malformed rejections.<br> <li> Tests all-or-nothing rollback behavior.<br> <li> Tests <code>updated_at</code> touch semantics.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/425/files#diff-6ba43a8100d66161dac0fae1b384cad4b41e5f33bed12a60b4f8c63368a35c4a">+230/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for proposing and applying outcomes to accused entities in a case.
  - Supports convicted, acquitted, and abated outcomes.
  - Reports unchanged relationships separately.
  - Validates proposed entities, roles, payloads, and outcomes before saving changes.

- **Bug Fixes**
  - Ensures outcome updates are applied atomically, preventing partial changes when a batch contains invalid entries.
  - Case timestamps are updated only when relationships change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->