### PR TITLE
fix(casework): annotate the 13 deliberate broad catches so ruff check passes again

### DIFF
--- a/casework/court_record.py
+++ b/casework/court_record.py
@@ -97,7 +97,7 @@ def defendant_names(api, case):
             logger.warning("court record %s/%s unreadable: HTTP %s",
                            court, number, exc.code)
             continue
-        except Exception as exc:  # network, decode, anything else
+        except Exception as exc:  # noqa: BLE001 - network, decode, anything else: a read failure is a skip
             skips.append(f"court reference {court}/{number} could not be read "
                          f"({type(exc).__name__})")
             logger.warning("court record %s/%s unreadable: %s",

--- a/casework/enrich_card.py
+++ b/casework/enrich_card.py
@@ -621,7 +621,7 @@ def _write_fields(ctx, accepted):
     try:
         ctx.api.patch_fields(
             ctx.slug, [(f, v) for f, _, v in accepted], if_match=ctx.etag)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - the atomic write failed; every field is reported failed
         # The write is atomic, so the failure is too: every field is reported
         # failed, because the server holds `current` for all of them.
         for field, current, value in accepted:
@@ -662,7 +662,7 @@ def main(argv=None):
 
     try:
         bootstrap(args.provider, args.model)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - bootstrap is the entrypoint; it reports and exits 1
         print(f"Bootstrap failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -717,7 +717,7 @@ def main(argv=None):
 
         try:
             detail, etag = api.get_case_with_etag(slug)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - a detail-fetch failure skips this case, never the run
             # NOT the donor's fall-back-to-the-list-payload. This stage must skip.
             #
             # The donor (and `enrich_description`) continue on `detail = case`,
@@ -849,7 +849,7 @@ def main(argv=None):
         try:
             result = _generate(detail, number, need_title, need_short,
                                invoke_text, usage)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - an LLM failure is recorded per-case and the run continues
             report.record(slug, "card", "error", f"LLM generation failed: {exc}")
             review.add(ReviewRow(slug=slug, status="error", before=current_for_review,
                                  note=f"LLM generation failed: {exc}"))

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -417,7 +417,7 @@ def main(argv=None):
     # Bootstrap Django + LLM (MUST come before importing llm.invoke)
     try:
         bootstrap(args.provider, args.model)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - bootstrap is the entrypoint; it reports and exits 1
         print(f"Bootstrap failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -474,7 +474,7 @@ def main(argv=None):
         fetch_ok = True
         try:
             detail, etag = api.get_case_with_etag(slug)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - donor-preserved fallback to the list payload
             # Donor-preserved fallback: a detail-fetch failure does not abort the
             # case. The LIST-shaped payload still yields a well-formed "unmet"
             # reason below (unresolved material), never a crash. Widened from the
@@ -559,7 +559,7 @@ def main(argv=None):
 
         try:
             source_block, fed = _assemble_source_text(chunks, invoke_text, usage)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - source assembly is per-case; the run continues
             report.record(slug, "description", "error", f"source assembly failed: {exc}")
             review.add(ReviewRow(slug=slug, status="error", before=before,
                                  note=f"source assembly failed: {exc}"))
@@ -576,7 +576,7 @@ def main(argv=None):
                 invoke_text=invoke_text,
                 usage=usage,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - an LLM failure is recorded per-case and the run continues
             report.record(slug, "description", "error", f"LLM generation failed: {exc}")
             review.add(ReviewRow(slug=slug, status="error", before=before, sources=fed,
                                  note="; ".join(filter(None, (
@@ -640,7 +640,7 @@ def main(argv=None):
                                  note=source_note))
             log_event(logger, paths["events"], run_id=run_id, stage="description",
                       slug=slug, step="write", status="enriched", detail=detail_msg)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - a PATCH failure is recorded per-case and the run continues
             report.record(slug, "description", "error", f"PATCH failed: {exc}")
             review.add(ReviewRow(slug=slug, status="error", before=before,
                                  generated=description, sources=fed,

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -594,7 +594,7 @@ def _resolve_with_vetoes(api, name, strict=False):
     read_error = None
     try:
         document = api.get_entity(decision.nes_id)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - unreadable == unverified, which is a valid verdict
         document = None  # unreadable == unverified
         read_error = str(exc)
     readable = isinstance(document, dict) and bool(document)
@@ -1377,7 +1377,7 @@ def main(argv=None):
         # above came from `get_case`, which returns no ETag.
         try:
             fresh, etag = api.get_case_with_etag(slug)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - falls back to the stale detail; the case still runs
             fresh, etag = detail, None
             log_event(logger, paths["events"], run_id=run_id, stage="entities", slug=slug,
                       step="fetch", status="fallback", detail=str(exc),
@@ -1473,7 +1473,7 @@ def main(argv=None):
 
         try:
             apply_entity_plan(api, plan)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - a bind failure is recorded per-case and the run continues
             report.record(slug, "entities", "error", f"bind failed: {exc}")
             log_event(logger, paths["events"], run_id=run_id, stage="entities", slug=slug,
                       step="write", status="error", detail=str(exc), level=logging.ERROR)


### PR DESCRIPTION
### **User description**
## Why

**`main` has been red since #418 merged.** `ruff check` reports 13 `BLE001` "do not catch blind exception" errors across the four casework enrichment scripts, so every PR opened since inherits a failing lint job that has nothing to do with its own change.

```
casework/court_record.py:100
casework/enrich_card.py:624, 665, 720, 852
casework/enrich_description.py:420, 477, 562, 579, 643
casework/enrich_related_entities.py:597, 1380, 1476
```

## What

Every one of the 13 is a **deliberate** best-effort catch, and most already carried a comment saying so. None should become a narrow `except`:

- the per-case catches exist because these are batch scripts whose contract is that one bad case is *recorded and skipped*, not that the run dies;
- the two `bootstrap()` catches exist to turn any startup failure into a message and `exit(1)` rather than a traceback.

So this **annotates rather than rewrites**, using the `# noqa: BLE001 - <reason>` form already established in `case_proposals/apply.py`. Each reason states why the breadth is correct at that site, rather than merely silencing the rule:

```python
except Exception as exc:  # noqa: BLE001 - unreadable == unverified, which is a valid verdict
```

## Verification

- `ruff check .` — **clean** (was 13 errors)
- **2018 tests pass** across `casework/` + `tests/`
- Comments only; no behaviour change
- `ruff format` stays ungated, as `ci.yml` documents ("the tree predates `ruff format`, which would reflag ~150 files")

## Note

Found while investigating a lint failure on #425, which turned out to be inheriting this one rather than causing it. Worth landing first so the other open PRs go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Silence deliberate `BLE001` catches

- Document best-effort batch behavior

- Preserve runtime behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Broad catches"] -- "annotated" --> B["Ruff BLE001 clean"]
  B -- "keeps" --> C["Best-effort enrichment runs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>court_record.py</strong><dd><code>Document court record read fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/court_record.py

<ul><li>Adds <code>BLE001</code> noqa reason to generic court-record read catch.<br> <li> Clarifies network/decode failures skip unreadable court references.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/426/files#diff-51e55f15514560b1abbf6be2894c0519f1a4b7a47c1bc7e6b650c3e1de4c6f87">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enrich_card.py</strong><dd><code>Annotate card enrichment broad catches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/enrich_card.py

<ul><li>Annotates atomic PATCH failure handler.<br> <li> Annotates bootstrap failure exit path.<br> <li> Annotates detail-fetch skip handler.<br> <li> Annotates per-case LLM failure handler.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/426/files#diff-92972ea4b06357e4d24ce1142c8d497fe2706e9aa7b8243f11026f5f77e259a5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enrich_description.py</strong><dd><code>Annotate description enrichment broad catches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/enrich_description.py

<ul><li>Annotates bootstrap failure exit path.<br> <li> Documents donor-preserved fetch fallback.<br> <li> Marks source assembly, LLM, PATCH errors as per-case failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/426/files#diff-5ae987953d8c0a7283b3d17be907f84a93dc39867ed0658f68300fb2d721f2e4">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enrich_related_entities.py</strong><dd><code>Annotate related-entity broad catches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/enrich_related_entities.py

<ul><li>Annotates unreadable entity lookup verdict handling.<br> <li> Documents stale-detail fallback after ETag fetch failure.<br> <li> Marks bind failure as per-case recoverable error.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/426/files#diff-8bf3ff939a79022cc02aaedae13701f729a26e22e900d041b4b928e39d06b708">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
