### PR TITLE
feat(mcp): run the MCP server inside the Django deployment, from one endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,39 @@ ZITADEL_MASTERKEY=MasterkeyNeedsToHave32Characters
 ZITADEL_HOST=localhost
 ZITADEL_PORT=48080
 OIDC_AUDIENCE=jawafdehi-platform-dev
+# Maximum seconds spent fetching OIDC signing keys.
+OIDC_JWKS_TIMEOUT=10
+# Embedded streamable-HTTP MCP endpoint: http://localhost:${PLATFORM_API_PORT}/mcp
+# "public" removes resource-intensive anonymous tools. A trusted ingress may
+# raise it to internal per request; an internal default cannot be downgraded.
+MCP_DEFAULT_MODE=public
+ASGI_LIMIT_CONCURRENCY=16
+# Canonical INTERNAL MCP resource URL used in OAuth discovery. It must be set
+# whenever the internal door is enabled; request Host headers are never trusted.
+OIDC_RESOURCE=http://localhost:48000/mcp
+# Additional comma-separated MCP Host and browser Origin values. The canonical
+# OIDC_RESOURCE host/origin and localhost loopback variants are added automatically.
+MCP_ALLOWED_HOSTS=
+MCP_ALLOWED_ORIGINS=
+# Least-privilege OIDC service-account bearer for anonymous public judicial SQL.
+# Grant only ngm.query; do not grant API roles.
+MCP_QUERY_API_TOKEN=
+# Optional full-capability bearer for a separately launched local stdio MCP.
+# docker-compose does not inject this into the HTTP platform process.
+JAWAFDEHI_API_TOKEN=
+# In-process API and document-conversion resource budgets.
+MCP_EMBEDDED_API_TIMEOUT=30
+MCP_EMBEDDED_API_MAX_CONCURRENCY=16
+MCP_CONTROL_PLANE_TIMEOUT=30
+MCP_QUERY_TIMEOUT=15
+MCP_PROXY_HTTP_TIMEOUT=30
+MCP_DOCUMENT_FETCH_TIMEOUT=20
+MCP_DOCUMENT_CONVERT_TIMEOUT=120
+MCP_DOCUMENT_MAX_CONCURRENCY=2
+MCP_DOCUMENT_MAX_INPUT_BYTES=26214400
+MCP_HTTP_MAX_REQUEST_BODY_BYTES=105906176
+MCP_DOCUMENT_MAX_OUTPUT_CHARS=5000000
+MCP_DOCUMENT_WORKER_MEMORY_BYTES=1073741824
 # Local-only Django SECRET_KEY for the compose stack. Must NOT be one of the
 # rejected sentinels (``dev-secret-change-me`` / ``django-insecure-*`` /
 # ``dev-insecure-*``) — the settings prod-guard rejects those even though the

--- a/.env.example
+++ b/.env.example
@@ -13,12 +13,12 @@ OIDC_AUDIENCE=jawafdehi-platform-dev
 # Maximum seconds spent fetching OIDC signing keys.
 OIDC_JWKS_TIMEOUT=10
 # Embedded streamable-HTTP MCP endpoint: http://localhost:${PLATFORM_API_PORT}/mcp
-# "public" removes resource-intensive anonymous tools. A trusted ingress may
-# raise it to internal per request; an internal default cannot be downgraded.
-MCP_DEFAULT_MODE=public
 ASGI_LIMIT_CONCURRENCY=16
-# Canonical INTERNAL MCP resource URL used in OAuth discovery. It must be set
-# whenever the internal door is enabled; request Host headers are never trusted.
+# Canonical MCP resource URL used in OAuth discovery, e.g.
+# https://api.jawafdehi.org/mcp in production. REQUIRED: it is the only way a
+# client discovers how to authenticate (an anonymous request is served the
+# read-only catalog, not challenged), and its host/origin is what MCP accepts.
+# Request Host and forwarding headers are never trusted for this.
 OIDC_RESOURCE=http://localhost:48000/mcp
 # Additional comma-separated MCP Host and browser Origin values. The canonical
 # OIDC_RESOURCE host/origin and localhost loopback variants are added automatically.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@
 # cut over to :main (matches docker-publish-platform.yml).
 name: CI
 on:
+  workflow_call: {}
   push:
     branches: ['main', 'v2']
   pull_request:

--- a/.github/workflows/docker-publish-platform.yml
+++ b/.github/workflows/docker-publish-platform.yml
@@ -8,18 +8,26 @@
 # after which main is the monolith and produces :main. v2 stays here so the current deploy (tracking
 # :v2) keeps building until it's cut over to :main; drop 'v2' once that cutover is done.
 name: Docker Publish (platform)
+concurrency:
+  group: docker-publish-platform-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: ['main', 'v2']
     tags: ['v*']
-  pull_request:
-    branches: ['main', 'v2']
   workflow_dispatch: {}
 env:
   REGISTRY: docker.io
   IMAGE_NAME: jawafdehi/jawafdehi-platform
 jobs:
+  unit-and-security-gate:
+    uses: ./.github/workflows/ci.yml
+
+  live-integration-gate:
+    uses: ./.github/workflows/integration.yml
+
   build-and-push:
+    needs: [unit-and-security-gate, live-integration-gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,11 +7,12 @@
 #   build image -> up (no zitadel) -> --wait + health loop -> seed_dev ->
 #   reindex_all --rebuild -> pytest (API) -> playwright (FE) -> artifacts -> down.
 #
-# Currently on workflow_dispatch + PR as a NON-BLOCKING signal (not a required
-# check). Flip it to a required status check once it's proven stable in Actions.
+# Runs directly on pull requests and is also reusable by the image publication
+# workflow, where it is a mandatory pre-publication gate.
 name: integration-tests
 
 on:
+  workflow_call: {}
   workflow_dispatch: {}
   pull_request:
     branches: [main, v2]
@@ -24,7 +25,6 @@ on:
 env:
   FRONTEND_REPO: jawafdehi/jawafdehi
   FRONTEND_REF: main
-  COMPOSE: -p jawaf-e2e --env-file docker-compose.e2e.env -f docker-compose.yml -f docker-compose.e2e.yml
   PLATFORM_BASE_URL: http://localhost:48010
 
 jobs:
@@ -54,34 +54,43 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Generate an ephemeral MCP query bearer
+        run: echo "MCP_E2E_BEARER=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
+
       - name: Build the platform image from THIS checkout
         run: docker build -t jawafdehi-platform:e2e -f Dockerfile .
 
       - name: Bring up the stack (no zitadel — dev-login replaces OIDC for E2E)
         run: |
-          docker compose ${COMPOSE} up -d --wait \
+          compose=(docker compose -p jawaf-e2e --env-file docker-compose.e2e.env \
+            -f docker-compose.yml -f docker-compose.e2e.yml)
+          "${compose[@]}" up -d --wait \
             postgres opensearch minio platform-migrate platform
 
       - name: Wait for health
         run: |
-          for i in $(seq 1 60); do
-            curl -sf "${PLATFORM_BASE_URL}/api/health" && break
+          for _ in {1..60}; do
+            if curl -sf "${PLATFORM_BASE_URL}/api/health"; then
+              exit 0
+            fi
             sleep 3
           done
-          curl -sf "${PLATFORM_BASE_URL}/api/health"
+          exit 1
 
       - name: Seed + index
         run: |
-          docker compose ${COMPOSE} exec -T platform uv run python manage.py seed_dev
-          docker compose ${COMPOSE} exec -T platform uv run python manage.py reindex_all --rebuild
+          compose=(docker compose -p jawaf-e2e --env-file docker-compose.e2e.env \
+            -f docker-compose.yml -f docker-compose.e2e.yml)
+          "${compose[@]}" exec -T platform uv run python manage.py seed_dev
+          "${compose[@]}" exec -T platform uv run python manage.py reindex_all --rebuild
 
       - name: API integration tests (pytest, live stack)
         working-directory: integration-tests
         env:
           SKIP_IF_STACK_DOWN: "0"
         run: |
-          uv sync --frozen || pip install -e .
-          uv run pytest -v || pytest -v
+          uv sync --frozen
+          uv run pytest -v
 
       - name: Frontend E2E (Playwright, real backend via proxy)
         working-directory: _frontend
@@ -101,7 +110,10 @@ jobs:
 
       - name: Collect compose logs
         if: always()
-        run: docker compose ${COMPOSE} logs > compose-logs.txt || true
+        run: |
+          compose=(docker compose -p jawaf-e2e --env-file docker-compose.e2e.env \
+            -f docker-compose.yml -f docker-compose.e2e.yml)
+          "${compose[@]}" logs > compose-logs.txt || true
 
       - name: Upload artifacts
         if: always()
@@ -115,4 +127,7 @@ jobs:
 
       - name: Tear down
         if: always()
-        run: docker compose ${COMPOSE} down -v
+        run: |
+          compose=(docker compose -p jawaf-e2e --env-file docker-compose.e2e.env \
+            -f docker-compose.yml -f docker-compose.e2e.yml)
+          "${compose[@]}" down -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,24 @@
 # Jawafdehi platform — ONE image, ONE Django project.
 #
 # NES, NGM and Jawafdehi run as Django apps in ONE project (config.settings)
-# served by ONE gunicorn. Build from the repo root:
+# served by ONE gunicorn ASGI deployment. Build from the repo root:
 #
 #   docker build -f Dockerfile -t jawafdehi-platform .
 #
 # It installs the single `jawafdehi` project, so one `uv sync` pulls every app
 # and every runtime dep (DuckDB/boto3, anthropic, jsonpatch, opensearch, etc.).
-FROM python:3.12-slim
+ARG PYTHON_IMAGE=python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea099626a4adb02acbac4c69920fe9d278f82
 
-# uv: fast, lockfile-driven installs.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+FROM ${UV_IMAGE} AS uv
 
-# psycopg2-binary ships wheels, but keep the postgres client + a compiler, and
-# git (needed for Jawafdehi's git-sourced deps: nepal-entity-service, likhit).
+FROM ${PYTHON_IMAGE} AS builder
+
+COPY --from=uv /uv /uvx /bin/
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     git \
-    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
-
-# Cloud SQL server CA certificate for TLS database connections (applies to all
-# three databases).
-COPY cloudsql-ca.pem /etc/ssl/certs/cloudsql-ca.pem
-ENV DATABASE_SSL_CA_CERT_FILE=/etc/ssl/certs/cloudsql-ca.pem
-ENV DATABASE_SSL_MODE=verify-ca
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy PYTHONUNBUFFERED=1
 WORKDIR /app
@@ -48,6 +42,7 @@ COPY newsletter/ ./newsletter/
 COPY jobs/ ./jobs/
 COPY case_events/ ./case_events/
 COPY llm/ ./llm/
+COPY jawafdehi_mcp/ ./jawafdehi_mcp/
 COPY search/ ./search/
 COPY discovery/ ./discovery/
 COPY content/ ./content/
@@ -58,6 +53,9 @@ COPY templates/ ./templates/
 RUN uv sync --frozen --no-dev
 
 ENV DJANGO_SETTINGS_MODULE=config.settings
+# Fail-safe anonymous MCP profile. A trusted ingress may raise a public default
+# to internal per request; an internal deployment cannot be downgraded.
+ENV MCP_DEFAULT_MODE=public
 
 # Collect static at build time (skips the prod OIDC/secret guards via the
 # _BUILD_TIME_COMMANDS list in settings). STATIC_ROOT resolves under BASE_DIR
@@ -65,9 +63,37 @@ ENV DJANGO_SETTINGS_MODULE=config.settings
 RUN DEBUG=False SECRET_KEY=foo-bar ALLOWED_HOSTS=portal.jawafdehi.org \
     uv run python manage.py collectstatic --noinput
 
+FROM ${PYTHON_IMAGE} AS runtime
+
+COPY --from=uv /uv /uvx /bin/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    antiword \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 jawafdehi \
+    && useradd --system --uid 10001 --gid jawafdehi \
+       --create-home --home-dir /home/jawafdehi jawafdehi
+
+# Cloud SQL server CA certificate for TLS database connections (applies to all
+# three databases).
+COPY cloudsql-ca.pem /etc/ssl/certs/cloudsql-ca.pem
+ENV DATABASE_SSL_CA_CERT_FILE=/etc/ssl/certs/cloudsql-ca.pem
+ENV DATABASE_SSL_MODE=verify-ca
+ENV PYTHONUNBUFFERED=1
+ENV DJANGO_SETTINGS_MODULE=config.settings
+# Fail-safe anonymous MCP profile. A trusted ingress may raise a public default
+# to internal per request; an internal deployment cannot be downgraded.
+ENV MCP_DEFAULT_MODE=public
+
+WORKDIR /app
+COPY --from=builder --chown=jawafdehi:jawafdehi /app /app
+
+USER jawafdehi
+
 EXPOSE 8080
-CMD ["uv", "run", \
-     "gunicorn", "config.wsgi:application", \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/mcp/health').status==200 else 1)"
+CMD ["/app/.venv/bin/gunicorn", "config.asgi:application", \
      "--config", "config/gunicorn.py", \
-     "--bind", "0.0.0.0:8080", "--workers", "2", "--threads", "4", \
+     "--worker-class", "config.asgi_worker.BoundedUvicornWorker", \
+     "--bind", "0.0.0.0:8080", "--workers", "2", \
      "--timeout", "60", "--access-logfile", "-", "--error-logfile", "-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,6 @@ COPY templates/ ./templates/
 RUN uv sync --frozen --no-dev
 
 ENV DJANGO_SETTINGS_MODULE=config.settings
-# Fail-safe anonymous MCP profile. A trusted ingress may raise a public default
-# to internal per request; an internal deployment cannot be downgraded.
-ENV MCP_DEFAULT_MODE=public
 
 # Collect static at build time (skips the prod OIDC/secret guards via the
 # _BUILD_TIME_COMMANDS list in settings). STATIC_ROOT resolves under BASE_DIR
@@ -80,9 +77,6 @@ ENV DATABASE_SSL_CA_CERT_FILE=/etc/ssl/certs/cloudsql-ca.pem
 ENV DATABASE_SSL_MODE=verify-ca
 ENV PYTHONUNBUFFERED=1
 ENV DJANGO_SETTINGS_MODULE=config.settings
-# Fail-safe anonymous MCP profile. A trusted ingress may raise a public default
-# to internal per request; an internal deployment cannot be downgraded.
-ENV MCP_DEFAULT_MODE=public
 
 WORKDIR /app
 COPY --from=builder --chown=jawafdehi:jawafdehi /app /app

--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -12,6 +12,10 @@
 ARG BASE_IMAGE=jawafdehi/jawafdehi-platform:main
 FROM ${BASE_IMAGE}
 
+HEALTHCHECK NONE
+
+USER root
+
 # Node.js 22 LTS via NodeSource (claude-code needs a recent Node). The slim base
 # lacks curl/gnupg needed to add the apt repo.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -25,10 +29,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # The claude_cli judge provider invokes this binary (settings.CLAUDE_CLI_BIN).
 RUN npm install -g --no-fund --no-audit @anthropic-ai/claude-code
 
-# Document conversion (likhit + markitdown) ships as the bigo-enrichment extra —
-# deliberately absent from the base API image (imported lazily, never at
-# startup). The consumer converts evidence sources locally, so it needs them.
-RUN uv sync --frozen --no-dev --extra bigo-enrichment
+# The embedded MCP puts likhit + MarkItDown in the base platform environment;
+# the consumer therefore needs no build-time dependency sync or git client.
+
+USER jawafdehi
 
 # Read-only by default (lists queued jobs and exits); the k8s CronJob overrides
 # this with `--apply --once` to actually drain the queue.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ jawafdehi-api/
                           served at /api/cms/v2/; see ARCHITECTURE §3.5
   llm/                    provider-agnostic LLM invocation (bedrock/proxy/cli,
                           in-process — no HTTP surface); see ARCHITECTURE §3.6
+  jawafdehi_mcp/          embedded MCP server + tools; served at /mcp by ASGI
   docs/                   design docs + sourcing artifacts
 ```
 
 ## Principles (locked decisions)
-- **One Django project**, one image, in-process inter-app calls (NOT REST between
-  apps). Exception: the async review/jobs poller is a separate OIDC HTTP client by
-  design and can target a remote portal.
+- **One Django project**, one image and one ASGI deployment. Django and MCP share
+  the process and port; MCP-to-API calls use an in-memory ASGI transport, not a
+  network service hop. Exception: the async review/jobs poller is a separate OIDC
+  HTTP client by design and can target a remote portal.
 - **Database-per-service preserved** via `config.db_router.ServiceDatabaseRouter`:
   `entities`→`nes`, `courts`/`materials`→`ngm`, everything else→`default`. No
   cross-DB FKs/joins — join in app.
@@ -50,10 +52,12 @@ jawafdehi-api/
 uv sync                                      # install app + dev tools
 uv run python manage.py check                # one manage.py / one settings (config.settings)
 uv run python manage.py runserver 0.0.0.0:48000
+uv run uvicorn config.asgi:application --host 0.0.0.0 --port 48000  # API + /mcp
 docker build -t jawafdehi .                  # single image, context = repo root
 ```
 
 For the local dev stack (Postgres ×3, OpenSearch, MinIO) see `docker-compose.yml`.
+For MCP architecture and configuration see [`docs/mcp/README.md`](./docs/mcp/README.md).
 
 ## Working model
 Trunk is **`main`**. `origin` = the org (`Jawafdehi/JawafdehiAPI`), `fork` = the

--- a/cases/management/commands/seed_dev.py
+++ b/cases/management/commands/seed_dev.py
@@ -1,9 +1,10 @@
 """Seed a minimal local-dev dataset + role users for the admin panel.
 
-DEV ONLY. Creates the standard groups, three login users (admin / moderator /
-caseworker, password == username), NES entities, NGM materials, courts, court
-cases, cases (one per state), and a blocklisted firm — enough to exercise every
-admin screen (incl. the case-edit entity linker + evidence/material picker).
+DEV ONLY. Creates the standard groups, five local users (admin / moderator /
+caseworker / readonly / MCP query principal, password == username), NES entities,
+NGM materials, courts, court cases, cases (one per state), and a blocklisted firm
+— enough to exercise every admin screen (incl. the case-edit entity linker +
+evidence/material picker).
 Idempotent: safe to re-run.
 
 Usage (with DEV_AUTH env, DEBUG=True):
@@ -56,10 +57,13 @@ MATERIALS = [
 # is Caseworker. The `moderator` username is kept for dev/E2E continuity but now
 # lands in the Caseworker group (moderator folded into caseworker).
 USERS = [
-    ("admin", [], True),
-    ("moderator", ["Caseworker"], False),
-    ("caseworker", ["Caseworker"], False),
-    ("readonly", ["ReadOnly"], False),
+    ("admin", [], True, True),
+    ("moderator", ["Caseworker"], False, True),
+    ("caseworker", ["Caseworker"], False, True),
+    ("readonly", ["ReadOnly"], False, True),
+    # Scope-only principal for the Zitadel-free MCP E2E query bearer. It must
+    # remain free of groups, direct permissions, staff, and superuser status.
+    ("mcp-query-e2e", [], False, False),
 ]
 
 CASES = [
@@ -76,12 +80,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         call_command("create_groups")
 
-        for name, groups, su in USERS:
+        for name, groups, su, staff in USERS:
             u, _ = User.objects.get_or_create(
                 username=name, defaults={"email": f"{name}@local.test"}
             )
             u.set_password(name)
-            u.is_staff = True
+            u.is_staff = staff
             u.is_superuser = su
             u.save()
             u.groups.clear()

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,4 +1,4 @@
-"""ASGI entrypoint for the unified platform."""
+"""ASGI entrypoint for the unified Django and MCP platform."""
 
 import os
 
@@ -6,4 +6,73 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
-application = get_asgi_application()
+django_application = get_asgi_application()
+
+# Import MCP only after Django has initialized its app registry. The tools can
+# then dispatch back into this Django application without a network hop.
+from jawafdehi_mcp.api_transport import configure_embedded_api  # noqa: E402
+from jawafdehi_mcp.http_server import (  # noqa: E402
+    WELL_KNOWN_PROTECTED_RESOURCE,
+    JawafdehiMCPServer,
+)
+
+MCP_PATH_PREFIX = "/mcp"
+MCP_PROTECTED_RESOURCE_PATH = f"{WELL_KNOWN_PROTECTED_RESOURCE}{MCP_PATH_PREFIX}"
+MCP_PROTOCOL_PATHS = frozenset({MCP_PATH_PREFIX, f"{MCP_PATH_PREFIX}/"})
+MCP_AUXILIARY_PATHS = frozenset(
+    {
+        f"{MCP_PATH_PREFIX}/health",
+        MCP_PROTECTED_RESOURCE_PATH,
+    }
+)
+
+
+class PlatformASGIApplication:
+    """Route MCP protocol traffic while leaving every other path to Django."""
+
+    def __init__(self, django_app, mcp_app):
+        self.django_app = django_app
+        self.mcp_app = mcp_app
+
+    @staticmethod
+    def _is_mcp_request(scope) -> bool:
+        path = scope.get("path", "")
+        return path in MCP_PROTOCOL_PATHS or path in MCP_AUXILIARY_PATHS
+
+    @staticmethod
+    def _mcp_scope(scope):
+        """Strip the monolith prefix so the original MCP route contract remains."""
+        path = scope.get("path", "")
+        if path == MCP_PROTECTED_RESOURCE_PATH:
+            new_path = WELL_KNOWN_PROTECTED_RESOURCE
+        elif path in MCP_PROTOCOL_PATHS:
+            new_path = "/"
+        elif path == f"{MCP_PATH_PREFIX}/health":
+            new_path = "/health"
+        else:
+            return scope
+
+        rebased = dict(scope)
+        rebased["path"] = new_path
+        if "raw_path" in rebased:
+            rebased["raw_path"] = new_path.encode()
+        if path in MCP_PROTOCOL_PATHS or path == f"{MCP_PATH_PREFIX}/health":
+            root_path = scope.get("root_path", "").rstrip("/")
+            rebased["root_path"] = f"{root_path}{MCP_PATH_PREFIX}"
+        return rebased
+
+    async def __call__(self, scope, receive, send):
+        # Django does not consume ASGI lifespan events. The MCP session manager
+        # does, and remains active for the lifetime of the shared worker.
+        if scope["type"] == "lifespan":
+            await self.mcp_app(scope, receive, send)
+            return
+        if scope["type"] == "http" and self._is_mcp_request(scope):
+            await self.mcp_app(self._mcp_scope(scope), receive, send)
+            return
+        await self.django_app(scope, receive, send)
+
+
+configure_embedded_api(django_application)
+mcp_application = JawafdehiMCPServer(stateless=True)
+application = PlatformASGIApplication(django_application, mcp_application)

--- a/config/asgi_worker.py
+++ b/config/asgi_worker.py
@@ -1,0 +1,34 @@
+"""Bounded Uvicorn worker for the platform's Gunicorn ASGI deployment."""
+
+from __future__ import annotations
+
+import os
+
+from uvicorn_worker import UvicornWorker
+
+DEFAULT_ASGI_LIMIT_CONCURRENCY = 16
+MAX_ASGI_LIMIT_CONCURRENCY = 256
+
+
+def asgi_limit_concurrency() -> int:
+    try:
+        value = int(
+            os.getenv(
+                "ASGI_LIMIT_CONCURRENCY",
+                str(DEFAULT_ASGI_LIMIT_CONCURRENCY),
+            )
+        )
+    except (TypeError, ValueError):
+        return DEFAULT_ASGI_LIMIT_CONCURRENCY
+    if value <= 0:
+        return DEFAULT_ASGI_LIMIT_CONCURRENCY
+    return min(value, MAX_ASGI_LIMIT_CONCURRENCY)
+
+
+class BoundedUvicornWorker(UvicornWorker):
+    """Reject excess concurrent requests with 503 instead of queuing forever."""
+
+    CONFIG_KWARGS = {
+        **UvicornWorker.CONFIG_KWARGS,
+        "limit_concurrency": asgi_limit_concurrency(),
+    }

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,7 +43,12 @@ from sentry_sdk.integrations.django import DjangoIntegration
 
 # Reuse the Jawafdehi project's structlog config (top-level `config` package,
 # importable via the services/jawafdehi editable install).
-from jawafdehi_shared.logging_config import configure_structlog
+from jawafdehi_mcp import __version__
+from jawafdehi_shared.logging_config import (
+    add_service_name,
+    configure_structlog,
+    drop_transport_noise,
+)
 
 load_dotenv()
 
@@ -78,6 +83,13 @@ def _drop_exec_originated_events(event, _hint):
     return event
 
 
+def _before_send(event, hint):
+    event = _drop_exec_originated_events(event, hint)
+    if event is None:
+        return None
+    return drop_transport_noise(event, hint)
+
+
 # Belt-and-suspenders: never ship events from local / dev runs even if a DSN
 # leaked into a developer's .env. Prod sets SENTRY_ENVIRONMENT=production.
 if _sentry_dsn and _sentry_environment.strip().lower() not in {
@@ -92,7 +104,8 @@ if _sentry_dsn and _sentry_environment.strip().lower() not in {
         traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "1.0")),
         send_default_pii=False,
         environment=_sentry_environment,
-        before_send=_drop_exec_originated_events,
+        release=os.getenv("SENTRY_RELEASE", f"jawafdehi@{__version__}"),
+        before_send=_before_send,
     )
 
 
@@ -229,6 +242,7 @@ LOGGING = {
                 _structlog.stdlib.add_logger_name,
                 _structlog.stdlib.add_log_level,
                 _structlog.stdlib.ExtraAdder(),
+                add_service_name,
             ],
         },
     },
@@ -371,6 +385,7 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "config.urls"
 WSGI_APPLICATION = "config.wsgi.application"
+ASGI_APPLICATION = "config.asgi.application"
 
 # django-auditlog: the audited manager (jawafdehi_shared.db.audited) logs one
 # LogEntry per changed row for a bulk ``QuerySet.update()`` / ``bulk_update()``
@@ -542,12 +557,13 @@ for _primary_alias, _read_env in _replica_url_env.items():
         DATABASES[_ro_alias] = dj_database_url.parse(_read_url)
         REPLICA_ALIASES[_primary_alias] = _ro_alias
 
-# Apply SSL options + connection pooling to every Postgres database.
+# Apply SSL options to every Postgres database. Django's persistent connections
+# are disabled under ASGI; production deployments should use an external pooler.
 for db_key in DATABASES:
     _apply_db_ssl_options(DATABASES[db_key])
     if DATABASES[db_key].get("ENGINE") == "django.db.backends.postgresql":
-        DATABASES[db_key]["CONN_MAX_AGE"] = 60
-        DATABASES[db_key]["CONN_HEALTH_CHECKS"] = True
+        DATABASES[db_key]["CONN_MAX_AGE"] = 0
+        DATABASES[db_key]["CONN_HEALTH_CHECKS"] = False
 
 DATABASE_ROUTERS = ["config.db_router.ServiceDatabaseRouter"]
 
@@ -641,6 +657,7 @@ OIDC_ROLES_CLAIM = os.getenv("OIDC_ROLES_CLAIM", "urn:zitadel:iam:org:project:ro
 OIDC_ALGORITHMS = get_env_list("OIDC_ALGORITHMS", "RS256")
 OIDC_LEEWAY = int(os.getenv("OIDC_LEEWAY", "30"))
 OIDC_JWKS_CACHE_SECONDS = int(os.getenv("OIDC_JWKS_CACHE_SECONDS", "300"))
+OIDC_JWKS_TIMEOUT = float(os.getenv("OIDC_JWKS_TIMEOUT", "10"))
 OIDC_SERVICE_ACCOUNT_SUBJECTS = get_env_list("OIDC_SERVICE_ACCOUNT_SUBJECTS")
 OIDC_SERVICE_ACCOUNT_ROLE = os.getenv("OIDC_SERVICE_ACCOUNT_ROLE", "contributor")
 
@@ -661,9 +678,15 @@ OIDC_RP_CLIENT_SECRET = os.getenv("OIDC_RP_CLIENT_SECRET", "")  # empty = public
 OIDC_USE_PKCE = True
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = "openid email profile"
-OIDC_OP_AUTHORIZATION_ENDPOINT = f"{ensure_trailing_slash(OIDC_ISSUER)}oauth/v2/authorize"
-OIDC_OP_TOKEN_ENDPOINT = f"{ensure_trailing_slash(OIDC_ISSUER)}oauth/v2/token"
-OIDC_OP_USER_ENDPOINT = f"{ensure_trailing_slash(OIDC_ISSUER)}oidc/v1/userinfo"
+OIDC_OP_AUTHORIZATION_ENDPOINT = os.getenv("OIDC_OP_AUTHORIZATION_ENDPOINT") or (
+    f"{ensure_trailing_slash(OIDC_ISSUER)}oauth/v2/authorize"
+)
+OIDC_OP_TOKEN_ENDPOINT = os.getenv("OIDC_OP_TOKEN_ENDPOINT") or (
+    f"{ensure_trailing_slash(OIDC_ISSUER)}oauth/v2/token"
+)
+OIDC_OP_USER_ENDPOINT = os.getenv("OIDC_OP_USER_ENDPOINT") or (
+    f"{ensure_trailing_slash(OIDC_ISSUER)}oidc/v1/userinfo"
+)
 OIDC_OP_JWKS_ENDPOINT = OIDC_JWKS_URI
 LOGIN_URL = "/oidc/authenticate/"
 LOGOUT_REDIRECT_URL = "/django-admin/login/"
@@ -751,9 +774,18 @@ WAGTAILADMIN_LOGIN_URL = LOGIN_URL
 # OIDCAuthentication stays FIRST so bearer tokens keep working unchanged; the
 # session/basic classes are additive and gated, so production auth is untouched.
 DEV_AUTH = env_flag("DEV_AUTH", False) and (DEBUG or TESTING)
+DEV_NGM_QUERY_TOKEN = (
+    os.getenv("DEV_NGM_QUERY_TOKEN", "") if DEV_AUTH and TESTING else ""
+)
+DEV_NGM_QUERY_USERNAME = os.getenv("DEV_NGM_QUERY_USERNAME", "mcp-query-e2e")
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
+        *(
+            ["jawafdehi_shared.auth.dev_service.DevelopmentQueryTokenAuthentication"]
+            if DEV_NGM_QUERY_TOKEN
+            else []
+        ),
         "jawafdehi_shared.auth.oidc.OIDCAuthentication",
         *(
             [

--- a/config/settings.py
+++ b/config/settings.py
@@ -557,8 +557,14 @@ for _primary_alias, _read_env in _replica_url_env.items():
         DATABASES[_ro_alias] = dj_database_url.parse(_read_url)
         REPLICA_ALIASES[_primary_alias] = _ro_alias
 
-# Apply SSL options to every Postgres database. Django's persistent connections
-# are disabled under ASGI; production deployments should use an external pooler.
+# Apply SSL options to every Postgres database, and disable Django's persistent
+# connections. Connection lifetime is not dependable under ASGI: `connections` is
+# a thread_critical Local (django.db.utils.ConnectionHandler), while the
+# request_finished signal that runs close_old_connections is sent from the event
+# loop, so the handler does not necessarily see the connection that served the
+# request. CONN_MAX_AGE = 0 keeps that from turning into idle backends that
+# nothing reclaims; the cost is one connect per request, which is part of why
+# ASGI_LIMIT_CONCURRENCY bounds how many can be in flight per worker.
 for db_key in DATABASES:
     _apply_db_ssl_options(DATABASES[db_key])
     if DATABASES[db_key].get("ENGINE") == "django.db.backends.postgresql":

--- a/courts/permissions.py
+++ b/courts/permissions.py
@@ -58,6 +58,15 @@ def token_scopes(request) -> set[str]:
     return set()
 
 
+def has_ngm_query_role(user) -> bool:
+    """Return whether a user may inspect the internal, unprojected query plane."""
+    if not (user and user.is_authenticated):
+        return False
+    if user.is_superuser:
+        return True
+    return user.groups.filter(name__in=NGM_QUERY_GROUPS).exists()
+
+
 class HasNgmRole(permissions.BasePermission):
     """Require an authenticated principal in an NGM-capable Django Group.
 
@@ -107,11 +116,8 @@ class HasNgmQueryAccess(permissions.BasePermission):
         user = getattr(request, "user", None)
         if not (user and user.is_authenticated):
             return False  # 401 via the authenticator's WWW-Authenticate header
-        if user.is_superuser:
-            return True
         if NGM_QUERY_SCOPE in token_scopes(request):
             return True
-        # ONE group query over the read-capable set. Note this is NGM_QUERY_GROUPS
-        # (ReadOnly + NGM roles), NOT HasNgmRole's NGM_ROLE_GROUPS, which excludes
-        # ReadOnly and gates writes only.
-        return user.groups.filter(name__in=NGM_QUERY_GROUPS).exists()
+        # Note this is NGM_QUERY_GROUPS (ReadOnly + NGM roles), NOT
+        # HasNgmRole's NGM_ROLE_GROUPS, which excludes ReadOnly and gates writes.
+        return has_ngm_query_role(user)

--- a/courts/query_guard.py
+++ b/courts/query_guard.py
@@ -1,17 +1,17 @@
 """Hardening for the gated raw-SQL ``/query`` endpoint.
 
-Ported verbatim (in spirit) from the FastAPI NGM ``ngm.api.query_guard``:
-SELECT-only, forbidden-keyword denylist, ``scraped_dates`` blocked, table
-allowlist, hard row cap, statement timeout. Pure functions — no DB or framework
-coupling — so they're equally usable against Postgres today or a DuckDB/Trino
-dialect later. This module owns *policy* (what is allowed); execution lives in
-the view.
+The policy is intentionally narrow: one parsed PostgreSQL ``SELECT``, a fixed
+table allowlist, and a fixed side-effect-free function allowlist. Execution
+adds a row cap, response-size cap, read-only transaction, and statement timeout.
 """
 
 from __future__ import annotations
 
 import os
 import re
+
+from sqlglot import exp, parse, parse_one
+from sqlglot.errors import ParseError
 
 # Tables the raw-SQL surface may read. Mirrors the FastAPI allowlist; the
 # document index and firms are intentionally NOT here yet. ``scraped_dates`` is
@@ -23,53 +23,186 @@ ALLOWED_TABLES = {
     "court_case_entities",
 }
 
-FORBIDDEN_KEYWORDS = [
-    "insert",
-    "update",
-    "delete",
-    "drop",
-    "create",
-    "alter",
-    "truncate",
-    "grant",
-    "revoke",
-    # DDL/DML that can appear inside a CTE or a stacked statement.
-    "merge",
-    "copy",
-    "call",
-    "do",
-    "vacuum",
-    "reindex",
-]
+# Scope-only query principals (notably the anonymous MCP's least-privilege
+# service account) query these fixed public projections. Base table names stay
+# stable for callers, but tombstones, orphaned child rows, and internal columns
+# never enter the outer user-controlled SELECT.
+_PUBLIC_PROJECTION_SQL = {
+    "courts": """
+        SELECT identifier, court_type, full_name_nepali, full_name_english
+        FROM courts
+    """,
+    "court_cases": """
+        SELECT
+            case_number,
+            court_identifier,
+            registration_date_bs,
+            registration_date_ad,
+            case_type,
+            case_status,
+            plaintiff,
+            defendant,
+            nes_id,
+            document_sources
+        FROM court_cases
+        WHERE NOT is_deleted
+    """,
+    "court_case_hearings": """
+        SELECT
+            h.id,
+            h.case_number,
+            h.court_identifier,
+            h.hearing_date_bs,
+            h.hearing_date_ad,
+            h.bench,
+            h.bench_type,
+            h.judge_names,
+            h.lawyer_names,
+            h.serial_no,
+            h.case_status,
+            h.decision_type,
+            h.remarks,
+            h.scraped_at,
+            h.extra_data
+        FROM court_case_hearings AS h
+        WHERE EXISTS (
+            SELECT 1
+            FROM court_cases AS c
+            WHERE c.case_number = h.case_number
+              AND c.court_identifier = h.court_identifier
+              AND NOT c.is_deleted
+        )
+    """,
+    "court_case_entities": """
+        SELECT
+            e.id,
+            e.case_number,
+            e.court_identifier,
+            e.side,
+            e.name,
+            e.address,
+            e.nes_id
+        FROM court_case_entities AS e
+        WHERE EXISTS (
+            SELECT 1
+            FROM court_cases AS c
+            WHERE c.case_number = e.case_number
+              AND c.court_identifier = e.court_identifier
+              AND NOT c.is_deleted
+        )
+    """,
+}
+_PUBLIC_PROJECTIONS = {
+    name: parse_one(sql, read="postgres")
+    for name, sql in _PUBLIC_PROJECTION_SQL.items()
+}
 
-# Volatile / resource-abuse functions blocked to stop a read-only SELECT from
-# being turned into a DoS (or reading server state). ``pg_sleep`` is the classic
-# time-based DoS; the ``pg_read_*`` / ``lo_*`` family can read files/large objects.
-FORBIDDEN_FUNCTIONS = [
+FORBIDDEN_FUNCTIONS = {
     "pg_sleep",
+    "pg_sleep_for",
+    "pg_sleep_until",
     "pg_read_file",
     "pg_read_binary_file",
     "pg_ls_dir",
+    "pg_ls_logdir",
+    "pg_ls_waldir",
     "pg_stat_file",
     "lo_import",
     "lo_export",
+    "lo_create",
+    "lo_unlink",
+    "lo_from_bytea",
+    "lo_put",
+    "lo_get",
     "dblink",
+    "dblink_exec",
     "query_to_xml",
-]
+    "query_to_xmlschema",
+    "query_to_xml_and_xmlschema",
+    "table_to_xml",
+    "table_to_xmlschema",
+    "table_to_xml_and_xmlschema",
+    "schema_to_xml",
+    "schema_to_xmlschema",
+    "schema_to_xml_and_xmlschema",
+    "database_to_xml",
+    "database_to_xmlschema",
+    "database_to_xml_and_xmlschema",
+    "cursor_to_xml",
+    "cursor_to_xmlschema",
+    "setval",
+    "nextval",
+    "set_config",
+    "pg_notify",
+    "pg_advisory_lock",
+    "pg_advisory_lock_shared",
+    "pg_advisory_xact_lock",
+    "pg_advisory_xact_lock_shared",
+    "pg_try_advisory_lock",
+    "pg_try_advisory_lock_shared",
+    "pg_try_advisory_xact_lock",
+    "pg_try_advisory_xact_lock_shared",
+    "pg_advisory_unlock",
+    "pg_advisory_unlock_shared",
+    "pg_advisory_unlock_all",
+    "pg_cancel_backend",
+    "pg_terminate_backend",
+    "pg_reload_conf",
+    "pg_rotate_logfile",
+    "pg_create_restore_point",
+    "pg_switch_wal",
+    "pg_logical_emit_message",
+    "pg_promote",
+    "pg_wal_replay_pause",
+    "pg_wal_replay_resume",
+}
+
+# SQLGlot normalizes some PostgreSQL spellings to semantic names, for example
+# DATE_TRUNC -> TIMESTAMP_TRUNC. Keep this list deliberately small: an unknown
+# function is rejected rather than assumed harmless.
+ALLOWED_FUNCTIONS = {
+    "abs",
+    "avg",
+    "bool_and",
+    "bool_or",
+    "cast",
+    "ceil",
+    "ceiling",
+    "char_length",
+    "coalesce",
+    "concat",
+    "concat_ws",
+    "count",
+    "current_date",
+    "date_trunc",
+    "dense_rank",
+    "extract",
+    "floor",
+    "greatest",
+    "least",
+    "length",
+    "lower",
+    "ltrim",
+    "max",
+    "min",
+    "nullif",
+    "rank",
+    "replace",
+    "round",
+    "row_number",
+    "rtrim",
+    "substring",
+    "sum",
+    "timestamp_trunc",
+    "to_char",
+    "trim",
+    "upper",
+}
 
 # Internal scrape-state table — never exposed via the query endpoint.
 BLOCKED_TABLES = {"scraped_dates"}
 
-# Schema prefixes that must never be reachable: Postgres system catalogs (hold
-# password hashes in ``pg_authid``, etc.) and the SQL information schema.
-BLOCKED_SCHEMA_PREFIXES = ("pg_", "information_schema")
-
-# Clause keywords that terminate a FROM/JOIN table list (so we can carve out the
-# table references between ``from``/``join`` and the next clause).
-_CLAUSE_BOUNDARY = (
-    r"where|group|order|limit|having|on|using|union|intersect|except|"
-    r"window|offset|fetch|for|join|left|right|inner|outer|cross|full|natural"
-)
+MAX_QUERY_CHARS = 20_000
 
 
 def _has_sql_comment(sql: str) -> bool:
@@ -99,96 +232,105 @@ def default_timeout_seconds() -> float:
         return 30.0
 
 
-def _extract_table_refs(normalized: str) -> set[str]:
-    """Return every table identifier referenced in a FROM/JOIN list.
+def default_max_response_bytes() -> int:
+    """Maximum serialized result size, bounded to 10 MiB."""
+    try:
+        value = int(os.getenv("NGM_QUERY_MAX_RESPONSE_BYTES", "1000000"))
+    except ValueError:
+        return 1_000_000
+    if value <= 0:
+        return 1_000_000
+    return min(value, 10_000_000)
 
-    Handles what the old single-identifier-after-FROM regex missed: comma-joins
-    (``FROM a, b, c``), schema-qualified names (``pg_catalog.pg_authid``), and
-    double-quoted identifiers (``"scraped_dates"``). We grab the text of each
-    FROM/JOIN clause up to the next SQL clause boundary, then pull every
-    identifier (optionally schema-qualified / quoted) out of that comma list.
-    Both the bare table name AND any schema qualifier are returned, so the
-    caller can block on either.
-    """
-    refs: set[str] = set()
-    # Each FROM/JOIN introduces a comma-separated table list that runs until the
-    # next clause keyword (WHERE/ON/GROUP/…) or the end of the (sub)query.
-    clause_re = re.compile(
-        rf"\b(?:from|join)\s+(.*?)(?=\b(?:{_CLAUSE_BOUNDARY})\b|\)|$)",
-        flags=re.DOTALL,
-    )
-    # An identifier is a quoted or unquoted name, optionally schema-qualified.
-    ident_re = re.compile(
-        r'(?:"([^"]+)"|([a-z_][a-z0-9_$]*))'
-        r'(?:\s*\.\s*(?:"([^"]+)"|([a-z_][a-z0-9_$]*)))?'
-    )
-    for clause in clause_re.findall(normalized):
-        # Split the clause on commas so each table in a comma-join is seen; take
-        # only the first identifier of each item (drop any alias after it).
-        for item in clause.split(","):
-            m = ident_re.search(item.strip())
-            if not m:
-                continue
-            left = m.group(1) or m.group(2)      # schema OR bare table
-            right = m.group(3) or m.group(4)     # table when schema-qualified
-            if right:  # schema.table → record BOTH the schema and the table
-                refs.add(left)
-                refs.add(right)
-            elif left:
-                refs.add(left)
-    return refs
+
+def _function_name(function: exp.Func) -> str:
+    if isinstance(function, exp.Anonymous):
+        return str(function.name).lower()
+    return function.sql_name().lower()
+
+
+def _and_terms(expression: exp.Expression):
+    """Yield top-level AND terms without treating OR branches as constraints."""
+    expression = expression.unnest()
+    if isinstance(expression, exp.And):
+        yield from _and_terms(expression.this)
+        yield from _and_terms(expression.expression)
+    else:
+        yield expression
+
+
+def _join_is_constrained(join: exp.Join) -> bool:
+    """Require a join key that directly constrains the newly joined relation."""
+    if str(join.args.get("kind") or "").upper() == "CROSS":
+        return False
+    if str(join.args.get("method") or "").upper() == "NATURAL":
+        return False
+    if join.args.get("using"):
+        return True
+
+    on_clause = join.args.get("on")
+    right_alias = str(join.this.alias_or_name or "").lower()
+    if on_clause is None or not right_alias:
+        return False
+
+    for term in _and_terms(on_clause):
+        term = term.unnest()
+        if not isinstance(term, exp.EQ):
+            continue
+        left = term.this.unnest()
+        right = term.expression.unnest()
+        if not isinstance(left, exp.Column) or not isinstance(right, exp.Column):
+            continue
+        left_table = str(left.table or "").lower()
+        right_table = str(right.table or "").lower()
+        if not left_table or not right_table or left_table == right_table:
+            continue
+        if right_alias in {left_table, right_table}:
+            return True
+    return False
 
 
 def validate_query(query: str) -> tuple[bool, str | None]:
-    """Validate user SQL against read-only and allowlist constraints.
-
-    Returns ``(ok, error_message)``. Enforces, in order: comment stripping,
-    single-statement, SELECT-only, forbidden-keyword denylist, forbidden-function
-    denylist (DoS/file-read), blocked system schemas, ``scraped_dates`` blocked,
-    and the table allowlist over EVERY FROM/JOIN reference (comma-joins + quoted +
-    schema-qualified included).
-    """
-    # Reject comments outright — they have no legit use on this allowlist surface
-    # and are a classic way to smuggle a forbidden keyword/table/statement past a
-    # string-level denylist.
+    """Validate one parsed PostgreSQL SELECT against strict allowlists."""
+    if not isinstance(query, str) or not query.strip():
+        return False, "Query cannot be empty"
+    if len(query) > MAX_QUERY_CHARS:
+        return False, f"Query exceeds the {MAX_QUERY_CHARS}-character limit"
     if _has_sql_comment(query):
         return False, "SQL comments are not allowed"
+    # PostgreSQL Unicode-escaped identifiers are not needed by this API and are
+    # parsed inconsistently across generic SQL parsers. Reject the syntax before
+    # parsing so U&"pg\005fsleep" can never disguise a function or table name.
+    if re.search(r'(?i)\bu\s*&\s*"', query) or re.search(
+        r"(?i)\buescape\b", query
+    ):
+        return False, "Unicode-escaped SQL identifiers are not allowed"
 
-    normalized = query.strip().lower().rstrip(";").strip()
-
-    if not normalized:
-        return False, "Query cannot be empty"
-
-    # Reject multiple statements: after dropping a single trailing ``;``, any
-    # remaining ``;`` means a stacked statement (``SELECT 1; SELECT pg_sleep(5)``
-    # or ``SELECT 1; DROP …``). Only a single statement is ever allowed.
-    if ";" in normalized:
+    try:
+        statements = parse(query, read="postgres")
+    except ParseError:
+        return False, "Query is not valid PostgreSQL SELECT syntax"
+    if len(statements) != 1:
         return False, "Multiple SQL statements are not allowed"
 
-    if not normalized.startswith("select"):
+    statement = statements[0]
+    if not isinstance(statement, exp.Select) or statement.find(exp.With):
         return False, "Only SELECT queries are allowed"
+    if statement.find(exp.Into) or statement.find(exp.Lock):
+        return False, "SELECT INTO and row-locking clauses are not allowed"
 
-    for keyword in FORBIDDEN_KEYWORDS:
-        if re.search(rf"\b{keyword}\b", normalized):
-            return False, f"Forbidden keyword detected: {keyword.upper()}"
+    referenced: set[str] = set()
+    for table in statement.find_all(exp.Table):
+        name = table.name.lower()
+        if table.catalog or table.db:
+            return False, "Schema-qualified table names are not allowed"
+        referenced.add(name)
 
-    for func in FORBIDDEN_FUNCTIONS:
-        if re.search(rf"\b{func}\b", normalized):
-            return False, f"Forbidden function detected: {func}"
-
-    referenced = _extract_table_refs(normalized)
-
-    # System catalogs / information_schema (by schema OR table prefix) are never
-    # reachable — this is what stops ``FROM courts, pg_catalog.pg_authid``.
-    for ref in referenced:
-        if ref.startswith(BLOCKED_SCHEMA_PREFIXES):
-            return False, f"Access to system schema/table '{ref}' is not allowed"
-
-    blocked = referenced & BLOCKED_TABLES
+    blocked = referenced.intersection(BLOCKED_TABLES)
     if blocked:
         return False, f"Access to '{', '.join(sorted(blocked))}' table is not allowed"
 
-    invalid_tables = referenced - ALLOWED_TABLES
+    invalid_tables = referenced.difference(ALLOWED_TABLES)
     if invalid_tables:
         return (
             False,
@@ -196,10 +338,45 @@ def validate_query(query: str) -> tuple[bool, str | None]:
             f"Allowed tables: {', '.join(sorted(ALLOWED_TABLES))}",
         )
 
+    for join in statement.find_all(exp.Join):
+        if not _join_is_constrained(join):
+            return (
+                False,
+                "JOINs must use USING or a qualified column equality that "
+                "constrains the joined relation",
+            )
+
+    for function in statement.find_all(exp.Func):
+        name = _function_name(function)
+        if name in FORBIDDEN_FUNCTIONS:
+            return False, f"Forbidden function detected: {name}"
+        if name not in ALLOWED_FUNCTIONS:
+            return False, f"Function is not allowed: {name}"
+
     return True, None
 
 
 def apply_row_cap(query: str, max_rows: int) -> str:
     """Wrap the query as a subquery with a hard ``LIMIT`` row cap."""
     cleaned = query.strip().rstrip(";")
-    return f"SELECT * FROM ({cleaned}) AS ngm_result LIMIT {int(max_rows)}"
+    return f"SELECT * FROM ({cleaned}) AS ngm_result LIMIT {max(1, int(max_rows))}"
+
+
+def apply_public_projection(query: str) -> str:
+    """Replace allowed base tables with fixed public row/column projections."""
+    statement = parse_one(query, read="postgres")
+    for table in list(statement.find_all(exp.Table)):
+        table_name = table.name.lower()
+        projection = _PUBLIC_PROJECTIONS.get(table_name)
+        if projection is None:
+            # Validation runs first, so reaching this branch means the call order
+            # is wrong rather than that caller-controlled SQL should be tolerated.
+            raise ValueError(f"No public projection exists for table: {table_name}")
+        alias = table.alias_or_name
+        table.replace(
+            exp.Subquery(
+                this=projection.copy(),
+                alias=exp.TableAlias(this=exp.to_identifier(alias)),
+            )
+        )
+    return statement.sql(dialect="postgres")

--- a/courts/tests/test_api.py
+++ b/courts/tests/test_api.py
@@ -100,7 +100,7 @@ class ReadPlaneTests(_DbAPITestCase):
     def test_list_cases_paginated_shape(self):
         resp = self.client.get("/api/courtcases/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        # Platform cursor pagination -> {results, next}
+        # DRF page-number pagination -> {count, next, previous, results}
         self.assertIn("results", resp.data)
         self.assertIn("next", resp.data)
         self.assertEqual(len(resp.data["results"]), 1)

--- a/courts/tests/test_query_guard_security.py
+++ b/courts/tests/test_query_guard_security.py
@@ -515,6 +515,68 @@ class TestLegitimateSelectAllowed(_QuerySecurityBase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(resp.data["rows"], [["deleted-case", True]])
 
+    # -- public_projection: a caller may ASK to be narrowed ------------------
+    #
+    # The embedded MCP server serves ngm_query_judicial anonymously using a shared
+    # service account, so "does this principal hold a role?" is the wrong question
+    # for those requests — the answer depends on how that account was provisioned,
+    # and getting it wrong publishes the internal plane to the open internet. The
+    # flag lets the client state that a request is not made on a person's behalf.
+
+    def test_public_projection_flag_narrows_a_role_bearing_caller(self):
+        """The flag wins over the caller's own entitlement."""
+        CourtCase.objects.create(case_number="live-case", court_id="supreme")
+        CourtCase.objects.create(
+            case_number="deleted-case",
+            court_id="supreme",
+            is_deleted=True,
+        )
+
+        resp = self._post(
+            "SELECT case_number FROM court_cases ORDER BY case_number",
+            public_projection=True,
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["rows"], [["live-case"]])
+
+    def test_public_projection_flag_hides_internal_columns_from_a_role_holder(self):
+        resp = self._post(
+            "SELECT is_deleted FROM court_cases",
+            public_projection=True,
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @pytest.mark.security
+    def test_public_projection_flag_is_one_way(self):
+        """A falsy flag must never WIDEN a caller that had no entitlement.
+
+        Otherwise the flag would be a privilege-escalation parameter: anyone could
+        post ``public_projection: false`` and read the internal plane.
+        """
+        CourtCase.objects.create(case_number="live-case", court_id="supreme")
+        CourtCase.objects.create(
+            case_number="deleted-case",
+            court_id="supreme",
+            is_deleted=True,
+        )
+        self.client.force_authenticate(
+            user=self.nobody, token={"scope": "openid ngm.query"}
+        )
+
+        resp = self.client.post(
+            QUERY_URL,
+            {
+                "query": "SELECT case_number FROM court_cases ORDER BY case_number",
+                "public_projection": False,
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["rows"], [["live-case"]])
+
     def test_columns_resembling_keywords_are_not_false_positives(self):
         # Column names that merely CONTAIN a forbidden keyword as a substring
         # (updated_at) must not trip the \bword\b denylist.

--- a/courts/tests/test_query_guard_security.py
+++ b/courts/tests/test_query_guard_security.py
@@ -39,14 +39,17 @@ passing tests:
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from courts import query_guard
-from courts.models import Court
+from courts import query_guard, views
+from courts.models import CaseEntity, Court, CourtCase
 
 # Every test in this module is part of the adversarial security suite. ``django_db``
 # is added so the DB-touching endpoint tests may hit every alias (see the
@@ -239,6 +242,45 @@ class TestDoS(_QuerySecurityBase):
         ok, _ = query_guard.validate_query("SELECT pg_sleep(30)")
         self.assertFalse(ok, msg="guard accepted pg_sleep DoS")
 
+    def test_unicode_escaped_pg_sleep_is_rejected_by_guard(self):
+        ok, _ = query_guard.validate_query(r'SELECT U&"pg\005fsleep"(30)')
+        self.assertFalse(ok, msg="guard accepted Unicode-escaped pg_sleep DoS")
+
+    def test_side_effecting_and_database_dump_functions_are_rejected(self):
+        queries = [
+            "SELECT setval('court_seq', 1)",
+            "SELECT nextval('court_seq')",
+            "SELECT lo_create(1234)",
+            "SELECT pg_advisory_lock(42)",
+            "SELECT pg_notify('events', 'payload')",
+            "SELECT pg_sleep_for(interval '1 minute')",
+            "SELECT pg_sleep_until(clock_timestamp() + interval '1 minute')",
+            "SELECT table_to_xml('scraped_dates'::regclass, true, false, '')",
+            "SELECT table_to_xmlschema('courts'::regclass, true, false, '')",
+            "SELECT query_to_xml_and_xmlschema('SELECT * FROM courts', true, false, '')",
+            "SELECT database_to_xml(true, false, '')",
+            "SELECT lo_get(1234)",
+        ]
+        for sql in queries:
+            with self.subTest(sql=sql):
+                ok, _ = query_guard.validate_query(sql)
+                self.assertFalse(ok, msg=f"guard accepted side-effecting SQL: {sql!r}")
+
+    def test_value_collecting_aggregates_are_rejected(self):
+        queries = [
+            "SELECT array_agg(case_number) FROM court_cases",
+            "SELECT string_agg(case_number, ',') FROM court_cases",
+            "SELECT group_concat(case_number) FROM court_cases",
+        ]
+        for sql in queries:
+            with self.subTest(sql=sql):
+                ok, error = query_guard.validate_query(sql)
+                self.assertFalse(
+                    ok,
+                    msg=f"guard accepted value-collecting aggregate: {sql!r}",
+                )
+                self.assertIn("not allowed", error)
+
     def test_timeout_over_upper_bound_is_400(self):
         self._assert_rejected(
             self._post("SELECT identifier FROM courts", timeout_seconds=121)
@@ -306,15 +348,61 @@ class TestBlockedTables(_QuerySecurityBase):
 
     # FIXED (was a real bypass; guard now blocks this) — locked as a passing test.
     def test_comma_cross_join_to_pg_catalog_is_rejected_by_guard(self):
-        ok, _ = query_guard.validate_query(
-            "SELECT * FROM courts, pg_catalog.pg_authid"
-        )
+        ok, _ = query_guard.validate_query("SELECT * FROM courts, pg_catalog.pg_authid")
         self.assertFalse(ok, msg="guard accepted a comma cross-join to pg_catalog")
 
     # FIXED (was a real bypass; guard now blocks this) — locked as a passing test.
     def test_quoted_blocked_table_is_rejected_by_guard(self):
         ok, _ = query_guard.validate_query('SELECT * FROM "scraped_dates"')
         self.assertFalse(ok, msg="guard accepted a double-quoted blocked table")
+
+
+# ---------------------------------------------------------------------------
+# 7. Resource-amplifying joins over otherwise allowed tables.
+# ---------------------------------------------------------------------------
+class TestJoinConstraints(_QuerySecurityBase):
+    def test_unconstrained_joins_are_rejected(self):
+        queries = [
+            "SELECT * FROM courts, court_cases",
+            "SELECT * FROM courts CROSS JOIN court_cases",
+            "SELECT * FROM courts JOIN court_cases ON TRUE",
+            "SELECT * FROM courts JOIN court_cases ON 1 = 1",
+            (
+                "SELECT * FROM courts c JOIN court_cases cc "
+                "ON c.identifier = c.identifier"
+            ),
+            (
+                "SELECT * FROM courts c JOIN court_cases cc "
+                "ON cc.case_number = cc.case_number"
+            ),
+            (
+                "SELECT * FROM courts c JOIN court_cases cc "
+                "ON c.identifier = cc.court_identifier OR TRUE"
+            ),
+            (
+                "SELECT * FROM courts c JOIN court_cases cc "
+                "ON identifier = court_identifier"
+            ),
+        ]
+        for sql in queries:
+            with self.subTest(sql=sql):
+                ok, error = query_guard.validate_query(sql)
+                self.assertFalse(ok, msg=f"guard accepted unconstrained join: {sql!r}")
+                self.assertIn("JOINs must use", error)
+
+    def test_qualified_equijoin_is_allowed(self):
+        ok, error = query_guard.validate_query(
+            "SELECT cc.case_number FROM courts c "
+            "JOIN court_cases cc ON c.identifier = cc.court_identifier"
+        )
+        self.assertTrue(ok, msg=error)
+
+    def test_using_join_is_allowed(self):
+        ok, error = query_guard.validate_query(
+            "SELECT case_number FROM court_cases "
+            "JOIN court_case_hearings USING (case_number)"
+        )
+        self.assertTrue(ok, msg=error)
 
 
 # ---------------------------------------------------------------------------
@@ -342,8 +430,143 @@ class TestLegitimateSelectAllowed(_QuerySecurityBase):
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
+    def test_scope_only_query_excludes_soft_deleted_cases(self):
+        CourtCase.objects.create(case_number="live-case", court_id="supreme")
+        CourtCase.objects.create(
+            case_number="deleted-case",
+            court_id="supreme",
+            is_deleted=True,
+        )
+        self.client.force_authenticate(
+            user=self.nobody, token={"scope": "openid ngm.query"}
+        )
+
+        resp = self.client.post(
+            QUERY_URL,
+            {
+                "query": (
+                    "SELECT case_number FROM court_cases "
+                    "ORDER BY case_number"
+                )
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["rows"], [["live-case"]])
+
+    def test_scope_only_query_excludes_children_of_deleted_cases(self):
+        CourtCase.objects.create(case_number="live-case", court_id="supreme")
+        CourtCase.objects.create(
+            case_number="deleted-case",
+            court_id="supreme",
+            is_deleted=True,
+        )
+        CaseEntity.objects.create(
+            case_number="live-case",
+            court_id="supreme",
+            side="plaintiff",
+            name="Visible",
+        )
+        CaseEntity.objects.create(
+            case_number="deleted-case",
+            court_id="supreme",
+            side="plaintiff",
+            name="Hidden",
+        )
+        self.client.force_authenticate(
+            user=self.nobody, token={"scope": "openid ngm.query"}
+        )
+
+        resp = self.client.post(
+            QUERY_URL,
+            {"query": "SELECT name FROM court_case_entities ORDER BY name"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["rows"], [["Visible"]])
+
+    def test_scope_only_query_cannot_select_internal_columns(self):
+        self.client.force_authenticate(
+            user=self.nobody, token={"scope": "openid ngm.query"}
+        )
+
+        resp = self.client.post(
+            QUERY_URL,
+            {"query": "SELECT is_deleted FROM court_cases"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_role_bearing_query_retains_internal_projection(self):
+        CourtCase.objects.create(
+            case_number="deleted-case",
+            court_id="supreme",
+            is_deleted=True,
+        )
+
+        resp = self._post(
+            "SELECT case_number, is_deleted FROM court_cases "
+            "WHERE case_number = 'deleted-case'"
+        )
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["rows"], [["deleted-case", True]])
+
     def test_columns_resembling_keywords_are_not_false_positives(self):
         # Column names that merely CONTAIN a forbidden keyword as a substring
         # (updated_at) must not trip the \bword\b denylist.
         resp = self._post("SELECT created_at, updated_at FROM court_cases")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+
+def test_postgres_execution_uses_read_only_transaction_and_local_timeout():
+    cursor = MagicMock()
+    cursor.description = [("identifier",)]
+    cursor.fetchmany.side_effect = [[("supreme",)], []]
+    connection = MagicMock(vendor="postgresql")
+    connection.cursor.return_value.__enter__.return_value = cursor
+
+    with (
+        patch.object(views.router, "db_for_read", return_value="ngm"),
+        patch.object(views, "connections", {"ngm": connection}),
+        patch.object(
+            views.transaction,
+            "atomic",
+            return_value=nullcontext(),
+        ) as atomic,
+    ):
+        result = views.QueryView._execute_select(
+            "SELECT identifier FROM courts",
+            timeout_seconds=2.5,
+        )
+
+    atomic.assert_called_once_with(using="ngm")
+    assert cursor.execute.call_args_list == [
+        (("SET TRANSACTION READ ONLY",),),
+        (("SET LOCAL statement_timeout = %s", [2500]),),
+        (("SELECT identifier FROM courts",),),
+    ]
+    assert result["rows"] == [["supreme"]]
+
+
+def test_query_execution_rejects_oversized_serialized_result():
+    cursor = MagicMock()
+    cursor.description = [("value",)]
+    cursor.fetchmany.side_effect = [[("x" * 100,)], []]
+    connection = MagicMock(vendor="sqlite")
+    connection.cursor.return_value.__enter__.return_value = cursor
+
+    with (
+        patch.object(views.router, "db_for_read", return_value="ngm"),
+        patch.object(views, "connections", {"ngm": connection}),
+        patch.object(views.transaction, "atomic", return_value=nullcontext()),
+        pytest.raises(views.QueryResultTooLarge),
+    ):
+        views.QueryView._execute_select(
+            "SELECT value FROM courts",
+            timeout_seconds=2.5,
+            max_response_bytes=50,
+        )

--- a/courts/tests/test_query_guard_security.py
+++ b/courts/tests/test_query_guard_security.py
@@ -584,12 +584,17 @@ class TestLegitimateSelectAllowed(_QuerySecurityBase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
 
-def test_postgres_execution_uses_read_only_transaction_and_local_timeout():
+def _mock_postgres_connection(*, in_atomic_block):
     cursor = MagicMock()
     cursor.description = [("identifier",)]
     cursor.fetchmany.side_effect = [[("supreme",)], []]
-    connection = MagicMock(vendor="postgresql")
+    connection = MagicMock(vendor="postgresql", in_atomic_block=in_atomic_block)
     connection.cursor.return_value.__enter__.return_value = cursor
+    return connection, cursor
+
+
+def test_postgres_execution_uses_read_only_transaction_and_local_timeout():
+    connection, cursor = _mock_postgres_connection(in_atomic_block=False)
 
     with (
         patch.object(views.router, "db_for_read", return_value="ngm"),
@@ -608,6 +613,33 @@ def test_postgres_execution_uses_read_only_transaction_and_local_timeout():
     atomic.assert_called_once_with(using="ngm")
     assert cursor.execute.call_args_list == [
         (("SET TRANSACTION READ ONLY",),),
+        (("SET LOCAL statement_timeout = %s", [2500]),),
+        (("SELECT identifier FROM courts",),),
+    ]
+    assert result["rows"] == [["supreme"]]
+
+
+def test_postgres_execution_skips_access_mode_inside_an_open_transaction():
+    """Postgres rejects SET TRANSACTION once a statement has run (25001).
+
+    If a caller already holds a transaction, ``atomic()`` yields a savepoint
+    rather than a fresh transaction, so issuing the access-mode change would
+    error the request out. The statement timeout still applies — ``SET LOCAL`` is
+    savepoint-scoped — and SELECT-only enforcement remains query_guard's job.
+    """
+    connection, cursor = _mock_postgres_connection(in_atomic_block=True)
+
+    with (
+        patch.object(views.router, "db_for_read", return_value="ngm"),
+        patch.object(views, "connections", {"ngm": connection}),
+        patch.object(views.transaction, "atomic", return_value=nullcontext()),
+    ):
+        result = views.QueryView._execute_select(
+            "SELECT identifier FROM courts",
+            timeout_seconds=2.5,
+        )
+
+    assert cursor.execute.call_args_list == [
         (("SET LOCAL statement_timeout = %s", [2500]),),
         (("SELECT identifier FROM courts",),),
     ]

--- a/courts/views.py
+++ b/courts/views.py
@@ -4,9 +4,8 @@ Ports the FastAPI NGM API plane to DRF:
 
 - Read plane (public, ``AllowAny``): courts, cases + the case sub-resources
   hearings / entities / documents, an entity-resolution search, and blacklisted
-  firms. List endpoints use the shared ``PlatformCursorPagination`` so the wire
-  shape is the platform ``{results, next}`` (the existing converted read plane's
-  contract), not the FastAPI ``{items, next_cursor}``.
+  firms. Paginated endpoints use DRF page-number pagination and return
+  ``{count, next, previous, results}``.
 - Gated SQL plane (``POST /query``): OIDC + NGM-role gated; the query_guard
   policy (SELECT-only, allowlist, scraped_dates blocked, row cap, statement
   timeout) is enforced in the view.
@@ -21,9 +20,11 @@ cases.
 
 from __future__ import annotations
 
+import json
 import time
 
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import IntegrityError, connections, router, transaction
 from rest_framework import mixins, status, viewsets
 
@@ -37,7 +38,7 @@ from rest_framework.views import APIView
 from . import query_guard, search_index
 from .models import BlacklistedFirm, CaseEntity, Court, CourtCase, CourtCaseHearing
 from .normalize import best_effort_normalize
-from .permissions import HasNgmQueryAccess, HasNgmRole
+from .permissions import HasNgmQueryAccess, HasNgmRole, has_ngm_query_role
 from .serializers import (
     BlacklistedFirmSerializer,
     BlacklistedFirmWriteSerializer,
@@ -53,6 +54,10 @@ from .serializers import (
 # (GET/HEAD/OPTIONS + the custom retrieve_composite/list_* actions) stay public;
 # create/update require an NGM role.
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+class QueryResultTooLarge(ValueError):
+    """Raised before a raw-query result can become an oversized API response."""
 
 
 class _PublicReadNgmWriteMixin(AuditlogActorMixin):
@@ -297,6 +302,7 @@ class QueryView(APIView):
             return Response({"detail": error}, status=status.HTTP_400_BAD_REQUEST)
 
         max_rows = query_guard.default_max_rows()
+        max_response_bytes = query_guard.default_max_response_bytes()
         timeout = body.get("timeout_seconds") or query_guard.default_timeout_seconds()
         try:
             timeout = float(timeout)
@@ -308,18 +314,40 @@ class QueryView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        capped = query_guard.apply_row_cap(sql, max_rows)
+        executable_sql = sql
+        if not has_ngm_query_role(request.user):
+            executable_sql = query_guard.apply_public_projection(sql)
+        capped = query_guard.apply_row_cap(executable_sql, max_rows)
         try:
-            result = self._execute_select(capped, timeout_seconds=timeout)
+            result = self._execute_select(
+                capped,
+                timeout_seconds=timeout,
+                max_response_bytes=max_response_bytes,
+            )
+        except QueryResultTooLarge:
+            return Response(
+                {
+                    "detail": (
+                        "Query result exceeds the configured response-size limit."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except Exception:  # noqa: BLE001 — never leak DB internals to the caller
             return Response(
                 {"detail": "Database query failed"}, status=status.HTTP_400_BAD_REQUEST
             )
         result["max_rows"] = max_rows
+        result["max_response_bytes"] = max_response_bytes
         return Response(result)
 
     @staticmethod
-    def _execute_select(query: str, *, timeout_seconds: float) -> dict:
+    def _execute_select(
+        query: str,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int | None = None,
+    ) -> dict:
         """Run a validated SELECT with a statement timeout; return columns/rows.
 
         Mirrors the FastAPI ``PostgresRawQueryExecutor``. On Postgres a
@@ -334,13 +362,44 @@ class QueryView(APIView):
         ngm_alias = router.db_for_read(CourtCase)
         connection = connections[ngm_alias]
         timeout_ms = int(timeout_seconds * 1000)
+        response_limit = (
+            max_response_bytes
+            if max_response_bytes is not None
+            else query_guard.default_max_response_bytes()
+        )
         start = time.perf_counter()
-        with connection.cursor() as cursor:
-            if connection.vendor == "postgresql":
-                cursor.execute("SET statement_timeout = %s", [timeout_ms])
-            cursor.execute(query)
-            columns = [c[0] for c in cursor.description] if cursor.description else []
-            rows = [list(r) for r in cursor.fetchall()]
+        with transaction.atomic(using=ngm_alias):
+            with connection.cursor() as cursor:
+                if connection.vendor == "postgresql":
+                    cursor.execute("SET TRANSACTION READ ONLY")
+                    cursor.execute("SET LOCAL statement_timeout = %s", [timeout_ms])
+                cursor.execute(query)
+                columns = (
+                    [c[0] for c in cursor.description] if cursor.description else []
+                )
+                response_bytes = len(
+                    json.dumps(
+                        {"columns": columns, "rows": []},
+                        cls=DjangoJSONEncoder,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+                rows = []
+                while batch := cursor.fetchmany(50):
+                    for raw_row in batch:
+                        row = list(raw_row)
+                        response_bytes += len(
+                            json.dumps(
+                                row,
+                                cls=DjangoJSONEncoder,
+                                ensure_ascii=False,
+                                separators=(",", ":"),
+                            ).encode("utf-8")
+                        ) + 1
+                        if response_bytes > response_limit:
+                            raise QueryResultTooLarge
+                        rows.append(row)
         return {
             "columns": columns,
             "rows": rows,

--- a/courts/views.py
+++ b/courts/views.py
@@ -314,8 +314,24 @@ class QueryView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # ``public_projection: true`` lets a caller REQUEST the narrower plane
+        # even when its own roles would grant the internal one. It is deliberately
+        # one-way — it can only turn the projection ON, never off — so honouring
+        # it from an untrusted body is safe.
+        #
+        # This exists because "is this caller entitled to internal columns?" and
+        # "is this request being made on someone's behalf?" are different
+        # questions, and only the client knows the second. The embedded MCP server
+        # serves ``ngm_query_judicial`` to ANONYMOUS callers using a shared
+        # service-account token, so role membership on that account is the wrong
+        # thing to infer disclosure from: provisioning it with ReadOnly (or any
+        # NGM role) would silently hand the unprojected plane — soft-deleted rows,
+        # ``is_deleted``, every internal column — to the open internet. MCP now
+        # sets this flag on those requests, so the guarantee no longer rests on
+        # how that account happens to be configured.
+        force_public_projection = bool(body.get("public_projection"))
         executable_sql = sql
-        if not has_ngm_query_role(request.user):
+        if force_public_projection or not has_ngm_query_role(request.user):
             executable_sql = query_guard.apply_public_projection(sql)
         capped = query_guard.apply_row_cap(executable_sql, max_rows)
         try:

--- a/courts/views.py
+++ b/courts/views.py
@@ -383,16 +383,33 @@ class QueryView(APIView):
             if max_response_bytes is not None
             else query_guard.default_max_response_bytes()
         )
+        # Postgres refuses SET TRANSACTION once a statement has run in the current
+        # transaction (25001 active_sql_transaction). Read this BEFORE opening the
+        # block below: if a caller already has one open, atomic() gives us a
+        # savepoint rather than a fresh transaction and the access-mode change
+        # would error out. In that case fall back to the statement timeout alone —
+        # read-only enforcement is defence in depth behind query_guard's
+        # SELECT-only allowlist, so degrading it beats failing the request.
+        nested = connection.in_atomic_block
         start = time.perf_counter()
         with transaction.atomic(using=ngm_alias):
             with connection.cursor() as cursor:
                 if connection.vendor == "postgresql":
-                    cursor.execute("SET TRANSACTION READ ONLY")
+                    if not nested:
+                        cursor.execute("SET TRANSACTION READ ONLY")
+                    # SET LOCAL is scoped to the savepoint, so it is safe either way.
                     cursor.execute("SET LOCAL statement_timeout = %s", [timeout_ms])
                 cursor.execute(query)
                 columns = (
                     [c[0] for c in cursor.description] if cursor.description else []
                 )
+                # Measuring means encoding each row here and again in the response
+                # renderer — deliberate. Encoding once and keeping the fragments to
+                # reuse would hold the rows AND their JSON in memory at the same
+                # time, which is the peak this cap exists to prevent; and any
+                # cheaper estimate would have to be conservative enough to reject
+                # results that would in fact have fit. The extra CPU is bounded by
+                # max_rows, so it is paid only on the largest allowed responses.
                 response_bytes = len(
                     json.dumps(
                         {"columns": columns, "rows": []},

--- a/docker-compose.e2e.env
+++ b/docker-compose.e2e.env
@@ -2,10 +2,13 @@
 # the dev-stack defaults (48000/45432/49200/49000/48080/40114) so a running dev
 # stack is untouched. The E2E API suite targets PLATFORM_API_PORT and the
 # Playwright webServer proxies to it.
+COMPOSE_HOST_BIND=127.0.0.1
 PLATFORM_API_PORT=48010
+OIDC_RESOURCE=http://localhost:48010/mcp
 POSTGRES_PORT=45440
 OPENSEARCH_PORT=49260
 MINIO_API_PORT=49010
 MINIO_CONSOLE_PORT=49011
 ZITADEL_PORT=48090
 FRONTEND_PORT=40124
+MCP_E2E_BEARER=e2e-ngm-query-only

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -35,19 +35,18 @@ services:
     environment:
       TESTING: "true"
       DEV_AUTH: "true"
+      # Zitadel is intentionally absent from E2E. This token is accepted only
+      # on /api/query/ by the TESTING+DEV_AUTH authenticator and maps to the
+      # no-group, scope-only `mcp-query-e2e` principal.
+      MCP_QUERY_API_TOKEN: ${MCP_E2E_BEARER:-e2e-ngm-query-only}
+      DEV_NGM_QUERY_TOKEN: ${MCP_E2E_BEARER:-e2e-ngm-query-only}
+      DEV_NGM_QUERY_USERNAME: mcp-query-e2e
       # No 429s during the E2E run (TESTING already disables throttling; explicit
       # for clarity if TESTING is ever toggled off in a variant).
       THROTTLE_RATE_ANON: "1000000/hour"
     healthcheck:
-      test:
-        - CMD-SHELL
-        - >-
-          python -c "import urllib.request,sys;
-          sys.exit(0 if urllib.request.urlopen('http://localhost:8080/api/health').status==200 else 1)"
       interval: 5s
-      timeout: 5s
       retries: 40
-      start_period: 20s
 
   platform-migrate:
     # Same worktree-built image so migrations match the running platform. TESTING

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,11 +118,10 @@ services:
       OIDC_OP_USER_ENDPOINT: http://zitadel:8080/oidc/v1/userinfo
       OIDC_AUDIENCE: ${OIDC_AUDIENCE:-jawafdehi-platform-dev}
       OIDC_JWKS_TIMEOUT: ${OIDC_JWKS_TIMEOUT:-10}
-      # The MCP protocol is served by this same process at /mcp. Default to the
-      # restricted anonymous tool profile when no trusted ingress mode header is
-      # present. Verified callers receive the full catalog; Django API
-      # permissions remain the write-authorization boundary.
-      MCP_DEFAULT_MODE: ${MCP_DEFAULT_MODE:-public}
+      # The MCP protocol is served by this same process at /mcp. Anonymous
+      # callers get a fixed read-only catalog; any verified bearer gets the full
+      # one regardless of role, and Django API permissions remain the
+      # authorization boundary for what those tools can actually do.
       # Two workers at 16 each keep direct-Postgres connection pressure bounded.
       # Production should still put PgBouncer in front of every database.
       ASGI_LIMIT_CONCURRENCY: ${ASGI_LIMIT_CONCURRENCY:-16}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,6 @@ services:
       # one regardless of role, and Django API permissions remain the
       # authorization boundary for what those tools can actually do.
       # Two workers at 16 each keep direct-Postgres connection pressure bounded.
-      # Production should still put PgBouncer in front of every database.
       ASGI_LIMIT_CONCURRENCY: ${ASGI_LIMIT_CONCURRENCY:-16}
       OIDC_RESOURCE: ${OIDC_RESOURCE:-http://localhost:48000/mcp}
       MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./infra/postgres-init:/docker-entrypoint-initdb.d:ro
-    ports: ["${POSTGRES_PORT:-45432}:5432"]
+    ports: ["${COMPOSE_HOST_BIND:-0.0.0.0}:${POSTGRES_PORT:-45432}:5432"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 5s
@@ -38,8 +38,8 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     volumes: ["miniodata:/data"]
     ports:
-      - "${MINIO_API_PORT:-49000}:9000"
-      - "${MINIO_CONSOLE_PORT:-49001}:9001"
+      - "${COMPOSE_HOST_BIND:-0.0.0.0}:${MINIO_API_PORT:-49000}:9000"
+      - "${COMPOSE_HOST_BIND:-0.0.0.0}:${MINIO_CONSOLE_PORT:-49001}:9001"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
@@ -67,7 +67,7 @@ services:
       memlock: { soft: -1, hard: -1 }
       nofile: { soft: 65536, hard: 65536 }
     volumes: ["osdata:/usr/share/opensearch/data"]
-    ports: ["${OPENSEARCH_PORT:-49200}:9200"]
+    ports: ["${COMPOSE_HOST_BIND:-0.0.0.0}:${OPENSEARCH_PORT:-49200}:9200"]
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
       interval: 10s
@@ -95,7 +95,7 @@ services:
       ZITADEL_MACHINE_IDENTIFICATION_HOSTNAME_ENABLED: "true"
     depends_on:
       postgres: { condition: service_healthy }
-    ports: ["${ZITADEL_PORT:-48080}:8080"]
+    ports: ["${COMPOSE_HOST_BIND:-0.0.0.0}:${ZITADEL_PORT:-48080}:8080"]
 
   # ── The consolidated platform (ONE Django project / image) ────────────────
   # NES, NGM and Jawafdehi run as apps in one process (config.settings).
@@ -110,8 +110,40 @@ services:
       NGM_DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/ngm
       DATABASE_SSL_MODE: disable
       OPENSEARCH_URL: http://opensearch:9200
-      OIDC_ISSUER: http://zitadel:8080
+      # Tokens carry Zitadel's browser-reachable external issuer. Back-channel
+      # endpoints use the service DNS name so the container can reach them.
+      OIDC_ISSUER: http://${ZITADEL_HOST:-localhost}:${ZITADEL_PORT:-48080}
+      OIDC_JWKS_URI: http://zitadel:8080/oauth/v2/keys
+      OIDC_OP_TOKEN_ENDPOINT: http://zitadel:8080/oauth/v2/token
+      OIDC_OP_USER_ENDPOINT: http://zitadel:8080/oidc/v1/userinfo
       OIDC_AUDIENCE: ${OIDC_AUDIENCE:-jawafdehi-platform-dev}
+      OIDC_JWKS_TIMEOUT: ${OIDC_JWKS_TIMEOUT:-10}
+      # The MCP protocol is served by this same process at /mcp. Default to the
+      # restricted anonymous tool profile when no trusted ingress mode header is
+      # present. Verified callers receive the full catalog; Django API
+      # permissions remain the write-authorization boundary.
+      MCP_DEFAULT_MODE: ${MCP_DEFAULT_MODE:-public}
+      # Two workers at 16 each keep direct-Postgres connection pressure bounded.
+      # Production should still put PgBouncer in front of every database.
+      ASGI_LIMIT_CONCURRENCY: ${ASGI_LIMIT_CONCURRENCY:-16}
+      OIDC_RESOURCE: ${OIDC_RESOURCE:-http://localhost:48000/mcp}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-}
+      MCP_ALLOWED_ORIGINS: ${MCP_ALLOWED_ORIGINS:-}
+      # Least-privilege bearer used only by the anonymous public SQL tool.
+      # Full-capability stdio credentials are never injected into the HTTP service.
+      MCP_QUERY_API_TOKEN: ${MCP_QUERY_API_TOKEN:-}
+      MCP_EMBEDDED_API_TIMEOUT: ${MCP_EMBEDDED_API_TIMEOUT:-30}
+      MCP_EMBEDDED_API_MAX_CONCURRENCY: ${MCP_EMBEDDED_API_MAX_CONCURRENCY:-16}
+      MCP_CONTROL_PLANE_TIMEOUT: ${MCP_CONTROL_PLANE_TIMEOUT:-30}
+      MCP_QUERY_TIMEOUT: ${MCP_QUERY_TIMEOUT:-15}
+      MCP_PROXY_HTTP_TIMEOUT: ${MCP_PROXY_HTTP_TIMEOUT:-30}
+      MCP_DOCUMENT_FETCH_TIMEOUT: ${MCP_DOCUMENT_FETCH_TIMEOUT:-20}
+      MCP_DOCUMENT_CONVERT_TIMEOUT: ${MCP_DOCUMENT_CONVERT_TIMEOUT:-120}
+      MCP_DOCUMENT_MAX_CONCURRENCY: ${MCP_DOCUMENT_MAX_CONCURRENCY:-2}
+      MCP_DOCUMENT_MAX_INPUT_BYTES: ${MCP_DOCUMENT_MAX_INPUT_BYTES:-26214400}
+      MCP_HTTP_MAX_REQUEST_BODY_BYTES: ${MCP_HTTP_MAX_REQUEST_BODY_BYTES:-105906176}
+      MCP_DOCUMENT_MAX_OUTPUT_CHARS: ${MCP_DOCUMENT_MAX_OUTPUT_CHARS:-5000000}
+      MCP_DOCUMENT_WORKER_MEMORY_BYTES: ${MCP_DOCUMENT_WORKER_MEMORY_BYTES:-1073741824}
       SECRET_KEY: ${PLATFORM_SECRET_KEY:-local-dev-only-9f3a2c7e1b6d4058a1e2c3d4e5f60718}
       DEBUG: "False"
       ALLOWED_HOSTS: "*"
@@ -125,7 +157,17 @@ services:
     depends_on:
       postgres: { condition: service_healthy }
       platform-migrate: { condition: service_completed_successfully }
-    ports: ["${PLATFORM_API_PORT:-48000}:8080"]
+    ports: ["${COMPOSE_HOST_BIND:-0.0.0.0}:${PLATFORM_API_PORT:-48000}:8080"]
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python -c "import urllib.request,sys;
+          sys.exit(0 if urllib.request.urlopen('http://localhost:8080/mcp/health').status==200 else 1)"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   # ── Frontend (Vite dev server) ────────────────────────────────────────────
   # Local-dev only: runs `vite` with hot reload, source bind-mounted. All /api,
@@ -158,7 +200,7 @@ services:
       # node_modules from being shadowed by the host mount.
       - ../frontend:/app
       - /app/node_modules
-    ports: ["${FRONTEND_PORT:-40114}:40114"]
+    ports: ["${COMPOSE_HOST_BIND:-0.0.0.0}:${FRONTEND_PORT:-40114}:40114"]
     depends_on:
       platform: { condition: service_started }
 
@@ -169,12 +211,15 @@ services:
   platform-migrate:
     image: jawafdehi-platform:latest
     build: { context: ., dockerfile: Dockerfile }
+    healthcheck:
+      disable: true
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/jawafdehi
       NES_DB_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/nes
       NGM_DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/ngm
       DATABASE_SSL_MODE: disable
-      OIDC_ISSUER: http://zitadel:8080
+      OIDC_ISSUER: http://${ZITADEL_HOST:-localhost}:${ZITADEL_PORT:-48080}
+      OIDC_JWKS_URI: http://zitadel:8080/oauth/v2/keys
       SECRET_KEY: ${PLATFORM_SECRET_KEY:-local-dev-only-9f3a2c7e1b6d4058a1e2c3d4e5f60718}
       DEBUG: "False"
       ALLOWED_HOSTS: "*"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,14 +11,17 @@ a monolith**; this doc describes the shipped result, not the journey.
 
 ## 1. Shape: one Django monolith, three databases
 
-- **One Django project** in the `jawafdehi-api` repo (trunk `main`), one WSGI, one
-  image, runs at **`:48000`**. (The R1 collapse flattened the earlier
+- **One Django project** in the `jawafdehi-api` repo (trunk `main`), one ASGI
+  deployment, one image, runs at **`:48000`**. The same ASGI process serves the
+  streamable-HTTP MCP endpoint at **`/mcp`**; MCP is not a sidecar or separate
+  service. (The R1 collapse flattened the earlier
   `monolith/` + `services/{nes,ngm,jawafdehi}/` layout into top-level apps.)
 - **Apps** (all top-level dirs, in `INSTALLED_APPS`): `entities` (NES), `courts`
   + `materials` (NGM), the Jawafdehi apps `cases` + `review`, plus the
   platform-level `search`, `discovery`, `jobs`, `content` (headless Wagtail CMS —
   the "Newsroom"; see §3.5), and `llm` (a provider-agnostic LLM invocation layer —
-  see §3.6). Project glue lives in the top-level `config/` package (`settings.py`,
+  see §3.6). `jawafdehi_mcp/` contains the embedded MCP protocol server and tool
+  registry. Project glue lives in the top-level `config/` package (`settings.py`,
   `urls.py`, `wsgi.py`, `asgi.py`, `db_router.py`). _(The `case_workflows` app was
   dropped — migration `cases/migrations/0040_drop_case_workflows_tables.py`.)_
 - **Database-per-service preserved** via a DB **router** (`config.db_router.
@@ -30,12 +33,18 @@ a monolith**; this doc describes the shipped result, not the journey.
   `/api/…` by design — it can target a **remote** portal (see
   `review/ngm_client.py`, `review/jds_client.py`, `jobs-queue-design.md`); that is
   a poller, not a revived internal REST proxy.
+- **MCP-to-API calls are in-process.** Existing API paths remain the contract and
+  still enforce OIDC, permissions, and serializers, but `httpx.ASGITransport`
+  dispatches them directly to Django instead of opening a loopback connection.
+  Streamable HTTP is stateless so Gunicorn workers and pod replicas do not need
+  MCP session affinity. See [`mcp/README.md`](./mcp/README.md).
 - **uv workspace** (not poetry): one top-level `pyproject.toml` + `uv.lock`. The
   cross-app libs live in the top-level **`jawafdehi_shared/`** package:
   `auth.oidc`, `entities.ids`, `search.opensearch` + `search.mappings` +
   `search.transliterate`, `drf.base`.
-- **Testing:** engine-agnostic; SQLite fallback per DB alias for the full suite
-  (~1057 unit tests pass). Integration tests target the one host `:48000`.
+- **Testing:** engine-agnostic; SQLite fallback per DB alias for the full suite,
+  including the migrated MCP tests. Integration tests target the one host
+  `:48000`.
 
 ## 2. Identity: schema.org JSON-LD keyed by `@id` IRIs
 

--- a/docs/DOC-STATUS.md
+++ b/docs/DOC-STATUS.md
@@ -24,6 +24,9 @@ read [`ARCHITECTURE.md`](./ARCHITECTURE.md).
   HTTP client by design — `review/ngm_client.py`, `review/jds_client.py`)_. One image.
   **uv workspace** (NOT poetry — one top-level `pyproject.toml` + `uv.lock`). Cross-app libs
   in top-level `jawafdehi_shared/`. Runs at `:48000`.
+- **MCP is embedded in the same ASGI deployment** at `/mcp`; there is no MCP
+  sidecar. Its API-backed tools dispatch into Django in-process while preserving
+  the API auth and serializer boundary. See [`mcp/README.md`](./mcp/README.md).
 - **Headless Wagtail CMS** (`content/` app, "Newsroom") serves public updates/news at `/api/cms/v2/…`; consumed by the SPA `/updates` routes. It was dropped from `v2` in the R1 collapse commit `4c39d8c`, then **forward-ported back into `v2`** (PR #270, adapted from `origin/main`) with the frontend contract preserved — so it now ships on trunk `main`. See ARCHITECTURE §3.5.
 - **schema.org JSON-LD is the canonical stored form** for NES entities AND NGM materials,
   keyed by **`@id` IRIs**: `https://jawafdehi.org/entity/<prefix>/<slug>`,
@@ -69,6 +72,8 @@ A `>` status banner has been added in-place to the most-misleading STALE docs (m
 | `ARCHITECTURE.md` | CURRENT | **Single source of truth** for the current platform (monolith, 3 DBs/router, schema.org/IRI, unified OpenSearch, OIDC); §5 = data plane (Postgres-SoR, lakehouse-lite) | Keep. |
 | `DOC-STATUS.md` (this file) | CURRENT | The orientation index / per-doc audit | Keep. |
 | `testing.md` | CURRENT (NEW) | The testing tiers: sqlite unit gate (`config.settings_test`) + `-m security` adversarial suite + the live-stack E2E (pytest API half in `integration-tests/` and the frontend Playwright half), driven by the `docker-compose.e2e.yml` overlay; documents the CI E2E gate | Keep. |
+| `mcp/README.md` | CURRENT | Embedded MCP runtime: same ASGI process/image/port as Django, `/mcp`, in-process API dispatch, auth modes, and commands | Keep. |
+| `mcp/ADDING_TOOLS.md` | CURRENT | Tool registration and in-process API client pattern | Keep. |
 | `security/threat-model.md` | CURRENT (NEW) | Threat model for the accountability archive: assets, threat actors, controls-with-tests, and residual/accepted risks (F5 IRI fork, F14 per-worker throttle, write-gate drift). Records the 5 gated-SQL guard bypasses found + fixed | Keep. |
 | `data-plane-design.md` | CURRENT (BUILT) | Data-plane consolidation: Postgres-SoR + R2 archive + OpenSearch; **no live Iceberg** (`lakehouse/` dormant seam); `material_convert` FTS feed shipped (#264). Reconciles ARCHITECTURE §5; incorporates the jobs queue + cases-own-no-documents ADR | Keep (load-bearing). |
 | `unified-search-plan.md` | CURRENT (BUILT & LIVE) | §0 = pre-build starting point (marked as such); §1-§8 reconciled to the live build (hard-fail no-fallback, four index constants, case_id done, no "internal" role). NOTE: `Material.visibility` now EXISTS (added by #263) and gates material indexing — supersedes the old "no `visibility` field" caveat | Keep. |

--- a/docs/mcp/ADDING_TOOLS.md
+++ b/docs/mcp/ADDING_TOOLS.md
@@ -1,0 +1,28 @@
+# Adding MCP Tools
+
+Tools live in `jawafdehi_mcp/tools/` and subclass `BaseTool`.
+
+1. Add the tool module and implement `name`, `description`, `input_schema`, and
+   async `execute`.
+2. Export the class from `jawafdehi_mcp/tools/__init__.py`.
+3. Add an instance to `TOOLS` in `jawafdehi_mcp/server.py`.
+4. Add focused tests under `tests/mcp/`.
+
+For a normal Jawafdehi control-plane endpoint, use the shared fixed-path client:
+
+```python
+from jawafdehi_mcp.control_plane import request_control_plane
+
+result = await request_control_plane(
+    "POST",
+    "/api/example/",
+    json_body={"value": 1},
+)
+```
+
+The client accepts only `/api/*` paths, forwards request auth, returns a stable
+status/data envelope, uses the bounded in-memory Django transport for embedded
+HTTP, and uses normal network HTTP for stdio. API permission checks remain the
+authorization boundary. Use raw `embedded_api_client_kwargs()` only for a
+protocol that the shared JSON client cannot represent, such as multipart file
+upload.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -17,8 +17,11 @@ other traffic to Django. MCP uses stateless streamable HTTP, so requests can be
 served by any Gunicorn worker or pod without session affinity.
 
 Only the explicit MCP protocol, health, and protected-resource metadata paths
-are routed to MCP. `X-MCP-Mode` selects the authentication door after routing;
-it cannot turn another Django path into an MCP endpoint.
+are routed to MCP; no other Django path can become an MCP endpoint.
+
+There is **one** endpoint and one deployment — in production
+`https://api.jawafdehi.org/mcp`. There is no separate public/internal hostname
+and no ingress-injected mode header.
 
 MCP tools that consume Jawafdehi APIs retain the existing API contracts,
 authentication, permission checks, and serializers. In the embedded HTTP
@@ -37,26 +40,52 @@ path proxy is exposed.
 
 The embedded server reads the platform's `OIDC_ISSUER`, `OIDC_AUDIENCE`, and
 derived JWKS/userinfo settings. JWKS network fetches use the shared
-`OIDC_JWKS_TIMEOUT` bound. A trusted ingress may set:
+`OIDC_JWKS_TIMEOUT` bound.
 
-- `X-MCP-Mode: public`: anonymous callers receive the restricted public set.
-- `X-MCP-Mode: internal`: anonymous callers receive an OAuth challenge.
+One rule decides the catalog:
 
-`MCP_DEFAULT_MODE=public` is the safe fallback when the ingress header is
-absent. A header may raise that default to `internal`; an
-`MCP_DEFAULT_MODE=internal` deployment cannot be downgraded by a request
-header. Invalid values fail to the deployment's safe floor.
+| Caller | Catalog |
+|---|---|
+| Anonymous (no bearer) | the read-only `ANONYMOUS_TOOL_NAMES` set (13 tools) |
+| Any verified bearer, **any role including none** | all 26 tools |
+| stdio with `JAWAFDEHI_API_TOKEN` | all 26 (the service token is authentication) |
+
+An anonymous request is **not** challenged, because every anonymous tool wraps a
+REST route that is already `AllowAny` — `/api/entities`, `/api/search/`,
+`/api/materials/`, `/api/courts/`. Serving those through MCP grants nothing the
+API does not already serve without a token. A bearer that is *present but
+invalid* is still rejected with `401` and a `WWW-Authenticate` challenge; that is
+a broken caller, not an anonymous one.
+
+Two consequences of not challenging anonymous callers:
+
+- MCP clients begin an OAuth flow only on a `401`, so an anonymous client is
+  never prompted to log in — it simply sees the smaller catalog.
+  `get_current_user` is how a caller tells which side it is on, and
+  `GET /.well-known/oauth-protected-resource/mcp` is how it discovers where to
+  authenticate. That metadata document is therefore always served, and
+  `OIDC_RESOURCE` is **required** — the endpoint returns `503` without it.
+- `convert_to_markdown` is excluded from the anonymous set. It is one of the few
+  tools with no `/api/` route behind it, so the catalog is its only gate — and
+  that gate is enforced on `tools/call`, not merely on `tools/list`. It needs
+  authentication but no particular role.
+
+Catalog visibility is not an authorization grant. Tools forward the caller's
+verified bearer to Django, whose API permissions remain the final boundary for
+reads and writes — including the rules `docs/security/authz-model.md` pins on
+MCP as a principal: the `ngm.query` scope-only bypass and the service-account
+subject allowlist on `/api/caseworker/me`.
 
 MCP rejects unrecognized `Host` and `Origin` headers. The host and origin from
-`OIDC_RESOURCE` plus local loopback hosts are trusted automatically. A
-deployment with additional public/internal DNS names must list them in
-`MCP_ALLOWED_HOSTS` and browser origins in `MCP_ALLOWED_ORIGINS`.
+`OIDC_RESOURCE` plus local loopback hosts are trusted automatically; additional
+DNS names go in `MCP_ALLOWED_HOSTS` and browser origins in
+`MCP_ALLOWED_ORIGINS`.
 
-Any verified bearer receives the full MCP tool catalog, independent of its
-roles. Catalog visibility is not an authorization grant: tools forward that
-bearer to Django, whose API permissions remain the final boundary for reads and
-writes. Anonymous callers continue to receive only the catalog selected by the
-request mode.
+`GET /mcp/health` reports lifespan readiness only. A missing `OIDC_RESOURCE`
+does not make it unready: the anonymous read catalog still serves correctly, and
+failing the probe would remove a pod that is doing its job. That
+misconfiguration surfaces on the metadata endpoint and on every authenticated
+call instead.
 
 `JAWAFDEHI_API_TOKEN` enables service-authenticated stdio use. It is not
 injected into the HTTP platform process, never authenticates or elevates an HTTP

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -1,0 +1,130 @@
+# Embedded MCP Server
+
+The Jawafdehi MCP server is part of this repository and runs inside the same
+Gunicorn ASGI deployment as Django. It is not a sidecar or separately deployed
+service.
+
+## Runtime
+
+- Streamable HTTP endpoint: `POST /mcp`
+- MCP readiness: `GET /mcp/health`
+- OAuth protected-resource metadata:
+  `GET /.well-known/oauth-protected-resource/mcp`
+- Django APIs: unchanged under `/api/`
+
+`config.asgi.application` routes protocol requests to `jawafdehi_mcp` and all
+other traffic to Django. MCP uses stateless streamable HTTP, so requests can be
+served by any Gunicorn worker or pod without session affinity.
+
+Only the explicit MCP protocol, health, and protected-resource metadata paths
+are routed to MCP. `X-MCP-Mode` selects the authentication door after routing;
+it cannot turn another Django path into an MCP endpoint.
+
+MCP tools that consume Jawafdehi APIs retain the existing API contracts,
+authentication, permission checks, and serializers. In the embedded HTTP
+runtime, a bounded `httpx.ASGITransport` wrapper dispatches those requests
+directly to Django in memory. It enforces a wall-clock deadline and shared
+concurrency limit that stock `ASGITransport` does not provide. The caller's
+verified bearer is forwarded. The stdio module runner remains a remote API
+client and uses `JAWAFDEHI_API_BASE_URL`.
+
+Task-oriented control-plane tools cover unified search, entity history/delete,
+materials, courts and ingestion, case-update proposals, casework reviews, and
+the central jobs queue. They map only to fixed `/api/*` routes; no arbitrary
+path proxy is exposed.
+
+## Authentication
+
+The embedded server reads the platform's `OIDC_ISSUER`, `OIDC_AUDIENCE`, and
+derived JWKS/userinfo settings. JWKS network fetches use the shared
+`OIDC_JWKS_TIMEOUT` bound. A trusted ingress may set:
+
+- `X-MCP-Mode: public`: anonymous callers receive the restricted public set.
+- `X-MCP-Mode: internal`: anonymous callers receive an OAuth challenge.
+
+`MCP_DEFAULT_MODE=public` is the safe fallback when the ingress header is
+absent. A header may raise that default to `internal`; an
+`MCP_DEFAULT_MODE=internal` deployment cannot be downgraded by a request
+header. Invalid values fail to the deployment's safe floor.
+
+MCP rejects unrecognized `Host` and `Origin` headers. The host and origin from
+`OIDC_RESOURCE` plus local loopback hosts are trusted automatically. A
+deployment with additional public/internal DNS names must list them in
+`MCP_ALLOWED_HOSTS` and browser origins in `MCP_ALLOWED_ORIGINS`.
+
+Any verified bearer receives the full MCP tool catalog, independent of its
+roles. Catalog visibility is not an authorization grant: tools forward that
+bearer to Django, whose API permissions remain the final boundary for reads and
+writes. Anonymous callers continue to receive only the catalog selected by the
+request mode.
+
+`JAWAFDEHI_API_TOKEN` enables service-authenticated stdio use. It is not
+injected into the HTTP platform process, never authenticates or elevates an HTTP
+caller, and general case/NES HTTP calls forward only the caller's verified OIDC
+bearer. The intentionally public `ngm_query_judicial` tool uses the separate
+`MCP_QUERY_API_TOKEN` fallback needed to reach the API's SELECT-gated public
+court-data plane. That credential must carry only the `ngm.query` scope. A local
+stdio process may fall back to its full `JAWAFDEHI_API_TOKEN` for this query when
+no dedicated query token is configured. When neither credential is available,
+the tool is omitted from anonymous catalogs rather than advertising an
+operation that cannot authenticate.
+
+## Resource budgets
+
+The shared process keeps MCP work bounded with:
+
+- `MCP_EMBEDDED_API_TIMEOUT` and `MCP_EMBEDDED_API_MAX_CONCURRENCY`
+- `MCP_CONTROL_PLANE_TIMEOUT`, `MCP_QUERY_TIMEOUT`, and
+  `MCP_PROXY_HTTP_TIMEOUT`
+- `MCP_DOCUMENT_FETCH_TIMEOUT`, `MCP_DOCUMENT_CONVERT_TIMEOUT`,
+  `MCP_DOCUMENT_MAX_CONCURRENCY`, `MCP_DOCUMENT_MAX_INPUT_BYTES`, and
+  `MCP_DOCUMENT_MAX_OUTPUT_CHARS`
+- `MCP_DOCUMENT_WORKER_MEMORY_BYTES`
+
+Defaults are listed in `.env.example` and passed through by `docker-compose.yml`.
+Remote and inline document bytes are parsed in a spawned, killable worker with
+RSS, CPU, file-size, descriptor, output, and wall-clock limits. The parent and
+worker exchange bounded raw bytes rather than pickled objects.
+
+## Filesystem boundary
+
+The embedded HTTP server cannot read or write server-local paths supplied by
+MCP clients. `convert_to_markdown` accepts remote HTTP(S) and data URIs over
+HTTP, but `file_path`, `file://`, and `output_path` are stdio-only. Remote
+targets must resolve to public IP addresses on ports 80/443, redirects are
+revalidated, and downloads/conversion output are bounded. Plugins are always
+disabled for remote and data inputs. Installed plugins are opt-in only for
+trusted local stdio files via `enable_plugins=true`.
+`ngm_extract_case_data` and `upload_material_file` are also stdio-only because
+their contracts write or read local files.
+
+## Commands
+
+Run the combined local ASGI application:
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true \
+  uv run uvicorn config.asgi:application --host 0.0.0.0 --port 48000
+```
+
+Run the retained stdio transport directly as a Python module:
+
+```bash
+JAWAFDEHI_API_BASE_URL=https://api.jawafdehi.org \
+  JAWAFDEHI_API_TOKEN=<oidc-access-token> \
+  uv run python -m jawafdehi_mcp.server
+```
+
+Run MCP tests:
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true \
+  uv run pytest -q tests/mcp
+```
+
+The production image starts `config.asgi:application` with
+`config.asgi_worker.BoundedUvicornWorker`. There is no standalone MCP HTTP
+command; the project does not install a separate MCP CLI entry point.
+
+The migrated MCP component retains its Hippocratic License 3.0 terms in
+[`LICENSE`](../../jawafdehi_mcp/LICENSE).

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -76,6 +76,14 @@ reads and writes — including the rules `docs/security/authz-model.md` pins on
 MCP as a principal: the `ngm.query` scope-only bypass and the service-account
 subject allowlist on `/api/caseworker/me`.
 
+`ngm_query_judicial` is the one anonymous tool that does not run as the caller:
+with no bearer to forward it authenticates with `MCP_QUERY_API_TOKEN`, a shared
+service account. Those requests therefore send `public_projection: true`, which
+forces the API's narrow public plane no matter what roles that account holds.
+The flag is one-way — it can only narrow — so the guarantee does not depend on
+how the account is provisioned. A forwarded caller bearer is unaffected, and
+local stdio keeps the internal plane.
+
 MCP rejects unrecognized `Host` and `Origin` headers. The host and origin from
 `OIDC_RESOURCE` plus local loopback hosts are trusted automatically; additional
 DNS names go in `MCP_ALLOWED_HOSTS` and browser origins in

--- a/docs/security/authz-model.md
+++ b/docs/security/authz-model.md
@@ -162,7 +162,23 @@ explicitly in any centralization:
    `can_change_case`.
 4. **OAuth scope bypass (NGM SQL).** `HasNgmQueryAccess` accepts the
    `ngm.query` scope on the token *instead of* a role — for scope-only machine
-   clients (MCP).
+   clients (MCP). **Disclosure is a second, separate decision:** whether
+   `POST /query` applies `apply_public_projection` (hiding `is_deleted`,
+   soft-deleted rows and internal columns) normally follows
+   `has_ngm_query_role`, i.e. Group membership. A request may also set
+   `public_projection: true` in the body to force the narrow plane regardless of
+   its own entitlement. That flag is **one-way** — it can only turn the
+   projection on, never off — so it is safe to honour from an untrusted body, and
+   a falsy value grants nothing.
+
+   The embedded MCP server sets it on every anonymous `ngm_query_judicial`
+   request, because those authenticate as a shared service account rather than a
+   person. Without it, the safety of an unauthenticated internet-facing SQL
+   surface would depend on that account never being provisioned with `ReadOnly`
+   or an NGM role — `_sync_user` rewrites Group membership from the token's role
+   claims on every request, so such drift would silently publish the internal
+   plane. Requests carrying a real caller's forwarded bearer are unaffected, and
+   local stdio callers keep the internal plane.
 5. **Service-account subject allowlist.** `/caseworker/me` gates on `sub ∈
    OIDC_SERVICE_ACCOUNT_SUBJECTS`, orthogonal to Group roles.
 6. **Superuser sync + admin `is_staff`.** `admin` role ⇒ `is_superuser`;

--- a/docs/security/authz-model.md
+++ b/docs/security/authz-model.md
@@ -388,13 +388,10 @@ severity, not by change number.
    `CaseworkAuthContext.tsx` consume this shape. Coordinate: either keep
    injecting a synthetic `"admin"` role for superusers, or update `roles.ts` +
    `isAdmin` to key on the payload's `is_admin` flag.
-10. **MCP still hardcodes the RETIRED `contributor` role name.**
-    `jawafdehi-mcp/identity.py:66` `_DEFAULT_WRITE_ROLES = ("contributor",
-    "admin", "moderator")`. It matches raw token role keys, independent of Django
-    groups. If Zitadel keeps the `contributor` key (see D), MCP keeps working;
-    if the key is renamed, MCP write-tool access breaks unless `MCP_WRITE_ROLES`
-    env or the default is updated. MCP tests (`test_identity.py:35` etc.) assert
-    the old set.
+10. **MCP catalog visibility is authentication-based, not role-based.**
+    Any verified bearer receives the full MCP tool catalog. Write tools forward
+    that bearer to Django, so the API's role and object-level permissions remain
+    authoritative; anonymous callers retain a restricted catalog.
 11. **`ReviewAssistant`→`JobPoller` MUST be a Group-row RENAME migration, not a
     mapping change.** The OIDC sync only *attaches existing* groups
     (`oidc.py:277`), never creates them. A mapping-only change would silently
@@ -431,8 +428,8 @@ severity, not by change number.
     mid-rollout maps to nothing (or to the remapped group). **Safe rollout
     order:** (1) update Django map to remap surviving keys, (2) apply DB
     migrations (rename JobPoller, delete Admin/Public/tiers, drop
-    Case.contributors), (3) update FE `roles.ts` + MCP write-role list, (4)
-    optionally `terraform apply` Zitadel last.
+    Case.contributors), (3) update FE `roles.ts`, (4) optionally `terraform
+    apply` Zitadel last. MCP catalog visibility does not depend on role names.
 
 ### F. Schema vs data migrations required
 

--- a/docs/security/authz-v3-change-map.md
+++ b/docs/security/authz-v3-change-map.md
@@ -239,12 +239,12 @@ accepted, not a bug. Listed here so it is a conscious decision, not a surprise.
   group-less dev superuser is locked out of the whole admin panel. This is why
   F2 is a blocker, not a polish item.
 
-### B18. MCP — `jawafdehi-mcp/identity.py:66`
-- `_DEFAULT_WRITE_ROLES = ("contributor", "admin", "moderator")` — keep
-  `contributor` (Zitadel key survives) + `moderator`; these still map to the
-  content role. No change strictly required since it matches token keys, but add
-  a comment. Tests (`test_identity.py:35`) assert the set — leave unless keys
-  change. **Out of scope for this PR unless we retire the `contributor` key.**
+### B18. MCP — `jawafdehi_mcp/identity.py`
+- MCP catalog visibility no longer maps token roles. Any verified bearer
+  receives the full tool catalog; anonymous callers retain their mode-specific
+  restricted catalogs.
+- Write tools forward the verified bearer to Django. The API's role and
+  object-level permissions remain the authorization boundary.
 
 ---
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -59,13 +59,19 @@ place, and the residual/accepted risks.
 
 ### Input / injection
 - Gated SQL (`/api/query/`) is SELECT-only, allowlist-guarded, timeout-bounded, and runs on the
-  `ngm` connection only. **The adversarial sweep found and fixed five real guard bypasses**
+  `ngm` connection only. Scope-only principals such as the anonymous MCP query account are
+  transparently restricted to fixed public row/column projections: soft-deleted court cases,
+  their hearings/entities, and internal columns are unavailable even through raw SQL.
+  **The adversarial sweep found and fixed five real guard bypasses**
   (`courts/query_guard.py`): a comma cross-join reached a blocked table or a system catalog
   (`FROM courts, pg_catalog.pg_authid` → password hashes on Postgres), a double-quoted identifier
   slipped past table detection, `pg_sleep` gave a DoS primitive, and a stacked `SELECT` passed. The
-  guard now strips/rejects comments, rejects any statement separator, denylists volatile/file-read
-  functions, blocks system schemas, and enumerates EVERY FROM/JOIN entry (comma-joins + quoted +
-  schema-qualified) against the allow/block lists. _Tests: `courts/tests/test_query_guard_security.py`._
+  guard now rejects comments and multiple parsed statements, denylists volatile/file-read and
+  value-collecting aggregate functions, blocks system schemas, and enumerates EVERY FROM/JOIN
+  entry (comma-joins + quoted + schema-qualified) against the allow/block lists. Joins over allowed
+  tables must constrain the newly joined relation through `USING` or a qualified column equality;
+  comma/CROSS, `ON TRUE`, and same-side equalities are rejected. _Tests:
+  `courts/tests/test_query_guard_security.py`._
 - Entity/material IRIs are length-bounded (`MAX_IRI_LENGTH=300`) and host-canonicalized on write, so
   a foreign-host or over-length join key can't be stored. _Tests:
   `entities/tests/test_schemaorg.py`, `jawafdehi_shared/entities/tests/test_ids.py`._

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,15 @@ DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true uv run ruff check .
 DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true uv run pytest -q --ignore=integration-tests
 ```
 
+The unit gate includes `tests/mcp/`: the migrated MCP tool suite, a real ASGI
+lifespan/initialize/tools-list exchange proving Django and MCP share
+`config.asgi.application`, and a subprocess initialize/list/call test for the
+retained stdio transport. Run that slice alone with:
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true uv run pytest -q tests/mcp
+```
+
 - Lints with `ruff check` only (formatting is intentionally NOT gated).
 - `integration-tests/` is excluded here — it is the live-stack suite (Tier 2).
 - **Caveat (what the sqlite gate can hide):** a few behaviors differ from prod
@@ -71,13 +80,16 @@ docker compose -p jawaf-e2e --env-file docker-compose.e2e.env \
 
 - `reindex_all --rebuild` is MANDATORY after `seed_dev` and before any
   search-dependent assertion (a fresh index otherwise auto-maps fields wrong).
-- Health is `GET /api/health` (no trailing slash).
+- API liveness is `GET /api/health` (no trailing slash).
+- MCP is checked on the same host at `POST /mcp`; `GET /mcp/health` reports
+  readiness after the MCP lifespan manager starts.
+- E2E host ports bind to `127.0.0.1`. CI generates a fresh scope-only MCP query
+  bearer; it is accepted only by `/api/query/` and maps to a no-group principal.
 - OIDC-gated tests self-skip when no Zitadel is up (dev-login covers the
   authenticated surface).
 
 ### CI
 
-`integration-tests/.github/workflows/integration.yml` runs this exact flow as a
-cross-repo gate (it checks out the frontend repo alongside and runs both halves).
-It is wired on `pull_request` as a **non-blocking** signal for now; promote it to a
-required status check once it is proven stable in Actions.
+`.github/workflows/integration.yml` runs this exact flow as a cross-repo gate
+(it checks out the frontend repo alongside and runs both halves). Image
+publication depends on both this live gate and the unit/security gate.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -38,6 +38,7 @@ resource kind (no per-service prefix):
 | Materials        | `/api/materials/` |
 | Gated SQL / batch | `/api/query/`, `/api/ingestion/*` |
 | Unified search   | `/api/search/` |
+| MCP              | `/mcp` (streamable HTTP), `/mcp/health` (readiness) |
 | Discovery        | `/sitemap.xml`, `/.well-known/resourcesync`, `/robots.txt` |
 
 `.env` / `.env.example` set the single `PLATFORM_BASE_URL`; the legacy
@@ -76,6 +77,7 @@ tests/
   nes/            # entities API contract smoke tests (/api/entities)
   ngm/            # court-case API contract smoke tests (/api/courtcases/, gated /api/query/)
   jawafdehi/      # corruption-case API contract smoke tests (/api/cases/)
+  mcp/            # MCP health + protocol handshake on the same process
   cross_service/  # the real prize: multi-service flows, unified search, discovery
 fixtures/
   sample_data.py  # canonical sample records (NES entity, NGM case+party, doc source)

--- a/integration-tests/tests/mcp/test_mcp_smoke.py
+++ b/integration-tests/tests/mcp/test_mcp_smoke.py
@@ -1,0 +1,195 @@
+"""Live contract checks for MCP on the shared platform process."""
+
+import json
+import os
+
+import pytest
+
+MCP_HEADERS = {"accept": "application/json, text/event-stream"}
+MCP_E2E_BEARER = os.getenv("MCP_E2E_BEARER", "e2e-ngm-query-only")
+ANONYMOUS_TOOL_CATALOG = {
+    "get_current_user",
+    "search_control_plane",
+    "ngm_query_judicial",
+    "search_jawafdehi_cases",
+    "get_jawafdehi_case",
+    "search_nes_entities",
+    "get_nes_entities",
+    "get_nes_entity_prefixes",
+    "get_nes_tags",
+    "get_nes_entity_versions",
+    "browse_materials",
+    "browse_court_data",
+    "convert_date",
+}
+FULL_TOOL_CATALOG = {
+    "get_current_user",
+    "search_control_plane",
+    "ngm_query_judicial",
+    "ngm_extract_case_data",
+    "search_jawafdehi_cases",
+    "get_jawafdehi_case",
+    "create_jawafdehi_case",
+    "patch_jawafdehi_case",
+    "delete_jawafdehi_case",
+    "submit_nes_change",
+    "upload_material_file",
+    "search_nes_entities",
+    "get_nes_entities",
+    "get_nes_entity_prefixes",
+    "get_nes_tags",
+    "get_nes_entity_versions",
+    "delete_nes_entity",
+    "browse_materials",
+    "manage_material",
+    "browse_court_data",
+    "manage_court_data",
+    "manage_case_update_proposals",
+    "manage_casework_reviews",
+    "manage_jobs",
+    "convert_date",
+    "convert_to_markdown",
+}
+
+
+@pytest.mark.live
+@pytest.mark.smoke
+def test_mcp_health_and_protocol(clients):
+    client = clients["platform"]
+
+    health = client.get("/mcp/health")
+    assert health.status_code == 200
+
+    initialize = client.post(
+        "/mcp",
+        headers=MCP_HEADERS,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "integration-tests", "version": "1.0"},
+            },
+        },
+    )
+    assert initialize.status_code == 200, initialize.text
+    assert initialize.json()["result"]["serverInfo"]["name"] == "jawafdehi-mcp"
+
+    listed = client.post(
+        "/mcp",
+        headers=MCP_HEADERS,
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    )
+    assert listed.status_code == 200, listed.text
+    tool_names = {tool["name"] for tool in listed.json()["result"]["tools"]}
+    assert tool_names == ANONYMOUS_TOOL_CATALOG
+
+    hidden = client.post(
+        "/mcp",
+        headers=MCP_HEADERS,
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "create_jawafdehi_case",
+                "arguments": {},
+            },
+        },
+    )
+    assert hidden.status_code == 200, hidden.text
+    hidden_result = hidden.json()["result"]
+    assert hidden_result["isError"] is True
+    assert "not available for the current user" in hidden_result["content"][0]["text"]
+
+    query = client.post(
+        "/mcp",
+        headers=MCP_HEADERS,
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "ngm_query_judicial",
+                "arguments": {
+                    "query": (
+                        "SELECT identifier FROM courts "
+                        "ORDER BY identifier LIMIT 1"
+                    )
+                },
+            },
+        },
+    )
+    assert query.status_code == 200, query.text
+    tool_payload = query.json()["result"]["content"][0]["text"]
+    result = json.loads(tool_payload)
+    assert result["success"] is True, result
+    assert result["data"]["row_count"] == 1
+
+
+@pytest.mark.live
+@pytest.mark.smoke
+def test_authenticated_mcp_catalog_and_forwarded_authorization(clients):
+    client = clients["platform"]
+    headers = {
+        **MCP_HEADERS,
+        "authorization": f"Bearer {MCP_E2E_BEARER}",
+    }
+
+    listed = client.post(
+        "/mcp",
+        headers=headers,
+        json={"jsonrpc": "2.0", "id": 10, "method": "tools/list", "params": {}},
+    )
+    assert listed.status_code == 200, listed.text
+    tool_names = {tool["name"] for tool in listed.json()["result"]["tools"]}
+    assert tool_names == FULL_TOOL_CATALOG
+
+    query = client.post(
+        "/mcp",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "ngm_query_judicial",
+                "arguments": {
+                    "query": (
+                        "SELECT identifier FROM courts "
+                        "ORDER BY identifier LIMIT 1"
+                    )
+                },
+            },
+        },
+    )
+    assert query.status_code == 200, query.text
+    query_result = json.loads(query.json()["result"]["content"][0]["text"])
+    assert query_result["success"] is True, query_result
+    assert query_result["data"]["row_count"] == 1
+
+    denied_write = client.post(
+        "/mcp",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {
+                "name": "manage_material",
+                "arguments": {
+                    "action": "delete",
+                    "iri": "https://jawafdehi.org/material/court/not-present",
+                },
+            },
+        },
+    )
+    assert denied_write.status_code == 200, denied_write.text
+    assert denied_write.json()["result"]["isError"] is True
+    write_result = json.loads(
+        denied_write.json()["result"]["content"][0]["text"]
+    )
+    assert write_result["success"] is False
+    assert write_result["status_code"] == 401

--- a/jawafdehi_mcp/LICENSE
+++ b/jawafdehi_mcp/LICENSE
@@ -1,0 +1,24 @@
+Hippocratic License Version 3.0
+
+Licensor: Jawafdehi.org
+Project: Jawafdehi MCP
+
+Rights Granted
+
+Subject to the terms and conditions of this License, Licensor hereby grants to any person obtaining a copy of this software and associated documentation files (the "Software"), a worldwide, royalty-free, non-exclusive, perpetual license to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this License or a subsequent version published on the Hippocratic License Website (https://firstdonoharm.dev/) shall be included in all copies or substantial portions of the Software. Licensee has the option of following the terms and conditions either of the above numbered version of this License or of any subsequent version published on the Hippocratic License Website.
+
+2. Compliance with Human Rights Laws and Human Rights Principles:
+
+   a. Human Rights Laws. The Software shall not be used by any person or entity for any systems, activities, or other uses that violate any applicable laws, regulations, or rules that protect human, civil, labor, privacy, political, environmental, security, economic, due process, or similar rights (collectively, "Human Rights Laws"). Where the Human Rights Laws of more than one jurisdiction are applicable to the use of the Software, the Software shall not be used in any manner that violates any of the Human Rights Laws.
+
+   b. Human Rights Principles. Licensee is advised to consult the articles of the United Nations Universal Declaration of Human Rights (https://www.un.org/en/universal-declaration-human-rights/) and the United Nations Global Compact (https://www.unglobalcompact.org/what-is-gc/mission/principles) that define recognized principles of international human rights (collectively, "Human Rights Principles"). It is Licensor's express intent that all use of the Software be consistent with Human Rights Principles. If Licensor receives notification or otherwise learns of an alleged violation of any Human Rights Principles relating to Licensee's use of the Software, Licensor may in its discretion and without obligation (i) (a) notify Licensee of such allegation and (b) allow Licensee 90 days from notification under (i)(a) to investigate and respond to Licensor regarding the allegation and (ii) (a) after the earlier of 90 days from notification under (i)(a), or Licensee's response under (i)(b), notify Licensee of License termination and (b) allow Licensee an additional 90 days from notification under (ii)(a) to cease use of the Software.
+
+   c. Indemnity. Licensee shall hold harmless and indemnify Licensor against all losses, damages, liabilities, deficiencies, claims, actions, judgments, settlements, interest, awards, penalties, fines, costs, or expenses of whatever kind, including Licensor's reasonable attorneys' fees, arising out of or relating to Licensee's non-compliance with this License or use of the Software in violation of Human Rights Laws or Human Rights Principles.
+
+3. Enforceability: If any portion or provision of this License is determined to be invalid, illegal, or unenforceable by a court of competent jurisdiction, then such invalidity, illegality, or unenforceability shall not affect any other term or provision of this License or invalidate or render unenforceable such term or provision in any other jurisdiction. Upon a determination that any term or provision is invalid, illegal, or unenforceable, to the extent permitted by applicable law, the court may modify this License to affect the original intent of the parties as closely as possible. The section headings are for convenience only and are not intended to affect the construction or interpretation of this License. Any rule of construction to the effect that ambiguities are to be resolved against the drafting party shall not apply in interpreting this License. The language in this License shall be interpreted as to its fair meaning and not strictly for or against any party.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The Hippocratic License is an Ethical Source license (https://ethicalsource.dev).

--- a/jawafdehi_mcp/__init__.py
+++ b/jawafdehi_mcp/__init__.py
@@ -1,0 +1,8 @@
+"""Jawafdehi MCP Server - Tools for querying Nepal's judicial data."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("jawafdehi")
+except PackageNotFoundError:  # source tree before installation
+    __version__ = "0+unknown"

--- a/jawafdehi_mcp/api_transport.py
+++ b/jawafdehi_mcp/api_transport.py
@@ -1,0 +1,155 @@
+"""In-process transport for MCP calls to the colocated Django API."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import threading
+import weakref
+from typing import Any
+
+import httpx
+
+from .request_context import current_transport
+
+_embedded_api_application: Any | None = None
+_limiter_lock = threading.Lock()
+_limiters: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, tuple[int, asyncio.Semaphore]
+] = weakref.WeakKeyDictionary()
+
+
+def _positive_env_float(name: str, default: float, maximum: float) -> float:
+    raw = os.getenv(name, str(default))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(value) or value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _positive_env_int(name: str, default: int, maximum: int) -> int:
+    raw = os.getenv(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _embedded_timeout_seconds() -> float:
+    return _positive_env_float("MCP_EMBEDDED_API_TIMEOUT", 30.0, 300.0)
+
+
+def _embedded_max_concurrency() -> int:
+    return _positive_env_int("MCP_EMBEDDED_API_MAX_CONCURRENCY", 16, 256)
+
+
+def _loop_limiter(limit: int) -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    with _limiter_lock:
+        existing = _limiters.get(loop)
+        if existing is None or existing[0] != limit:
+            existing = (limit, asyncio.Semaphore(limit))
+            _limiters[loop] = existing
+        return existing[1]
+
+
+def _release_limiter_when_done(
+    task: asyncio.Task[httpx.Response],
+    limiter: asyncio.Semaphore,
+) -> None:
+    """Release retained capacity and consume a detached task's result."""
+    limiter.release()
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except Exception:  # noqa: BLE001 — retrieving it IS the point; see below
+        # The request already returned a timeout/cancellation to its caller.
+        # Retrieving the exception prevents a detached-task warning.
+        pass
+
+
+class BoundedASGITransport(httpx.AsyncBaseTransport):
+    """ASGI transport with a real deadline and shared concurrency bound.
+
+    HTTPX's stock ``ASGITransport`` does not enforce its timeout extension.
+    Without this wrapper, an embedded API call can wait forever even when the
+    caller supplied ``timeout=30``.
+    """
+
+    def __init__(self, application: Any) -> None:
+        self._transport = httpx.ASGITransport(
+            app=application,
+            raise_app_exceptions=False,
+        )
+
+    @staticmethod
+    def _deadline_for(request: httpx.Request) -> float:
+        configured = _embedded_timeout_seconds()
+        request_timeouts = request.extensions.get("timeout")
+        if not isinstance(request_timeouts, dict):
+            return configured
+        try:
+            read_timeout = float(request_timeouts.get("read"))
+        except (TypeError, ValueError):
+            return configured
+        if not math.isfinite(read_timeout) or read_timeout <= 0:
+            return configured
+        return min(read_timeout, configured)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        deadline = self._deadline_for(request)
+        limiter = _loop_limiter(_embedded_max_concurrency())
+        worker: asyncio.Task[httpx.Response] | None = None
+        acquired = False
+        try:
+            async with asyncio.timeout(deadline):
+                await limiter.acquire()
+                acquired = True
+                worker = asyncio.create_task(
+                    self._transport.handle_async_request(request)
+                )
+                return await asyncio.shield(worker)
+        except TimeoutError as exc:
+            raise httpx.ReadTimeout(
+                f"Embedded API call exceeded {deadline:g} seconds",
+                request=request,
+            ) from exc
+        finally:
+            if acquired:
+                if worker is None or worker.done():
+                    limiter.release()
+                else:
+                    # Sync Django work may outlive cancellation. Keep its capacity
+                    # slot until it actually exits so repeated timeouts cannot
+                    # create unbounded work behind the shared ASGI process.
+                    worker.add_done_callback(
+                        lambda task: _release_limiter_when_done(task, limiter)
+                    )
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
+def configure_embedded_api(application: Any | None) -> None:
+    """Set the Django ASGI application used by embedded HTTP MCP requests."""
+    global _embedded_api_application
+    _embedded_api_application = application
+
+
+def embedded_api_client_kwargs() -> dict[str, Any]:
+    """Return AsyncClient kwargs for an in-memory API call when embedded.
+
+    Stdio retains normal network behavior. Requests entering through the
+    monolith's MCP HTTP surface are dispatched to Django in-process.
+    """
+    if current_transport.get() != "http" or _embedded_api_application is None:
+        return {}
+    return {"transport": BoundedASGITransport(_embedded_api_application)}

--- a/jawafdehi_mcp/configuration.py
+++ b/jawafdehi_mcp/configuration.py
@@ -1,0 +1,33 @@
+"""Configuration compatibility between the embedded MCP and Django."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_DJANGO_SETTING_NAMES = {
+    "OIDC_ISSUER": "OIDC_ISSUER",
+    "OIDC_JWKS_URL": "OIDC_JWKS_URI",
+    "OIDC_API_AUDIENCE": "OIDC_AUDIENCE",
+    "OIDC_OP_USER_ENDPOINT": "OIDC_OP_USER_ENDPOINT",
+}
+
+
+def get_oidc_config(name: str) -> Any | None:
+    """Read authoritative Django OIDC settings, with standalone env fallback."""
+    setting_name = _DJANGO_SETTING_NAMES.get(name)
+    if setting_name is not None:
+        try:
+            from django.conf import settings
+        except ImportError:
+            settings = None
+
+        if settings is not None and settings.configured:
+            value = getattr(settings, setting_name, None)
+            if value not in (None, "", [], ()):
+                return value
+
+    value = os.getenv(name)
+    if value and value.strip():
+        return value.strip()
+    return None

--- a/jawafdehi_mcp/control_plane.py
+++ b/jawafdehi_mcp/control_plane.py
@@ -1,0 +1,108 @@
+"""Shared HTTP client for bounded calls into the Jawafdehi control plane."""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any, Mapping
+from urllib.parse import unquote
+
+import httpx
+
+from .api_transport import embedded_api_client_kwargs
+from .request_context import get_forwarded_headers, get_local_service_token
+
+
+def _base_url() -> str:
+    value = os.getenv("JAWAFDEHI_API_BASE_URL", "https://api.jawafdehi.org").rstrip("/")
+    if not value.startswith(("http://", "https://")):
+        raise ValueError("JAWAFDEHI_API_BASE_URL must be an HTTP(S) URL.")
+    return value
+
+
+def _timeout_seconds() -> float:
+    raw = os.getenv("MCP_CONTROL_PLANE_TIMEOUT", "30")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 30.0
+    if not math.isfinite(value) or value <= 0:
+        return 30.0
+    return min(value, 120.0)
+
+
+def _auth_headers() -> dict[str, str]:
+    headers = get_forwarded_headers()
+    if headers:
+        return headers
+    token = get_local_service_token()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _validate_api_path(path: str) -> None:
+    if (
+        not path.startswith("/api/")
+        or "://" in path
+        or "?" in path
+        or "#" in path
+        or "\\" in path
+    ):
+        raise ValueError("Control-plane requests require a fixed /api/ path.")
+    decoded = path
+    for _ in range(6):
+        if any(segment in {".", ".."} for segment in decoded.split("/")):
+            raise ValueError("Control-plane path contains a traversal segment.")
+        next_value = unquote(decoded)
+        if next_value == decoded:
+            return
+        decoded = next_value
+    raise ValueError("Control-plane path is excessively percent-encoded.")
+
+
+def _response_payload(response: httpx.Response) -> Any:
+    if not response.content:
+        return None
+    try:
+        return response.json()
+    except ValueError:
+        return response.text
+
+
+async def request_control_plane(
+    method: str,
+    path: str,
+    *,
+    params: Mapping[str, Any] | list[tuple[str, Any]] | None = None,
+    json_body: Any = None,
+    headers: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Call one fixed control-plane route and return a stable tool envelope."""
+    _validate_api_path(path)
+    request_headers = _auth_headers()
+    if headers:
+        request_headers.update(headers)
+
+    timeout = _timeout_seconds()
+    async with httpx.AsyncClient(
+        **embedded_api_client_kwargs(),
+        follow_redirects=False,
+        timeout=timeout,
+    ) as client:
+        response = await client.request(
+            method,
+            f"{_base_url()}{path}",
+            params=params,
+            json=json_body,
+            headers=request_headers,
+        )
+
+    result: dict[str, Any] = {
+        "success": response.is_success,
+        "status_code": response.status_code,
+        "data": _response_payload(response),
+    }
+    if etag := response.headers.get("etag"):
+        result["etag"] = etag
+    if not response.is_success:
+        result["error"] = "Jawafdehi control-plane request failed."
+    return result

--- a/jawafdehi_mcp/http_server.py
+++ b/jawafdehi_mcp/http_server.py
@@ -70,20 +70,21 @@ def _authorization_offered(headers: dict[bytes, bytes]) -> bool:
     return bool(headers.get(b"authorization", b"").strip())
 
 
-def _bearer_challenge(error: str, headers: dict[bytes, bytes]) -> str:
+def _bearer_challenge(error: str) -> str:
     """Build a ``WWW-Authenticate`` value, pointing at RFC 9728 metadata."""
     challenge = f'Bearer error="{error}"'
-    rm_url = _resource_metadata_url(_canonical_base_url(headers))
+    rm_url = _resource_metadata_url(_canonical_base_url())
     if rm_url:
         challenge += f', resource_metadata="{rm_url}"'
     return challenge
 
 
-def _canonical_base_url(_headers: dict[bytes, bytes] | None = None) -> str | None:
+def _canonical_base_url() -> str | None:
     """Absolute base URL of this MCP server for RFC 9728 metadata.
 
-    Only the trusted OIDC_RESOURCE configuration may define security metadata.
-    Request Host and forwarding headers are intentionally never consulted."""
+    Takes no request input on purpose. Only the trusted OIDC_RESOURCE
+    configuration may define security metadata, so Host and forwarding headers
+    cannot reach this decision rather than merely being ignored by it."""
     configured = (os.getenv("OIDC_RESOURCE") or "").strip()
     if not configured:
         return None
@@ -398,7 +399,7 @@ class JawafdehiMCPServer:
         if path == WELL_KNOWN_PROTECTED_RESOURCE:
             # Always advertised. This is now the only way a client discovers how
             # to authenticate, since an anonymous request is not challenged.
-            base = _canonical_base_url(headers)
+            base = _canonical_base_url()
             if not base:
                 await self._send_json(
                     send,
@@ -428,7 +429,7 @@ class JawafdehiMCPServer:
                     "detail": "Authorization header is not a Bearer credential.",
                 },
                 extra_headers=[
-                    ("www-authenticate", _bearer_challenge("invalid_request", headers))
+                    ("www-authenticate", _bearer_challenge("invalid_request"))
                 ],
             )
             return
@@ -445,7 +446,7 @@ class JawafdehiMCPServer:
                     401,
                     {"error": "invalid_token", "detail": str(exc)},
                     extra_headers=[
-                        ("www-authenticate", _bearer_challenge("invalid_token", headers))
+                        ("www-authenticate", _bearer_challenge("invalid_token"))
                     ],
                 )
                 return

--- a/jawafdehi_mcp/http_server.py
+++ b/jawafdehi_mcp/http_server.py
@@ -182,19 +182,24 @@ def _resource_metadata_url(base_url: str | None) -> str:
     return urlunsplit((parsed.scheme, parsed.netloc, metadata_path, "", ""))
 
 
-def _protected_resource_metadata(base_url: str | None = None) -> dict:
+def _protected_resource_metadata(base_url: str) -> dict:
     """RFC 9728 Protected Resource Metadata so OAuth clients discover the
     authorization server (Zitadel, Design 1a) and the scopes to request.
 
     ``base_url`` is the absolute canonical URL of this MCP server (see
-    _canonical_base_url); falls back to OIDC_API_AUDIENCE for hostless callers."""
+    :func:`_canonical_base_url`) and is REQUIRED. There is deliberately no
+    fallback to OIDC_API_AUDIENCE: RFC 9728 defines ``resource`` as the
+    resource's URL, and an audience identifier is not one. With a single endpoint
+    there is exactly one canonical URL, so a caller that cannot supply it is a
+    misconfigured deployment — which the sole caller reports as a 503 rather than
+    advertising a document no client can use."""
     raw_audience = get_oidc_config("OIDC_API_AUDIENCE")
     if isinstance(raw_audience, (list, tuple)):
         audience = str(raw_audience[0]) if raw_audience else ""
     else:
         audience = str(raw_audience or "").strip()
     issuer = str(get_oidc_config("OIDC_ISSUER") or "").strip()
-    resource = base_url or audience
+    resource = base_url
     # offline_access must be advertised for clients (e.g. Claude Code) to request
     # a refresh token; the project-aud urn puts our project id in the token
     # audience so the API + this server accept the bearer.
@@ -322,6 +327,41 @@ class JawafdehiMCPServer:
         path = scope.get("path", "")
         method = scope.get("method", "GET").upper()
         headers = dict(scope.get("headers", []))
+
+        # Readiness is answered BEFORE the Host allowlist, deliberately. A
+        # Kubernetes httpGet probe defaults Host to the pod IP, which is not in
+        # MCP_ALLOWED_HOSTS and should not have to be — validating it here would
+        # 421 every probe and the pod would never be marked ready. That would
+        # also contradict the rule just below, where a missing OIDC_RESOURCE is
+        # deliberately kept from failing the probe.
+        #
+        # Safe because this endpoint takes no credential, reads no request data,
+        # and returns one of two fixed strings. DNS-rebinding protection exists
+        # to keep a browser off the MCP *protocol* endpoint, which is still
+        # guarded below.
+        if path == "/health":
+            if method != "GET":
+                await self._send_response(
+                    send,
+                    405,
+                    [("content-type", "text/plain"), ("allow", "GET")],
+                    b"method not allowed",
+                )
+                return
+            # Lifespan readiness only. A missing OIDC_RESOURCE is NOT unready:
+            # the anonymous read catalog serves correctly without it, and failing
+            # the probe would take down a pod that is doing its job. The
+            # misconfiguration surfaces on the metadata endpoint, which 503s, and
+            # on every authenticated call.
+            ready = self._ready
+            await self._send_response(
+                send,
+                200 if ready else 503,
+                [("content-type", "text/plain")],
+                b"ready" if ready else b"not ready",
+            )
+            return
+
         host = headers.get(b"host", b"").decode(errors="replace").strip()
         if not _matches_allowed_header(
             host,
@@ -347,28 +387,12 @@ class JawafdehiMCPServer:
             )
             return
 
-        if path in {"/health", WELL_KNOWN_PROTECTED_RESOURCE} and method != "GET":
+        if path == WELL_KNOWN_PROTECTED_RESOURCE and method != "GET":
             await self._send_response(
                 send,
                 405,
                 [("content-type", "text/plain"), ("allow", "GET")],
                 b"method not allowed",
-            )
-            return
-        if path == "/health":
-            # Lifespan readiness only. A missing OIDC_RESOURCE is NOT unready:
-            # the anonymous read catalog serves correctly without it, and failing
-            # the probe would take down a pod that is doing its job. The
-            # misconfiguration surfaces on the metadata endpoint below, which
-            # 503s, and on every authenticated call.
-            ready = self._ready
-            status_code = 200 if ready else 503
-            body = b"ready" if ready else b"not ready"
-            await self._send_response(
-                send,
-                status_code,
-                [("content-type", "text/plain")],
-                body,
             )
             return
         if path == WELL_KNOWN_PROTECTED_RESOURCE:

--- a/jawafdehi_mcp/http_server.py
+++ b/jawafdehi_mcp/http_server.py
@@ -18,7 +18,7 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.server.transport_security import TransportSecuritySettings
 
 from .configuration import get_oidc_config
-from .identity import current_request_mode, current_user_identity
+from .identity import current_user_identity
 from .oidc import OIDCError, resolve_bearer_identity
 from .request_context import current_transport, jawafdehi_bearer_token
 from .server import app as mcp_app
@@ -37,19 +37,6 @@ Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
 Headers = Iterable[tuple[str, str]]
 
 WELL_KNOWN_PROTECTED_RESOURCE = "/.well-known/oauth-protected-resource"
-MCP_RESOURCE_PATH = "/mcp"
-# Injected by the ingress (Traefik overwrites it, so a client value can't win):
-#   "internal" -> OAuth-gated door; unauthenticated requests get a 401 challenge
-#   "public"   -> anonymous door; restricted tools, OAuth never advertised
-#   absent     -> falls back to MCP_DEFAULT_MODE (the per-deployment floor),
-#                 else legacy/OWUI-facing in-cluster behavior (unchanged)
-MODE_HEADER = b"x-mcp-mode"
-# Per-deployment safe floor for the mode when the header is missing. Set to
-# "public" on the internet-facing deployment so a stripped/absent header can
-# never widen anonymous access to the fuller legacy read-only set (which
-# includes OCR + SQL); unset for the in-cluster OWUI deploy (legacy behavior).
-MODE_DEFAULT_ENV = "MCP_DEFAULT_MODE"
-VALID_MODES = frozenset({"public", "internal"})
 _LOCAL_ALLOWED_HOSTS = (
     "localhost",
     "localhost:*",
@@ -72,24 +59,24 @@ def _bearer_from_headers(headers: dict[bytes, bytes]) -> str | None:
     return parts[1].strip()
 
 
-def _mode_from_headers(headers: dict[bytes, bytes]) -> str | None:
-    """Resolve the door mode without weakening the deployment's mode floor."""
-    default_raw = (os.getenv(MODE_DEFAULT_ENV) or "").strip().lower()
-    if default_raw:
-        default_mode = default_raw if default_raw in VALID_MODES else "public"
-    else:
-        default_mode = None
+def _authorization_offered(headers: dict[bytes, bytes]) -> bool:
+    """Whether the caller sent an ``Authorization`` header of any shape.
 
-    # Internal is the stricter deployment posture. A request header may never
-    # downgrade it to the anonymous public door, even when an ingress fails to
-    # overwrite a client-supplied value.
-    if default_mode == "internal":
-        return "internal"
+    Distinguishes "anonymous" from "tried to authenticate and got it wrong".
+    ``_bearer_from_headers`` returns ``None`` for both, and with a single door
+    those two must not be treated alike: an anonymous caller is served, while a
+    malformed credential has to be told so.
+    """
+    return bool(headers.get(b"authorization", b"").strip())
 
-    raw = headers.get(MODE_HEADER, b"").decode(errors="replace").strip().lower()
-    if raw:
-        return raw if raw in VALID_MODES else "public"
-    return default_mode
+
+def _bearer_challenge(error: str, headers: dict[bytes, bytes]) -> str:
+    """Build a ``WWW-Authenticate`` value, pointing at RFC 9728 metadata."""
+    challenge = f'Bearer error="{error}"'
+    rm_url = _resource_metadata_url(_canonical_base_url(headers))
+    if rm_url:
+        challenge += f', resource_metadata="{rm_url}"'
+    return challenge
 
 
 def _canonical_base_url(_headers: dict[bytes, bytes] | None = None) -> str | None:
@@ -318,10 +305,19 @@ class JawafdehiMCPServer:
     ) -> None:
         """Authenticate the request's bearer token, then delegate to MCP.
 
-        Behavior varies by the ingress-injected mode (see MODE_HEADER):
-        ``internal`` challenges anonymous callers with a 401 so MCP clients
-        start OAuth; ``public`` serves anonymous callers a restricted tool set
-        and never advertises OAuth; absent = legacy behavior.
+        One door, one rule. A verified bearer resolves an identity and receives
+        the full catalog; an anonymous request proceeds with the read-only
+        anonymous catalog (see ``identity.ANONYMOUS_TOOL_NAMES``) rather than a
+        401, because every tool in that set wraps an ``AllowAny`` REST route that
+        ``/api/`` already serves anonymously. A bearer that is *present but
+        invalid* is still rejected with a challenge — that is a broken caller,
+        not an anonymous one.
+
+        Consequence worth knowing: MCP clients begin an OAuth flow only on a
+        401, so an anonymous client is never prompted to log in. It gets the
+        read-only catalog, and ``get_current_user`` is how it can tell. The
+        protected-resource metadata below is what makes authenticating
+        discoverable.
         """
         path = scope.get("path", "")
         method = scope.get("method", "GET").upper()
@@ -350,7 +346,6 @@ class JawafdehiMCPServer:
                 b"invalid origin header",
             )
             return
-        mode = _mode_from_headers(headers)
 
         if path in {"/health", WELL_KNOWN_PROTECTED_RESOURCE} and method != "GET":
             await self._send_response(
@@ -361,8 +356,12 @@ class JawafdehiMCPServer:
             )
             return
         if path == "/health":
-            configured = mode != "internal" or bool(_canonical_base_url(headers))
-            ready = self._ready and configured
+            # Lifespan readiness only. A missing OIDC_RESOURCE is NOT unready:
+            # the anonymous read catalog serves correctly without it, and failing
+            # the probe would take down a pod that is doing its job. The
+            # misconfiguration surfaces on the metadata endpoint below, which
+            # 503s, and on every authenticated call.
+            ready = self._ready
             status_code = 200 if ready else 503
             body = b"ready" if ready else b"not ready"
             await self._send_response(
@@ -373,20 +372,16 @@ class JawafdehiMCPServer:
             )
             return
         if path == WELL_KNOWN_PROTECTED_RESOURCE:
-            if mode == "public":
-                # The public door does not advertise OAuth.
-                await self._send_response(
-                    send, 404, [("content-type", "text/plain")], b"not found"
-                )
-                return
+            # Always advertised. This is now the only way a client discovers how
+            # to authenticate, since an anonymous request is not challenged.
             base = _canonical_base_url(headers)
-            if mode == "internal" and not base:
+            if not base:
                 await self._send_json(
                     send,
                     503,
                     {
                         "error": "server_configuration_error",
-                        "detail": "OIDC_RESOURCE is required for internal MCP.",
+                        "detail": "OIDC_RESOURCE is required to serve MCP metadata.",
                     },
                 )
                 return
@@ -395,60 +390,49 @@ class JawafdehiMCPServer:
 
         token = _bearer_from_headers(headers)
 
-        if mode == "internal" and not _canonical_base_url(headers):
-            await self._send_json(
-                send,
-                503,
-                {
-                    "error": "server_configuration_error",
-                    "detail": "OIDC_RESOURCE is required for internal MCP.",
-                },
-            )
-            return
-
-        # Internal door: an anonymous request is challenged so the MCP client
-        # begins the OAuth flow (clients only start auth on a 401/403).
-        if not token and mode == "internal":
-            rm_url = _resource_metadata_url(_canonical_base_url(headers))
-            challenge = f'Bearer resource_metadata="{rm_url}"' if rm_url else "Bearer"
+        # A credential we cannot parse is a malformed request, not an anonymous
+        # one (RFC 6750 §3.1 `invalid_request`). Without this branch a wrong
+        # scheme or an empty `Bearer` would fall through to the anonymous catalog
+        # with a 200, and the caller would never learn its header was wrong —
+        # exactly the silent degradation this door already risks.
+        if token is None and _authorization_offered(headers):
             await self._send_json(
                 send,
                 401,
-                {"error": "unauthorized", "detail": "authentication required"},
-                extra_headers=[("www-authenticate", challenge)],
+                {
+                    "error": "invalid_request",
+                    "detail": "Authorization header is not a Bearer credential.",
+                },
+                extra_headers=[
+                    ("www-authenticate", _bearer_challenge("invalid_request", headers))
+                ],
             )
             return
 
         token_ctx = None
         identity_ctx = None
-        transport_ctx = None
 
         if token:
             try:
                 identity = await resolve_bearer_identity(token)
             except OIDCError as exc:
-                challenge = 'Bearer error="invalid_token"'
-                if mode == "internal":
-                    rm_url = _resource_metadata_url(_canonical_base_url(headers))
-                    if rm_url:
-                        challenge += f', resource_metadata="{rm_url}"'
                 await self._send_json(
                     send,
                     401,
                     {"error": "invalid_token", "detail": str(exc)},
-                    extra_headers=[("www-authenticate", challenge)],
+                    extra_headers=[
+                        ("www-authenticate", _bearer_challenge("invalid_token", headers))
+                    ],
                 )
                 return
             token_ctx = jawafdehi_bearer_token.set(token)
             identity_ctx = current_user_identity.set(identity)
 
-        mode_ctx = current_request_mode.set(mode)
         transport_ctx = current_transport.set("http")
         try:
             await self.session_manager.handle_request(scope, receive, send)
         finally:
             current_transport.reset(transport_ctx)
-            current_request_mode.reset(mode_ctx)
             if identity_ctx is not None:
                 current_user_identity.reset(identity_ctx)
             if token_ctx is not None:

--- a/jawafdehi_mcp/http_server.py
+++ b/jawafdehi_mcp/http_server.py
@@ -1,0 +1,455 @@
+"""Streamable HTTP transport for jawafdehi-mcp.
+
+Wraps the MCP server with a Streamable HTTP transport using mcp's built-in
+StreamableHTTPSessionManager, and authenticates each request as an OIDC
+resource server: a verified ``Authorization: Bearer`` token resolves the
+caller's identity and is forwarded to the embedded Django API. The HTTP
+transport is hosted only by ``config.asgi:application``.
+"""
+
+import json
+import os
+from collections.abc import Awaitable, Callable, Iterable, MutableMapping
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import structlog
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
+
+from .configuration import get_oidc_config
+from .identity import current_request_mode, current_user_identity
+from .oidc import OIDCError, resolve_bearer_identity
+from .request_context import current_transport, jawafdehi_bearer_token
+from .server import app as mcp_app
+
+logger = structlog.get_logger()
+
+# The three ASGI plumbing types, spelled out rather than imported from
+# ``starlette.types``. mcp pulls starlette in transitively, but no first-party
+# module imports it directly and this file should not be the reason it becomes a
+# declared dependency (cf. the httpcore note in pyproject.toml, where a direct
+# import IS declared). These are the ASGI spec's shapes and do not change.
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+#: ``(name, value)`` response headers, as this module builds them before encode.
+Headers = Iterable[tuple[str, str]]
+
+WELL_KNOWN_PROTECTED_RESOURCE = "/.well-known/oauth-protected-resource"
+MCP_RESOURCE_PATH = "/mcp"
+# Injected by the ingress (Traefik overwrites it, so a client value can't win):
+#   "internal" -> OAuth-gated door; unauthenticated requests get a 401 challenge
+#   "public"   -> anonymous door; restricted tools, OAuth never advertised
+#   absent     -> falls back to MCP_DEFAULT_MODE (the per-deployment floor),
+#                 else legacy/OWUI-facing in-cluster behavior (unchanged)
+MODE_HEADER = b"x-mcp-mode"
+# Per-deployment safe floor for the mode when the header is missing. Set to
+# "public" on the internet-facing deployment so a stripped/absent header can
+# never widen anonymous access to the fuller legacy read-only set (which
+# includes OCR + SQL); unset for the in-cluster OWUI deploy (legacy behavior).
+MODE_DEFAULT_ENV = "MCP_DEFAULT_MODE"
+VALID_MODES = frozenset({"public", "internal"})
+_LOCAL_ALLOWED_HOSTS = (
+    "localhost",
+    "localhost:*",
+    "127.0.0.1",
+    "127.0.0.1:*",
+    "[::1]",
+    "[::1]:*",
+)
+_MIB = 1024 * 1024
+
+
+def _bearer_from_headers(headers: dict[bytes, bytes]) -> str | None:
+    raw = headers.get(b"authorization", b"").decode(errors="replace").strip()
+    if not raw:
+        return None
+    # Split on any run of whitespace (HTTP allows multiple spaces / tabs).
+    parts = raw.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1].strip():
+        return None
+    return parts[1].strip()
+
+
+def _mode_from_headers(headers: dict[bytes, bytes]) -> str | None:
+    """Resolve the door mode without weakening the deployment's mode floor."""
+    default_raw = (os.getenv(MODE_DEFAULT_ENV) or "").strip().lower()
+    if default_raw:
+        default_mode = default_raw if default_raw in VALID_MODES else "public"
+    else:
+        default_mode = None
+
+    # Internal is the stricter deployment posture. A request header may never
+    # downgrade it to the anonymous public door, even when an ingress fails to
+    # overwrite a client-supplied value.
+    if default_mode == "internal":
+        return "internal"
+
+    raw = headers.get(MODE_HEADER, b"").decode(errors="replace").strip().lower()
+    if raw:
+        return raw if raw in VALID_MODES else "public"
+    return default_mode
+
+
+def _canonical_base_url(_headers: dict[bytes, bytes] | None = None) -> str | None:
+    """Absolute base URL of this MCP server for RFC 9728 metadata.
+
+    Only the trusted OIDC_RESOURCE configuration may define security metadata.
+    Request Host and forwarding headers are intentionally never consulted."""
+    configured = (os.getenv("OIDC_RESOURCE") or "").strip()
+    if not configured:
+        return None
+    parsed = urlsplit(configured)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    return configured.rstrip("/")
+
+
+def _positive_int_env(name: str, default: int, maximum: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _max_request_body_size() -> int:
+    """Allow the configured raw document limit after URI/JSON encoding."""
+    input_bytes = _positive_int_env(
+        "MCP_DOCUMENT_MAX_INPUT_BYTES",
+        25 * _MIB,
+        100 * _MIB,
+    )
+    computed = input_bytes * 4 + _MIB
+    return _positive_int_env(
+        "MCP_HTTP_MAX_REQUEST_BODY_BYTES",
+        computed,
+        401 * _MIB,
+    )
+
+
+def _csv_env(name: str) -> list[str]:
+    return [
+        item.strip()
+        for item in os.getenv(name, "").split(",")
+        if item.strip()
+    ]
+
+
+def _transport_security_settings() -> TransportSecuritySettings:
+    hosts = set(_LOCAL_ALLOWED_HOSTS)
+    origins = set(_csv_env("MCP_ALLOWED_ORIGINS"))
+    hosts.update(_csv_env("MCP_ALLOWED_HOSTS"))
+
+    if resource := _canonical_base_url():
+        parsed = urlsplit(resource)
+        hosts.add(parsed.netloc)
+        origins.add(urlunsplit((parsed.scheme, parsed.netloc, "", "", "")))
+
+    try:
+        from django.conf import settings
+
+        if settings.configured and getattr(settings, "TESTING", False):
+            hosts.add("testserver")
+    except ImportError:
+        pass
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=sorted(hosts),
+        allowed_origins=sorted(origins),
+    )
+
+
+def _matches_allowed_header(value: str, allowed_values: list[str]) -> bool:
+    if value in allowed_values:
+        return True
+    return any(
+        allowed.endswith(":*")
+        and value.startswith(f"{allowed[:-2]}:")
+        for allowed in allowed_values
+    )
+
+
+def _resource_metadata_url(base_url: str | None) -> str:
+    """Return the RFC 9728 metadata URL for a possibly path-based resource."""
+    if not base_url:
+        return ""
+    parsed = urlsplit(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    resource_path = parsed.path.rstrip("/")
+    metadata_path = WELL_KNOWN_PROTECTED_RESOURCE
+    if resource_path:
+        metadata_path = f"{metadata_path}{resource_path}"
+    return urlunsplit((parsed.scheme, parsed.netloc, metadata_path, "", ""))
+
+
+def _protected_resource_metadata(base_url: str | None = None) -> dict:
+    """RFC 9728 Protected Resource Metadata so OAuth clients discover the
+    authorization server (Zitadel, Design 1a) and the scopes to request.
+
+    ``base_url`` is the absolute canonical URL of this MCP server (see
+    _canonical_base_url); falls back to OIDC_API_AUDIENCE for hostless callers."""
+    raw_audience = get_oidc_config("OIDC_API_AUDIENCE")
+    if isinstance(raw_audience, (list, tuple)):
+        audience = str(raw_audience[0]) if raw_audience else ""
+    else:
+        audience = str(raw_audience or "").strip()
+    issuer = str(get_oidc_config("OIDC_ISSUER") or "").strip()
+    resource = base_url or audience
+    # offline_access must be advertised for clients (e.g. Claude Code) to request
+    # a refresh token; the project-aud urn puts our project id in the token
+    # audience so the API + this server accept the bearer.
+    scopes = ["openid", "email", "profile", "offline_access"]
+    if audience:
+        scopes.append(f"urn:zitadel:iam:org:project:id:{audience}:aud")
+    return {
+        "resource": resource,
+        "authorization_servers": [issuer] if issuer else [],
+        "bearer_methods_supported": ["header"],
+        "scopes_supported": scopes,
+    }
+
+
+class JawafdehiMCPServer:
+    """Minimal ASGI app wrapping StreamableHTTPSessionManager with per-request
+    OIDC bearer authentication (see resolve_bearer_identity)."""
+
+    def __init__(self, *, stateless: bool = True) -> None:
+        self._ready = False
+        self.security_settings = _transport_security_settings()
+        self.session_manager = StreamableHTTPSessionManager(
+            app=mcp_app,
+            json_response=True,
+            # The tools hold no protocol-session state. Stateless mode lets the
+            # monolith retain multiple gunicorn workers and pod replicas without
+            # requiring load-balancer affinity for MCP session IDs.
+            stateless=stateless,
+            security_settings=self.security_settings,
+            max_request_body_size=_max_request_body_size(),
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "lifespan":
+            await self._handle_lifespan(scope, receive, send)
+        elif scope["type"] == "http":
+            await self._handle_http(scope, receive, send)
+
+    @staticmethod
+    async def _send_response(
+        send: Send,
+        status_code: int,
+        headers: Headers,
+        body: bytes = b"",
+    ) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status_code,
+                "headers": [(k.encode(), v.encode()) for k, v in headers],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+    async def _send_json(
+        self,
+        send: Send,
+        status_code: int,
+        payload: dict[str, Any],
+        extra_headers: Headers | None = None,
+    ) -> None:
+        body = json.dumps(payload).encode()
+        headers = [("content-type", "application/json")]
+        if extra_headers:
+            headers.extend(extra_headers)
+        await self._send_response(send, status_code, headers, body)
+
+    async def _handle_lifespan(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Handle ASGI lifespan protocol."""
+        started = False
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                logger.info("http_server_starting")
+                self._lifespan_ctx = self.session_manager.run()
+                try:
+                    await self._lifespan_ctx.__aenter__()
+                except BaseException as exc:
+                    self._ready = False
+                    await send(
+                        {
+                            "type": "lifespan.startup.failed",
+                            "message": str(exc),
+                        }
+                    )
+                    raise
+                started = True
+                self._ready = True
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                self._ready = False
+                if started:
+                    await self._lifespan_ctx.__aexit__(None, None, None)
+                logger.info("http_server_stopped")
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+    async def _handle_http(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Authenticate the request's bearer token, then delegate to MCP.
+
+        Behavior varies by the ingress-injected mode (see MODE_HEADER):
+        ``internal`` challenges anonymous callers with a 401 so MCP clients
+        start OAuth; ``public`` serves anonymous callers a restricted tool set
+        and never advertises OAuth; absent = legacy behavior.
+        """
+        path = scope.get("path", "")
+        method = scope.get("method", "GET").upper()
+        headers = dict(scope.get("headers", []))
+        host = headers.get(b"host", b"").decode(errors="replace").strip()
+        if not _matches_allowed_header(
+            host,
+            self.security_settings.allowed_hosts,
+        ):
+            await self._send_response(
+                send,
+                421,
+                [("content-type", "text/plain")],
+                b"invalid host header",
+            )
+            return
+        origin = headers.get(b"origin", b"").decode(errors="replace").strip()
+        if origin and not _matches_allowed_header(
+            origin,
+            self.security_settings.allowed_origins,
+        ):
+            await self._send_response(
+                send,
+                403,
+                [("content-type", "text/plain")],
+                b"invalid origin header",
+            )
+            return
+        mode = _mode_from_headers(headers)
+
+        if path in {"/health", WELL_KNOWN_PROTECTED_RESOURCE} and method != "GET":
+            await self._send_response(
+                send,
+                405,
+                [("content-type", "text/plain"), ("allow", "GET")],
+                b"method not allowed",
+            )
+            return
+        if path == "/health":
+            configured = mode != "internal" or bool(_canonical_base_url(headers))
+            ready = self._ready and configured
+            status_code = 200 if ready else 503
+            body = b"ready" if ready else b"not ready"
+            await self._send_response(
+                send,
+                status_code,
+                [("content-type", "text/plain")],
+                body,
+            )
+            return
+        if path == WELL_KNOWN_PROTECTED_RESOURCE:
+            if mode == "public":
+                # The public door does not advertise OAuth.
+                await self._send_response(
+                    send, 404, [("content-type", "text/plain")], b"not found"
+                )
+                return
+            base = _canonical_base_url(headers)
+            if mode == "internal" and not base:
+                await self._send_json(
+                    send,
+                    503,
+                    {
+                        "error": "server_configuration_error",
+                        "detail": "OIDC_RESOURCE is required for internal MCP.",
+                    },
+                )
+                return
+            await self._send_json(send, 200, _protected_resource_metadata(base))
+            return
+
+        token = _bearer_from_headers(headers)
+
+        if mode == "internal" and not _canonical_base_url(headers):
+            await self._send_json(
+                send,
+                503,
+                {
+                    "error": "server_configuration_error",
+                    "detail": "OIDC_RESOURCE is required for internal MCP.",
+                },
+            )
+            return
+
+        # Internal door: an anonymous request is challenged so the MCP client
+        # begins the OAuth flow (clients only start auth on a 401/403).
+        if not token and mode == "internal":
+            rm_url = _resource_metadata_url(_canonical_base_url(headers))
+            challenge = f'Bearer resource_metadata="{rm_url}"' if rm_url else "Bearer"
+            await self._send_json(
+                send,
+                401,
+                {"error": "unauthorized", "detail": "authentication required"},
+                extra_headers=[("www-authenticate", challenge)],
+            )
+            return
+
+        token_ctx = None
+        identity_ctx = None
+        transport_ctx = None
+
+        if token:
+            try:
+                identity = await resolve_bearer_identity(token)
+            except OIDCError as exc:
+                challenge = 'Bearer error="invalid_token"'
+                if mode == "internal":
+                    rm_url = _resource_metadata_url(_canonical_base_url(headers))
+                    if rm_url:
+                        challenge += f', resource_metadata="{rm_url}"'
+                await self._send_json(
+                    send,
+                    401,
+                    {"error": "invalid_token", "detail": str(exc)},
+                    extra_headers=[("www-authenticate", challenge)],
+                )
+                return
+            token_ctx = jawafdehi_bearer_token.set(token)
+            identity_ctx = current_user_identity.set(identity)
+
+        mode_ctx = current_request_mode.set(mode)
+        transport_ctx = current_transport.set("http")
+        try:
+            await self.session_manager.handle_request(scope, receive, send)
+        finally:
+            current_transport.reset(transport_ctx)
+            current_request_mode.reset(mode_ctx)
+            if identity_ctx is not None:
+                current_user_identity.reset(identity_ctx)
+            if token_ctx is not None:
+                jawafdehi_bearer_token.reset(token_ctx)

--- a/jawafdehi_mcp/identity.py
+++ b/jawafdehi_mcp/identity.py
@@ -1,9 +1,9 @@
 """Per-request identity and tool-catalog helpers for jawafdehi-mcp.
 
-Identity is built from the caller's verified OIDC bearer token (see
-``oidc.py`` and ``http_server.py``) and stored in a request-scoped ContextVar.
-Authenticated callers receive the full catalog; request mode controls only the
-anonymous catalog.
+Identity is built from the caller's verified OIDC bearer token (see ``oidc.py``
+and ``http_server.py``) and stored in a request-scoped ContextVar. There is one
+endpoint and one catalog rule: an anonymous caller gets the read-only set below,
+and any verified bearer gets everything.
 """
 
 from contextvars import ContextVar
@@ -12,18 +12,20 @@ current_user_identity: ContextVar[dict | None] = ContextVar(
     "current_user_identity", default=None
 )
 
-# Which "door" the request came through, tagged by the ingress (X-MCP-Mode):
-#   "public"   -> anonymous, restricted tool set (mcp.jawafdehi.org)
-#   "internal" -> OAuth-gated (mcp-internal.jawafdehi.org); anonymous requests
-#                 are challenged with 401 upstream in http_server, so an
-#                 anonymous request should not normally reach tool gating here.
-#   None       -> legacy/unset (OWUI-facing in-cluster deploy, stdio) — keep the
-#                 historical anonymous behavior (full read-only set).
-current_request_mode: ContextVar[str | None] = ContextVar(
-    "current_request_mode", default=None
-)
-
-PUBLIC_READ_ONLY_TOOL_NAMES: set[str] = {
+#: Tools an unauthenticated caller may list and call.
+#:
+#: Every entry here wraps a REST route that is already ``AllowAny``, so this set
+#: grants nothing that ``/api/`` does not serve anonymously — which is what makes
+#: a single door with an anonymous catalog consistent rather than lax.
+#: ``ngm_query_judicial`` belongs for the same reason: the judicial lake is public
+#: court record and its SQL plane is SELECT-gated.
+#:
+#: ``convert_to_markdown`` is deliberately ABSENT. It is one of the few tools with
+#: no ``/api/`` route behind it, so this catalog is its ONLY gate (enforced in
+#: ``server.call_tool``, not just in ``tools/list``), and each call spends real
+#: fetch/OCR budget. It requires authentication — but no particular role, like
+#: every other authenticated tool.
+ANONYMOUS_TOOL_NAMES: set[str] = {
     "get_current_user",
     "search_jawafdehi_cases",
     "get_jawafdehi_case",
@@ -37,43 +39,22 @@ PUBLIC_READ_ONLY_TOOL_NAMES: set[str] = {
     "browse_court_data",
     "ngm_query_judicial",
     "convert_date",
-    "convert_to_markdown",
 }
-
-# Anonymous tool set for the public internet door. Drops convert_to_markdown,
-# which burns real resources (OCR / LLM credits) for unauthenticated callers.
-# ngm_query_judicial is intentionally exposed here: the judicial lake is public
-# court data and the SQL plane is already SELECT-gated.
-PUBLIC_HOST_TOOL_NAMES: set[str] = PUBLIC_READ_ONLY_TOOL_NAMES - {
-    "convert_to_markdown",
-}
-
-
-def anonymous_tool_names(mode: str | None) -> set[str]:
-    """Tool set for an unauthenticated caller, by request mode.
-
-    Only the public internet door restricts the set; the legacy/unset and
-    internal doors keep the full read-only set (the internal door 401s
-    anonymous callers before this anyway).
-    """
-    if mode == "public":
-        return PUBLIC_HOST_TOOL_NAMES
-    return PUBLIC_READ_ONLY_TOOL_NAMES
 
 
 def get_allowed_tool_names(
     identity: dict | None,
     all_tool_names: set[str],
-    mode: str | None = None,
 ) -> set[str]:
-    """Return the set of tool names allowed for the given identity + mode.
+    """Return the set of tool names allowed for the given identity.
 
-    - No identity → anonymous tools for the request mode (restricted on the
-      public internet door, full read-only otherwise).
-    - Any verified identity → all tools. The downstream Django API remains the
-      authorization boundary for operations performed by those tools.
+    - No identity → :data:`ANONYMOUS_TOOL_NAMES`.
+    - Any verified identity → every tool, independent of its roles. Catalog
+      visibility is not an authorization grant: the tools forward that bearer to
+      Django, whose API permissions remain the final boundary for reads and
+      writes.
     """
     if identity is None:
-        return anonymous_tool_names(mode) & all_tool_names
+        return ANONYMOUS_TOOL_NAMES & all_tool_names
 
     return all_tool_names

--- a/jawafdehi_mcp/identity.py
+++ b/jawafdehi_mcp/identity.py
@@ -1,0 +1,79 @@
+"""Per-request identity and tool-catalog helpers for jawafdehi-mcp.
+
+Identity is built from the caller's verified OIDC bearer token (see
+``oidc.py`` and ``http_server.py``) and stored in a request-scoped ContextVar.
+Authenticated callers receive the full catalog; request mode controls only the
+anonymous catalog.
+"""
+
+from contextvars import ContextVar
+
+current_user_identity: ContextVar[dict | None] = ContextVar(
+    "current_user_identity", default=None
+)
+
+# Which "door" the request came through, tagged by the ingress (X-MCP-Mode):
+#   "public"   -> anonymous, restricted tool set (mcp.jawafdehi.org)
+#   "internal" -> OAuth-gated (mcp-internal.jawafdehi.org); anonymous requests
+#                 are challenged with 401 upstream in http_server, so an
+#                 anonymous request should not normally reach tool gating here.
+#   None       -> legacy/unset (OWUI-facing in-cluster deploy, stdio) — keep the
+#                 historical anonymous behavior (full read-only set).
+current_request_mode: ContextVar[str | None] = ContextVar(
+    "current_request_mode", default=None
+)
+
+PUBLIC_READ_ONLY_TOOL_NAMES: set[str] = {
+    "get_current_user",
+    "search_jawafdehi_cases",
+    "get_jawafdehi_case",
+    "search_nes_entities",
+    "get_nes_entities",
+    "get_nes_tags",
+    "get_nes_entity_prefixes",
+    "get_nes_entity_versions",
+    "search_control_plane",
+    "browse_materials",
+    "browse_court_data",
+    "ngm_query_judicial",
+    "convert_date",
+    "convert_to_markdown",
+}
+
+# Anonymous tool set for the public internet door. Drops convert_to_markdown,
+# which burns real resources (OCR / LLM credits) for unauthenticated callers.
+# ngm_query_judicial is intentionally exposed here: the judicial lake is public
+# court data and the SQL plane is already SELECT-gated.
+PUBLIC_HOST_TOOL_NAMES: set[str] = PUBLIC_READ_ONLY_TOOL_NAMES - {
+    "convert_to_markdown",
+}
+
+
+def anonymous_tool_names(mode: str | None) -> set[str]:
+    """Tool set for an unauthenticated caller, by request mode.
+
+    Only the public internet door restricts the set; the legacy/unset and
+    internal doors keep the full read-only set (the internal door 401s
+    anonymous callers before this anyway).
+    """
+    if mode == "public":
+        return PUBLIC_HOST_TOOL_NAMES
+    return PUBLIC_READ_ONLY_TOOL_NAMES
+
+
+def get_allowed_tool_names(
+    identity: dict | None,
+    all_tool_names: set[str],
+    mode: str | None = None,
+) -> set[str]:
+    """Return the set of tool names allowed for the given identity + mode.
+
+    - No identity → anonymous tools for the request mode (restricted on the
+      public internet door, full read-only otherwise).
+    - Any verified identity → all tools. The downstream Django API remains the
+      authorization boundary for operations performed by those tools.
+    """
+    if identity is None:
+        return anonymous_tool_names(mode) & all_tool_names
+
+    return all_tool_names

--- a/jawafdehi_mcp/logging_setup.py
+++ b/jawafdehi_mcp/logging_setup.py
@@ -1,0 +1,147 @@
+"""Logging setup for jawafdehi-mcp — structlog + optional Sentry + optional GCP Cloud Logging."""
+
+import logging
+import os
+import sys
+
+import structlog
+from structlog.types import EventDict, WrappedLogger
+
+from jawafdehi_shared.logging_config import drop_transport_noise
+
+SERVICE_NAME = "jawafdehi-mcp"
+
+
+def _get_version() -> str:
+    try:
+        from . import __version__
+
+        return __version__
+    except ImportError:
+        return "0.0.0"
+
+
+def _sentry_processor(
+    logger: WrappedLogger,
+    method_name: str,
+    event_dict: EventDict,
+) -> EventDict:
+    """Forward structlog context to Sentry scope (replaces removed StructlogIntegration)."""
+    try:
+        import sentry_sdk
+
+        scope = sentry_sdk.get_current_scope()
+        if scope:
+            exclude = {
+                "event",
+                "level",
+                "timestamp",
+                "logger",
+                "exception",
+                "stack_info",
+            }
+            for key, value in event_dict.items():
+                if key not in exclude:
+                    scope.set_context(
+                        "structlog", {**scope.contexts.get("structlog", {}), key: value}
+                    )
+    except Exception:  # noqa: BLE001 — enriching a log line must never break the log call
+        pass
+    return event_dict
+
+
+def _init_sentry() -> None:
+    # Opt-in error reporting: only initialize when a DSN is explicitly provided
+    # (prod injects SENTRY_DSN via the jawafdehi-mcp-env secret). Local and
+    # stdio-bridge dev runs leave it unset and stay silent — no events are
+    # shipped from developer machines.
+    sentry_dsn = os.getenv("SENTRY_DSN", "").strip()
+    if not sentry_dsn:
+        return
+
+    try:
+        import sentry_sdk
+
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+            traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
+            profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.1")),
+            release=os.getenv("SENTRY_RELEASE", f"{SERVICE_NAME}@{_get_version()}"),
+            before_send=drop_transport_noise,
+        )
+    except Exception:  # noqa: BLE001 — error reporting is optional; startup must survive it
+        print("Failed to initialize Sentry SDK", file=sys.stderr)
+
+
+def _init_gcp_logging() -> None:
+    gcp_project = os.getenv("GCP_LOG_PROJECT", "").strip()
+    if not gcp_project:
+        return
+
+    try:
+        import google.cloud.logging
+
+        client = google.cloud.logging.Client(project=gcp_project)
+        client.setup_logging(
+            log_level=_resolve_log_level(os.getenv("LOG_LEVEL", "INFO")),
+        )
+    except Exception:  # noqa: BLE001 — log shipping is optional; startup must survive it
+        print("Failed to initialize GCP Cloud Logging", file=sys.stderr)
+
+
+def _resolve_log_level(level_name: str) -> int:
+    return getattr(logging, level_name.upper(), logging.INFO)
+
+
+def setup_logging() -> None:
+    """Configure structlog logging and optionally initialize Sentry."""
+    _init_sentry()
+
+    structlog.contextvars.bind_contextvars(service=SERVICE_NAME)
+
+    timestamper = structlog.processors.TimeStamper(fmt="iso")
+
+    shared_processors = [
+        structlog.contextvars.merge_contextvars,
+        _sentry_processor,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+        timestamper,
+    ]
+
+    debug = os.getenv("DEBUG", "").lower() in ("1", "true", "yes")
+    if debug:
+        renderer = structlog.dev.ConsoleRenderer()
+    else:
+        renderer = structlog.processors.JSONRenderer()
+
+    structlog.configure(
+        processors=shared_processors
+        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+    )
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers = [handler]
+    root_logger.setLevel(_resolve_log_level(os.getenv("LOG_LEVEL", "INFO")))
+
+    _init_gcp_logging()

--- a/jawafdehi_mcp/oidc.py
+++ b/jawafdehi_mcp/oidc.py
@@ -1,0 +1,173 @@
+"""OIDC bearer-token verification for jawafdehi-mcp.
+
+Verifies Zitadel-issued RS256 access tokens via JWKS and resolves the caller's
+identity (email, name, roles) from the OIDC userinfo endpoint. Mirrors
+jawafdehi-api's OIDCJWTAuthentication so both services trust the same tokens.
+"""
+
+import asyncio
+import hashlib
+import secrets
+import time
+from typing import Any
+
+import httpx
+import structlog
+from rest_framework import exceptions
+
+from jawafdehi_shared.auth.oidc import decode_oidc_token
+from .configuration import get_oidc_config
+
+logger = structlog.get_logger()
+
+# A non-default User-Agent is required: the Cloudflare WAF in front of
+# auth.jawafdehi.org 403s the stock ``Python-urllib``/client agents.
+_USER_AGENT = "jawafdehi-mcp/1.0"
+
+# Userinfo cached by token id so we call the userinfo endpoint at most once per
+# access token (not on every request).
+_userinfo_cache: dict[str, tuple[float, dict]] = {}
+
+
+class OIDCError(Exception):
+    """Raised when a bearer token cannot be verified or its identity resolved."""
+
+
+def _env(name: str) -> Any:
+    value = get_oidc_config(name)
+    if not value:
+        raise OIDCError(f"{name} is not configured")
+    return value
+
+
+def verify_bearer_token(token: str) -> dict:
+    """Validate a Zitadel RS256 access token and return its claims.
+
+    Raises OIDCError on any failure: a JWE rather than a JWS, bad signature,
+    wrong audience/issuer, or expiry.
+    """
+    # A JWS has 3 segments (2 dots); a JWE has 5. We only accept JWS.
+    if token.count(".") != 2:
+        raise OIDCError("encrypted (JWE) tokens are not accepted")
+
+    try:
+        return decode_oidc_token(token)
+    except exceptions.AuthenticationFailed as exc:
+        logger.warning("oidc_token_validation_failed", error=str(exc))
+        raise OIDCError("invalid token or signature") from exc
+
+
+async def fetch_userinfo(token: str, claims: dict) -> dict:
+    """Return userinfo claims (email/name/roles) for this access token.
+
+    The access token carries only sub/aud/iss; email and the flattened ``roles``
+    array live in userinfo, so we fetch them here and cache per token (until the
+    token's ``exp``) to avoid a call per request.
+    """
+    key = claims.get("jti") or hashlib.sha256(token.encode()).hexdigest()
+    now = time.time()
+    cached = _userinfo_cache.get(key)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    endpoint = str(_env("OIDC_OP_USER_ENDPOINT"))
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                endpoint,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "User-Agent": _USER_AGENT,
+                    "Accept": "application/json",
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            info: dict = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.warning("oidc_userinfo_fetch_failed", error=str(exc))
+        raise OIDCError("could not resolve user identity") from exc
+
+    # Prune expired entries so the per-token cache can't grow unbounded.
+    for stale in [k for k, (exp, _) in _userinfo_cache.items() if exp <= now]:
+        del _userinfo_cache[stale]
+    _userinfo_cache[key] = (float(claims.get("exp", now + 300)), info)
+    return info
+
+
+def build_identity(claims: dict, info: dict) -> dict:
+    """Assemble the request-scoped identity dict from token + userinfo claims."""
+    roles = info.get("roles", claims.get("roles"))
+    if isinstance(roles, dict):
+        roles = list(roles)
+    if not isinstance(roles, list):
+        roles = []
+    name = (
+        info.get("name")
+        or claims.get("name")
+        or " ".join(
+            part
+            for part in (
+                info.get("given_name") or claims.get("given_name"),
+                info.get("family_name") or claims.get("family_name"),
+            )
+            if part
+        ).strip()
+    )
+    return {
+        "sub": claims.get("sub"),
+        "email": (info.get("email") or claims.get("email") or "").lower() or None,
+        "name": name or None,
+        "roles": [str(role) for role in roles],
+    }
+
+
+def _development_identity(token: str) -> dict | None:
+    """Resolve the Zitadel-free E2E bearer under Django's test-only guard.
+
+    The same token is authenticated again by
+    ``DevelopmentQueryTokenAuthentication`` when a tool forwards it to DRF.
+    Both ``TESTING`` and ``DEV_AUTH`` must be enabled, so this path cannot be
+    activated in production.
+    """
+    try:
+        from django.conf import settings
+
+        if not (
+            getattr(settings, "TESTING", False)
+            and getattr(settings, "DEV_AUTH", False)
+        ):
+            return None
+        configured = str(getattr(settings, "DEV_NGM_QUERY_TOKEN", "") or "")
+        if not configured or not secrets.compare_digest(token, configured):
+            return None
+        username = str(
+            getattr(settings, "DEV_NGM_QUERY_USERNAME", "mcp-query-e2e")
+            or "mcp-query-e2e"
+        )
+    except Exception:  # noqa: BLE001 — fail closed: any error here means "not authenticated"
+        return None
+
+    return {
+        "sub": username,
+        "email": None,
+        "name": username,
+        "roles": [],
+    }
+
+
+async def resolve_bearer_identity(token: str) -> dict:
+    """Verify a bearer token and enrich its identity when userinfo is available."""
+    if identity := _development_identity(token):
+        return identity
+
+    # verify_bearer_token may do a blocking JWKS fetch (first call / key
+    # rotation); run it off the event loop.
+    claims = await asyncio.to_thread(verify_bearer_token, token)
+    try:
+        info = await fetch_userinfo(token, claims)
+    except OIDCError:
+        # JWT verification is the authentication boundary. Userinfo is optional
+        # identity/audit enrichment and is unavailable for some machine tokens.
+        info = {}
+    return build_identity(claims, info)

--- a/jawafdehi_mcp/path_safety.py
+++ b/jawafdehi_mcp/path_safety.py
@@ -1,0 +1,57 @@
+"""Validation and encoding for user-controlled API path components."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+from jawafdehi_shared.entities.ids import (
+    build_entity_iri,
+    build_material_iri,
+    canonicalize_entity_iri,
+    is_valid_case_iri,
+)
+
+
+def encode_path_segment(value: Any, *, label: str = "identifier") -> str:
+    """Encode one opaque route segment after rejecting route separators."""
+    raw = str(value).strip()
+    if not raw:
+        raise ValueError(f"{label} must not be empty.")
+    if len(raw) > 300:
+        raise ValueError(f"{label} is too long.")
+    has_separator = any(char in raw for char in ("/", "\\", "?", "#"))
+    has_control = any(ord(char) < 32 for char in raw)
+    if raw in {".", ".."} or has_separator or has_control:
+        raise ValueError(f"{label} contains an invalid path component.")
+    return quote(raw, safe="")
+
+
+def encode_case_slug(value: Any) -> str:
+    """Validate a Jawafdehi case slug against the canonical shared grammar."""
+    slug = str(value).strip()
+    probe = f"https://jawafdehi.invalid/case/{slug}"
+    if not is_valid_case_iri(probe, any_host=True):
+        raise ValueError("slug is not a valid Jawafdehi case slug.")
+    return quote(slug, safe="")
+
+
+def encode_entity_ref(value: Any) -> str:
+    """Validate an entity IRI or prefix/slug reference and encode it opaquely."""
+    ref = str(value).strip()
+    if ref.startswith(("http://", "https://")):
+        ref = canonicalize_entity_iri(ref)
+    else:
+        prefix, separator, slug = ref.rpartition("/")
+        if not separator:
+            raise ValueError("entity reference must be an IRI or prefix/slug.")
+        ref = build_entity_iri(prefix, slug)
+    return quote(ref, safe="")
+
+
+def encode_material_parts(source: Any, ident: Any) -> tuple[str, str]:
+    """Validate material source/ident values against their canonical grammar."""
+    source_value = str(source).strip()
+    ident_value = str(ident).strip()
+    build_material_iri(source_value, ident_value)
+    return quote(source_value, safe=""), quote(ident_value, safe="")

--- a/jawafdehi_mcp/request_context.py
+++ b/jawafdehi_mcp/request_context.py
@@ -1,0 +1,43 @@
+"""Request-scoped context for MCP transports and bearer-token forwarding."""
+
+import os
+from contextvars import ContextVar
+
+current_transport: ContextVar[str | None] = ContextVar(
+    "current_transport", default=None
+)
+
+jawafdehi_bearer_token: ContextVar[str | None] = ContextVar(
+    "jawafdehi_bearer_token", default=None
+)
+
+
+def is_local_stdio_transport() -> bool:
+    """Return whether process-local capabilities are safe for this request."""
+    return current_transport.get() == "stdio"
+
+
+def get_local_service_token() -> str | None:
+    """Return the configured API token only to a local stdio request."""
+    if not is_local_stdio_transport():
+        return None
+    return os.getenv("JAWAFDEHI_API_TOKEN", "").strip() or None
+
+
+def get_query_service_token() -> str | None:
+    """Return the least-privilege SQL token, with stdio-only full-token fallback."""
+    token = os.getenv("MCP_QUERY_API_TOKEN", "").strip()
+    return token or get_local_service_token()
+
+
+def get_forwarded_headers() -> dict[str, str]:
+    """Headers forwarded to upstream jawafdehi-api calls.
+
+    Forwards the caller's verified OIDC bearer so the API authenticates as the
+    same user (OIDCJWTAuthentication). Empty in stdio/dev, where tools fall back
+    to a service token.
+    """
+    token = jawafdehi_bearer_token.get()
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}

--- a/jawafdehi_mcp/server.py
+++ b/jawafdehi_mcp/server.py
@@ -1,0 +1,227 @@
+"""MCP server for Jawafdehi and NGM judicial data queries."""
+
+import time
+import uuid
+from typing import Any
+
+import structlog
+import structlog.contextvars
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import CallToolResult, TextContent, Tool
+from prometheus_client import Counter, Histogram
+
+from . import __version__
+from .identity import (
+    current_request_mode,
+    current_user_identity,
+    get_allowed_tool_names,
+)
+from .request_context import (
+    current_transport,
+    get_local_service_token,
+    get_query_service_token,
+)
+
+from .tools import (
+    BaseTool,
+    BrowseCourtDataTool,
+    BrowseMaterialsTool,
+    CreateJawafdehiCaseTool,
+    DateConverterTool,
+    DeleteJawafdehiCaseTool,
+    DeleteNESEntityTool,
+    DocumentConverterTool,
+    GetCurrentUserTool,
+    GetJawafdehiCaseTool,
+    GetNESEntityPrefixesTool,
+    GetNESEntityVersionsTool,
+    ManageCaseUpdateProposalsTool,
+    ManageCaseworkReviewsTool,
+    ManageCourtDataTool,
+    ManageJobsTool,
+    ManageMaterialTool,
+    NGMExtractCaseDataTool,
+    NGMJudicialTool,
+    PatchJawafdehiCaseTool,
+    SearchControlPlaneTool,
+    SearchJawafdehiCasesTool,
+    SubmitNESChangeTool,
+    ToolExecutionResult,
+    UploadMaterialFileTool,
+)
+from .tools.nes import (
+    GetNESEntitiesTool,
+    GetNESTagsTool,
+    SearchNESEntitiesTool,
+)
+
+logger = structlog.get_logger()
+
+app = Server("jawafdehi-mcp", version=__version__)
+
+TOOL_CALLS = Counter(
+    "jawafdehi_mcp_tool_calls_total",
+    "MCP tool calls completed by outcome.",
+    ("tool", "outcome"),
+)
+TOOL_DURATION = Histogram(
+    "jawafdehi_mcp_tool_duration_seconds",
+    "MCP tool execution time in seconds.",
+    ("tool",),
+)
+
+TOOLS: list[BaseTool] = [
+    GetCurrentUserTool(),
+    SearchControlPlaneTool(),
+    NGMJudicialTool(),
+    NGMExtractCaseDataTool(),
+    SearchJawafdehiCasesTool(),
+    GetJawafdehiCaseTool(),
+    CreateJawafdehiCaseTool(),
+    PatchJawafdehiCaseTool(),
+    DeleteJawafdehiCaseTool(),
+    SubmitNESChangeTool(),
+    UploadMaterialFileTool(),
+    SearchNESEntitiesTool(),
+    GetNESEntitiesTool(),
+    GetNESEntityPrefixesTool(),
+    GetNESTagsTool(),
+    GetNESEntityVersionsTool(),
+    DeleteNESEntityTool(),
+    BrowseMaterialsTool(),
+    ManageMaterialTool(),
+    BrowseCourtDataTool(),
+    ManageCourtDataTool(),
+    ManageCaseUpdateProposalsTool(),
+    ManageCaseworkReviewsTool(),
+    ManageJobsTool(),
+    DateConverterTool(),
+    DocumentConverterTool(),
+]
+
+TOOL_MAP = {tool.name: tool for tool in TOOLS}
+ALL_TOOL_NAMES: set[str] = set(TOOL_MAP.keys())
+
+
+def _has_api_token() -> bool:
+    """Whether a local stdio client may use the configured service token."""
+    return get_local_service_token() is not None
+
+
+def _get_runtime_allowed_tool_names() -> set[str]:
+    identity = current_user_identity.get()
+    if identity is None and _has_api_token():
+        return ALL_TOOL_NAMES
+
+    mode = current_request_mode.get()
+    allowed = get_allowed_tool_names(identity, ALL_TOOL_NAMES, mode)
+    if identity is None and get_query_service_token() is None:
+        allowed.discard("ngm_query_judicial")
+    return allowed
+
+
+def _get_allowed_tools() -> list[BaseTool]:
+    allowed = _get_runtime_allowed_tool_names()
+    return [tool for tool in TOOLS if tool.name in allowed]
+
+
+def _is_tool_allowed(name: str) -> bool:
+    return name in _get_runtime_allowed_tool_names()
+
+
+def _bind_audit_context(identity: dict | None) -> None:
+    if identity:
+        structlog.contextvars.bind_contextvars(
+            jawafdehi_user_sub=str(identity.get("sub", "")),
+            jawafdehi_user_email=identity.get("email", ""),
+            jawafdehi_roles=identity.get("roles", []),
+        )
+
+
+def _unbind_audit_context() -> None:
+    structlog.contextvars.unbind_contextvars(
+        "jawafdehi_user_sub",
+        "jawafdehi_user_email",
+        "jawafdehi_roles",
+    )
+
+
+@app.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available MCP tools based on the current user's identity."""
+    return [tool.to_tool() for tool in _get_allowed_tools()]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: Any) -> list[TextContent] | CallToolResult:
+    """Handle tool execution requests with per-user authorization."""
+    if not _is_tool_allowed(name):
+        identity = current_user_identity.get()
+        user_info = ""
+        if identity:
+            user_info = (
+                f" (email={identity.get('email')}, roles={identity.get('roles')})"
+            )
+        raise ValueError(
+            f"Tool '{name}' is not available for the current user{user_info}. "
+            "Authenticate with a bearer token to access it."
+        )
+
+    tool = TOOL_MAP.get(name)
+    if not tool:
+        logger.error("unknown_tool_requested", tool_name=name)
+        raise ValueError(f"Unknown tool: {name}")
+
+    identity = current_user_identity.get()
+    request_id = str(uuid.uuid4())
+    started = time.perf_counter()
+    outcome = "completed"
+    structlog.contextvars.bind_contextvars(request_id=request_id)
+    _bind_audit_context(identity)
+    logger.info("tool_call_started", tool_name=name)
+    try:
+        result = await tool.execute(arguments)
+        if isinstance(result, ToolExecutionResult):
+            if result.is_error:
+                outcome = "failed"
+            return CallToolResult(
+                content=list(result),
+                isError=result.is_error,
+            )
+        return result
+    except Exception:
+        outcome = "failed"
+        logger.exception("tool_execution_failed", tool_name=name)
+        raise
+    finally:
+        TOOL_CALLS.labels(tool=name, outcome=outcome).inc()
+        TOOL_DURATION.labels(tool=name).observe(time.perf_counter() - started)
+        _unbind_audit_context()
+        structlog.contextvars.unbind_contextvars("request_id")
+
+
+def main() -> None:
+    """Run the MCP server via stdio."""
+    from .logging_setup import setup_logging
+
+    setup_logging()
+    logger.info("server_starting")
+
+    import asyncio
+
+    async def run() -> None:
+        async with stdio_server() as (read_stream, write_stream):
+            transport_ctx = current_transport.set("stdio")
+            try:
+                await app.run(
+                    read_stream, write_stream, app.create_initialization_options()
+                )
+            finally:
+                current_transport.reset(transport_ctx)
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/jawafdehi_mcp/server.py
+++ b/jawafdehi_mcp/server.py
@@ -13,7 +13,6 @@ from prometheus_client import Counter, Histogram
 
 from . import __version__
 from .identity import (
-    current_request_mode,
     current_user_identity,
     get_allowed_tool_names,
 )
@@ -114,8 +113,7 @@ def _get_runtime_allowed_tool_names() -> set[str]:
     if identity is None and _has_api_token():
         return ALL_TOOL_NAMES
 
-    mode = current_request_mode.get()
-    allowed = get_allowed_tool_names(identity, ALL_TOOL_NAMES, mode)
+    allowed = get_allowed_tool_names(identity, ALL_TOOL_NAMES)
     if identity is None and get_query_service_token() is None:
         allowed.discard("ngm_query_judicial")
     return allowed

--- a/jawafdehi_mcp/tools/__init__.py
+++ b/jawafdehi_mcp/tools/__init__.py
@@ -1,0 +1,67 @@
+"""Tool implementations for Jawafdehi MCP server."""
+
+from .base import BaseTool, ToolExecutionResult, error_text
+from .control_plane import (
+    BrowseCourtDataTool,
+    BrowseMaterialsTool,
+    DeleteNESEntityTool,
+    GetNESEntityVersionsTool,
+    ManageCaseUpdateProposalsTool,
+    ManageCaseworkReviewsTool,
+    ManageCourtDataTool,
+    ManageJobsTool,
+    ManageMaterialTool,
+    SearchControlPlaneTool,
+)
+from .date_converter import DateConverterTool
+from .document_converter import DocumentConverterTool
+from .jawafdehi_cases import (
+    CreateJawafdehiCaseTool,
+    DeleteJawafdehiCaseTool,
+    GetJawafdehiCaseTool,
+    PatchJawafdehiCaseTool,
+    SearchJawafdehiCasesTool,
+    SubmitNESChangeTool,
+    UploadMaterialFileTool,
+)
+from .nes import (
+    GetNESEntitiesTool,
+    GetNESEntityPrefixesTool,
+    GetNESTagsTool,
+    SearchNESEntitiesTool,
+)
+from .ngm_extract import NGMExtractCaseDataTool
+from .ngm_judicial import NGMJudicialTool
+from .whoami import GetCurrentUserTool
+
+__all__ = [
+    "BaseTool",
+    "ToolExecutionResult",
+    "error_text",
+    "SearchControlPlaneTool",
+    "GetNESEntityVersionsTool",
+    "DeleteNESEntityTool",
+    "BrowseMaterialsTool",
+    "ManageMaterialTool",
+    "BrowseCourtDataTool",
+    "ManageCourtDataTool",
+    "ManageCaseUpdateProposalsTool",
+    "ManageCaseworkReviewsTool",
+    "ManageJobsTool",
+    "GetCurrentUserTool",
+    "NGMJudicialTool",
+    "NGMExtractCaseDataTool",
+    "SearchJawafdehiCasesTool",
+    "GetJawafdehiCaseTool",
+    "CreateJawafdehiCaseTool",
+    "DeleteJawafdehiCaseTool",
+    "PatchJawafdehiCaseTool",
+    "SubmitNESChangeTool",
+    "UploadMaterialFileTool",
+    "SearchNESEntitiesTool",
+    "GetNESEntitiesTool",
+    "GetNESEntityPrefixesTool",
+    "GetNESTagsTool",
+    "DateConverterTool",
+    "DocumentConverterTool",
+]

--- a/jawafdehi_mcp/tools/base.py
+++ b/jawafdehi_mcp/tools/base.py
@@ -1,0 +1,73 @@
+"""Base tool interface for MCP tools."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Any
+
+from mcp.types import TextContent, Tool
+
+
+class ToolExecutionResult(list[TextContent]):
+    """List-compatible tool content with an explicit protocol outcome."""
+
+    def __init__(
+        self,
+        content: Iterable[TextContent] = (),
+        *,
+        is_error: bool = False,
+    ) -> None:
+        super().__init__(content)
+        self.is_error = is_error
+
+
+def error_text(message: str) -> ToolExecutionResult:
+    """Return text content that the MCP transport must mark as an error."""
+    return ToolExecutionResult(
+        [TextContent(type="text", text=message)],
+        is_error=True,
+    )
+
+
+class BaseTool(ABC):
+    """Base class for MCP tools."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the tool name."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Return the tool description."""
+        pass
+
+    @property
+    @abstractmethod
+    def input_schema(self) -> dict[str, Any]:
+        """Return the JSON schema for tool input."""
+        pass
+
+    def to_tool(self) -> Tool:
+        """Convert to MCP Tool object."""
+        return Tool(
+            name=self.name,
+            description=self.description,
+            inputSchema=self.input_schema,
+        )
+
+    @abstractmethod
+    async def execute(
+        self, arguments: dict[str, Any]
+    ) -> list[TextContent] | ToolExecutionResult:
+        """
+        Execute the tool with given arguments.
+
+        Args:
+            arguments: Tool input arguments
+
+        Returns:
+            List of TextContent responses
+        """
+        pass

--- a/jawafdehi_mcp/tools/control_plane.py
+++ b/jawafdehi_mcp/tools/control_plane.py
@@ -1,0 +1,722 @@
+"""Task-oriented tools for the unified Jawafdehi control plane."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+import httpx
+import structlog
+from mcp.types import TextContent
+
+from ..control_plane import request_control_plane
+from ..path_safety import encode_entity_ref, encode_path_segment
+from .base import BaseTool, ToolExecutionResult
+from .control_plane_schemas import (
+    browse_court_data_schema,
+    browse_materials_schema,
+    manage_case_update_proposals_schema,
+    manage_casework_reviews_schema,
+    manage_court_data_schema,
+    manage_jobs_schema,
+    manage_material_schema,
+)
+
+logger = structlog.get_logger()
+
+
+def _text(payload: Any) -> list[TextContent]:
+    return [
+        TextContent(
+            type="text",
+            text=json.dumps(payload, indent=2, ensure_ascii=False),
+        )
+    ]
+
+
+def _error(message: str) -> ToolExecutionResult:
+    return ToolExecutionResult(
+        _text({"success": False, "error": message}),
+        is_error=True,
+    )
+
+
+def _required(arguments: dict[str, Any], *names: str) -> str | None:
+    missing = [
+        name
+        for name in names
+        if arguments.get(name) is None or arguments.get(name) == ""
+    ]
+    if not missing:
+        return None
+    return f"Missing required argument(s): {', '.join(missing)}."
+
+
+def _query_params(
+    arguments: dict[str, Any],
+    names: Iterable[str],
+) -> dict[str, Any]:
+    return {
+        name: arguments[name]
+        for name in names
+        if name in arguments and arguments[name] is not None
+    }
+
+
+def _path_segment(value: Any) -> str:
+    return encode_path_segment(value)
+
+
+class _ControlPlaneTool(BaseTool):
+    async def _call(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        body: Any = None,
+        headers: dict[str, str] | None = None,
+    ) -> list[TextContent] | ToolExecutionResult:
+        try:
+            payload = await request_control_plane(
+                method,
+                path,
+                params=params,
+                json_body=body,
+                headers=headers,
+            )
+            content = _text(payload)
+            if payload.get("success") is False:
+                return ToolExecutionResult(content, is_error=True)
+            return content
+        except httpx.TimeoutException:
+            logger.warning(
+                "control_plane_timeout",
+                tool_name=self.name,
+                method=method,
+                path=path,
+            )
+            if method.upper() in {"GET", "HEAD", "OPTIONS"}:
+                return _error("Jawafdehi control-plane request timed out.")
+            return _error(
+                "Jawafdehi control-plane request timed out; the operation's "
+                "outcome is unknown. Verify current state before retrying."
+            )
+        except httpx.HTTPError as exc:
+            logger.error(
+                "control_plane_http_error",
+                tool_name=self.name,
+                method=method,
+                path=path,
+                error=str(exc),
+            )
+            return _error(f"Jawafdehi control-plane HTTP error: {exc}")
+        except ValueError as exc:
+            return _error(str(exc))
+        except Exception as exc:
+            logger.exception(
+                "control_plane_unexpected_error",
+                tool_name=self.name,
+                method=method,
+                path=path,
+            )
+            return _error(f"Unexpected control-plane error: {exc}")
+
+
+class SearchControlPlaneTool(_ControlPlaneTool):
+    @property
+    def name(self) -> str:
+        return "search_control_plane"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the unified public corpus across entities, materials, court "
+            "cases, and published Jawafdehi cases."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "q": {"type": "string"},
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["entity", "material", "courtcase", "case"],
+                    },
+                    "uniqueItems": True,
+                },
+                "lang": {
+                    "type": "string",
+                    "enum": ["ne", "en", "both"],
+                    "default": "both",
+                },
+                "sort": {
+                    "type": "string",
+                    "enum": ["relevance", "newest", "oldest", "title"],
+                    "default": "relevance",
+                },
+                "entity_type": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "case_type": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "status": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "page": {"type": "integer", "minimum": 1, "default": 1},
+                "page_size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10,
+                },
+                "cursor": {"type": "string"},
+            },
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        params = _query_params(
+            arguments,
+            (
+                "q",
+                "type",
+                "lang",
+                "sort",
+                "entity_type",
+                "case_type",
+                "tags",
+                "status",
+                "page",
+                "page_size",
+                "cursor",
+            ),
+        )
+        return await self._call("GET", "/api/search/", params=params)
+
+
+class GetNESEntityVersionsTool(_ControlPlaneTool):
+    @property
+    def name(self) -> str:
+        return "get_nes_entity_versions"
+
+    @property
+    def description(self) -> str:
+        return "Retrieve the version history of one NES entity."
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Canonical entity IRI or prefix/slug reference.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 100,
+                },
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            },
+            "required": ["entity_id"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        if message := _required(arguments, "entity_id"):
+            return _error(message)
+        try:
+            ref = encode_entity_ref(arguments["entity_id"])
+        except ValueError as exc:
+            return _error(str(exc))
+        params = _query_params(arguments, ("limit", "offset"))
+        return await self._call(
+            "GET",
+            f"/api/entities/{ref}/versions",
+            params=params,
+        )
+
+
+class DeleteNESEntityTool(_ControlPlaneTool):
+    @property
+    def name(self) -> str:
+        return "delete_nes_entity"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Soft-delete an NES entity. The control plane enforces the caller's "
+            "write role."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Canonical entity IRI or prefix/slug reference.",
+                }
+            },
+            "required": ["entity_id"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        if message := _required(arguments, "entity_id"):
+            return _error(message)
+        try:
+            ref = encode_entity_ref(arguments["entity_id"])
+        except ValueError as exc:
+            return _error(str(exc))
+        return await self._call("DELETE", f"/api/entities/{ref}")
+
+
+class BrowseMaterialsTool(_ControlPlaneTool):
+    ACTIONS = ("list", "get")
+
+    @property
+    def name(self) -> str:
+        return "browse_materials"
+
+    @property
+    def description(self) -> str:
+        return "List materials or retrieve one material by its canonical IRI."
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return browse_materials_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        if action == "get":
+            if message := _required(arguments, "iri"):
+                return _error(message)
+            return await self._call(
+                "GET",
+                "/api/materials/",
+                params={"iri": arguments["iri"]},
+            )
+        if action == "list":
+            params = _query_params(arguments, ("source", "material_type", "cursor"))
+            return await self._call("GET", "/api/materials/", params=params)
+        return _error("action must be 'list' or 'get'.")
+
+
+class ManageMaterialTool(_ControlPlaneTool):
+    ACTIONS = ("upsert", "patch", "delete")
+
+    @property
+    def name(self) -> str:
+        return "manage_material"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Upsert, JSON-Patch, or soft-delete a material. Existing control-plane "
+            "permissions and optional ETag preconditions remain authoritative."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return manage_material_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        if action == "upsert":
+            if message := _required(arguments, "material"):
+                return _error(message)
+            body = {"material": arguments["material"]}
+            for name in ("material_type", "visibility_policy"):
+                if name in arguments:
+                    body[name] = arguments[name]
+            return await self._call("POST", "/api/materials/", body=body)
+
+        if action == "patch":
+            if message := _required(arguments, "iri"):
+                return _error(message)
+            if "patch_ops" not in arguments and "visibility_policy" not in arguments:
+                return _error("Material patch requires patch_ops or visibility_policy.")
+            body = {
+                name: arguments[name]
+                for name in ("patch_ops", "visibility_policy")
+                if name in arguments
+            }
+            headers = (
+                {"If-Match": str(arguments["if_match"])}
+                if arguments.get("if_match")
+                else None
+            )
+            return await self._call(
+                "PATCH",
+                "/api/materials/",
+                params={"iri": arguments["iri"]},
+                body=body,
+                headers=headers,
+            )
+
+        if action == "delete":
+            if message := _required(arguments, "iri"):
+                return _error(message)
+            return await self._call(
+                "DELETE",
+                "/api/materials/",
+                params={"iri": arguments["iri"]},
+            )
+
+        return _error("Unknown material action.")
+
+
+class BrowseCourtDataTool(_ControlPlaneTool):
+    ACTIONS = (
+        "list_courts",
+        "get_court",
+        "list_cases",
+        "get_case",
+        "list_hearings",
+        "list_entities",
+        "list_documents",
+        "search_entities",
+        "list_firms",
+        "get_firm",
+    )
+
+    @property
+    def name(self) -> str:
+        return "browse_court_data"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Browse courts, court cases and their subresources, resolved case "
+            "entities, and blacklisted firms."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return browse_court_data_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        if action == "list_courts":
+            return await self._call("GET", "/api/courts/")
+        if action == "get_court":
+            if message := _required(arguments, "court"):
+                return _error(message)
+            return await self._call(
+                "GET", f"/api/courts/{_path_segment(arguments['court'])}/"
+            )
+        if action == "list_cases":
+            params = _query_params(
+                arguments,
+                ("court", "type", "status", "date_from", "date_to", "page"),
+            )
+            return await self._call("GET", "/api/courtcases/", params=params)
+        if action in {
+            "get_case",
+            "list_hearings",
+            "list_entities",
+            "list_documents",
+        }:
+            if message := _required(arguments, "court", "case_number"):
+                return _error(message)
+            base = (
+                f"/api/courtcases/{_path_segment(arguments['court'])}/"
+                f"{_path_segment(arguments['case_number'])}"
+            )
+            suffix = {
+                "get_case": "/",
+                "list_hearings": "/hearings/",
+                "list_entities": "/entities/",
+                "list_documents": "/documents/",
+            }[action]
+            params = (
+                _query_params(arguments, ("page",))
+                if action in {"list_hearings", "list_entities"}
+                else None
+            )
+            return await self._call("GET", f"{base}{suffix}", params=params)
+        if action == "search_entities":
+            params = _query_params(arguments, ("nes_id", "name", "page"))
+            return await self._call("GET", "/api/courtcase-entities/", params=params)
+        if action == "list_firms":
+            params = _query_params(arguments, ("nes_id", "name", "page"))
+            return await self._call("GET", "/api/firms/", params=params)
+        if action == "get_firm":
+            if message := _required(arguments, "firm_id"):
+                return _error(message)
+            return await self._call("GET", f"/api/firms/{int(arguments['firm_id'])}/")
+        return _error("Unknown court-data browse action.")
+
+
+class ManageCourtDataTool(_ControlPlaneTool):
+    ACTIONS = (
+        "create_court",
+        "update_court",
+        "create_case",
+        "update_case",
+        "delete_case",
+        "ingest_cases",
+        "resolve_entities",
+        "register_documents",
+        "ingest_firms",
+        "create_firm",
+        "update_firm",
+    )
+
+    @property
+    def name(self) -> str:
+        return "manage_court_data"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create or update courts and court cases, soft-delete a court case, "
+            "or invoke a bounded court-data ingestion operation."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return manage_court_data_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        if action == "create_court":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("POST", "/api/courts/", body=arguments["body"])
+        if action == "update_court":
+            if message := _required(arguments, "court", "body"):
+                return _error(message)
+            return await self._call(
+                "PATCH",
+                f"/api/courts/{_path_segment(arguments['court'])}/",
+                body=arguments["body"],
+            )
+        if action == "create_case":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("POST", "/api/courtcases/", body=arguments["body"])
+        if action in {"update_case", "delete_case"}:
+            if message := _required(arguments, "court", "case_number"):
+                return _error(message)
+            path = (
+                f"/api/courtcases/{_path_segment(arguments['court'])}/"
+                f"{_path_segment(arguments['case_number'])}/"
+            )
+            if action == "delete_case":
+                return await self._call("DELETE", path)
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("PATCH", path, body=arguments["body"])
+
+        if action == "create_firm":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("POST", "/api/firms/", body=arguments["body"])
+        if action == "update_firm":
+            if message := _required(arguments, "firm_id", "body"):
+                return _error(message)
+            return await self._call(
+                "PATCH",
+                f"/api/firms/{int(arguments['firm_id'])}/",
+                body=arguments["body"],
+            )
+
+        ingestion_paths = {
+            "ingest_cases": "/api/ingestion/cases/",
+            "resolve_entities": "/api/ingestion/entities/resolve/",
+            "register_documents": "/api/ingestion/documents/",
+            "ingest_firms": "/api/ingestion/firms/",
+        }
+        if action in ingestion_paths:
+            if message := _required(arguments, "items"):
+                return _error(message)
+            return await self._call(
+                "POST",
+                ingestion_paths[action],
+                body={"items": arguments["items"]},
+            )
+        return _error("Unknown court-data management action.")
+
+
+class ManageCaseUpdateProposalsTool(_ControlPlaneTool):
+    ACTIONS = ("list", "get", "create", "edit", "approve", "reject")
+
+    @property
+    def name(self) -> str:
+        return "manage_case_update_proposals"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List, retrieve, create, edit, approve, or reject human-reviewed "
+            "case-update proposals."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return manage_case_update_proposals_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        collection = "/api/case-update-proposals/"
+        if action == "list":
+            params = _query_params(
+                arguments, ("status", "source_kind", "case_slug", "page")
+            )
+            return await self._call("GET", collection, params=params)
+        if action == "create":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("POST", collection, body=arguments["body"])
+        if action in {"get", "edit", "approve", "reject"}:
+            if message := _required(arguments, "proposal_id"):
+                return _error(message)
+            base = f"{collection}{int(arguments['proposal_id'])}/"
+            if action == "get":
+                return await self._call("GET", base)
+            if action == "edit":
+                if message := _required(arguments, "body"):
+                    return _error(message)
+                return await self._call(
+                    "PATCH", f"{base}intent/", body=arguments["body"]
+                )
+            return await self._call(
+                "POST",
+                f"{base}{action}/",
+                body=arguments.get("body") or {},
+            )
+        return _error("Unknown case-update proposal action.")
+
+
+class ManageCaseworkReviewsTool(_ControlPlaneTool):
+    ACTIONS = (
+        "list",
+        "list_grouped",
+        "get",
+        "submit",
+        "list_rules",
+        "get_rule",
+        "get_config",
+        "update_config",
+        "regrade_all",
+    )
+
+    @property
+    def name(self) -> str:
+        return "manage_casework_reviews"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Inspect and submit casework reviews, read rules, manage review "
+            "configuration, or request a full regrade."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return manage_casework_reviews_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        if action in {"list", "list_grouped"}:
+            path = (
+                "/api/casework/reviews/grouped/"
+                if action == "list_grouped"
+                else "/api/casework/reviews/"
+            )
+            params = _query_params(arguments, ("slug", "page"))
+            return await self._call("GET", path, params=params)
+        if action == "get":
+            if message := _required(arguments, "review_id"):
+                return _error(message)
+            return await self._call(
+                "GET",
+                f"/api/casework/reviews/{int(arguments['review_id'])}/",
+            )
+        if action == "submit":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call(
+                "POST",
+                "/api/casework/reviews/submit/",
+                body=arguments["body"],
+            )
+        if action == "list_rules":
+            return await self._call("GET", "/api/casework/rules/")
+        if action == "get_rule":
+            if message := _required(arguments, "rule_id"):
+                return _error(message)
+            return await self._call(
+                "GET", f"/api/casework/rules/{int(arguments['rule_id'])}/"
+            )
+        if action == "get_config":
+            return await self._call("GET", "/api/casework/config/")
+        if action == "update_config":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call(
+                "PUT", "/api/casework/config/", body=arguments["body"]
+            )
+        if action == "regrade_all":
+            return await self._call(
+                "POST", "/api/casework/reviews/regrade-all/", body={}
+            )
+        return _error("Unknown casework review action.")
+
+
+class ManageJobsTool(_ControlPlaneTool):
+    ACTIONS = ("list", "enqueue", "claim", "stage", "result")
+
+    @property
+    def name(self) -> str:
+        return "manage_jobs"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Observe, enqueue, claim, heartbeat, or finalize jobs through the "
+            "central control-plane queue."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return manage_jobs_schema(self.ACTIONS)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        action = arguments.get("action")
+        if action == "list":
+            params = _query_params(arguments, ("kind", "status", "limit"))
+            return await self._call("GET", "/api/jobs/", params=params)
+        if action == "enqueue":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("POST", "/api/jobs/", body=arguments["body"])
+        if action == "claim":
+            if message := _required(arguments, "body"):
+                return _error(message)
+            return await self._call("POST", "/api/jobs/claim/", body=arguments["body"])
+        if action in {"stage", "result"}:
+            if message := _required(arguments, "job_id", "body"):
+                return _error(message)
+            return await self._call(
+                "POST",
+                f"/api/jobs/{int(arguments['job_id'])}/{action}/",
+                body=arguments["body"],
+            )
+        return _error("Unknown jobs action.")

--- a/jawafdehi_mcp/tools/control_plane_schemas.py
+++ b/jawafdehi_mcp/tools/control_plane_schemas.py
@@ -1,0 +1,681 @@
+"""JSON Schemas for the task-oriented control-plane tools.
+
+The schemas are intentionally static so the MCP server can still run over stdio
+without bootstrapping Django. Unit tests compare their field sets with the
+authoritative DRF serializers to catch contract drift.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping, Sequence
+
+Schema = dict[str, Any]
+ActionContract = dict[str, Any]
+
+
+def _object(
+    properties: Mapping[str, Schema],
+    *,
+    required: Sequence[str] = (),
+    additional_properties: bool = False,
+    **constraints: Any,
+) -> Schema:
+    schema: Schema = {
+        "type": "object",
+        "properties": deepcopy(dict(properties)),
+        "additionalProperties": additional_properties,
+    }
+    if required:
+        schema["required"] = list(required)
+    schema.update(constraints)
+    return schema
+
+
+def _nullable(schema: Schema) -> Schema:
+    return {"anyOf": [deepcopy(schema), {"type": "null"}]}
+
+
+def _string(
+    *,
+    max_length: int | None = None,
+    min_length: int | None = None,
+    format_: str | None = None,
+    description: str | None = None,
+) -> Schema:
+    schema: Schema = {"type": "string"}
+    if max_length is not None:
+        schema["maxLength"] = max_length
+    if min_length is not None:
+        schema["minLength"] = min_length
+    if format_ is not None:
+        schema["format"] = format_
+    if description is not None:
+        schema["description"] = description
+    return schema
+
+
+def _array(
+    items: Schema,
+    *,
+    min_items: int | None = None,
+    max_items: int | None = None,
+) -> Schema:
+    schema: Schema = {"type": "array", "items": deepcopy(items)}
+    if min_items is not None:
+        schema["minItems"] = min_items
+    if max_items is not None:
+        schema["maxItems"] = max_items
+    return schema
+
+
+def _contract(
+    *,
+    required: Sequence[str] = (),
+    properties: Mapping[str, Schema] | None = None,
+    any_of_required: Sequence[Sequence[str]] = (),
+) -> ActionContract:
+    return {
+        "required": tuple(required),
+        "properties": deepcopy(dict(properties or {})),
+        "any_of_required": tuple(tuple(group) for group in any_of_required),
+    }
+
+
+def _action_schema(
+    actions: Sequence[str],
+    properties: Mapping[str, Schema],
+    contracts: Mapping[str, ActionContract],
+) -> Schema:
+    """Build a root schema whose required fields vary with ``action``."""
+    if set(actions) != set(contracts):
+        missing = sorted(set(actions) - set(contracts))
+        extra = sorted(set(contracts) - set(actions))
+        raise ValueError(
+            f"Action contracts do not match actions (missing={missing}, extra={extra})."
+        )
+
+    root_properties = {
+        "action": {"type": "string", "enum": list(actions)},
+        **deepcopy(dict(properties)),
+    }
+    rules = []
+    for action in actions:
+        contract = contracts[action]
+        required = list(contract["required"])
+        refinements = contract["properties"]
+        referenced = set(required) | set(refinements)
+        referenced.update(
+            name for group in contract["any_of_required"] for name in group
+        )
+        unknown = sorted(referenced - set(root_properties))
+        if unknown:
+            raise ValueError(f"{action} contract references unknown fields: {unknown}.")
+
+        then: Schema = {}
+        if required:
+            then["required"] = required
+        if refinements:
+            then["properties"] = deepcopy(refinements)
+        if contract["any_of_required"]:
+            then["anyOf"] = [
+                {"required": list(group)} for group in contract["any_of_required"]
+            ]
+        rules.append(
+            {
+                "if": {
+                    "properties": {"action": {"const": action}},
+                    "required": ["action"],
+                },
+                "then": then,
+            }
+        )
+
+    schema = _object(root_properties, required=("action",))
+    schema["allOf"] = rules
+    return schema
+
+
+JSON_PATCH_OPERATION_SCHEMA = _object(
+    {
+        "op": {
+            "type": "string",
+            "enum": ["add", "remove", "replace", "move", "copy", "test"],
+        },
+        "path": _string(),
+        "from": _string(),
+        "value": {},
+    },
+    required=("op", "path"),
+)
+JSON_PATCH_OPERATION_SCHEMA["allOf"] = [
+    {
+        "if": {
+            "properties": {"op": {"enum": ["move", "copy"]}},
+            "required": ["op"],
+        },
+        "then": {"required": ["from"]},
+    },
+    {
+        "if": {
+            "properties": {"op": {"enum": ["add", "replace", "test"]}},
+            "required": ["op"],
+        },
+        "then": {"required": ["value"]},
+    },
+]
+JSON_PATCH_SCHEMA = _array(
+    JSON_PATCH_OPERATION_SCHEMA,
+    min_items=1,
+    max_items=100,
+)
+
+VISIBILITY_POLICY_SCHEMA = {
+    "type": "string",
+    "enum": ["PUBLIC", "CASE_GATED", "PRIVATE"],
+}
+
+
+def browse_materials_schema(actions: Sequence[str]) -> Schema:
+    return _action_schema(
+        actions,
+        {
+            "iri": _string(format_="uri"),
+            "source": _string(),
+            "material_type": _string(),
+            "cursor": _string(),
+        },
+        {
+            "list": _contract(),
+            "get": _contract(required=("iri",)),
+        },
+    )
+
+
+def manage_material_schema(actions: Sequence[str]) -> Schema:
+    return _action_schema(
+        actions,
+        {
+            "iri": _string(format_="uri"),
+            "material": _object({}, additional_properties=True, minProperties=1),
+            "material_type": _string(),
+            "visibility_policy": VISIBILITY_POLICY_SCHEMA,
+            "patch_ops": JSON_PATCH_SCHEMA,
+            "if_match": _string(description="ETag returned by a prior material read."),
+        },
+        {
+            "upsert": _contract(required=("material",)),
+            "patch": _contract(
+                required=("iri",),
+                any_of_required=(("patch_ops",), ("visibility_policy",)),
+            ),
+            "delete": _contract(required=("iri",)),
+        },
+    )
+
+
+COURT_BODY_PROPERTIES: dict[str, Schema] = {
+    "identifier": _string(max_length=50),
+    "court_type": _string(max_length=20),
+    "full_name_nepali": _string(max_length=200),
+    "full_name_english": _nullable(_string(max_length=200)),
+}
+COURT_CREATE_BODY_SCHEMA = _object(
+    COURT_BODY_PROPERTIES,
+    required=("identifier", "court_type", "full_name_nepali"),
+)
+COURT_UPDATE_BODY_SCHEMA = _object(COURT_BODY_PROPERTIES, minProperties=1)
+
+COURT_CASE_BODY_PROPERTIES: dict[str, Schema] = {
+    "case_number": _string(max_length=50),
+    "court_identifier": _string(max_length=50),
+    "registration_date_bs": _nullable(_string(max_length=20)),
+    "registration_date_ad": _nullable(_string(format_="date")),
+    "case_type": _nullable(_string(max_length=200)),
+    "case_status": _nullable(_string(max_length=100)),
+    "plaintiff": _nullable(_string()),
+    "defendant": _nullable(_string()),
+    "nes_id": _nullable(_string(format_="uri", max_length=300)),
+    "extra_data": _nullable(_object({}, additional_properties=True)),
+    "document_sources": _nullable(_array(_object({}, additional_properties=True))),
+}
+COURT_CASE_CREATE_BODY_SCHEMA = _object(
+    COURT_CASE_BODY_PROPERTIES,
+    required=("case_number", "court_identifier"),
+)
+COURT_CASE_UPDATE_BODY_SCHEMA = _object(
+    COURT_CASE_BODY_PROPERTIES,
+    minProperties=1,
+)
+
+FIRM_BODY_PROPERTIES: dict[str, Schema] = {
+    "firm_name": _string(max_length=500),
+    "proprietor_name": _nullable(_string(max_length=500)),
+    "address": _nullable(_string(max_length=500)),
+    "blacklist_date_bs": _nullable(_string(max_length=20)),
+    "blacklist_date_ad": _nullable(_string(format_="date")),
+    "effective_until_bs": _nullable(_string(max_length=20)),
+    "effective_until_ad": _nullable(_string(format_="date")),
+    "duration": _nullable(_string(max_length=100)),
+    "reason": _nullable(_string()),
+    "recommending_office": _nullable(_string(max_length=500)),
+    "nes_id": _nullable(_string(format_="uri", max_length=300)),
+}
+FIRM_CREATE_BODY_SCHEMA = _object(FIRM_BODY_PROPERTIES, required=("firm_name",))
+FIRM_UPDATE_BODY_SCHEMA = _object(FIRM_BODY_PROPERTIES, minProperties=1)
+
+COURT_CASE_INGEST_ITEM_SCHEMA = _object(
+    {
+        **COURT_CASE_BODY_PROPERTIES,
+        "court": _string(max_length=50),
+    },
+    required=("case_number",),
+)
+COURT_CASE_INGEST_ITEM_SCHEMA["anyOf"] = [
+    {"required": ["court"]},
+    {"required": ["court_identifier"]},
+]
+
+ENTITY_RESOLUTION_ITEM_SCHEMA = _object(
+    {
+        "court": _string(max_length=50),
+        "court_identifier": _string(max_length=50),
+        "case_number": _string(max_length=50),
+        "nes_id": _string(format_="uri", max_length=300),
+        "side": _string(max_length=20),
+        "name": _string(max_length=500),
+    },
+    required=("case_number", "nes_id"),
+)
+ENTITY_RESOLUTION_ITEM_SCHEMA["anyOf"] = [
+    {"required": ["court"]},
+    {"required": ["court_identifier"]},
+]
+
+ROLED_LINK_SCHEMA = _object(
+    {
+        "link": _string(format_="uri"),
+        "role": _string(),
+    },
+    required=("link", "role"),
+    additional_properties=True,
+)
+DOCUMENT_SOURCE_SCHEMA = _object(
+    {
+        "document_id": _string(),
+        "url": _array(ROLED_LINK_SCHEMA),
+    },
+    additional_properties=True,
+)
+DOCUMENT_INGEST_ITEM_SCHEMA = _object(
+    {
+        "court": _string(max_length=50),
+        "court_identifier": _string(max_length=50),
+        "case_number": _string(max_length=50),
+        "document_source": DOCUMENT_SOURCE_SCHEMA,
+    },
+    required=("case_number", "document_source"),
+)
+DOCUMENT_INGEST_ITEM_SCHEMA["anyOf"] = [
+    {"required": ["court"]},
+    {"required": ["court_identifier"]},
+]
+
+FIRM_INGEST_ITEM_PROPERTIES = deepcopy(FIRM_BODY_PROPERTIES)
+FIRM_INGEST_ITEM_PROPERTIES["blacklist_date_bs"] = _string(max_length=20)
+FIRM_INGEST_ITEM_SCHEMA = _object(
+    FIRM_INGEST_ITEM_PROPERTIES,
+    required=("firm_name", "blacklist_date_bs"),
+)
+
+
+def browse_court_data_schema(actions: Sequence[str]) -> Schema:
+    contracts = {
+        "list_courts": _contract(),
+        "get_court": _contract(required=("court",)),
+        "list_cases": _contract(),
+        "get_case": _contract(required=("court", "case_number")),
+        "list_hearings": _contract(required=("court", "case_number")),
+        "list_entities": _contract(required=("court", "case_number")),
+        "list_documents": _contract(required=("court", "case_number")),
+        "search_entities": _contract(),
+        "list_firms": _contract(),
+        "get_firm": _contract(required=("firm_id",)),
+    }
+    return _action_schema(
+        actions,
+        {
+            "court": _string(),
+            "case_number": _string(),
+            "firm_id": {"type": "integer", "minimum": 1},
+            "type": _string(),
+            "status": _string(),
+            "date_from": _string(format_="date"),
+            "date_to": _string(format_="date"),
+            "nes_id": _string(format_="uri"),
+            "name": _string(),
+            "page": {"type": "integer", "minimum": 1, "default": 1},
+        },
+        contracts,
+    )
+
+
+def manage_court_data_schema(actions: Sequence[str]) -> Schema:
+    generic_body = _object({}, additional_properties=True)
+    generic_items = _array(_object({}, additional_properties=True), max_items=500)
+    contracts = {
+        "create_court": _contract(
+            required=("body",),
+            properties={"body": COURT_CREATE_BODY_SCHEMA},
+        ),
+        "update_court": _contract(
+            required=("court", "body"),
+            properties={"body": COURT_UPDATE_BODY_SCHEMA},
+        ),
+        "create_case": _contract(
+            required=("body",),
+            properties={"body": COURT_CASE_CREATE_BODY_SCHEMA},
+        ),
+        "update_case": _contract(
+            required=("court", "case_number", "body"),
+            properties={"body": COURT_CASE_UPDATE_BODY_SCHEMA},
+        ),
+        "delete_case": _contract(required=("court", "case_number")),
+        "ingest_cases": _contract(
+            required=("items",),
+            properties={"items": _array(COURT_CASE_INGEST_ITEM_SCHEMA, max_items=500)},
+        ),
+        "resolve_entities": _contract(
+            required=("items",),
+            properties={"items": _array(ENTITY_RESOLUTION_ITEM_SCHEMA, max_items=500)},
+        ),
+        "register_documents": _contract(
+            required=("items",),
+            properties={"items": _array(DOCUMENT_INGEST_ITEM_SCHEMA, max_items=500)},
+        ),
+        "ingest_firms": _contract(
+            required=("items",),
+            properties={"items": _array(FIRM_INGEST_ITEM_SCHEMA, max_items=500)},
+        ),
+        "create_firm": _contract(
+            required=("body",),
+            properties={"body": FIRM_CREATE_BODY_SCHEMA},
+        ),
+        "update_firm": _contract(
+            required=("firm_id", "body"),
+            properties={"body": FIRM_UPDATE_BODY_SCHEMA},
+        ),
+    }
+    return _action_schema(
+        actions,
+        {
+            "court": _string(),
+            "case_number": _string(),
+            "firm_id": {"type": "integer", "minimum": 1},
+            "body": generic_body,
+            "items": generic_items,
+        },
+        contracts,
+    )
+
+
+TIMELINE_ENTRY_SCHEMA = _object(
+    {
+        "date": _string(),
+        "title": _string(min_length=1),
+        "description": _string(),
+        "date_bs": _string(),
+        "end_date": _string(),
+        "end_date_bs": _string(),
+    },
+    required=("date", "title"),
+)
+PROPOSAL_INTENT_SCHEMA: Schema = {
+    "oneOf": [
+        _object(
+            {
+                "type": {"const": "append_timeline_entry"},
+                "entry": TIMELINE_ENTRY_SCHEMA,
+            },
+            required=("type", "entry"),
+        ),
+        _object(
+            {
+                "type": {"const": "link_material"},
+                "material": _string(format_="uri"),
+                "relation": _string(),
+            },
+            required=("type", "material"),
+        ),
+        _object(
+            {
+                "type": {"const": "raw_patch"},
+                "patch": _array(
+                    JSON_PATCH_OPERATION_SCHEMA,
+                    min_items=1,
+                    max_items=100,
+                ),
+            },
+            required=("type", "patch"),
+        ),
+    ]
+}
+PROPOSAL_CREATE_BODY_PROPERTIES: dict[str, Schema] = {
+    "case_slug": _string(max_length=50),
+    "case_title": _string(max_length=200),
+    "source_kind": {
+        "type": "string",
+        "enum": [
+            "ngm_docket",
+            "court_order",
+            "ciaa_press",
+            "news",
+            "caseworker",
+        ],
+    },
+    "intent": PROPOSAL_INTENT_SCHEMA,
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    "source": _string(max_length=500),
+    "detected_by": _string(max_length=100),
+    "dedup_key": _string(max_length=300),
+    "origin_subject": _string(max_length=100),
+    "origin_msg_id": _string(max_length=100),
+    "subject_refs": _array(_string()),
+}
+PROPOSAL_CREATE_BODY_SCHEMA = _object(
+    PROPOSAL_CREATE_BODY_PROPERTIES,
+    required=(
+        "case_slug",
+        "source_kind",
+        "intent",
+        "confidence",
+        "detected_by",
+        "dedup_key",
+    ),
+)
+PROPOSAL_EDIT_BODY_SCHEMA = _object(
+    {"intent": PROPOSAL_INTENT_SCHEMA},
+    required=("intent",),
+)
+PROPOSAL_DECISION_BODY_SCHEMA = _object(
+    {"notes": _string()},
+)
+
+
+def manage_case_update_proposals_schema(actions: Sequence[str]) -> Schema:
+    contracts = {
+        "list": _contract(),
+        "get": _contract(required=("proposal_id",)),
+        "create": _contract(
+            required=("body",),
+            properties={"body": PROPOSAL_CREATE_BODY_SCHEMA},
+        ),
+        "edit": _contract(
+            required=("proposal_id", "body"),
+            properties={"body": PROPOSAL_EDIT_BODY_SCHEMA},
+        ),
+        "approve": _contract(
+            required=("proposal_id",),
+            properties={"body": PROPOSAL_DECISION_BODY_SCHEMA},
+        ),
+        "reject": _contract(
+            required=("proposal_id",),
+            properties={"body": PROPOSAL_DECISION_BODY_SCHEMA},
+        ),
+    }
+    return _action_schema(
+        actions,
+        {
+            "proposal_id": {"type": "integer", "minimum": 1},
+            "body": _object({}, additional_properties=True),
+            "status": {
+                "type": "string",
+                "enum": ["pending", "approved", "rejected"],
+            },
+            "source_kind": deepcopy(PROPOSAL_CREATE_BODY_PROPERTIES["source_kind"]),
+            "case_slug": _string(max_length=50),
+            "page": {"type": "integer", "minimum": 1},
+        },
+        contracts,
+    )
+
+
+REVIEW_SUBMIT_BODY_SCHEMA = _object(
+    {
+        "iri": _string(format_="uri", max_length=300),
+        "slug": _string(max_length=255),
+    }
+)
+REVIEW_SUBMIT_BODY_SCHEMA["oneOf"] = [
+    {"required": ["iri"]},
+    {"required": ["slug"]},
+]
+REVIEW_CONFIG_BODY_PROPERTIES: dict[str, Schema] = {
+    "pass_threshold": {"type": "integer"},
+    "revise_threshold": {"type": "integer"},
+    "llm_samples": {"type": "integer", "minimum": 1},
+}
+REVIEW_CONFIG_BODY_SCHEMA = _object(
+    REVIEW_CONFIG_BODY_PROPERTIES,
+    minProperties=1,
+)
+
+
+def manage_casework_reviews_schema(actions: Sequence[str]) -> Schema:
+    contracts = {
+        "list": _contract(),
+        "list_grouped": _contract(),
+        "get": _contract(required=("review_id",)),
+        "submit": _contract(
+            required=("body",),
+            properties={"body": REVIEW_SUBMIT_BODY_SCHEMA},
+        ),
+        "list_rules": _contract(),
+        "get_rule": _contract(required=("rule_id",)),
+        "get_config": _contract(),
+        "update_config": _contract(
+            required=("body",),
+            properties={"body": REVIEW_CONFIG_BODY_SCHEMA},
+        ),
+        "regrade_all": _contract(),
+    }
+    return _action_schema(
+        actions,
+        {
+            "review_id": {"type": "integer", "minimum": 1},
+            "rule_id": {"type": "integer", "minimum": 1},
+            "slug": _string(),
+            "page": {"type": "integer", "minimum": 1},
+            "body": _object({}, additional_properties=True),
+        },
+        contracts,
+    )
+
+
+JOB_ENQUEUE_BODY_PROPERTIES: dict[str, Schema] = {
+    "kind": _string(max_length=64),
+    "payload": _object({}, additional_properties=True),
+    "dedup_key": _nullable(_string(max_length=255)),
+    "priority": {"type": "integer"},
+}
+JOB_ENQUEUE_BODY_SCHEMA = _object(
+    JOB_ENQUEUE_BODY_PROPERTIES,
+    required=("kind",),
+)
+JOB_CLAIM_BODY_SCHEMA = _object(
+    {
+        "kinds": _array(_string(max_length=64), min_items=1),
+    },
+    required=("kinds",),
+)
+JOB_STAGE_BODY_SCHEMA = _object(
+    {"stage": _string(max_length=64)},
+)
+JOB_RESULT_BODY_SCHEMA = _object(
+    {
+        "status": {"type": "string", "enum": ["done", "failed"]},
+        "result": {},
+        "error": _string(),
+        "retryable": {"type": "boolean", "default": False},
+        "duration_seconds": _nullable({"type": "number", "minimum": 0}),
+    },
+    required=("status",),
+)
+JOB_RESULT_BODY_SCHEMA["allOf"] = [
+    {
+        "if": {
+            "properties": {"status": {"const": "done"}},
+            "required": ["status"],
+        },
+        "then": {
+            "required": ["result"],
+            "properties": {"result": {"not": {"type": "null"}}},
+        },
+    },
+    {
+        "if": {
+            "properties": {"status": {"const": "failed"}},
+            "required": ["status"],
+        },
+        "then": {
+            "required": ["error"],
+            "properties": {"error": _string(min_length=1)},
+        },
+    },
+]
+
+
+def manage_jobs_schema(actions: Sequence[str]) -> Schema:
+    contracts = {
+        "list": _contract(),
+        "enqueue": _contract(
+            required=("body",),
+            properties={"body": JOB_ENQUEUE_BODY_SCHEMA},
+        ),
+        "claim": _contract(
+            required=("body",),
+            properties={"body": JOB_CLAIM_BODY_SCHEMA},
+        ),
+        "stage": _contract(
+            required=("job_id", "body"),
+            properties={"body": JOB_STAGE_BODY_SCHEMA},
+        ),
+        "result": _contract(
+            required=("job_id", "body"),
+            properties={"body": JOB_RESULT_BODY_SCHEMA},
+        ),
+    }
+    return _action_schema(
+        actions,
+        {
+            "job_id": {"type": "integer", "minimum": 1},
+            "kind": _string(max_length=64),
+            "status": {
+                "type": "string",
+                "enum": ["queued", "running", "done", "failed", "dead"],
+            },
+            "limit": {"type": "integer", "minimum": 1, "maximum": 1000},
+            "body": _object({}, additional_properties=True),
+        },
+        contracts,
+    )

--- a/jawafdehi_mcp/tools/date_converter.py
+++ b/jawafdehi_mcp/tools/date_converter.py
@@ -1,0 +1,116 @@
+import datetime
+from typing import Any
+
+import nepali_datetime
+import structlog
+from mcp.types import TextContent
+
+from .base import BaseTool, error_text
+
+logger = structlog.get_logger()
+
+
+class DateConverterTool(BaseTool):
+    """Tool for converting dates between AD (Gregorian) and BS (Bikram Sambat).
+
+    This tool converts dates between AD and BS, working in the conversion in
+    Asia/Kathmandu time zone. The conversion requires precise calculations
+    which the tool will provide securely.
+    """
+
+    @property
+    def name(self) -> str:
+        return "convert_date"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Convert dates between AD (Gregorian) and BS (Bikram Sambat). "
+            "Works in the Asia/Kathmandu time zone. Often times, LLMs convert date wrongly and this tool will "
+            "provide the correct conversion."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "dates": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "description": "A list of dates to convert in YYYY-MM-DD format (e.g. ['2023-01-15', '2079-10-01']).",
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["ad_to_bs", "bs_to_ad"],
+                    "description": "The direction of the conversion ('ad_to_bs' or 'bs_to_ad').",
+                },
+            },
+            "required": ["dates", "mode"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        dates = arguments.get("dates")
+        mode = arguments.get("mode")
+
+        if not dates or not isinstance(dates, list) or not mode:
+            return error_text(
+                "Error: 'dates' (non-empty list) and 'mode' are required parameters."
+            )
+
+        if len(dates) > 100:
+            return error_text(
+                "Error: at most 100 dates may be converted per call."
+            )
+
+        if mode not in ["ad_to_bs", "bs_to_ad"]:
+            return error_text(
+                "Error: mode must be 'ad_to_bs' or 'bs_to_ad'."
+            )
+
+        results = []
+        success_count = 0
+        for date_str in dates:
+            try:
+                year, month, day = map(int, date_str.split("-"))
+            except ValueError:
+                results.append(
+                    f"{date_str}: Error - date must be in YYYY-MM-DD format."
+                )
+                continue
+
+            try:
+                if mode == "ad_to_bs":
+                    ad_date = datetime.date(year, month, day)
+                    bs_date = nepali_datetime.date.from_datetime_date(ad_date)
+                    result = bs_date.strftime("%Y-%m-%d")
+                    results.append(
+                        f"Converted AD {date_str} to BS: {result} (Asia/Kathmandu Timezone Context)"
+                    )
+                    success_count += 1
+
+                elif mode == "bs_to_ad":
+                    bs_date = nepali_datetime.date(year, month, day)
+                    ad_date = bs_date.to_datetime_date()
+                    result = ad_date.strftime("%Y-%m-%d")
+                    results.append(
+                        f"Converted BS {date_str} to AD: {result} (Asia/Kathmandu Timezone Context)"
+                    )
+                    success_count += 1
+            except Exception as e:  # noqa: BLE001 — one bad date is reported, the batch continues
+                logger.error(
+                    "date_conversion_failed",
+                    date_str=date_str,
+                    mode=mode,
+                    error=str(e),
+                )
+                results.append(f"{date_str}: Error performing conversion: {str(e)}")
+
+        text = "\n".join(results)
+        if success_count == 0:
+            return error_text(text)
+        return [TextContent(type="text", text=text)]

--- a/jawafdehi_mcp/tools/document_converter.py
+++ b/jawafdehi_mcp/tools/document_converter.py
@@ -1,0 +1,861 @@
+"""Unified document conversion with bounded local and remote inputs."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import io
+import ipaddress
+import math
+import multiprocessing
+import os
+import socket
+import threading
+import weakref
+from dataclasses import dataclass
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import Any, Callable, NoReturn
+from urllib.parse import unquote, unquote_to_bytes, urljoin, urlparse
+from urllib.request import url2pathname
+
+import httpcore
+import httpx
+import structlog
+from markitdown import MarkItDown, StreamInfo
+from mcp.types import TextContent
+
+from ..request_context import is_local_stdio_transport
+from .base import BaseTool, error_text
+
+logger = structlog.get_logger()
+
+_REMOTE_SCHEMES = frozenset({"http", "https"})
+_ALLOWED_REMOTE_PORTS = frozenset({80, 443})
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_MAX_REDIRECTS = 5
+_USER_AGENT = "jawafdehi-mcp/1.0"
+
+_conversion_limiter_lock = threading.Lock()
+_conversion_limiters: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, tuple[int, asyncio.Semaphore]
+] = weakref.WeakKeyDictionary()
+
+
+def _positive_int_env(name: str, default: int, maximum: int) -> int:
+    raw = os.getenv(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _positive_float_env(name: str, default: float, maximum: float) -> float:
+    raw = os.getenv(name, str(default))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(value) or value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _max_input_bytes() -> int:
+    return _positive_int_env(
+        "MCP_DOCUMENT_MAX_INPUT_BYTES",
+        25 * 1024 * 1024,
+        100 * 1024 * 1024,
+    )
+
+
+def _max_output_chars() -> int:
+    return _positive_int_env(
+        "MCP_DOCUMENT_MAX_OUTPUT_CHARS",
+        5_000_000,
+        20_000_000,
+    )
+
+
+def _fetch_timeout_seconds() -> float:
+    return _positive_float_env("MCP_DOCUMENT_FETCH_TIMEOUT", 20.0, 120.0)
+
+
+def _conversion_timeout_seconds() -> float:
+    return _positive_float_env("MCP_DOCUMENT_CONVERT_TIMEOUT", 120.0, 600.0)
+
+
+def _conversion_max_concurrency() -> int:
+    return _positive_int_env("MCP_DOCUMENT_MAX_CONCURRENCY", 2, 16)
+
+
+def _worker_memory_bytes() -> int:
+    return _positive_int_env(
+        "MCP_DOCUMENT_WORKER_MEMORY_BYTES",
+        1024 * 1024 * 1024,
+        2 * 1024 * 1024 * 1024,
+    )
+
+
+def _conversion_limiter() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    limit = _conversion_max_concurrency()
+    with _conversion_limiter_lock:
+        existing = _conversion_limiters.get(loop)
+        if existing is None or existing[0] != limit:
+            existing = (limit, asyncio.Semaphore(limit))
+            _conversion_limiters[loop] = existing
+        return existing[1]
+
+
+def _is_global_address(value: str) -> bool:
+    try:
+        return ipaddress.ip_address(value).is_global
+    except ValueError:
+        return False
+
+
+def _normalized_hostname(value: str) -> str:
+    host = value.rstrip(".")
+    try:
+        return ipaddress.ip_address(host).compressed
+    except ValueError:
+        return host.encode("idna").decode("ascii").lower()
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedRemoteTarget:
+    hostname: str
+    port: int
+    addresses: tuple[str, ...]
+
+
+async def _validate_remote_url(uri: str) -> _ResolvedRemoteTarget:
+    """Validate and resolve one URL hop, returning only approved peer addresses."""
+    parsed = urlparse(uri)
+    scheme = parsed.scheme.lower()
+    if scheme not in _REMOTE_SCHEMES:
+        raise ValueError("Remote documents must use http:// or https://.")
+    if parsed.username or parsed.password:
+        raise ValueError("Remote document URLs must not contain credentials.")
+    if not parsed.hostname:
+        raise ValueError("Remote document URL must include a hostname.")
+    if "%" in parsed.hostname:
+        raise ValueError("IPv6 zone identifiers are not allowed in remote URLs.")
+
+    try:
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError as exc:
+        raise ValueError("Remote document URL contains an invalid port.") from exc
+    if port not in _ALLOWED_REMOTE_PORTS:
+        raise ValueError("Remote document URLs may use only ports 80 and 443.")
+
+    host = parsed.hostname.rstrip(".")
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            async with asyncio.timeout(3.0):
+                records = await asyncio.to_thread(
+                    socket.getaddrinfo,
+                    host,
+                    port,
+                    type=socket.SOCK_STREAM,
+                )
+        except TimeoutError as exc:
+            raise ValueError("Remote document hostname lookup timed out.") from exc
+        except socket.gaierror as exc:
+            raise ValueError("Remote document hostname could not be resolved.") from exc
+        addresses = tuple(dict.fromkeys(record[4][0] for record in records))
+        if not addresses or any(not _is_global_address(value) for value in addresses):
+            raise ValueError(
+                "Remote document URLs must resolve only to public IP addresses."
+            )
+    else:
+        if not literal.is_global:
+            raise ValueError("Remote document URLs must target a public IP address.")
+        addresses = (literal.compressed,)
+
+    return _ResolvedRemoteTarget(
+        hostname=_normalized_hostname(host),
+        port=port,
+        addresses=addresses,
+    )
+
+
+class _PinnedNetworkBackend:
+    """Connect to prevalidated IPs while preserving the URL host for TLS SNI."""
+
+    def __init__(self, backend: Any, target: _ResolvedRemoteTarget) -> None:
+        self._backend = backend
+        self._target = target
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Any = None,
+    ) -> Any:
+        if (
+            _normalized_hostname(host) != self._target.hostname
+            or port != self._target.port
+        ):
+            raise httpcore.ConnectError("Remote document connection target changed.")
+
+        last_error: Exception | None = None
+        for address in self._target.addresses:
+            try:
+                return await self._backend.connect_tcp(
+                    address,
+                    port,
+                    timeout=timeout,
+                    local_address=local_address,
+                    socket_options=socket_options,
+                )
+            except Exception as exc:  # noqa: BLE001 — try the next prevalidated address
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise httpcore.ConnectError("Remote document hostname has no approved address.")
+
+    async def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Any = None,
+    ) -> NoReturn:
+        raise httpcore.ConnectError("Unix sockets are not valid remote targets.")
+
+    async def sleep(self, seconds: float) -> None:
+        await self._backend.sleep(seconds)
+
+
+class _PinnedHTTPTransport(httpx.AsyncHTTPTransport):
+    """HTTPX transport whose socket backend cannot perform a second DNS lookup."""
+
+    def __init__(self, target: _ResolvedRemoteTarget) -> None:
+        super().__init__(
+            trust_env=False,
+            limits=httpx.Limits(max_connections=1, max_keepalive_connections=0),
+        )
+        # HTTPX does not expose custom DNS resolution publicly. Wrapping
+        # httpcore's backend keeps the original URL host for Host/TLS SNI while
+        # making the actual TCP peer one of the addresses validated above.
+        backend = self._pool._network_backend
+        self._pool._network_backend = _PinnedNetworkBackend(backend, target)
+
+
+def _stream_info_for_response(response: httpx.Response) -> StreamInfo:
+    content_type = response.headers.get("content-type", "")
+    parts = [part.strip() for part in content_type.split(";") if part.strip()]
+    mimetype = parts[0] if parts else None
+    charset = None
+    for part in parts[1:]:
+        if part.lower().startswith("charset="):
+            charset = part.split("=", 1)[1].strip("\"'")
+            break
+
+    path = unquote(response.url.path)
+    filename = Path(path).name or None
+    extension = Path(filename).suffix if filename else None
+    return StreamInfo(
+        mimetype=mimetype,
+        charset=charset,
+        filename=filename,
+        extension=extension,
+        url=str(response.url),
+    )
+
+
+async def _fetch_remote_document(uri: str) -> tuple[bytes, StreamInfo]:
+    max_bytes = _max_input_bytes()
+    timeout = _fetch_timeout_seconds()
+    current = uri
+
+    async with asyncio.timeout(timeout):
+        for redirect_count in range(_MAX_REDIRECTS + 1):
+            target = await _validate_remote_url(current)
+            async with httpx.AsyncClient(
+                transport=_PinnedHTTPTransport(target),
+                follow_redirects=False,
+                timeout=httpx.Timeout(
+                    connect=min(5.0, timeout),
+                    read=min(10.0, timeout),
+                    write=min(10.0, timeout),
+                    pool=min(5.0, timeout),
+                ),
+                trust_env=False,
+                headers={"User-Agent": _USER_AGENT},
+            ) as client:
+                async with client.stream("GET", current) as response:
+                    if response.status_code in _REDIRECT_STATUSES:
+                        if redirect_count == _MAX_REDIRECTS:
+                            raise ValueError(
+                                f"Remote document exceeded {_MAX_REDIRECTS} redirects."
+                            )
+                        location = response.headers.get("location")
+                        if not location:
+                            raise ValueError(
+                                "Remote document redirect omitted Location."
+                            )
+                        current = urljoin(str(response.url), location)
+                        continue
+
+                    response.raise_for_status()
+                    content_length = response.headers.get("content-length")
+                    if content_length:
+                        try:
+                            declared = int(content_length)
+                        except ValueError:
+                            declared = 0
+                        if declared > max_bytes:
+                            raise ValueError(
+                                f"Remote document exceeds the {max_bytes}-byte limit."
+                            )
+
+                    payload = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        payload.extend(chunk)
+                        if len(payload) > max_bytes:
+                            raise ValueError(
+                                f"Remote document exceeds the {max_bytes}-byte limit."
+                            )
+                    return bytes(payload), _stream_info_for_response(response)
+
+    raise ValueError("Remote document fetch did not complete.")
+
+
+def _decode_data_uri(uri: str) -> tuple[bytes, StreamInfo]:
+    try:
+        header, encoded = uri[5:].split(",", 1)
+    except ValueError as exc:
+        raise ValueError("Malformed data URI.") from exc
+
+    max_bytes = _max_input_bytes()
+    if len(encoded) > max_bytes * 4 + 16:
+        raise ValueError(f"Data URI exceeds the {max_bytes}-byte limit.")
+
+    parts = header.split(";") if header else []
+    mimetype = parts[0] if parts and "/" in parts[0] else "text/plain"
+    attributes = parts[1:] if parts and "/" in parts[0] else parts
+    is_base64 = bool(attributes and attributes[-1].lower() == "base64")
+    if is_base64:
+        attributes = attributes[:-1]
+        try:
+            payload = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("Malformed base64 data URI.") from exc
+    else:
+        payload = unquote_to_bytes(encoded)
+
+    if len(payload) > max_bytes:
+        raise ValueError(f"Data URI exceeds the {max_bytes}-byte limit.")
+
+    charset = None
+    for attribute in attributes:
+        if attribute.lower().startswith("charset="):
+            charset = attribute.split("=", 1)[1].strip("\"'")
+            break
+    return payload, StreamInfo(mimetype=mimetype, charset=charset)
+
+
+async def _run_bounded_conversion(
+    operation: Callable[[], Any],
+    acquired_limiter: asyncio.Semaphore,
+) -> Any:
+    """Run a trusted local-file parser without blocking the ASGI event loop.
+
+    HTTP callers cannot reach this path. Untrusted remote and inline documents
+    use the killable subprocess path below.
+    """
+    worker: asyncio.Task | None = None
+    try:
+        async with asyncio.timeout(_conversion_timeout_seconds()):
+            worker = asyncio.create_task(asyncio.to_thread(operation))
+            return await asyncio.shield(worker)
+    except TimeoutError as exc:
+        raise ValueError("Document conversion timed out.") from exc
+    finally:
+        if worker is None or worker.done():
+            acquired_limiter.release()
+        else:
+            # A Python worker thread cannot be killed safely. Retain its
+            # capacity slot until it exits so repeated timeouts cannot grow
+            # an unbounded pool of still-running parsers.
+            worker.add_done_callback(
+                lambda task: _consume_conversion_task(task, acquired_limiter)
+            )
+
+
+def _consume_conversion_task(
+    task: asyncio.Task,
+    acquired_limiter: asyncio.Semaphore,
+) -> None:
+    """Release retained capacity and consume a detached parser outcome."""
+    acquired_limiter.release()
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except Exception:  # noqa: BLE001 — retrieving it IS the point; see below
+        # The caller already received a timeout. Retrieving the late exception
+        # prevents asyncio from reporting an unobserved detached-task failure.
+        pass
+
+
+@dataclass(frozen=True, slots=True)
+class _StreamConversionRequest:
+    payload: bytes
+    stream_info: dict[str, str | None]
+    kwargs: dict[str, Any]
+    max_output_chars: int
+
+
+def _apply_worker_resource_limits() -> None:
+    """Apply best-effort POSIX limits before an untrusted parser runs."""
+    try:
+        import resource
+    except ImportError:  # pragma: no cover - production image is Linux
+        return
+
+    cpu_seconds = max(1, math.ceil(_conversion_timeout_seconds()))
+    file_bytes = max(_max_input_bytes() * 4, _max_output_chars() * 2)
+    limits = (
+        (resource.RLIMIT_CPU, cpu_seconds, cpu_seconds + 1),
+        (resource.RLIMIT_FSIZE, file_bytes, file_bytes),
+        (resource.RLIMIT_NOFILE, 64, 64),
+        (resource.RLIMIT_CORE, 0, 0),
+    )
+    for kind, soft, hard in limits:
+        try:
+            resource.setrlimit(kind, (soft, hard))
+        except (OSError, ValueError):
+            # Containers can impose a stricter immutable hard limit. Retain it
+            # rather than failing conversion before the parser starts.
+            continue
+
+
+def _process_rss_bytes(process: multiprocessing.Process) -> int | None:
+    """Return a Linux child process's resident memory, if observable."""
+    if process.pid is None:
+        return None
+    try:
+        status = Path(f"/proc/{process.pid}/status").read_text(encoding="ascii")
+    except (OSError, UnicodeError):
+        return None
+    for line in status.splitlines():
+        if line.startswith("VmRSS:"):
+            try:
+                return int(line.split()[1]) * 1024
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def _stream_conversion_worker(
+    send_connection: Connection,
+    request: _StreamConversionRequest,
+) -> None:
+    """Child-process entrypoint for untrusted stream conversion."""
+    try:
+        _apply_worker_resource_limits()
+        result = MarkItDown(enable_plugins=False).convert_stream(
+            io.BytesIO(request.payload),
+            stream_info=StreamInfo(**request.stream_info),
+            **request.kwargs,
+        )
+        markdown = result.markdown
+        if not isinstance(markdown, str):
+            raise ValueError("Document converter returned an invalid result.")
+        if len(markdown) > request.max_output_chars:
+            raise ValueError("Converted Markdown exceeds the configured output limit.")
+        # Never send pickled objects from the untrusted worker. If a parser were
+        # compromised, Connection.recv() would otherwise give it a pickle-based
+        # code-execution path back into the parent process.
+        send_connection.send_bytes(b"\x00" + markdown.encode("utf-8"))
+    # noqa justified: this is the child process's outer boundary. The parent
+    # reads the reason off the pipe, so ANY exit has to be reported there —
+    # including the SystemExit/MemoryError that _apply_worker_resource_limits'
+    # rlimits raise. Letting one escape gives the parent a silent EOF instead.
+    except BaseException as exc:  # noqa: BLE001
+        try:
+            error = f"{type(exc).__name__}: {exc}".encode("utf-8", errors="replace")[
+                :8192
+            ]
+            send_connection.send_bytes(b"\x01" + error)
+        except Exception:  # noqa: BLE001 — a broken pipe here leaves the parent its EOF path
+            pass
+    finally:
+        send_connection.close()
+
+
+def _stop_process(process: multiprocessing.Process) -> None:
+    if not process.is_alive():
+        process.join(timeout=0.1)
+        return
+    process.terminate()
+    process.join(timeout=1.0)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=1.0)
+
+
+async def _run_isolated_stream_conversion(
+    payload: bytes,
+    stream_info: StreamInfo,
+    kwargs: dict[str, Any],
+) -> str:
+    """Convert untrusted bytes in a killable, resource-limited subprocess."""
+    context = multiprocessing.get_context("spawn")
+    receive_connection, send_connection = context.Pipe(duplex=False)
+    request = _StreamConversionRequest(
+        payload=payload,
+        stream_info={
+            "mimetype": stream_info.mimetype,
+            "extension": stream_info.extension,
+            "charset": stream_info.charset,
+            "filename": stream_info.filename,
+            "local_path": stream_info.local_path,
+            "url": stream_info.url,
+        },
+        kwargs=kwargs,
+        max_output_chars=_max_output_chars(),
+    )
+    process = context.Process(
+        target=_stream_conversion_worker,
+        args=(send_connection, request),
+        daemon=True,
+        name="mcp-document-converter",
+    )
+    timeout = _conversion_timeout_seconds()
+    deadline = asyncio.get_running_loop().time() + timeout
+    started = False
+    try:
+        process.start()
+        started = True
+        send_connection.close()
+
+        # Drain the pipe before waiting for process exit. A Markdown result can
+        # be much larger than the OS pipe buffer; waiting for exit first would
+        # deadlock the child in send_bytes() until the conversion timeout.
+        while not receive_connection.poll():
+            if not process.is_alive():
+                raise ValueError(
+                    "Document conversion worker exited unexpectedly "
+                    f"(status {process.exitcode})."
+                )
+            rss_bytes = _process_rss_bytes(process)
+            if rss_bytes is not None and rss_bytes > _worker_memory_bytes():
+                raise ValueError(
+                    "Document conversion exceeded the configured memory limit."
+                )
+            if asyncio.get_running_loop().time() >= deadline:
+                raise ValueError("Document conversion timed out.")
+            await asyncio.sleep(0.05)
+
+        remaining = max(0.01, deadline - asyncio.get_running_loop().time())
+        max_message_bytes = _max_output_chars() * 4 + 8193
+        try:
+            async with asyncio.timeout(remaining):
+                message = await asyncio.to_thread(
+                    receive_connection.recv_bytes,
+                    max_message_bytes,
+                )
+        except TimeoutError as exc:
+            raise ValueError("Document conversion timed out.") from exc
+        except (EOFError, OSError) as exc:
+            raise ValueError(
+                "Document conversion worker returned an invalid result."
+            ) from exc
+
+        remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+        await asyncio.to_thread(process.join, min(1.0, remaining))
+        if process.is_alive():
+            raise ValueError("Document conversion worker failed to exit.")
+        if process.exitcode != 0:
+            raise ValueError(
+                "Document conversion worker exited unexpectedly "
+                f"(status {process.exitcode})."
+            )
+        if not message:
+            raise ValueError("Document conversion worker returned an invalid result.")
+        value = message[1:].decode("utf-8", errors="replace")
+        if message[0] == 0:
+            return value
+        if message[0] == 1:
+            raise ValueError(f"Document conversion failed: {value}")
+        raise ValueError("Document conversion worker returned an invalid result.")
+    finally:
+        receive_connection.close()
+        send_connection.close()
+        if started:
+            await asyncio.to_thread(_stop_process, process)
+            process.close()
+
+
+async def _acquire_document_slot() -> asyncio.Semaphore:
+    limiter = _conversion_limiter()
+    try:
+        async with asyncio.timeout(_conversion_timeout_seconds()):
+            await limiter.acquire()
+    except TimeoutError as exc:
+        raise ValueError("Document conversion capacity is exhausted.") from exc
+    return limiter
+
+
+class DocumentConverterTool(BaseTool):
+    """Convert a bounded local, remote, or inline document to Markdown."""
+
+    @property
+    def name(self) -> str:
+        return "convert_to_markdown"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Convert documents to Markdown through MarkItDown. Local file_path "
+            "and file:// inputs, plus output_path, are available only through "
+            "local stdio. HTTP(S) downloads and data URIs are size- and "
+            "time-bounded and parsed in a resource-limited subprocess with "
+            "plugins disabled. Installed plugins such as `likhit` are opt-in "
+            "for trusted local stdio files only. Optional PDF pages use a "
+            "1-based page or page range."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute local path. Available only through local stdio "
+                        "and mutually exclusive with uri."
+                    ),
+                },
+                "uri": {
+                    "type": "string",
+                    "description": (
+                        "Explicit file:// (local stdio only), http://, https://, "
+                        "or data: URI. Bare filesystem paths are rejected."
+                    ),
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": (
+                        "Optional local Markdown destination, supported only "
+                        "through local stdio."
+                    ),
+                },
+                "pages": {
+                    "type": "string",
+                    "pattern": r"^[1-9]\d*(?:-[1-9]\d*)?$",
+                    "description": "Optional 1-based PDF page or inclusive range.",
+                },
+                "enable_plugins": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Enable installed plugins for trusted local stdio file "
+                        "inputs. Remote and data URI conversion never loads "
+                        "plugins."
+                    ),
+                },
+            },
+            "required": [],
+            "oneOf": [
+                {"required": ["file_path"]},
+                {"required": ["uri"]},
+            ],
+        }
+
+    def _get_source_path(self, arguments: dict[str, Any]) -> tuple[str, bool]:
+        file_path = arguments.get("file_path")
+        uri = arguments.get("uri")
+        if file_path and uri:
+            raise ValueError(
+                "Cannot specify both 'file_path' and 'uri'. Use one or the other."
+            )
+        if file_path:
+            return str(file_path), True
+        if not uri:
+            raise ValueError("Must specify either 'file_path' or 'uri'.")
+        if not isinstance(uri, str):
+            raise ValueError("'uri' must be a string.")
+
+        parsed = urlparse(uri)
+        scheme = parsed.scheme.lower()
+        if scheme == "file":
+            if parsed.netloc not in ("", "localhost"):
+                raise ValueError(
+                    "Unsupported file URI. Netloc must be empty or localhost."
+                )
+            return url2pathname(unquote(parsed.path)), True
+        if scheme in _REMOTE_SCHEMES or scheme == "data":
+            return uri, False
+        if not scheme:
+            raise ValueError(
+                "Bare paths are not valid URIs; use file_path through local stdio."
+            )
+        raise ValueError(
+            "Unsupported URI scheme. Use file://, http://, https://, or data:."
+        )
+
+    @staticmethod
+    def _get_output_path(arguments: dict[str, Any]) -> Path | None:
+        output_path = arguments.get("output_path")
+        return Path(output_path) if output_path else None
+
+    @staticmethod
+    def _is_local_stdio() -> bool:
+        return is_local_stdio_transport()
+
+    @staticmethod
+    def _conversion_kwargs(arguments: dict[str, Any]) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        pages = arguments.get("pages")
+        if pages:
+            if not isinstance(pages, str):
+                raise ValueError("'pages' must be a string.")
+            if "-" in pages:
+                start_page, end_page = map(int, pages.split("-", 1))
+                if start_page > end_page:
+                    raise ValueError("Invalid 'pages' range: start must be <= end.")
+            kwargs["pages"] = pages
+        return kwargs
+
+    async def _convert_with_markitdown(
+        self,
+        source: str,
+        *,
+        is_local_file: bool,
+        arguments: dict[str, Any],
+    ) -> str:
+        kwargs = self._conversion_kwargs(arguments)
+        enable_plugins = bool(arguments.get("enable_plugins", False))
+        limiter = await _acquire_document_slot()
+
+        if is_local_file:
+            source_uri = Path(source).resolve().as_uri()
+
+            def convert() -> Any:
+                return MarkItDown(enable_plugins=enable_plugins).convert_uri(
+                    source_uri, **kwargs
+                )
+
+            conversion_started = False
+            try:
+                conversion_started = True
+                result = await _run_bounded_conversion(convert, limiter)
+            finally:
+                if not conversion_started:
+                    limiter.release()
+            markdown = result.markdown
+        else:
+            try:
+                if enable_plugins:
+                    raise ValueError(
+                        "enable_plugins is supported only for trusted local "
+                        "stdio file inputs."
+                    )
+                if source.lower().startswith(("http://", "https://")):
+                    payload, stream_info = await _fetch_remote_document(source)
+                else:
+                    payload, stream_info = _decode_data_uri(source)
+                markdown = await _run_isolated_stream_conversion(
+                    payload,
+                    stream_info,
+                    kwargs,
+                )
+            finally:
+                limiter.release()
+
+        if not isinstance(markdown, str):
+            raise ValueError("Document converter returned an invalid result.")
+        if len(markdown) > _max_output_chars() and not arguments.get("output_path"):
+            raise ValueError(
+                "Converted Markdown is too large to return; use output_path "
+                "through local stdio."
+            )
+        return markdown
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        output_path = self._get_output_path(arguments)
+        if output_path and not self._is_local_stdio():
+            return error_text(
+                "Error: output_path is only supported by local stdio MCP "
+                "servers. HTTP-hosted MCP servers must not write files."
+            )
+
+        try:
+            source, is_local_file = self._get_source_path(arguments)
+        except ValueError as exc:
+            return error_text(f"Error: {exc}")
+
+        if is_local_file and not self._is_local_stdio():
+            return error_text(
+                "Error: local file inputs are only supported by local stdio "
+                "MCP servers. HTTP-hosted MCP servers cannot read server "
+                "filesystem paths."
+            )
+
+        if is_local_file:
+            path = Path(source)
+            if not path.exists():
+                return error_text(f"Error: File not found: {source}")
+            if not path.is_file():
+                return error_text(f"Error: Path is not a file: {source}")
+
+        converter_used = "MarkItDown"
+        if is_local_file and arguments.get("enable_plugins", False):
+            converter_used += " + plugins"
+        try:
+            markdown = await self._convert_with_markitdown(
+                source,
+                is_local_file=is_local_file,
+                arguments=arguments,
+            )
+        except Exception as exc:  # noqa: BLE001 — tool boundary: a bad document is a result, not a crash
+            logger.warning(
+                "document_conversion_failed",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            return error_text(f"Error converting document with {converter_used}: {exc}")
+
+        if output_path:
+            try:
+                if is_local_file:
+                    source_path = Path(source).resolve(strict=False)
+                    target_path = output_path.resolve(strict=False)
+                    if target_path == source_path:
+                        return error_text(
+                            "Error: output_path must differ from the source file."
+                        )
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(markdown, encoding="utf-8")
+                return [
+                    TextContent(
+                        type="text",
+                        text=(
+                            f"Converted with {converter_used}\n"
+                            f"Markdown written to {output_path}"
+                        ),
+                    )
+                ]
+            except Exception as exc:  # noqa: BLE001 — tool boundary: report the write failure to the caller
+                return error_text(f"Error writing to {output_path}: {exc}")
+
+        return [
+            TextContent(
+                type="text",
+                text=f"Converted with {converter_used}\n\n{markdown}",
+            )
+        ]

--- a/jawafdehi_mcp/tools/jawafdehi_cases.py
+++ b/jawafdehi_mcp/tools/jawafdehi_cases.py
@@ -1,0 +1,1097 @@
+import json
+import os
+import re
+import urllib.parse
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import httpx
+import structlog
+from mcp.types import TextContent
+
+from ..api_transport import embedded_api_client_kwargs
+from ..path_safety import (
+    encode_case_slug,
+    encode_entity_ref,
+    encode_material_parts,
+)
+from ..request_context import (
+    get_forwarded_headers,
+    get_local_service_token,
+    is_local_stdio_transport,
+    jawafdehi_bearer_token,
+)
+from .base import BaseTool, ToolExecutionResult, error_text
+from .control_plane_schemas import JSON_PATCH_SCHEMA
+
+logger = structlog.get_logger()
+
+CASE_TYPE_VALUES = [
+    "CORRUPTION",
+    "BRIBERY",
+    "FORGERY",
+    "EMBEZZLEMENT",
+    "ABUSE_OF_OFFICE",
+    "MONEY_LAUNDERING",
+    "ILLEGAL_PROPERTY",
+    "EXAM_RIGGING",
+    "TAX_EVASION",
+    "BANKING_OFFENCE",
+]
+CASE_STATE_VALUES = ["DRAFT"]
+MAX_MATERIAL_UPLOAD_BYTES = 100 * 1024 * 1024
+
+
+def _nullable_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    return {"anyOf": [schema, {"type": "null"}]}
+
+
+TIMELINE_ITEM_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "date": {"type": "string"},
+        "title": {"type": "string", "minLength": 1},
+        "description": {"type": "string"},
+        "date_bs": {"type": "string"},
+        "end_date": {"type": "string"},
+        "end_date_bs": {"type": "string"},
+    },
+    "required": ["date", "title"],
+    "additionalProperties": False,
+}
+EVIDENCE_ITEM_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "material_iri": {"type": "string", "format": "uri"},
+        "additional_details": _nullable_schema({"type": "string"}),
+    },
+    "required": ["material_iri"],
+    "additionalProperties": False,
+}
+CASE_CREATE_PROPERTIES: dict[str, Any] = {
+    "case_type": {
+        "type": "string",
+        "enum": CASE_TYPE_VALUES,
+        "description": "Case type.",
+    },
+    "state": {
+        "type": "string",
+        "enum": CASE_STATE_VALUES,
+        "default": "DRAFT",
+        "description": "New cases must be created in DRAFT state.",
+    },
+    "title": {
+        "type": "string",
+        "maxLength": 200,
+        "description": "Case title.",
+    },
+    "short_description": {"type": "string"},
+    "description": {
+        "type": "string",
+        "description": "Full case description in Markdown.",
+    },
+    "thumbnail_url": {"type": "string", "maxLength": 500},
+    "banner_url": {"type": "string", "maxLength": 500},
+    "case_start_date": _nullable_schema({"type": "string", "format": "date"}),
+    "case_end_date": _nullable_schema({"type": "string", "format": "date"}),
+    "tags": {"type": "array", "items": {"type": "string"}},
+    "key_allegations": {"type": "array", "items": {"type": "string"}},
+    "timeline": {"type": "array", "items": TIMELINE_ITEM_INPUT_SCHEMA},
+    "evidence": {"type": "array", "items": EVIDENCE_ITEM_INPUT_SCHEMA},
+    "notes": {"type": "string"},
+    "public_notes": {"type": "string"},
+    "alleged_entities": {
+        "type": "array",
+        "items": {"type": "string", "format": "uri"},
+    },
+    "related_entities": {
+        "type": "array",
+        "items": {"type": "string", "format": "uri"},
+    },
+    "slug": _nullable_schema({"type": "string", "maxLength": 50}),
+    "court_cases": _nullable_schema(
+        {
+            "type": "array",
+            "items": {"type": "string", "format": "uri"},
+        }
+    ),
+    "missing_details": _nullable_schema({"type": "string"}),
+    "bigo": _nullable_schema(
+        {
+            "type": "integer",
+            "minimum": -9223372036854775808,
+            "maximum": 9223372036854775807,
+        }
+    ),
+}
+CASE_CREATE_FIELDS = tuple(CASE_CREATE_PROPERTIES)
+
+
+def _get_jawafdehi_base_url() -> str:
+    return os.getenv("JAWAFDEHI_API_BASE_URL", "https://api.jawafdehi.org").rstrip("/")
+
+
+def _get_jawafdehi_api_token() -> str | None:
+    return get_local_service_token()
+
+
+def _has_upstream_auth() -> bool:
+    """True if the request can authenticate to jawafdehi-api: a forwarded OIDC
+    bearer (HTTP transport) or a service token (stdio/dev fallback)."""
+    return bool(jawafdehi_bearer_token.get()) or bool(_get_jawafdehi_api_token())
+
+
+def _get_auth_headers() -> dict[str, str]:
+    """Return Authorization headers for upstream calls.
+
+    Prefer the caller's forwarded OIDC bearer; fall back to the service token
+    (stdio/dev), also sent as ``Bearer``. The unified platform is OIDC-only —
+    the legacy DRF ``Token`` scheme is no longer honoured (2026-07 hard cut).
+    HTTP requests never fall back to the process service token.
+    """
+    headers = get_forwarded_headers()
+    if not headers:
+        token = _get_jawafdehi_api_token()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+_NO_AUTH_MESSAGE = (
+    "Authentication required: sign in (OIDC bearer) or set JAWAFDEHI_API_TOKEN."
+)
+
+
+def _json_text_content(payload: Any) -> list[TextContent]:
+    return [
+        TextContent(type="text", text=json.dumps(payload, indent=2, ensure_ascii=False))
+    ]
+
+
+def _json_error_content(payload: Any) -> ToolExecutionResult:
+    return ToolExecutionResult(_json_text_content(payload), is_error=True)
+
+
+def _error_text_content(message: str) -> ToolExecutionResult:
+    return error_text(message)
+
+
+def _mutation_timeout_content(operation: str) -> ToolExecutionResult:
+    return _error_text_content(
+        f"{operation} timed out; the operation's outcome is unknown. "
+        "Verify current state before retrying."
+    )
+
+
+def _build_http_error_payload(response: httpx.Response, prefix: str) -> dict[str, Any]:
+    try:
+        details: Any = response.json()
+    except ValueError:
+        details = response.text
+
+    payload = {
+        "error": prefix,
+        "status_code": response.status_code,
+        "details": details,
+    }
+    if etag := _response_etag(response):
+        payload["etag"] = etag
+    return payload
+
+
+def _response_etag(response: httpx.Response) -> str | None:
+    headers = getattr(response, "headers", None)
+    if not isinstance(headers, Mapping):
+        return None
+    return headers.get("etag")
+
+
+def _response_json_with_etag(response: httpx.Response) -> Any:
+    payload = response.json()
+    etag = _response_etag(response)
+    if etag and isinstance(payload, dict):
+        payload = {**payload, "etag": etag}
+    return payload
+
+
+def _flatten_lang_map(value: Any) -> str:
+    """Flatten a unified-search language map ({en, ne}) to a single string.
+
+    Prefers English, then Nepali, then any non-empty value. A plain string is
+    returned as-is; anything else becomes "".
+    """
+    if isinstance(value, dict):
+        for lang in ("en", "ne"):
+            text = value.get(lang)
+            if isinstance(text, str) and text:
+                return text
+        for text in value.values():
+            if isinstance(text, str) and text:
+                return text
+        return ""
+    return value if isinstance(value, str) else ""
+
+
+def _slug_from_search_hit(hit: dict[str, Any]) -> str:
+    """Extract a case slug from a unified-search hit.
+
+    The /api/search/ result carries the slug inside ``api_url``
+    (``/api/cases/<slug>/``) or ``url`` (``/case/<slug>``) — it has no bare
+    ``slug`` field. get_jawafdehi_case needs the slug, so derive it here.
+    """
+    for key, pattern in (
+        ("api_url", r"/api/cases/([^/]+)/?$"),
+        ("url", r"/case/([^/]+)/?$"),
+    ):
+        value = hit.get(key)
+        if isinstance(value, str):
+            match = re.search(pattern, value)
+            if match:
+                return match.group(1)
+    return ""
+
+
+def _shape_case_search_hit(hit: dict[str, Any]) -> dict[str, Any]:
+    """Map a raw /api/search/ case hit to the case shape the tool returns.
+
+    Keeps a ``slug`` (for get_jawafdehi_case), a flattened title/snippet, and
+    the case_type/date/url/score so the assistant can present and link results.
+    """
+    extra = hit.get("extra")
+    if not isinstance(extra, dict):
+        extra = {}
+    return {
+        "slug": _slug_from_search_hit(hit),
+        "title": _flatten_lang_map(hit.get("title")),
+        "snippet": _flatten_lang_map(hit.get("snippet")),
+        "case_type": extra.get("case_type"),
+        "date": extra.get("date"),
+        "url": hit.get("url"),
+        "score": hit.get("score"),
+    }
+
+
+class SearchJawafdehiCasesTool(BaseTool):
+    """Tool for searching Jawafdehi accountability cases."""
+
+    @property
+    def name(self) -> str:
+        return "search_jawafdehi_cases"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search published Jawafdehi accountability cases by keywords or tags. "
+            "Covers every case type (corruption, tax evasion, and others); pass "
+            "case_type only to narrow the results to a single type."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "search": {
+                    "type": "string",
+                    "description": (
+                        "Full-text search across title, description, "
+                        "and key allegations."
+                    ),
+                },
+                "tags": {
+                    "type": "string",
+                    "description": "Filter cases containing a specific tag.",
+                },
+                "case_type": {
+                    "type": "string",
+                    "description": (
+                        "Optional. Restrict results to one case type "
+                        "(e.g. CORRUPTION, TAX_EVASION, BRIBERY). Omit to search "
+                        "across all case types."
+                    ),
+                },
+                "page": {
+                    "type": "integer",
+                    "description": "Page number for pagination (defaults to 1).",
+                    "default": 1,
+                },
+            },
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        # Query the unified OpenSearch plane (/api/search/), NOT the legacy
+        # /api/cases/ list filter. That list filter is a plain ORM icontains
+        # over title/description that misses Nepali-script titles — English
+        # queries returned 0 results — and DRF 404s on an out-of-range page
+        # (BB-03). /api/search/ is the bilingual, ranked search and returns an
+        # empty page instead of a 404.
+        query_params: dict[str, str] = {"type": "case"}
+
+        search = arguments.get("search")
+        if search:
+            query_params["q"] = str(search)
+
+        tags = arguments.get("tags")
+        if tags:
+            query_params["tags"] = str(tags)
+
+        # Optional case-type filter — default is NO filter so every case type is
+        # searchable. A previously hard-coded case_type=CORRUPTION silently hid
+        # tax-evasion and other non-corruption cases from search and chat (BB-03).
+        case_type = arguments.get("case_type")
+        if case_type:
+            query_params["case_type"] = str(case_type)
+
+        if "page" in arguments:
+            query_params["page"] = str(arguments["page"])
+
+        query_string = urllib.parse.urlencode(query_params)
+        base_url = _get_jawafdehi_base_url()
+        url = f"{base_url.rstrip('/')}/api/search/?{query_string}"
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.get(
+                    url, headers=_get_auth_headers(), timeout=30.0
+                )
+                if not response.is_success:
+                    # Surface the API's own error body (status + detail) instead of
+                    # a bare status string, so failures like an expired forwarded
+                    # token ({"detail": "Token has expired."}) are diagnosable.
+                    error_payload = _build_http_error_payload(
+                        response, "Error accessing Jawafdehi search API."
+                    )
+                    # 401/403 is an expired/insufficient forwarded caller bearer —
+                    # expected auth churn, not a server fault — so log at warning
+                    # (below Sentry's ERROR threshold). 5xx and the rest stay error.
+                    log = (
+                        logger.warning
+                        if response.status_code in (401, 403)
+                        else logger.error
+                    )
+                    log(
+                        "jawafdehi_search_http_error",
+                        status_code=response.status_code,
+                        details=error_payload.get("details"),
+                    )
+                    return _json_error_content(error_payload)
+                data = response.json()
+
+            # Defensive: a well-behaved /api/search/ returns a JSON object with a
+            # list of dict hits, but never trust the shape blindly.
+            if not isinstance(data, dict):
+                data = {}
+            raw_results = data.get("results")
+            results = raw_results if isinstance(raw_results, list) else []
+            payload = {
+                "count": data.get("count"),
+                "page": data.get("page"),
+                "results": [
+                    _shape_case_search_hit(hit)
+                    for hit in results
+                    if isinstance(hit, dict)
+                ],
+            }
+            return _json_text_content(payload)
+        except httpx.TimeoutException:
+            logger.warning("jawafdehi_create_case_timeout")
+            return _mutation_timeout_content("Creating the Jawafdehi case")
+        except httpx.HTTPError as e:
+            logger.error("jawafdehi_search_http_error", error=str(e))
+            return _error_text_content(
+                f"Error accessing Jawafdehi cases API: {str(e)}\n\n"
+                f"Consider narrowing your search or checking parameters."
+            )
+        except Exception as e:
+            logger.exception("jawafdehi_search_unexpected_error", error=str(e))
+            return _error_text_content(f"Unexpected error: {str(e)}")
+
+
+class GetJawafdehiCaseTool(BaseTool):
+    """Tool for retrieving detailed info on a specific Jawafdehi case."""
+
+    @property
+    def name(self) -> str:
+        return "get_jawafdehi_case"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Retrieve detailed information about a specific Jawafdehi case "
+            "(published or draft), including its allegations, evidence, timeline, "
+            "and optionally its casework audit history. Each evidence entry is a reference into the "
+            "Materials store — ``{material_iri, additional_details, material}`` — "
+            "where ``material`` is the resolved material (display name, type, "
+            "roled URLs), embedded by the API. All cases (including drafts) have "
+            "auto-generated slugs. Use the 'slug' from search results for direct "
+            "lookup. Set include_history for the separate casework-gated transition "
+            "history."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "slug": {
+                    "type": "string",
+                    "description": (
+                        "The canonical URL slug of the case, typically from "
+                        "search_jawafdehi_cases results."
+                    ),
+                },
+                "include_history": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Include case-state transition history. This subresource "
+                        "requires a casework-viewing role."
+                    ),
+                },
+            },
+            "required": ["slug"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        base_url = _get_jawafdehi_base_url()
+        auth_headers = _get_auth_headers()
+
+        slug = arguments.get("slug")
+
+        if not slug or not isinstance(slug, str) or not slug.strip():
+            return _error_text_content(
+                "Error: 'slug' (string) is required. "
+                "Use the 'slug' field from search_jawafdehi_cases results."
+            )
+        try:
+            slug_path = encode_case_slug(slug)
+        except ValueError as exc:
+            return _error_text_content(f"Error: {exc}")
+        case_url = f"{base_url.rstrip('/')}/api/cases/{slug_path}/"
+        lookup_label = f"slug={slug.strip()}"
+
+        # The case detail already embeds each evidence entry's resolved material
+        # (cases own no documents — evidence is a CaseMaterialReference join, and
+        # CaseDetailSerializer resolves the material inline). No separate
+        # source-fetch loop is needed; the old /api/sources endpoint is gone.
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.get(
+                    case_url, headers=auth_headers, timeout=30.0
+                )
+                if response.status_code == 404:
+                    return _error_text_content(f"Case not found ({lookup_label}).")
+                if not response.is_success:
+                    # Surface the API's error body (e.g. an expired forwarded token
+                    # → {"detail": "Token has expired."}) rather than a bare status.
+                    error_payload = _build_http_error_payload(
+                        response,
+                        f"Error accessing Jawafdehi case API ({lookup_label}).",
+                    )
+                    # 401/403 is an expired/insufficient forwarded caller bearer —
+                    # expected auth churn, not a server fault — so log at warning
+                    # (below Sentry's ERROR threshold). 5xx and the rest stay error.
+                    log = (
+                        logger.warning
+                        if response.status_code in (401, 403)
+                        else logger.error
+                    )
+                    log(
+                        "jawafdehi_get_case_http_error",
+                        lookup_label=lookup_label,
+                        status_code=response.status_code,
+                        details=error_payload.get("details"),
+                    )
+                    return _json_error_content(error_payload)
+                payload = _response_json_with_etag(response)
+                if arguments.get("include_history") and isinstance(payload, dict):
+                    history_response = await client.get(
+                        f"{case_url}history/",
+                        headers=auth_headers,
+                        timeout=30.0,
+                    )
+                    if history_response.is_success:
+                        payload["history"] = history_response.json()
+                    else:
+                        payload["history_error"] = _build_http_error_payload(
+                            history_response,
+                            "Error accessing Jawafdehi case history.",
+                        )
+                return _json_text_content(payload)
+        except httpx.TimeoutException:
+            logger.warning(
+                "jawafdehi_patch_case_timeout",
+                lookup_label=lookup_label,
+            )
+            return _mutation_timeout_content(
+                f"Patching the Jawafdehi case ({lookup_label})"
+            )
+        except httpx.HTTPError as e:
+            logger.error(
+                "jawafdehi_get_case_http_error",
+                lookup_label=lookup_label,
+                error=str(e),
+            )
+            return _error_text_content(
+                f"Error accessing Jawafdehi API ({lookup_label}): {str(e)}"
+            )
+        except Exception as e:
+            logger.exception(
+                "jawafdehi_get_case_unexpected_error",
+                lookup_label=lookup_label,
+                error=str(e),
+            )
+            return _error_text_content(f"Unexpected error: {str(e)}")
+
+
+class CreateJawafdehiCaseTool(BaseTool):
+    """Tool for creating a draft Jawafdehi case."""
+
+    @property
+    def name(self) -> str:
+        return "create_jawafdehi_case"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create a draft Jawafdehi case using a simple authenticated interface. "
+            "Requires a signed-in user with write access."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": deepcopy(CASE_CREATE_PROPERTIES),
+            "required": ["title", "case_type"],
+            "additionalProperties": False,
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        title = arguments.get("title")
+        case_type = arguments.get("case_type")
+
+        if not _has_upstream_auth():
+            return _error_text_content(f"Error: {_NO_AUTH_MESSAGE}")
+
+        if not title:
+            return _error_text_content("Error: title is required")
+
+        if not case_type:
+            return _error_text_content("Error: case_type is required")
+
+        payload = {
+            field: arguments[field]
+            for field in CASE_CREATE_FIELDS
+            if field in arguments
+        }
+
+        url = f"{_get_jawafdehi_base_url()}/api/cases/"
+        headers = _get_auth_headers()
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=30.0,
+                )
+
+                if response.is_success:
+                    return _json_text_content(response.json())
+
+                return _json_error_content(
+                    _build_http_error_payload(
+                        response, "Error creating Jawafdehi case via API."
+                    )
+                )
+        except httpx.HTTPError as e:
+            logger.error("jawafdehi_create_case_http_error", error=str(e))
+            return _error_text_content(
+                f"Error accessing Jawafdehi create API: {str(e)}"
+            )
+        except Exception as e:
+            logger.exception("jawafdehi_create_case_unexpected_error", error=str(e))
+            return _error_text_content(f"Unexpected error: {str(e)}")
+
+
+class PatchJawafdehiCaseTool(BaseTool):
+    """Tool for patching a Jawafdehi case with RFC 6902 operations."""
+
+    @property
+    def name(self) -> str:
+        return "patch_jawafdehi_case"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Patch a Jawafdehi case using raw RFC 6902 JSON Patch operations. "
+            "Requires a signed-in user with write access. Use a slug (from "
+            "search results) for direct lookup."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "slug": {
+                    "type": "string",
+                    "description": (
+                        "The URL slug of the case to patch. "
+                        "Use the 'slug' field from search_jawafdehi_cases results."
+                    ),
+                },
+                "operations": {
+                    **deepcopy(JSON_PATCH_SCHEMA),
+                    "description": "RFC 6902 JSON Patch operations. Use Markdown for /description values.",
+                },
+                "if_match": {
+                    "type": "string",
+                    "description": "ETag returned by get_jawafdehi_case.",
+                },
+                "transition_reason": {
+                    "type": "string",
+                    "maxLength": 2000,
+                    "description": (
+                        "Optional audit reason when the patch changes case state."
+                    ),
+                },
+            },
+            "required": ["slug", "operations"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        operations = arguments.get("operations")
+        slug = arguments.get("slug")
+
+        if not _has_upstream_auth():
+            return _error_text_content(f"Error: {_NO_AUTH_MESSAGE}")
+
+        if not slug or not isinstance(slug, str) or not slug.strip():
+            return _error_text_content(
+                "Error: 'slug' (string) is required. "
+                "Use the 'slug' field from search_jawafdehi_cases results."
+            )
+
+        if not isinstance(operations, list) or not operations:
+            return _error_text_content(
+                "Error: operations must be a non-empty JSON Patch array of "
+                "operation objects."
+            )
+
+        try:
+            slug_path = encode_case_slug(slug)
+        except ValueError as exc:
+            return _error_text_content(f"Error: {exc}")
+        base_url = _get_jawafdehi_base_url()
+        url = f"{base_url.rstrip('/')}/api/cases/{slug_path}/"
+        lookup_label = f"slug={slug.strip()}"
+
+        headers = _get_auth_headers()
+        if arguments.get("if_match"):
+            headers["If-Match"] = str(arguments["if_match"])
+        if arguments.get("transition_reason"):
+            headers["X-Transition-Reason"] = str(arguments["transition_reason"])
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.patch(
+                    url,
+                    json=operations,
+                    headers=headers,
+                    timeout=30.0,
+                )
+
+                if response.is_success:
+                    return _json_text_content(_response_json_with_etag(response))
+
+                return _json_error_content(
+                    _build_http_error_payload(
+                        response,
+                        f"Error patching Jawafdehi case ({lookup_label}) via API.",
+                    )
+                )
+        except httpx.HTTPError as e:
+            logger.error(
+                "jawafdehi_patch_case_http_error",
+                lookup_label=lookup_label,
+                error=str(e),
+            )
+            return _error_text_content(
+                f"Error accessing Jawafdehi patch API ({lookup_label}): {str(e)}"
+            )
+        except Exception as e:
+            logger.exception(
+                "jawafdehi_patch_case_unexpected_error",
+                lookup_label=lookup_label,
+                error=str(e),
+            )
+            return _error_text_content(f"Unexpected error: {str(e)}")
+
+
+class DeleteJawafdehiCaseTool(BaseTool):
+    """Soft-delete a Jawafdehi case through the authoritative case API."""
+
+    @property
+    def name(self) -> str:
+        return "delete_jawafdehi_case"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Soft-delete a Jawafdehi case by transitioning it to CLOSED. "
+            "The Django control plane enforces delete permission."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "slug": {
+                    "type": "string",
+                    "description": "Canonical case slug.",
+                }
+            },
+            "required": ["slug"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        if not _has_upstream_auth():
+            return _error_text_content(f"Error: {_NO_AUTH_MESSAGE}")
+        try:
+            slug_path = encode_case_slug(arguments.get("slug", ""))
+        except ValueError as exc:
+            return _error_text_content(f"Error: {exc}")
+
+        url = f"{_get_jawafdehi_base_url()}/api/cases/{slug_path}/"
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.delete(
+                    url,
+                    headers=_get_auth_headers(),
+                    timeout=30.0,
+                )
+            if response.is_success:
+                return _json_text_content(
+                    {"success": True, "status_code": response.status_code}
+                )
+            return _json_error_content(
+                _build_http_error_payload(
+                    response,
+                    "Error deleting Jawafdehi case via API.",
+                )
+            )
+        except httpx.TimeoutException:
+            logger.warning("jawafdehi_delete_case_timeout")
+            return _mutation_timeout_content("Deleting the Jawafdehi case")
+        except httpx.HTTPError as exc:
+            logger.error("jawafdehi_delete_case_http_error", error=str(exc))
+            return _error_text_content(f"Error accessing Jawafdehi delete API: {exc}")
+
+
+class SubmitNESChangeTool(BaseTool):
+    """Write an NES entity directly via the unified entity write plane.
+
+    Post-unification (2026-07 hard cut) there is no NES *queue* endpoint
+    (``/api/submit_nes_change`` and the ADD_NAME/CREATE_ENTITY/UPDATE_ENTITY
+    NESQ actions are gone). Writes go straight to the entity store:
+      * CREATE → ``POST /api/entities`` with a JSON-LD / authoring ``document``.
+      * UPDATE → ``PATCH /api/entities/{ref}`` with RFC-6902 ``patch_ops``
+        (add-a-name is just an ``add`` op to ``/name`` — no dedicated action).
+    NES-contributor gated; the API enforces permissions and the ≥2-source held
+    /published gate does NOT apply to direct API writes (they publish).
+    """
+
+    @property
+    def name(self) -> str:
+        return "submit_nes_change"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Write an NES entity directly. Use action=CREATE with a JSON-LD "
+            "'document' to create an entity, or action=UPDATE with 'ref' "
+            "(the entity @id or prefix/slug) and RFC-6902 'patch_ops' to modify "
+            "one (e.g. add a name: [{'op':'add','path':'/name/en','value':'...'}])."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["CREATE", "UPDATE"],
+                    "description": "CREATE a new entity or UPDATE an existing one.",
+                },
+                "ref": {
+                    "type": "string",
+                    "description": (
+                        "UPDATE only: the entity @id IRI or 'prefix/slug' path "
+                        "(e.g. 'person/ram-chandra-poudel')."
+                    ),
+                },
+                "document": {
+                    "type": "object",
+                    "description": (
+                        "CREATE only: the JSON-LD / authoring entity document "
+                        "(must carry @id or prefix+slug + @type)."
+                    ),
+                },
+                "patch_ops": {
+                    **deepcopy(JSON_PATCH_SCHEMA),
+                    "description": (
+                        "UPDATE only: RFC-6902 JSON Patch operations. Immutable "
+                        "paths (@id/@type/@context/version) are rejected by the API."
+                    ),
+                },
+                "change_description": {
+                    "type": "string",
+                    "description": "Human-readable summary of the change.",
+                },
+            },
+            "required": ["action", "change_description"],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"action": {"const": "CREATE"}},
+                        "required": ["action"],
+                    },
+                    "then": {"required": ["document"]},
+                },
+                {
+                    "if": {
+                        "properties": {"action": {"const": "UPDATE"}},
+                        "required": ["action"],
+                    },
+                    "then": {"required": ["ref", "patch_ops"]},
+                },
+            ],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        if not _has_upstream_auth():
+            return _error_text_content(f"Error: {_NO_AUTH_MESSAGE}")
+
+        action = arguments.get("action")
+        change_description = arguments.get("change_description")
+        base_url = _get_jawafdehi_base_url()
+        headers = _get_auth_headers()
+        headers["Content-Type"] = "application/json"
+        headers["Accept"] = "application/json"
+
+        if action == "CREATE":
+            document = arguments.get("document")
+            if not isinstance(document, dict):
+                return _error_text_content(
+                    "Error: 'document' (object) is required for action=CREATE."
+                )
+            url = f"{base_url}/api/entities"
+            body = {**document, "change_description": change_description}
+            method = "POST"
+        elif action == "UPDATE":
+            ref = arguments.get("ref")
+            patch_ops = arguments.get("patch_ops")
+            if not ref or not isinstance(patch_ops, list) or not patch_ops:
+                return _error_text_content(
+                    "Error: 'ref' and a non-empty 'patch_ops' array are required for "
+                    "action=UPDATE."
+                )
+            try:
+                ref_path = encode_entity_ref(ref)
+            except ValueError as exc:
+                return _error_text_content(f"Error: {exc}")
+            url = f"{base_url}/api/entities/{ref_path}"
+            body = {"patch_ops": patch_ops, "change_description": change_description}
+            method = "PATCH"
+        else:
+            return _error_text_content(
+                f"Error: unsupported action {action!r} (use CREATE or UPDATE)."
+            )
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.request(
+                    method, url, json=body, headers=headers, timeout=30.0
+                )
+
+            if response.status_code in (200, 201):
+                return _json_text_content(response.json())
+
+            return _json_error_content(
+                _build_http_error_payload(response, "Error writing NES entity")
+            )
+        except httpx.TimeoutException:
+            logger.warning("jawafdehi_submit_nes_change_timeout")
+            return _mutation_timeout_content("Writing the NES entity")
+        except httpx.HTTPError as e:
+            logger.error("jawafdehi_submit_nes_change_http_error", error=str(e))
+            return _error_text_content(f"Error writing NES entity: {str(e)}")
+        except Exception as e:
+            logger.exception(
+                "jawafdehi_submit_nes_change_unexpected_error", error=str(e)
+            )
+            return _error_text_content(f"Unexpected error: {str(e)}")
+
+
+class UploadMaterialFileTool(BaseTool):
+    """Attach a file to a Material via the unified material upload endpoint.
+
+    Post-unification the document/evidence store is Materials: this streams a
+    local file to ``POST /api/materials/{source}/{ident}/file`` (multipart),
+    which places it in object storage and appends a roled schema.org
+    ``MediaObject`` to the material's ``associatedMedia`` (creating the material
+    if it does not yet exist). Replaces the retired ``/api/sources`` upload.
+    NGM-role gated.
+    """
+
+    @property
+    def name(self) -> str:
+        return "upload_material_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Attach a file (from disk) to a Material at @id "
+            "/material/{source}/{ident}, uploading it to storage as a roled "
+            "MediaObject. Creates the material if it does not exist (then "
+            "material_type is required). Local file uploads are only available "
+            "through a local stdio MCP server."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": (
+                        "Material source segment of the IRI "
+                        "(e.g. 'nkp', 'court'), i.e. /material/{source}/{ident}."
+                    ),
+                },
+                "ident": {
+                    "type": "string",
+                    "description": "Material ident segment of the IRI.",
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute path to the file on disk to upload. Only supported "
+                        "by local stdio servers."
+                    ),
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "RAW",
+                        "ALTERNATE",
+                        "PERMALINK",
+                        "MARKDOWN",
+                        "SOURCE_PAGE",
+                    ],
+                    "description": "Link role for the uploaded file (default RAW).",
+                    "default": "RAW",
+                },
+                "material_type": {
+                    "type": "string",
+                    "description": (
+                        "Required only when CREATING a new material "
+                        "(e.g. court_order). Ignored when the material exists."
+                    ),
+                },
+                "source_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Optional original source URL recorded as provenance.",
+                },
+                "skip_convert": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Skip server-side OCR when authoritative extracted text "
+                        "will be supplied separately."
+                    ),
+                },
+            },
+            "required": ["source", "ident", "file_path"],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        if not is_local_stdio_transport():
+            return _error_text_content(
+                "Local file uploads are only supported by local stdio MCP servers. "
+                "HTTP-hosted MCP servers cannot read server filesystem paths."
+            )
+
+        if not _has_upstream_auth():
+            return _error_text_content(_NO_AUTH_MESSAGE)
+
+        missing_keys = [
+            k for k in ["source", "ident", "file_path"] if not arguments.get(k)
+        ]
+        if missing_keys:
+            return _error_text_content(
+                f"Missing required arguments: {', '.join(missing_keys)}"
+            )
+
+        file_path = Path(arguments["file_path"])
+        try:
+            file_size = file_path.stat().st_size
+        except OSError as e:
+            return _error_text_content(f"Could not read file '{file_path}': {e}")
+        if file_size > MAX_MATERIAL_UPLOAD_BYTES:
+            max_mb = MAX_MATERIAL_UPLOAD_BYTES // (1024 * 1024)
+            return _error_text_content(
+                f"File exceeds the {max_mb} MB material upload limit."
+            )
+
+        try:
+            source, ident = encode_material_parts(
+                arguments["source"], arguments["ident"]
+            )
+        except ValueError as exc:
+            return _error_text_content(f"Error: {exc}")
+        base_url = _get_jawafdehi_base_url()
+        url = f"{base_url}/api/materials/{source}/{ident}/file"
+
+        headers = _get_auth_headers()
+        headers["Accept"] = "application/json"
+
+        data: dict[str, str] = {}
+        # input_schema "default" is metadata only (BaseTool doesn't inject it), so
+        # apply the advertised RAW default here rather than sending no role.
+        data["role"] = str(arguments.get("role") or "RAW")
+        if arguments.get("material_type"):
+            data["material_type"] = arguments["material_type"]
+        if arguments.get("source_url"):
+            data["source_url"] = str(arguments["source_url"])
+        if "skip_convert" in arguments:
+            data["skip_convert"] = "true" if arguments["skip_convert"] else "false"
+
+        try:
+            with file_path.open("rb") as file_handle:
+                files = {"file": (file_path.name, file_handle)}
+                async with httpx.AsyncClient(
+                    timeout=120.0, **embedded_api_client_kwargs()
+                ) as client:
+                    response = await client.post(
+                        url, headers=headers, data=data, files=files
+                    )
+
+            if response.status_code in (200, 201):
+                return _json_text_content(response.json())
+
+            return _json_error_content(
+                _build_http_error_payload(response, "Error uploading material file")
+            )
+        except Exception as e:
+            logger.exception("jawafdehi_upload_material_unexpected_error", error=str(e))
+            return _error_text_content(f"Unexpected error uploading material: {str(e)}")

--- a/jawafdehi_mcp/tools/nes.py
+++ b/jawafdehi_mcp/tools/nes.py
@@ -1,0 +1,363 @@
+import json
+import os
+import urllib.parse
+from typing import Any
+
+import httpx
+import structlog
+from mcp.types import TextContent
+
+from ..api_transport import embedded_api_client_kwargs
+from ..request_context import get_forwarded_headers, get_local_service_token
+from .base import BaseTool, ToolExecutionResult, error_text
+
+logger = structlog.get_logger()
+
+
+def _get_nes_base_url() -> str:
+    """Base URL for entity reads.
+
+    Post-unification NES entities are served by the ONE Jawafdehi host under a
+    bare ``/api/entities`` (the standalone ``nes.jawafdehi.org`` service + its
+    ``/api/nes`` prefix were retired in the 2026-07 hard cut, with no override:
+    a legacy NES base URL would silently read the frozen pre-cutover backend).
+    """
+    return os.getenv("JAWAFDEHI_API_BASE_URL", "https://api.jawafdehi.org").rstrip("/")
+
+
+def _get_nes_headers() -> dict[str, str]:
+    """Auth headers for entity reads.
+
+    Forward the caller's OIDC bearer when present (HTTP transport); otherwise
+    fall back to the service token as ``Bearer`` (stdio/dev). Mirrors the write
+    tools so token-only flows keep working once the unified API requires auth.
+    """
+    headers = get_forwarded_headers()
+    if "Authorization" not in headers:
+        token = get_local_service_token()
+        if token:
+            headers = {"Authorization": f"Bearer {token}"}
+    return headers
+
+
+def _build_text_response(payload: Any) -> list[TextContent]:
+    return [
+        TextContent(
+            type="text",
+            text=json.dumps(payload, indent=2, ensure_ascii=False),
+        )
+    ]
+
+
+def _extract_error_message(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text or response.reason_phrase
+
+    if isinstance(payload, dict):
+        return json.dumps(payload, indent=2, ensure_ascii=False)
+
+    return str(payload)
+
+
+class SearchNESEntitiesTool(BaseTool):
+    """Tool for searching NES entities."""
+
+    @property
+    def name(self) -> str:
+        return "search_nes_entities"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search or browse Nepal Entity Service (NES) entities by text, "
+            "primary type, canonical prefix, and tags."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "entity_type": {
+                    "type": "string",
+                    "description": "Filter by primary entity type (e.g., person, organization, location).",
+                },
+                "entity_prefix": {
+                    "type": "string",
+                    "description": (
+                        "Filter by canonical entity prefix (e.g. person or "
+                        "organization/political_party)."
+                    ),
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Text query to search in entity names (e.g., 'poudel').",
+                },
+                "tags": {
+                    "type": "string",
+                    "description": "Comma-separated tags to filter by (uses AND logic, e.g., 'politician,senior-leader').",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 100,
+                    "description": "Maximum number of entities to return.",
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Number of results to skip (default is 0).",
+                    "default": 0,
+                },
+            },
+            "required": [],
+            "additionalProperties": False,
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        query_params = {"limit": str(arguments.get("limit", 100))}
+
+        if arguments.get("query"):
+            query_params["query"] = arguments["query"]
+        if arguments.get("entity_type"):
+            query_params["entity_type"] = arguments["entity_type"]
+        if arguments.get("entity_prefix"):
+            query_params["entity_prefix"] = arguments["entity_prefix"]
+        if arguments.get("tags"):
+            query_params["tags"] = arguments["tags"]
+        if "offset" in arguments:
+            query_params["offset"] = str(arguments["offset"])
+
+        query_string = urllib.parse.urlencode(query_params)
+        url = f"{_get_nes_base_url()}/api/entities?{query_string}"
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.get(
+                    url, headers=_get_nes_headers(), timeout=30.0
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                return [
+                    TextContent(
+                        type="text", text=json.dumps(data, indent=2, ensure_ascii=False)
+                    )
+                ]
+        except httpx.HTTPError as e:
+            logger.error("nes_search_http_error", error=str(e))
+            return error_text(
+                f"Error accessing NES API: {str(e)}\n\n"
+                "Consider narrowing your search or checking parameters."
+            )
+        except Exception as e:
+            logger.exception("nes_search_unexpected_error", error=str(e))
+            return error_text(f"Unexpected error: {str(e)}")
+
+
+class GetNESEntitiesTool(BaseTool):
+    """Tool for retrieving detailed info on one or more NES entities by ID."""
+
+    @property
+    def name(self) -> str:
+        return "get_nes_entities"
+
+    @property
+    def description(self) -> str:
+        return "Retrieve the complete profiles of one or more NES entities by their unique IDs."
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "entity_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "description": (
+                        "Canonical entity IRIs to retrieve, for example "
+                        "['https://jawafdehi.org/entity/person/"
+                        "ram-chandra-poudel']."
+                    ),
+                },
+            },
+            "required": ["entity_ids"],
+            "additionalProperties": False,
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        entity_ids = arguments.get("entity_ids")
+        if not entity_ids or not isinstance(entity_ids, list):
+            return error_text(
+                "Error: entity_ids must be a non-empty list of strings."
+            )
+
+        if len(entity_ids) > 100:
+            return error_text(
+                "Error: at most 100 entity_ids may be requested per call."
+            )
+        if any(
+            not isinstance(entity_id, str) or not entity_id.strip()
+            for entity_id in entity_ids
+        ):
+            return error_text("Error: every entity_id must be a non-empty string.")
+
+        all_entities = []
+        errors = []
+
+        chunk_size = 25
+        base_url = _get_nes_base_url()
+
+        async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+            for i in range(0, len(entity_ids), chunk_size):
+                chunk = entity_ids[i : i + chunk_size]
+                ids_str = ",".join(chunk)
+                url = f"{base_url}/api/entities?ids={urllib.parse.quote(ids_str)}"
+
+                try:
+                    response = await client.get(
+                        url, headers=_get_nes_headers(), timeout=30.0
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+
+                    if "entities" in data:
+                        all_entities.extend(data["entities"])
+                    else:
+                        errors.append(
+                            f"Unexpected response format for chunk {i // chunk_size + 1}"
+                        )
+
+                except httpx.HTTPError as e:
+                    logger.error(
+                        "nes_get_entities_http_error",
+                        chunk=i // chunk_size + 1,
+                        error=str(e),
+                    )
+                    errors.append(
+                        f"HTTP Error for chunk {i // chunk_size + 1}: {str(e)}"
+                    )
+                except Exception as e:
+                    logger.exception(
+                        "nes_get_entities_unexpected_error",
+                        chunk=i // chunk_size + 1,
+                        error=str(e),
+                    )
+                    errors.append(
+                        f"Unexpected error for chunk {i // chunk_size + 1}: {str(e)}"
+                    )
+
+        result = {
+            "entities": all_entities,
+            "total_requested": len(entity_ids),
+            "total_found": len(all_entities),
+        }
+
+        if errors:
+            result["errors"] = errors
+
+        content = [
+            TextContent(
+                type="text", text=json.dumps(result, indent=2, ensure_ascii=False)
+            )
+        ]
+        if errors:
+            return ToolExecutionResult(content, is_error=True)
+        return content
+
+
+class GetNESTagsTool(BaseTool):
+    """Tool for fetching the complete list of unique entity tags."""
+
+    @property
+    def name(self) -> str:
+        return "get_nes_tags"
+
+    @property
+    def description(self) -> str:
+        return "Fetch the complete list of all unique entity tag values present in the NES database."
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        url = f"{_get_nes_base_url()}/api/entities/tags"
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.get(
+                    url, headers=_get_nes_headers(), timeout=30.0
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                return [
+                    TextContent(
+                        type="text", text=json.dumps(data, indent=2, ensure_ascii=False)
+                    )
+                ]
+        except httpx.HTTPError as e:
+            logger.error("nes_tags_http_error", error=str(e))
+            return error_text(f"Error accessing NES Tags API: {str(e)}")
+        except Exception as e:
+            logger.exception("nes_tags_unexpected_error", error=str(e))
+            return error_text(f"Unexpected error: {str(e)}")
+
+
+class GetNESEntityPrefixesTool(BaseTool):
+    """Tool for fetching available NES entity prefixes."""
+
+    @property
+    def name(self) -> str:
+        return "get_nes_entity_prefixes"
+
+    @property
+    def description(self) -> str:
+        return "Fetch the available NES entity prefixes and related metadata."
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        url = f"{_get_nes_base_url()}/api/entity_prefixes"
+
+        try:
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                response = await client.get(
+                    url, headers=_get_nes_headers(), timeout=30.0
+                )
+
+            if response.status_code == 200:
+                return _build_text_response(response.json())
+
+            error_message = _extract_error_message(response)
+            return error_text(
+                "Error fetching NES entity prefixes: "
+                f"HTTP {response.status_code}\n\n{error_message}"
+            )
+        except httpx.TimeoutException:
+            logger.warning("nes_prefixes_timeout")
+            return error_text(
+                "Error fetching NES entity prefixes: request timed out."
+            )
+        except httpx.HTTPError as exc:
+            logger.error("nes_prefixes_http_error", error=str(exc))
+            return error_text(f"Error fetching NES entity prefixes: {str(exc)}")
+        except Exception as exc:
+            logger.exception("nes_prefixes_unexpected_error", error=str(exc))
+            return error_text(f"Unexpected error: {str(exc)}")

--- a/jawafdehi_mcp/tools/ngm_extract.py
+++ b/jawafdehi_mcp/tools/ngm_extract.py
@@ -1,0 +1,382 @@
+"""NGM case data extraction query tool."""
+
+import json
+import os
+from typing import Any
+
+import httpx
+import structlog
+from mcp.types import TextContent
+
+from ..api_transport import embedded_api_client_kwargs
+from ..request_context import is_local_stdio_transport
+from .base import BaseTool, ToolExecutionResult
+from .ngm_proxy import (
+    execute_ngm_proxy_query,
+    get_jawafdehi_api_config,
+    rows_to_dicts,
+    sql_quote,
+)
+
+logger = structlog.get_logger()
+
+
+def _error_response(message: str) -> ToolExecutionResult:
+    return ToolExecutionResult(
+        [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {"success": False, "error": message},
+                    ensure_ascii=False,
+                ),
+            )
+        ],
+        is_error=True,
+    )
+
+
+class NGMExtractCaseDataTool(BaseTool):
+    """Tool for extracting complete NGM judicial case data directly to a markdown file."""
+
+    @property
+    def name(self) -> str:
+        return "ngm_extract_case_data"
+
+    @property
+    def description(self) -> str:
+        return """Extract complete judicial case information from Nepal's court system (NGM database) into a Markdown file. This tool is only available through a local stdio MCP server because it writes to the local filesystem.
+This includes case metadata, hearings, and entities (plaintiffs/defendants).
+
+Court IDs (court_identifier):
+- Supreme & Special: supreme, special
+- High Courts: biratnagarhc, illamhc, dhankutahc, okhaldhungahc, janakpurhc, rajbirajhc, birganjhc, patanhc, hetaudahc, pokharahc, baglunghc, tulsipurhc, butwalhc, nepalgunjhc, surkhethc, jumlahc, dipayalhc, mahendranagarhc
+- District Courts: achhamdc, argakhanchidc, etc."""
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "court_identifier": {
+                    "type": "string",
+                    "description": "Identifier for the court (e.g. supreme, patanhc, special)",
+                },
+                "case_number": {
+                    "type": "string",
+                    "description": "The exact case number to extract data for",
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute path to save the generated Markdown document. "
+                        "Only supported by local stdio servers."
+                    ),
+                },
+            },
+            "required": ["court_identifier", "case_number", "file_path"],
+        }
+
+    def _validate_environment(self) -> tuple[str, str]:
+        return get_jawafdehi_api_config()
+
+    @staticmethod
+    def _sql_quote(value: str) -> str:
+        return sql_quote(value)
+
+    @staticmethod
+    def _rows_to_dicts(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        return rows_to_dicts(payload)
+
+    async def _execute_proxy_query(
+        self,
+        client: httpx.AsyncClient,
+        base_url: str,
+        token: str,
+        query: str,
+    ) -> dict[str, Any]:
+        return await execute_ngm_proxy_query(
+            client,
+            base_url,
+            token,
+            query,
+            timeout=15,
+        )
+
+    def _format_markdown(
+        self, court_info: dict, case_info: dict, hearings: list, entities: list
+    ) -> str:
+        """Format the extracted data into a Markdown string."""
+        md = []
+
+        # Header
+        court_name_en = (
+            court_info.get("full_name_english", "Unknown Court")
+            if court_info
+            else "Unknown Court"
+        )
+        court_name_np = court_info.get("full_name_nepali", "") if court_info else ""
+        case_no = (
+            case_info.get("case_number", "Unknown Case")
+            if case_info
+            else "Unknown Case"
+        )
+
+        md.append(f"# Case Extract: {case_no}")
+        md.append(f"**Court:** {court_name_en} ({court_name_np})")
+
+        if not case_info:
+            md.append(
+                "\n*Could not find metadata for this exact case number and court.*"
+            )
+            return "\n".join(md)
+
+        md.append("\n## Case Information")
+        # Format case metadata as a table
+        md.append("| Property | Value |")
+        md.append("|---|---|")
+
+        # Mapping to readable labels
+        props = [
+            ("Case Type", "case_type"),
+            ("Status", "case_status"),
+            ("Registration Date (AD)", "registration_date_ad"),
+            ("Registration Date (BS)", "registration_date_bs"),
+            ("Division", "division"),
+            ("Category", "category"),
+            ("Section", "section"),
+            ("Priority", "priority"),
+            ("Original Case Number", "original_case_number"),
+            ("Verdict Date (AD)", "verdict_date_ad"),
+            ("Verdict Date (BS)", "verdict_date_bs"),
+            ("Verdict Judge", "verdict_judge"),
+        ]
+
+        def default_serializer(obj: Any) -> str:
+            return str(obj)
+
+        for label, key in props:
+            val = case_info.get(key)
+            if val is not None and val != "":
+                md.append(f"| **{label}** | {val} |")
+
+        # Entities
+        if entities:
+            md.append("\n## Entities Involved")
+
+            # Group entities by side side
+            plaintiffs = [
+                e for e in entities if str(e.get("side")).lower() == "plaintiff"
+            ]
+            defendants = [
+                e for e in entities if str(e.get("side")).lower() == "defendant"
+            ]
+            others = [
+                e
+                for e in entities
+                if str(e.get("side")).lower() not in ["plaintiff", "defendant"]
+            ]
+
+            if plaintiffs:
+                md.append("\n### Plaintiffs")
+                for e in plaintiffs:
+                    nes = f" (NES ID: {e.get('nes_id')})" if e.get("nes_id") else ""
+                    addr = f" - {e.get('address')}" if e.get("address") else ""
+                    md.append(f"- **{e.get('name', 'Unknown')}**{addr}{nes}")
+
+            if defendants:
+                md.append("\n### Defendants")
+                for e in defendants:
+                    nes = f" (NES ID: {e.get('nes_id')})" if e.get("nes_id") else ""
+                    addr = f" - {e.get('address')}" if e.get("address") else ""
+                    md.append(f"- **{e.get('name', 'Unknown')}**{addr}{nes}")
+
+            if others:
+                md.append("\n### Other Entities")
+                for e in others:
+                    nes = f" (NES ID: {e.get('nes_id')})" if e.get("nes_id") else ""
+                    side = f"[{e.get('side')}] " if e.get("side") else ""
+                    addr = f" - {e.get('address')}" if e.get("address") else ""
+                    md.append(f"- {side}**{e.get('name', 'Unknown')}**{addr}{nes}")
+
+        # Hearings
+        if hearings:
+            md.append("\n## Hearing History")
+            for h in sorted(hearings, key=lambda x: str(x.get("hearing_date_ad", ""))):
+                date_ad = h.get("hearing_date_ad")
+                date_bs = h.get("hearing_date_bs", "Unknown Date")
+                date_str = f"{date_bs} ({date_ad})" if date_ad else f"{date_bs}"
+
+                md.append(f"\n### {date_str} - {h.get('decision_type', 'Hearing')}")
+
+                judge = h.get("judge_names", h.get("bench", "Unknown Bench"))
+                md.append(f"- **Judges / Bench:** {judge}")
+
+                if h.get("bench_type"):
+                    md.append(f"- **Bench Type:** {h.get('bench_type')}")
+
+                if h.get("case_status"):
+                    md.append(f"- **Case Status:** {h.get('case_status')}")
+
+                if h.get("lawyer_names"):
+                    md.append(f"- **Lawyers:** {h.get('lawyer_names')}")
+
+                if h.get("remarks"):
+                    md.append(f"\n> **Remarks:** {h.get('remarks')}")
+
+        # Appendix: raw data for integrity
+        md.append("\n---")
+        md.append("\n## Appendix: Raw Data")
+        md.append(
+            "*This section contains unformatted raw database records for reference and data integrity.*"
+        )
+
+        if case_info:
+            md.append("\n### Full Case Record")
+            md.append("```json")
+            md.append(
+                json.dumps(
+                    case_info,
+                    indent=2,
+                    ensure_ascii=False,
+                    default=default_serializer,
+                )
+            )
+            md.append("```")
+
+        if hearings:
+            md.append("\n### Hearing Records")
+            sorted_hearings = sorted(
+                hearings, key=lambda x: str(x.get("hearing_date_ad", ""))
+            )
+            for i, h in enumerate(sorted_hearings, start=1):
+                date_ad = h.get("hearing_date_ad")
+                date_bs = h.get("hearing_date_bs", "Unknown Date")
+                date_str = f"{date_bs} ({date_ad})" if date_ad else f"{date_bs}"
+                decision = h.get("decision_type", "Hearing")
+                md.append(f"\n#### Hearing {i}: {date_str} \u2014 {decision}")
+                md.append("```json")
+                md.append(
+                    json.dumps(
+                        h,
+                        indent=2,
+                        ensure_ascii=False,
+                        default=default_serializer,
+                    )
+                )
+                md.append("```")
+
+        return "\n".join(md)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        if not is_local_stdio_transport():
+            return _error_response(
+                "file_path is only supported by local stdio MCP servers; "
+                "HTTP-hosted MCP servers cannot write server filesystem paths"
+            )
+
+        court_identifier = arguments.get("court_identifier")
+        case_number = arguments.get("case_number")
+        file_path = arguments.get("file_path")
+
+        if not all([court_identifier, case_number, file_path]):
+            return _error_response(
+                "court_identifier, case_number, and file_path parameters are required"
+            )
+
+        # Ensure path is absolute
+        if not os.path.isabs(file_path):
+            file_path = os.path.abspath(file_path)
+
+        try:
+            base_url, token = self._validate_environment()
+            court_id_sql = self._sql_quote(court_identifier)
+            case_no_sql = self._sql_quote(case_number)
+
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                court_payload = await self._execute_proxy_query(
+                    client,
+                    base_url,
+                    token,
+                    (
+                        "SELECT * FROM courts "
+                        f"WHERE identifier = '{court_id_sql}' "
+                        "LIMIT 1"
+                    ),
+                )
+                court_rows = self._rows_to_dicts(court_payload)
+                court_info = court_rows[0] if court_rows else {}
+
+                case_payload = await self._execute_proxy_query(
+                    client,
+                    base_url,
+                    token,
+                    (
+                        "SELECT * FROM court_cases "
+                        f"WHERE court_identifier = '{court_id_sql}' "
+                        f"AND case_number = '{case_no_sql}' "
+                        "LIMIT 1"
+                    ),
+                )
+                case_rows = self._rows_to_dicts(case_payload)
+                case_info = case_rows[0] if case_rows else {}
+
+                entities_payload = await self._execute_proxy_query(
+                    client,
+                    base_url,
+                    token,
+                    (
+                        "SELECT * FROM court_case_entities "
+                        f"WHERE court_identifier = '{court_id_sql}' "
+                        f"AND case_number = '{case_no_sql}'"
+                    ),
+                )
+                entities = self._rows_to_dicts(entities_payload)
+
+                hearings_payload = await self._execute_proxy_query(
+                    client,
+                    base_url,
+                    token,
+                    (
+                        "SELECT * FROM court_case_hearings "
+                        f"WHERE court_identifier = '{court_id_sql}' "
+                        f"AND case_number = '{case_no_sql}'"
+                    ),
+                )
+                hearings = self._rows_to_dicts(hearings_payload)
+
+            # 5. Format to Markdown
+            markdown_content = self._format_markdown(
+                court_info, case_info, hearings, entities
+            )
+
+            # 6. Write to File
+
+            # Ensure directory exists
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(markdown_content)
+
+            response = {
+                "success": True,
+                "message": f"Case data successfully extracted to {file_path}",
+                "file_path": file_path,
+                "stats": {
+                    "case_found": bool(case_info),
+                    "hearings_count": len(hearings),
+                    "entities_count": len(entities),
+                },
+            }
+
+            return [TextContent(type="text", text=json.dumps(response))]
+
+        except httpx.HTTPError as e:
+            logger.error("ngm_extract_http_error", error=str(e), category="http")
+            return _error_response(f"HTTP error: {e}")
+        except RuntimeError as e:
+            logger.error("ngm_extract_proxy_error", error=str(e), category="proxy")
+            return _error_response(f"Proxy error: {e}")
+        except Exception as e:
+            logger.exception("ngm_extract_unexpected_error", error=str(e))
+            return _error_response(f"Unexpected error: {e}")

--- a/jawafdehi_mcp/tools/ngm_judicial.py
+++ b/jawafdehi_mcp/tools/ngm_judicial.py
@@ -176,6 +176,11 @@ Court IDs (court_identifier):
         except httpx.HTTPError as e:
             logger.error("ngm_query_http_error", error=str(e), category="http")
             return _error_response(f"HTTP error: {e}")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 — tool boundary: an unexpected fault is a result
+            # Deliberately generic to the caller. This tool is reachable
+            # ANONYMOUSLY, and the Django view it fronts already returns only
+            # "Database query failed" for the same reason: an unexpected
+            # exception's text can carry SQL, schema or connection detail. The
+            # full traceback goes to the log via logger.exception.
             logger.exception("ngm_query_unexpected_error", error=str(e))
-            return _error_response(f"Unexpected error: {e}")
+            return _error_response("Unexpected error running the query.")

--- a/jawafdehi_mcp/tools/ngm_judicial.py
+++ b/jawafdehi_mcp/tools/ngm_judicial.py
@@ -1,0 +1,181 @@
+"""NGM judicial data query tool."""
+
+import json
+import os
+from typing import Any
+
+import httpx
+import structlog
+from courts.query_guard import validate_query
+from mcp.types import TextContent
+
+from ..api_transport import embedded_api_client_kwargs
+from .base import BaseTool, ToolExecutionResult
+from .ngm_proxy import NGMProxyError, execute_ngm_proxy_query, get_jawafdehi_api_config
+
+logger = structlog.get_logger()
+
+
+def _json_response(payload: dict[str, Any]) -> list[TextContent]:
+    return [
+        TextContent(
+            type="text",
+            text=json.dumps(payload, ensure_ascii=False),
+        )
+    ]
+
+
+def _error_response(message: str) -> ToolExecutionResult:
+    return ToolExecutionResult(
+        _json_response(
+            {
+                "success": False,
+                "data": None,
+                "error": message,
+                "query_time_ms": 0,
+            }
+        ),
+        is_error=True,
+    )
+
+
+def _get_max_query_timeout() -> float:
+    """Return max allowed query timeout in seconds (env MCP_QUERY_TIMEOUT, default 15)."""
+    raw = os.getenv("MCP_QUERY_TIMEOUT", "15")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning("invalid_mcp_query_timeout", value=raw)
+        return 15.0
+
+
+class NGMJudicialTool(BaseTool):
+    """Tool for querying Nepal's judicial data from NGM database."""
+
+    @property
+    def name(self) -> str:
+        return "ngm_query_judicial"
+
+    @property
+    def description(self) -> str:
+        return """Search judicial cases from Nepal's court system. Execute SELECT queries against NGM court and court case tables. By default, we should fetch only a few results (e.g. 5) to avoid eating up the context window.
+
+Public table schemas (scope-only callers receive these fixed projections):
+- courts: identifier (PK), court_type, full_name_nepali, full_name_english
+- court_cases: case_number (PK), court_identifier (PK), registration_date_bs, registration_date_ad, case_type, case_status, plaintiff, defendant, nes_id, document_sources. Soft-deleted rows are excluded.
+- court_case_hearings: id (PK), case_number, court_identifier, hearing_date_bs, hearing_date_ad, bench, bench_type, judge_names, lawyer_names, serial_no, case_status, decision_type, remarks, extra_data
+- court_case_entities: id (PK), case_number, court_identifier, side, name, address, nes_id
+
+Court IDs (court_identifier):
+- Supreme & Special: supreme, special
+- High Courts: biratnagarhc, illamhc, dhankutahc, okhaldhungahc, janakpurhc, rajbirajhc, birganjhc, patanhc, hetaudahc, pokharahc, baglunghc, tulsipurhc, butwalhc, nepalgunjhc, surkhethc, jumlahc, dipayalhc, mahendranagarhc
+- District Courts: achhamdc, argakhanchidc, etc."""
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "SQL SELECT query to execute. Must be read-only. By default, we should fetch only a few results (e.g. 5) to avoid eating up the context window.",
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": "Query timeout in seconds (default: 15)",
+                    "default": 15,
+                },
+            },
+            "required": ["query"],
+        }
+
+    def _validate_environment(self) -> tuple[str, str | None]:
+        """
+        Validate required environment variables.
+
+        Returns:
+            Tuple of (base_url, optional token)
+
+        Raises:
+            ValueError: If required API configuration is missing or invalid
+        """
+        return get_jawafdehi_api_config()
+
+    def _validate_query(self, query: str) -> tuple[bool, str | None]:
+        """Apply the same SQL policy enforced by the API execution boundary."""
+        return validate_query(query)
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        """Execute the NGM judicial query tool."""
+        # Extract arguments
+        query = arguments.get("query")
+        raw_timeout = arguments.get("timeout", 15)
+
+        # Validate and clamp timeout
+        try:
+            timeout = float(raw_timeout)
+        except (TypeError, ValueError):
+            return _error_response("timeout must be a number")
+        if timeout <= 0:
+            return _error_response("timeout must be greater than 0")
+        timeout = min(timeout, _get_max_query_timeout())
+
+        if not query:
+            return _error_response("Query parameter is required")
+
+        # Validate query
+        is_valid, error_msg = self._validate_query(query)
+        if not is_valid:
+            return _error_response(error_msg or "Query is not allowed")
+
+        # Execute query
+        try:
+            base_url, token = self._validate_environment()
+
+            async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+                payload = await execute_ngm_proxy_query(
+                    client,
+                    base_url,
+                    token,
+                    query,
+                    timeout=timeout,
+                )
+
+            # Wrap in stable tool-owned envelope
+            proxy_data = payload.get("data") or {}
+            response = {
+                "success": True,
+                "data": {
+                    "columns": proxy_data.get("columns", []),
+                    "rows": proxy_data.get("rows", []),
+                    "row_count": proxy_data.get(
+                        "row_count", len(proxy_data.get("rows", []))
+                    ),
+                },
+                "error": None,
+                "query_time_ms": payload.get("query_time_ms", 0),
+            }
+            return _json_response(response)
+        except NGMProxyError as e:
+            # A 4xx means the caller's SQL was rejected by the gated query plane
+            # (subquery/CTE/non-allowlisted table/bad column) — an expected input
+            # error, not a server fault, so log at warning: diagnosable in logs but
+            # below Sentry's ERROR capture threshold so it does not page. A 5xx (or
+            # a malformed 2xx) is a real upstream problem and stays at error.
+            log = logger.warning if 400 <= e.status_code < 500 else logger.error
+            log(
+                "ngm_query_failed",
+                error=str(e),
+                status_code=e.status_code,
+                category="proxy_api",
+            )
+            return _error_response(f"Proxy API error: {e}")
+        except RuntimeError as e:
+            logger.error("ngm_query_failed", error=str(e), category="proxy_api")
+            return _error_response(f"Proxy API error: {e}")
+        except httpx.HTTPError as e:
+            logger.error("ngm_query_http_error", error=str(e), category="http")
+            return _error_response(f"HTTP error: {e}")
+        except Exception as e:
+            logger.exception("ngm_query_unexpected_error", error=str(e))
+            return _error_response(f"Unexpected error: {e}")

--- a/jawafdehi_mcp/tools/ngm_proxy.py
+++ b/jawafdehi_mcp/tools/ngm_proxy.py
@@ -13,7 +13,11 @@ from typing import Any
 import httpx
 import structlog
 
-from ..request_context import get_forwarded_headers, get_query_service_token
+from ..request_context import (
+    get_forwarded_headers,
+    get_query_service_token,
+    is_local_stdio_transport,
+)
 
 logger = structlog.get_logger()
 
@@ -116,11 +120,27 @@ async def execute_ngm_proxy_query(
     if token:
         headers["Authorization"] = f"Bearer {token}"
     # A forwarded caller bearer (HTTP transport) overrides the service token.
-    headers.update(get_forwarded_headers())
+    forwarded = get_forwarded_headers()
+    headers.update(forwarded)
+
+    body: dict[str, Any] = {"query": query, "timeout_seconds": timeout}
+    # No forwarded bearer over HTTP means this request authenticates as the shared
+    # MCP service account rather than as a person — the anonymous
+    # ``ngm_query_judicial`` path. Ask the API for the narrower public plane
+    # explicitly instead of letting it infer disclosure from that account's role
+    # membership, which would leak the internal plane to the open internet if the
+    # account were ever provisioned with ReadOnly or an NGM role.
+    #
+    # Computed here rather than at the call sites so it cannot be forgotten by a
+    # new one. stdio is excluded deliberately: there the token belongs to a
+    # trusted local operator who is entitled to the internal plane, and that is
+    # the behaviour this must not change.
+    if not forwarded and not is_local_stdio_transport():
+        body["public_projection"] = True
 
     response = await client.post(
         f"{base_url}/api/query/",
-        json={"query": query, "timeout_seconds": timeout},
+        json=body,
         headers=headers,
         timeout=_get_proxy_http_timeout(),
     )

--- a/jawafdehi_mcp/tools/ngm_proxy.py
+++ b/jawafdehi_mcp/tools/ngm_proxy.py
@@ -1,0 +1,160 @@
+"""Shared helpers for NGM court-data access via the unified Jawafdehi API.
+
+Post-unification (2026-07 hard cut) there is no ``/api/ngm`` proxy: court data
+is queried through the platform's gated SQL plane ``POST /api/query/`` on the one
+Jawafdehi host. Auth is the caller's OIDC bearer (forwarded), with a service
+token fallback for stdio/dev.
+"""
+
+import json
+import os
+from typing import Any
+
+import httpx
+import structlog
+
+from ..request_context import get_forwarded_headers, get_query_service_token
+
+logger = structlog.get_logger()
+
+
+class NGMProxyError(RuntimeError):
+    """A non-success response from the gated ``/api/query/`` plane.
+
+    Carries the upstream HTTP ``status_code`` so callers can tell a 4xx (the
+    caller's SQL was rejected by the allowlist — an expected input error) apart
+    from a 5xx (a real upstream fault) when deciding how loudly to log. Subclasses
+    ``RuntimeError`` so existing ``except RuntimeError`` handlers still catch it.
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def get_jawafdehi_api_config() -> tuple[str, str | None]:
+    """Return the API base URL and least-privilege query credential."""
+    base_url = os.getenv("JAWAFDEHI_API_BASE_URL", "https://api.jawafdehi.org")
+    base_url = base_url.rstrip("/")
+    token = get_query_service_token()
+
+    if not base_url.startswith(("http://", "https://")):
+        raise ValueError(
+            f"JAWAFDEHI_API_BASE_URL must be an HTTP(S) URL. Got: {base_url[:30]}..."
+        )
+
+    return base_url, token
+
+
+def get_jawafdehi_api_config_strict() -> tuple[str, str]:
+    """Return validated Jawafdehi API base URL and token (token required)."""
+    base_url, token = get_jawafdehi_api_config()
+    if not token:
+        raise ValueError(
+            "MCP_QUERY_API_TOKEN is required (or JAWAFDEHI_API_TOKEN for stdio)."
+        )
+    return base_url, token
+
+
+def rows_to_dicts(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert proxy response rows+columns payload into dict records."""
+    data = payload.get("data") or {}
+    columns = data.get("columns") or []
+    rows = data.get("rows") or []
+    records: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, list) or len(row) != len(columns):
+            raise RuntimeError(
+                "Malformed proxy payload: "
+                f"row {index} has "
+                f"{len(row) if isinstance(row, list) else 'non-list'} values "
+                f"for {len(columns)} columns"
+            )
+        records.append(dict(zip(columns, row)))
+    return records
+
+
+def sql_quote(value: str) -> str:
+    """Quote a SQL string literal by escaping single quotes."""
+    return value.replace("'", "''")
+
+
+def _get_proxy_http_timeout() -> float:
+    """Return the HTTP call timeout for proxy requests (env MCP_PROXY_HTTP_TIMEOUT, default 30s)."""
+    raw = os.getenv("MCP_PROXY_HTTP_TIMEOUT", "30.0")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning("invalid_mcp_proxy_http_timeout", value=raw)
+        return 30.0
+
+
+async def execute_ngm_proxy_query(
+    client: httpx.AsyncClient,
+    base_url: str,
+    token: str | None,
+    query: str,
+    timeout: float = 15,
+) -> dict[str, Any]:
+    """Execute a gated SELECT via the unified court-data SQL plane.
+
+    Posts to ``POST /api/query/`` (the gated SQL route mounted alongside the
+    ``/api/courtcases`` read plane; the former ``/api/ngm/query_judicial`` proxy
+    is gone). The request body renames ``timeout`` -> ``timeout_seconds``.
+
+    Auth is OIDC ``Bearer``: the caller's forwarded bearer wins, else the service
+    token is sent as ``Bearer`` (the platform is OIDC-only — the legacy DRF
+    ``Token`` scheme is no longer honoured).
+
+    The endpoint returns a FLAT payload (``{columns, rows, row_count,
+    query_time_ms, max_rows}``) and signals success via the HTTP status — there
+    is no ``{success, data}`` envelope. We normalise it back into the
+    ``{data: {columns, rows, row_count}, query_time_ms}`` shape the callers
+    (``rows_to_dicts`` / ``NGMJudicialTool``) already consume.
+    """
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    # A forwarded caller bearer (HTTP transport) overrides the service token.
+    headers.update(get_forwarded_headers())
+
+    response = await client.post(
+        f"{base_url}/api/query/",
+        json={"query": query, "timeout_seconds": timeout},
+        headers=headers,
+        timeout=_get_proxy_http_timeout(),
+    )
+
+    try:
+        payload: dict[str, Any] = response.json()
+    except ValueError:
+        # A non-JSON body on a SUCCESS status (empty body, HTML proxy error page,
+        # …) can't be normalized into columns/rows — surface it instead of
+        # silently returning an empty successful result.
+        if response.is_success:
+            raise NGMProxyError(
+                f"Non-JSON response from query endpoint "
+                f"({response.status_code}): {response.text}",
+                response.status_code,
+            )
+        payload = {
+            "detail": f"Non-JSON response from query endpoint ({response.status_code})",
+            "raw": response.text,
+        }
+
+    if not response.is_success:
+        raise NGMProxyError(
+            f"NGM query failed ({response.status_code}): "
+            f"{json.dumps(payload, ensure_ascii=False)}",
+            response.status_code,
+        )
+
+    return {
+        "success": True,
+        "data": {
+            "columns": payload.get("columns", []),
+            "rows": payload.get("rows", []),
+            "row_count": payload.get("row_count", len(payload.get("rows", []))),
+        },
+        "query_time_ms": payload.get("query_time_ms", 0),
+    }

--- a/jawafdehi_mcp/tools/whoami.py
+++ b/jawafdehi_mcp/tools/whoami.py
@@ -1,0 +1,51 @@
+"""Tool reporting the current authenticated user's identity and roles."""
+
+import json
+from typing import Any
+
+from mcp.types import TextContent
+
+from ..identity import current_user_identity
+from .base import BaseTool
+
+
+class GetCurrentUserTool(BaseTool):
+    """Return the current user's display name, email, and roles."""
+
+    @property
+    def name(self) -> str:
+        return "get_current_user"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Return the current authenticated user's identity — display name, "
+            "email, and roles. Use this to check who you are acting as and what "
+            "permissions you have. Returns an anonymous result when not signed in."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}, "required": []}
+
+    async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        identity = current_user_identity.get()
+        if identity is None:
+            payload: dict[str, Any] = {
+                "authenticated": False,
+                "message": "No authenticated user; public read-only access.",
+            }
+        else:
+            payload = {
+                "authenticated": True,
+                "name": identity.get("name"),
+                "email": identity.get("email"),
+                "roles": identity.get("roles", []),
+                "sub": identity.get("sub"),
+            }
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(payload, indent=2, ensure_ascii=False),
+            )
+        ]

--- a/jawafdehi_shared/auth/dev_service.py
+++ b/jawafdehi_shared/auth/dev_service.py
@@ -1,0 +1,62 @@
+"""Test-only bearer authentication for the Zitadel-free E2E stack."""
+
+from __future__ import annotations
+
+import secrets
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from rest_framework import authentication, exceptions
+
+
+class DevelopmentQueryTokenAuthentication(authentication.BaseAuthentication):
+    """Map one configured E2E bearer to a scope-only query principal.
+
+    This class is installed only when both TESTING and DEV_AUTH are true. It is
+    not part of the production authentication list, and it deliberately ignores
+    every endpoint except the gated judicial query plane.
+    """
+
+    keyword = b"bearer"
+    query_path = "/api/query/"
+
+    def authenticate(self, request):
+        if not (getattr(settings, "TESTING", False) and settings.DEV_AUTH):
+            return None
+        if request.path_info != self.query_path:
+            return None
+
+        configured = getattr(settings, "DEV_NGM_QUERY_TOKEN", "")
+        if not configured:
+            return None
+
+        header = authentication.get_authorization_header(request).split()
+        if len(header) != 2 or header[0].lower() != self.keyword:
+            return None
+        try:
+            candidate = header[1].decode()
+        except UnicodeDecodeError:
+            return None
+        if not secrets.compare_digest(candidate, configured):
+            return None
+
+        username = getattr(settings, "DEV_NGM_QUERY_USERNAME", "mcp-query-e2e")
+        try:
+            user = get_user_model().objects.get(username=username, is_active=True)
+        except get_user_model().DoesNotExist as exc:
+            raise exceptions.AuthenticationFailed(
+                "Configured development query principal does not exist."
+            ) from exc
+        if (
+            user.is_staff
+            or user.is_superuser
+            or user.groups.exists()
+            or user.user_permissions.exists()
+        ):
+            raise exceptions.AuthenticationFailed(
+                "Development query principal must not have roles or permissions."
+            )
+        return user, {"sub": user.username, "scope": "ngm.query"}
+
+    def authenticate_header(self, request):
+        return "Bearer"

--- a/jawafdehi_shared/auth/oidc.py
+++ b/jawafdehi_shared/auth/oidc.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import re
 import threading
+import time
 
 import jwt
 from django.conf import settings
@@ -117,6 +118,8 @@ DEFAULT_ROLE_TO_GROUP = {
 # management commands) without import-time failures.
 _jwks_client: PyJWKClient | None = None
 _jwks_lock = threading.Lock()
+_jwks_last_refresh = 0.0
+_JWKS_MIN_REFRESH_INTERVAL = 60.0
 
 
 def _get_jwks_client() -> PyJWKClient:
@@ -139,6 +142,7 @@ def _get_jwks_client() -> PyJWKClient:
                     jwks_uri,
                     cache_keys=True,
                     lifespan=getattr(settings, "OIDC_JWKS_CACHE_SECONDS", 300),
+                    timeout=getattr(settings, "OIDC_JWKS_TIMEOUT", 10),
                     headers={
                         "User-Agent": getattr(
                             settings,
@@ -157,9 +161,71 @@ def reset_jwks_client() -> None:
     Test hook: lets tests inject a fresh client / re-read settings between
     cases. Not used in production.
     """
-    global _jwks_client
+    global _jwks_client, _jwks_last_refresh
     with _jwks_lock:
         _jwks_client = None
+        _jwks_last_refresh = 0.0
+
+
+def _signing_key_for(token: str):
+    """Resolve a signing key without allowing unknown kids to force fetch storms."""
+    global _jwks_last_refresh
+
+    client = _get_jwks_client()
+    # Keep compatibility with simple test doubles and older PyJWT clients.
+    if not hasattr(client, "get_signing_keys") or not hasattr(client, "match_kid"):
+        return client.get_signing_key_from_jwt(token)
+
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid")
+    if not isinstance(kid, str) or not kid:
+        raise jwt.exceptions.PyJWKClientError("Token header is missing a key id")
+
+    with _jwks_lock:
+        signing_keys = client.get_signing_keys(refresh=False)
+        signing_key = client.match_kid(signing_keys, kid)
+        if signing_key is not None:
+            return signing_key
+
+        now = time.monotonic()
+        if now - _jwks_last_refresh < _JWKS_MIN_REFRESH_INTERVAL:
+            raise jwt.exceptions.PyJWKClientError(
+                f'Unable to find a signing key that matches: "{kid}"'
+            )
+
+        # Record before network I/O so a failing JWKS endpoint is also bounded.
+        _jwks_last_refresh = now
+        signing_keys = client.get_signing_keys(refresh=True)
+        signing_key = client.match_kid(signing_keys, kid)
+        if signing_key is None:
+            raise jwt.exceptions.PyJWKClientError(
+                f'Unable to find a signing key that matches: "{kid}"'
+            )
+        return signing_key
+
+
+def decode_oidc_token(token: str) -> dict:
+    """Validate one access token using the platform's authoritative OIDC policy."""
+    try:
+        signing_key = _signing_key_for(token)
+        return jwt.decode(
+            token,
+            signing_key.key,
+            # Pin the algorithm; never trust the alg in the token header.
+            algorithms=getattr(settings, "OIDC_ALGORITHMS", ["RS256"]),
+            audience=settings.OIDC_AUDIENCE,
+            issuer=settings.OIDC_ISSUER,
+            options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+            leeway=getattr(settings, "OIDC_LEEWAY", 30),
+        )
+    except jwt.ExpiredSignatureError:
+        raise exceptions.AuthenticationFailed("Token has expired.")
+    except jwt.InvalidAudienceError:
+        raise exceptions.AuthenticationFailed("Invalid token audience.")
+    except jwt.InvalidIssuerError:
+        raise exceptions.AuthenticationFailed("Invalid token issuer.")
+    except jwt.PyJWTError as exc:
+        raise exceptions.AuthenticationFailed(f"Invalid token: {exc}")
 
 
 def extract_role_keys(claims: dict) -> set[str]:
@@ -220,27 +286,7 @@ class OIDCAuthentication(authentication.BaseAuthentication):
         return (user, claims)
 
     def _decode(self, token: str) -> dict:
-        try:
-            signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
-            return jwt.decode(
-                token,
-                signing_key.key,
-                # Pin the algorithm; never trust the alg in the token header
-                # (defends against alg-confusion / alg=none).
-                algorithms=getattr(settings, "OIDC_ALGORITHMS", ["RS256"]),
-                audience=settings.OIDC_AUDIENCE,
-                issuer=settings.OIDC_ISSUER,
-                options={"require": ["exp", "iat", "iss", "aud", "sub"]},
-                leeway=getattr(settings, "OIDC_LEEWAY", 30),
-            )
-        except jwt.ExpiredSignatureError:
-            raise exceptions.AuthenticationFailed("Token has expired.")
-        except jwt.InvalidAudienceError:
-            raise exceptions.AuthenticationFailed("Invalid token audience.")
-        except jwt.InvalidIssuerError:
-            raise exceptions.AuthenticationFailed("Invalid token issuer.")
-        except jwt.PyJWTError as exc:
-            raise exceptions.AuthenticationFailed(f"Invalid token: {exc}")
+        return decode_oidc_token(token)
 
     def _sync_user(self, claims: dict):
         """Get-or-create the Django user for ``sub`` and sync its groups.

--- a/jawafdehi_shared/auth/oidc.py
+++ b/jawafdehi_shared/auth/oidc.py
@@ -181,9 +181,26 @@ def _signing_key_for(token: str):
     if not isinstance(kid, str) or not kid:
         raise jwt.exceptions.PyJWKClientError("Token header is missing a key id")
 
+    # Deliberately OUTSIDE _jwks_lock. On a cold or expired cache PyJWT falls
+    # through from the cache read to a network fetch here, and holding the lock
+    # across that I/O serialises every concurrent authentication in the process:
+    # N requests against a slow JWKS endpoint queue up to N * OIDC_JWKS_TIMEOUT
+    # instead of overlapping. The cost of staying out here is at most one round
+    # of redundant parallel fetches on a cold start — PyJWT caches on success,
+    # so the round after it is an in-memory hit — which is strictly cheaper than
+    # a serial queue. On the warm-cache happy path the lock is never taken.
+    signing_key = client.match_kid(client.get_signing_keys(refresh=False), kid)
+    if signing_key is not None:
+        return signing_key
+
+    # Only the rate-limited refresh needs mutual exclusion, because it is the
+    # one thing that must happen at most once per _JWKS_MIN_REFRESH_INTERVAL no
+    # matter how many unknown kids arrive at once.
     with _jwks_lock:
-        signing_keys = client.get_signing_keys(refresh=False)
-        signing_key = client.match_kid(signing_keys, kid)
+        # Re-check under the lock: a concurrent refresh may have just landed
+        # this kid, in which case spending the refresh budget again is waste.
+        # Cheap — a refresh by that thread left the cache warm.
+        signing_key = client.match_kid(client.get_signing_keys(refresh=False), kid)
         if signing_key is not None:
             return signing_key
 

--- a/jawafdehi_shared/logging_config.py
+++ b/jawafdehi_shared/logging_config.py
@@ -10,10 +10,29 @@ SHARED_CONTEXT_VARS = [
     "service",
 ]
 
+_IGNORED_TRANSPORT_ERROR_SIGNATURES = (
+    "ClientDisconnect",
+    "Attempted to exit cancel scope in a different task",
+)
+
 
 def add_service_name(_, __, event_dict):
     event_dict.setdefault("service", os.getenv("SERVICE_NAME", "jawafdehi-api"))
     return event_dict
+
+
+def drop_transport_noise(event, hint):
+    """Drop benign streamable-HTTP disconnect noise from Sentry."""
+    exc_info = hint.get("exc_info") if hint else None
+    if exc_info and exc_info[0] is not None:
+        text = f"{exc_info[0].__name__}: {exc_info[1]}"
+        if any(sig in text for sig in _IGNORED_TRANSPORT_ERROR_SIGNATURES):
+            return None
+    for value in (event.get("exception") or {}).get("values") or []:
+        signature = f"{value.get('type', '')}: {value.get('value', '')}"
+        if any(sig in signature for sig in _IGNORED_TRANSPORT_ERROR_SIGNATURES):
+            return None
+    return event
 
 
 def configure_structlog():
@@ -28,11 +47,10 @@ def configure_structlog():
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
             structlog.processors.UnicodeDecoder(),
-            (
-                structlog.dev.ConsoleRenderer()
-                if os.getenv("STRUCTLOG_CONSOLE", "1") == "1"
-                else structlog.processors.JSONRenderer()
-            ),
+            add_service_name,
+            # Django's LOGGING config owns the final renderer. Wrapping here
+            # avoids rendering console text and then nesting it inside JSON.
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Jawafdehi platform — ONE Django project, ONE installable package.
 #
 # NES, NGM and Jawafdehi run as Django *apps* in a single project (``config.settings``):
-# one process, one wsgi, one image. Database-per-service is preserved via DB routers
+# one process, one ASGI entrypoint, one image. Database-per-service is preserved via DB routers
 # (each app's models route to its own Postgres DB — see config/db_router.py).
 #
 # There is no uv workspace and no per-service packages: every app is a plain top-level
@@ -15,6 +15,8 @@
 name = "jawafdehi"
 version = "0.1.0"
 description = "Jawafdehi platform — ONE Django project running NES, NGM and Jawafdehi as apps in one process (database-per-service preserved via DB routers)."
+license = "LicenseRef-Hippocratic-3.0"
+license-files = ["jawafdehi_mcp/LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     # --- core web stack ---
@@ -24,6 +26,8 @@ dependencies = [
     "django-filter>=25.2",
     "drf-spectacular>=0.29",
     "gunicorn>=23.0",
+    "uvicorn[standard]>=0.34,<1",
+    "uvicorn-worker>=0.3,<1",
     "whitenoise>=6.11",
     # Prometheus /metrics (multiprocess-aware for the gunicorn workers).
     "django-prometheus>=2.3",
@@ -50,6 +54,18 @@ dependencies = [
     # when NATS_URL is unset — but it ships in the base image because the
     # consumer Deployment runs off that image.
     "nats-py>=2.9",
+    # The MCP tools' HTTP client, and a base dependency rather than an extra
+    # because MCP runs inside the platform process. Embedded, it carries the
+    # bounded ASGITransport that dispatches /api/ calls to Django in memory
+    # (jawafdehi_mcp/api_transport.py); over stdio it is a plain remote client.
+    # httpcore is a DIRECT import, and both bounds are deliberate: the document
+    # converter's SSRF guard substitutes its own httpcore network backend into
+    # httpx's private `_pool._network_backend`, so a validated address cannot be
+    # re-resolved between check and connect while the URL host is still used for
+    # Host/TLS SNI. That leans on internals of both projects, so a major bump of
+    # either has to be reviewed rather than absorbed.
+    "httpx>=0.28",
+    "httpcore>=1.0,<2",
     # --- entities/materials (NES + NGM) ---
     "jsonpatch>=1.33",          # RFC-6902 PATCH /api/entities/{ref}
     # --- ngm lakehouse / object storage ---
@@ -85,20 +101,27 @@ dependencies = [
     "wagtail>=7.4,<7.5",
     "wagtail-headless-preview>=0.9,<0.10",
     "markdown>=3.5",
+    # --- embedded Model Context Protocol server ---
+    "mcp>=1.26,<2",
+    "nepali-datetime>=1.0.8.4",
+    "markitdown[docx,pdf,pptx,xlsx]>=0.1.5",
+    "likhit",
+    "google-cloud-logging>=3.12",
+    "sqlglot>=26.33,<28",
 ]
 
 [project.optional-dependencies]
-# Document-conversion enrichment (BIGO / CIAA). Imported lazily inside management
-# commands, so the base image need not carry them.
+# Compatibility alias retained for Dockerfile.consumer and existing developer
+# commands. These packages are also base dependencies now because MCP runs in
+# the platform process.
 bigo-enrichment = [
     "markitdown[docx,pdf,pptx,xlsx]>=0.1.5",
     "likhit",
 ]
 
 [tool.uv.sources]
-# Git source for the optional bigo-enrichment extra only (likhit is imported lazily
-# inside management commands / the review converter, never at startup).
-likhit = { git = "https://github.com/Jawafdehi/likhit.git", rev = "main" }
+# Shared by material enrichment and the embedded MCP document converter.
+likhit = { git = "https://github.com/Jawafdehi/likhit.git", rev = "e98eb446437f8a086e1e8da409d413ca81106532" }
 
 [build-system]
 requires = ["hatchling"]
@@ -122,10 +145,14 @@ packages = [
     "jobs",
     "case_events",
     "llm",
+    "jawafdehi_mcp",
     "search",
     "discovery",
     "content",
 ]
+
+[tool.hatch.build.targets.wheel.force-include]
+"jawafdehi_mcp/LICENSE" = "jawafdehi_mcp/LICENSE"
 
 [dependency-groups]
 # Dev tooling (lint/format/test). Not shipped in the image.

--- a/review/views.py
+++ b/review/views.py
@@ -231,6 +231,13 @@ def _enqueue_review_job(review, *, submitted_by=None):
 # stale-result 409 guard, leases, retries, and dedup. See docs/jobs-queue-design.md.
 
 
+def _normalized_review_slug(request):
+    raw_slug = request.query_params.get("slug")
+    if not raw_slug:
+        return None
+    return raw_slug.strip().strip("/") or None
+
+
 class ReviewListView(generics.ListAPIView):
     serializer_class = CaseReviewListSerializer
     permission_classes = [CanReadReview]
@@ -242,13 +249,9 @@ class ReviewListView(generics.ListAPIView):
         # ``?slug=`` scopes the flat list to one case's runs, newest-first (via
         # Meta.ordering). The per-case review page uses this to show a case's
         # whole run history without pulling the entire table.
-        slug = self.request.query_params.get("slug")
+        slug = _normalized_review_slug(self.request)
         if slug:
-            # Normalize like SubmitSerializer (strip whitespace + surrounding
-            # slashes) so "?slug=case-a/" and "?slug= case-a " still match.
-            slug = slug.strip().strip("/")
-            if slug:
-                qs = qs.filter(case__slug=slug)
+            qs = qs.filter(case__slug=slug)
         return qs
 
 
@@ -276,9 +279,12 @@ class GroupedReviewListView(generics.ListAPIView):
         # loading the whole CaseReview table into memory to group in Python.
         # exclude(case_id=None): a review whose backfill left it unlinked would
         # otherwise form a bogus None-group with an empty slug in the UI.
+        reviews = CaseReview.objects.exclude(case_id=None)
+        if slug := _normalized_review_slug(request):
+            reviews = reviews.filter(case__slug=slug)
+
         case_id_qs = (
-            CaseReview.objects.exclude(case_id=None)
-            .values("case_id")
+            reviews.values("case_id")
             .annotate(latest_created_at=Max("created_at"))
             .order_by("-latest_created_at")
             .values_list("case_id", flat=True)

--- a/tests/api/test_reviews_grouped.py
+++ b/tests/api/test_reviews_grouped.py
@@ -72,6 +72,20 @@ def test_grouped_groups_executions_by_slug():
 
 
 @pytest.mark.django_db
+def test_grouped_slug_filter_returns_only_that_case():
+    _review("case-a", case_title="Case A", status="done")
+    _review("case-a", case_title="Case A", status="done")
+    _review("case-b", case_title="Case B", status="done")
+
+    response = _reader_client().get(URL, {"slug": " /case-a/ "})
+
+    assert response.status_code == 200
+    assert response.data["count"] == 1
+    assert [group["slug"] for group in response.data["results"]] == ["case-a"]
+    assert len(response.data["results"][0]["executions"]) == 2
+
+
+@pytest.mark.django_db
 def test_grouped_latest_is_newest_execution():
     older = _review("case-c", case_title="Old title")
     newer = _review("case-c", case_title="New title")

--- a/tests/mcp/__init__.py
+++ b/tests/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Jawafdehi MCP server."""

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration and fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    """Set up mock environment variables for all tests."""
+    monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "https://jawafdehi.invalid")
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")

--- a/tests/mcp/test_asgi_worker.py
+++ b/tests/mcp/test_asgi_worker.py
@@ -1,0 +1,33 @@
+"""Tests for bounded ASGI worker configuration."""
+
+from config.asgi_worker import (
+    DEFAULT_ASGI_LIMIT_CONCURRENCY,
+    MAX_ASGI_LIMIT_CONCURRENCY,
+    BoundedUvicornWorker,
+    asgi_limit_concurrency,
+)
+
+
+def test_asgi_worker_has_a_default_concurrency_ceiling():
+    assert (
+        BoundedUvicornWorker.CONFIG_KWARGS["limit_concurrency"]
+        == DEFAULT_ASGI_LIMIT_CONCURRENCY
+    )
+
+
+def test_asgi_concurrency_ceiling_is_configurable(monkeypatch):
+    monkeypatch.setenv("ASGI_LIMIT_CONCURRENCY", "64")
+    assert asgi_limit_concurrency() == 64
+
+
+def test_asgi_concurrency_ceiling_rejects_invalid_values(monkeypatch):
+    monkeypatch.setenv("ASGI_LIMIT_CONCURRENCY", "0")
+    assert asgi_limit_concurrency() == DEFAULT_ASGI_LIMIT_CONCURRENCY
+
+    monkeypatch.setenv("ASGI_LIMIT_CONCURRENCY", "not-a-number")
+    assert asgi_limit_concurrency() == DEFAULT_ASGI_LIMIT_CONCURRENCY
+
+
+def test_asgi_concurrency_ceiling_is_bounded(monkeypatch):
+    monkeypatch.setenv("ASGI_LIMIT_CONCURRENCY", "999999")
+    assert asgi_limit_concurrency() == MAX_ASGI_LIMIT_CONCURRENCY

--- a/tests/mcp/test_control_plane_client.py
+++ b/tests/mcp/test_control_plane_client.py
@@ -1,0 +1,196 @@
+"""Tests for authenticated, bounded in-process control-plane calls."""
+
+import asyncio
+import json
+from time import monotonic
+
+import httpx
+import pytest
+
+from config.asgi import django_application
+from jawafdehi_mcp.api_transport import (
+    configure_embedded_api,
+    embedded_api_client_kwargs,
+)
+from jawafdehi_mcp.control_plane import request_control_plane
+from jawafdehi_mcp.request_context import (
+    current_transport,
+    jawafdehi_bearer_token,
+)
+
+
+async def _consume_request(receive):
+    while True:
+        message = await receive()
+        if not message.get("more_body"):
+            return
+
+
+@pytest.mark.asyncio
+async def test_embedded_client_forwards_only_the_request_bearer(monkeypatch):
+    seen = {}
+
+    async def fake_api(scope, receive, send):
+        await _consume_request(receive)
+        seen["path"] = scope["path"]
+        seen["authorization"] = dict(scope["headers"]).get(b"authorization")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"etag", b'"v1"'),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": json.dumps({"results": []}).encode(),
+            }
+        )
+
+    configure_embedded_api(fake_api)
+    transport = current_transport.set("http")
+    bearer = jawafdehi_bearer_token.set("caller-token")
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "must-not-be-used")
+    try:
+        result = await request_control_plane("GET", "/api/materials/")
+    finally:
+        jawafdehi_bearer_token.reset(bearer)
+        current_transport.reset(transport)
+        configure_embedded_api(django_application)
+
+    assert seen == {
+        "path": "/api/materials/",
+        "authorization": b"Bearer caller-token",
+    }
+    assert result == {
+        "success": True,
+        "status_code": 200,
+        "data": {"results": []},
+        "etag": '"v1"',
+    }
+
+
+@pytest.mark.asyncio
+async def test_control_plane_client_rejects_arbitrary_paths():
+    with pytest.raises(ValueError, match="fixed /api/ path"):
+        await request_control_plane("GET", "https://metadata.invalid/latest")
+
+
+@pytest.mark.asyncio
+@pytest.mark.security
+async def test_control_plane_client_rejects_nested_encoded_traversal():
+    with pytest.raises(ValueError, match="traversal"):
+        await request_control_plane("GET", "/api/courts/%25252e%25252e/health")
+
+
+@pytest.mark.asyncio
+async def test_embedded_transport_enforces_deadline(monkeypatch):
+    finished = asyncio.Event()
+
+    async def slow_api(scope, receive, send):
+        await _consume_request(receive)
+        await asyncio.sleep(0.05)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+        await send({"type": "http.response.body", "body": b""})
+        finished.set()
+
+    configure_embedded_api(slow_api)
+    transport = current_transport.set("http")
+    monkeypatch.setenv("MCP_EMBEDDED_API_TIMEOUT", "0.02")
+    started = monotonic()
+    try:
+        async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+            with pytest.raises(httpx.ReadTimeout):
+                await client.get("http://testserver/api/slow", timeout=5)
+    finally:
+        await asyncio.wait_for(finished.wait(), timeout=0.5)
+        current_transport.reset(transport)
+        configure_embedded_api(django_application)
+
+    assert monotonic() - started < 0.5
+
+
+@pytest.mark.asyncio
+async def test_timed_out_work_retains_its_concurrency_slot(monkeypatch):
+    started = 0
+    release = asyncio.Event()
+
+    async def slow_api(scope, receive, send):
+        nonlocal started
+        await _consume_request(receive)
+        started += 1
+        await release.wait()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+        await send({"type": "http.response.body", "body": b""})
+
+    configure_embedded_api(slow_api)
+    transport = current_transport.set("http")
+    monkeypatch.setenv("MCP_EMBEDDED_API_TIMEOUT", "0.02")
+    monkeypatch.setenv("MCP_EMBEDDED_API_MAX_CONCURRENCY", "1")
+    try:
+        async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+            with pytest.raises(httpx.ReadTimeout):
+                await client.get("http://testserver/api/first")
+            with pytest.raises(httpx.ReadTimeout):
+                await client.get("http://testserver/api/second")
+            assert started == 1
+            release.set()
+            await asyncio.sleep(0)
+    finally:
+        release.set()
+        current_transport.reset(transport)
+        configure_embedded_api(django_application)
+
+
+@pytest.mark.asyncio
+async def test_embedded_transport_enforces_shared_concurrency(monkeypatch):
+    active = 0
+    maximum = 0
+
+    async def bounded_api(scope, receive, send):
+        nonlocal active, maximum
+        await _consume_request(receive)
+        active += 1
+        maximum = max(maximum, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+        await send({"type": "http.response.body", "body": b""})
+
+    async def make_request():
+        async with httpx.AsyncClient(**embedded_api_client_kwargs()) as client:
+            return await client.get("http://testserver/api/work")
+
+    configure_embedded_api(bounded_api)
+    transport = current_transport.set("http")
+    monkeypatch.setenv("MCP_EMBEDDED_API_MAX_CONCURRENCY", "1")
+    try:
+        responses = await asyncio.gather(*(make_request() for _ in range(3)))
+    finally:
+        current_transport.reset(transport)
+        configure_embedded_api(django_application)
+
+    assert [response.status_code for response in responses] == [204, 204, 204]
+    assert maximum == 1

--- a/tests/mcp/test_control_plane_tools.py
+++ b/tests/mcp/test_control_plane_tools.py
@@ -1,0 +1,970 @@
+"""Contract tests for task-oriented control-plane MCP tools."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from jsonschema import Draft202012Validator
+
+from jawafdehi_mcp.server import TOOL_MAP
+from jawafdehi_mcp.tools.control_plane import (
+    BrowseCourtDataTool,
+    BrowseMaterialsTool,
+    DeleteNESEntityTool,
+    GetNESEntityVersionsTool,
+    ManageCaseUpdateProposalsTool,
+    ManageCaseworkReviewsTool,
+    ManageCourtDataTool,
+    ManageJobsTool,
+    ManageMaterialTool,
+    SearchControlPlaneTool,
+)
+from jawafdehi_mcp.tools.control_plane_schemas import (
+    COURT_CASE_CREATE_BODY_SCHEMA,
+    COURT_CREATE_BODY_SCHEMA,
+    FIRM_CREATE_BODY_SCHEMA,
+    FIRM_INGEST_ITEM_SCHEMA,
+    JOB_CLAIM_BODY_SCHEMA,
+    JOB_ENQUEUE_BODY_SCHEMA,
+    JOB_RESULT_BODY_SCHEMA,
+    JOB_STAGE_BODY_SCHEMA,
+    PROPOSAL_CREATE_BODY_SCHEMA,
+    PROPOSAL_DECISION_BODY_SCHEMA,
+    PROPOSAL_EDIT_BODY_SCHEMA,
+    REVIEW_CONFIG_BODY_SCHEMA,
+    REVIEW_SUBMIT_BODY_SCHEMA,
+)
+from case_proposals.serializers import (
+    CaseUpdateProposalSerializer,
+    ProposalDecisionSerializer,
+    ProposalIntentEditSerializer,
+)
+from courts.serializers import (
+    BlacklistedFirmSerializer,
+    BlacklistedFirmWriteSerializer,
+    CourtCaseWriteSerializer,
+    CourtSerializer,
+)
+from jobs.serializers import (
+    JobClaimSerializer,
+    JobEnqueueSerializer,
+    JobResultSerializer,
+    JobStageSerializer,
+)
+from review.serializers import ReviewConfigSerializer, SubmitSerializer
+
+
+async def _call(tool, arguments):
+    request = AsyncMock(
+        return_value={"success": True, "status_code": 200, "data": {"ok": True}}
+    )
+    with patch(
+        "jawafdehi_mcp.tools.control_plane.request_control_plane",
+        new=request,
+    ):
+        result = await tool.execute(arguments)
+    return request, json.loads(result[0].text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "expected"),
+    [
+        ("GET", "request timed out."),
+        ("POST", "outcome is unknown"),
+    ],
+)
+async def test_timeout_distinguishes_reads_from_mutations(method, expected):
+    tool = SearchControlPlaneTool()
+    with patch(
+        "jawafdehi_mcp.tools.control_plane.request_control_plane",
+        new=AsyncMock(side_effect=httpx.ReadTimeout("deadline")),
+    ):
+        result = await tool._call(method, "/api/search/")
+
+    assert result.is_error is True
+    assert expected in json.loads(result[0].text)["error"]
+
+
+def test_parity_tools_are_registered():
+    assert {
+        "search_control_plane",
+        "get_nes_entity_versions",
+        "delete_nes_entity",
+        "browse_materials",
+        "manage_material",
+        "browse_court_data",
+        "manage_court_data",
+        "manage_case_update_proposals",
+        "manage_casework_reviews",
+        "manage_jobs",
+    }.issubset(TOOL_MAP)
+
+
+def _writable_field_names(serializer_class):
+    return {
+        name for name, field in serializer_class().fields.items() if not field.read_only
+    }
+
+
+@pytest.mark.parametrize(
+    ("schema", "serializer_class"),
+    [
+        (COURT_CREATE_BODY_SCHEMA, CourtSerializer),
+        (COURT_CASE_CREATE_BODY_SCHEMA, CourtCaseWriteSerializer),
+        (FIRM_CREATE_BODY_SCHEMA, BlacklistedFirmSerializer),
+        (FIRM_INGEST_ITEM_SCHEMA, BlacklistedFirmWriteSerializer),
+        (PROPOSAL_CREATE_BODY_SCHEMA, CaseUpdateProposalSerializer),
+        (PROPOSAL_EDIT_BODY_SCHEMA, ProposalIntentEditSerializer),
+        (PROPOSAL_DECISION_BODY_SCHEMA, ProposalDecisionSerializer),
+        (REVIEW_SUBMIT_BODY_SCHEMA, SubmitSerializer),
+        (REVIEW_CONFIG_BODY_SCHEMA, ReviewConfigSerializer),
+        (JOB_ENQUEUE_BODY_SCHEMA, JobEnqueueSerializer),
+        (JOB_CLAIM_BODY_SCHEMA, JobClaimSerializer),
+        (JOB_STAGE_BODY_SCHEMA, JobStageSerializer),
+        (JOB_RESULT_BODY_SCHEMA, JobResultSerializer),
+    ],
+)
+def test_control_plane_body_schemas_track_drf_serializers(schema, serializer_class):
+    assert set(schema["properties"]) == _writable_field_names(serializer_class)
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        BrowseMaterialsTool(),
+        ManageMaterialTool(),
+        BrowseCourtDataTool(),
+        ManageCourtDataTool(),
+        ManageCaseUpdateProposalsTool(),
+        ManageCaseworkReviewsTool(),
+        ManageJobsTool(),
+    ],
+    ids=lambda tool: tool.name,
+)
+def test_every_aggregate_action_has_a_schema_contract(tool):
+    schema = tool.input_schema
+    actions = set(tool.ACTIONS)
+    conditional_actions = {
+        rule["if"]["properties"]["action"]["const"] for rule in schema["allOf"]
+    }
+
+    assert set(schema["properties"]["action"]["enum"]) == actions
+    assert conditional_actions == actions
+
+
+ACTION_ROUTE_CASES = [
+    pytest.param(
+        BrowseMaterialsTool(),
+        {"action": "list", "source": "nkp", "cursor": "next"},
+        "GET",
+        "/api/materials/",
+        {"source": "nkp", "cursor": "next"},
+        None,
+        id="materials-list",
+    ),
+    pytest.param(
+        BrowseMaterialsTool(),
+        {"action": "get", "iri": "https://jawafdehi.org/material/nkp/1"},
+        "GET",
+        "/api/materials/",
+        {"iri": "https://jawafdehi.org/material/nkp/1"},
+        None,
+        id="materials-get",
+    ),
+    pytest.param(
+        ManageMaterialTool(),
+        {
+            "action": "upsert",
+            "material": {
+                "@id": "https://jawafdehi.org/material/nkp/1",
+                "@type": "Legislation",
+            },
+        },
+        "POST",
+        "/api/materials/",
+        None,
+        {
+            "material": {
+                "@id": "https://jawafdehi.org/material/nkp/1",
+                "@type": "Legislation",
+            }
+        },
+        id="materials-upsert",
+    ),
+    pytest.param(
+        ManageMaterialTool(),
+        {
+            "action": "patch",
+            "iri": "https://jawafdehi.org/material/nkp/1",
+            "visibility_policy": "PRIVATE",
+        },
+        "PATCH",
+        "/api/materials/",
+        {"iri": "https://jawafdehi.org/material/nkp/1"},
+        {"visibility_policy": "PRIVATE"},
+        id="materials-patch",
+    ),
+    pytest.param(
+        ManageMaterialTool(),
+        {
+            "action": "delete",
+            "iri": "https://jawafdehi.org/material/nkp/1",
+        },
+        "DELETE",
+        "/api/materials/",
+        {"iri": "https://jawafdehi.org/material/nkp/1"},
+        None,
+        id="materials-delete",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "list_courts"},
+        "GET",
+        "/api/courts/",
+        None,
+        None,
+        id="courts-list",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "get_court", "court": "special"},
+        "GET",
+        "/api/courts/special/",
+        None,
+        None,
+        id="courts-get",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "list_cases", "court": "special", "page": 3},
+        "GET",
+        "/api/courtcases/",
+        {"court": "special", "page": 3},
+        None,
+        id="court-cases-list",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "get_case", "court": "special", "case_number": "082-CR-1"},
+        "GET",
+        "/api/courtcases/special/082-CR-1/",
+        None,
+        None,
+        id="court-cases-get",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {
+            "action": "list_hearings",
+            "court": "special",
+            "case_number": "082-CR-1",
+            "page": 2,
+        },
+        "GET",
+        "/api/courtcases/special/082-CR-1/hearings/",
+        {"page": 2},
+        None,
+        id="court-hearings-list",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {
+            "action": "list_entities",
+            "court": "special",
+            "case_number": "082-CR-1",
+            "page": 2,
+        },
+        "GET",
+        "/api/courtcases/special/082-CR-1/entities/",
+        {"page": 2},
+        None,
+        id="court-case-entities-list",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {
+            "action": "list_documents",
+            "court": "special",
+            "case_number": "082-CR-1",
+        },
+        "GET",
+        "/api/courtcases/special/082-CR-1/documents/",
+        None,
+        None,
+        id="court-documents-list",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "search_entities", "name": "Ram", "page": 4},
+        "GET",
+        "/api/courtcase-entities/",
+        {"name": "Ram", "page": 4},
+        None,
+        id="court-entities-search",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "list_firms", "name": "Acme", "page": 2},
+        "GET",
+        "/api/firms/",
+        {"name": "Acme", "page": 2},
+        None,
+        id="firms-list",
+    ),
+    pytest.param(
+        BrowseCourtDataTool(),
+        {"action": "get_firm", "firm_id": 7},
+        "GET",
+        "/api/firms/7/",
+        None,
+        None,
+        id="firms-get",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "create_court",
+            "body": {
+                "identifier": "special",
+                "court_type": "special",
+                "full_name_nepali": "Bises Adalat",
+            },
+        },
+        "POST",
+        "/api/courts/",
+        None,
+        {
+            "identifier": "special",
+            "court_type": "special",
+            "full_name_nepali": "Bises Adalat",
+        },
+        id="courts-create",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "update_court",
+            "court": "special",
+            "body": {"full_name_english": "Special Court"},
+        },
+        "PATCH",
+        "/api/courts/special/",
+        None,
+        {"full_name_english": "Special Court"},
+        id="courts-update",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "create_case",
+            "body": {"case_number": "082-CR-1", "court_identifier": "special"},
+        },
+        "POST",
+        "/api/courtcases/",
+        None,
+        {"case_number": "082-CR-1", "court_identifier": "special"},
+        id="court-cases-create",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "update_case",
+            "court": "special",
+            "case_number": "082-CR-1",
+            "body": {
+                "case_number": "082-CR-1",
+                "court_identifier": "special",
+                "case_status": "decided",
+            },
+        },
+        "PATCH",
+        "/api/courtcases/special/082-CR-1/",
+        None,
+        {
+            "case_number": "082-CR-1",
+            "court_identifier": "special",
+            "case_status": "decided",
+        },
+        id="court-cases-update",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "delete_case",
+            "court": "special",
+            "case_number": "082-CR-1",
+        },
+        "DELETE",
+        "/api/courtcases/special/082-CR-1/",
+        None,
+        None,
+        id="court-cases-delete",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "ingest_cases",
+            "items": [{"court": "special", "case_number": "1"}],
+        },
+        "POST",
+        "/api/ingestion/cases/",
+        None,
+        {"items": [{"court": "special", "case_number": "1"}]},
+        id="court-cases-ingest",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "resolve_entities",
+            "items": [
+                {
+                    "court": "special",
+                    "case_number": "1",
+                    "nes_id": "https://jawafdehi.org/entity/person/ram",
+                }
+            ],
+        },
+        "POST",
+        "/api/ingestion/entities/resolve/",
+        None,
+        {
+            "items": [
+                {
+                    "court": "special",
+                    "case_number": "1",
+                    "nes_id": "https://jawafdehi.org/entity/person/ram",
+                }
+            ]
+        },
+        id="court-entities-resolve",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "register_documents",
+            "items": [
+                {
+                    "court": "special",
+                    "case_number": "1",
+                    "document_source": {},
+                }
+            ],
+        },
+        "POST",
+        "/api/ingestion/documents/",
+        None,
+        {
+            "items": [
+                {
+                    "court": "special",
+                    "case_number": "1",
+                    "document_source": {},
+                }
+            ]
+        },
+        id="court-documents-register",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "ingest_firms",
+            "items": [{"firm_name": "Acme", "blacklist_date_bs": "2080-01-01"}],
+        },
+        "POST",
+        "/api/ingestion/firms/",
+        None,
+        {"items": [{"firm_name": "Acme", "blacklist_date_bs": "2080-01-01"}]},
+        id="firms-ingest",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {"action": "create_firm", "body": {"firm_name": "Acme"}},
+        "POST",
+        "/api/firms/",
+        None,
+        {"firm_name": "Acme"},
+        id="firms-create",
+    ),
+    pytest.param(
+        ManageCourtDataTool(),
+        {
+            "action": "update_firm",
+            "firm_id": 7,
+            "body": {"reason": "settled"},
+        },
+        "PATCH",
+        "/api/firms/7/",
+        None,
+        {"reason": "settled"},
+        id="firms-update",
+    ),
+    pytest.param(
+        ManageCaseUpdateProposalsTool(),
+        {"action": "list", "status": "pending", "page": 2},
+        "GET",
+        "/api/case-update-proposals/",
+        {"status": "pending", "page": 2},
+        None,
+        id="proposals-list",
+    ),
+    pytest.param(
+        ManageCaseUpdateProposalsTool(),
+        {"action": "get", "proposal_id": 3},
+        "GET",
+        "/api/case-update-proposals/3/",
+        None,
+        None,
+        id="proposals-get",
+    ),
+    pytest.param(
+        ManageCaseUpdateProposalsTool(),
+        {
+            "action": "create",
+            "body": {
+                "case_slug": "case-a",
+                "source_kind": "caseworker",
+                "intent": {
+                    "type": "append_timeline_entry",
+                    "entry": {"date": "2026-01-01", "title": "Filed"},
+                },
+                "confidence": 1,
+                "detected_by": "caseworker:test",
+                "dedup_key": "case-a:filed",
+            },
+        },
+        "POST",
+        "/api/case-update-proposals/",
+        None,
+        {
+            "case_slug": "case-a",
+            "source_kind": "caseworker",
+            "intent": {
+                "type": "append_timeline_entry",
+                "entry": {"date": "2026-01-01", "title": "Filed"},
+            },
+            "confidence": 1,
+            "detected_by": "caseworker:test",
+            "dedup_key": "case-a:filed",
+        },
+        id="proposals-create",
+    ),
+    pytest.param(
+        ManageCaseUpdateProposalsTool(),
+        {
+            "action": "edit",
+            "proposal_id": 3,
+            "body": {
+                "intent": {
+                    "type": "link_material",
+                    "material": "https://jawafdehi.org/material/court/order-1",
+                }
+            },
+        },
+        "PATCH",
+        "/api/case-update-proposals/3/intent/",
+        None,
+        {
+            "intent": {
+                "type": "link_material",
+                "material": "https://jawafdehi.org/material/court/order-1",
+            }
+        },
+        id="proposals-edit",
+    ),
+    pytest.param(
+        ManageCaseUpdateProposalsTool(),
+        {"action": "approve", "proposal_id": 3, "body": {"notes": "ok"}},
+        "POST",
+        "/api/case-update-proposals/3/approve/",
+        None,
+        {"notes": "ok"},
+        id="proposals-approve",
+    ),
+    pytest.param(
+        ManageCaseUpdateProposalsTool(),
+        {"action": "reject", "proposal_id": 3},
+        "POST",
+        "/api/case-update-proposals/3/reject/",
+        None,
+        {},
+        id="proposals-reject",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "list", "slug": "case-a", "page": 2},
+        "GET",
+        "/api/casework/reviews/",
+        {"slug": "case-a", "page": 2},
+        None,
+        id="reviews-list",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "list_grouped", "slug": "case-a", "page": 2},
+        "GET",
+        "/api/casework/reviews/grouped/",
+        {"slug": "case-a", "page": 2},
+        None,
+        id="reviews-list-grouped",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "get", "review_id": 4},
+        "GET",
+        "/api/casework/reviews/4/",
+        None,
+        None,
+        id="reviews-get",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "submit", "body": {"slug": "case-a"}},
+        "POST",
+        "/api/casework/reviews/submit/",
+        None,
+        {"slug": "case-a"},
+        id="reviews-submit",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "list_rules"},
+        "GET",
+        "/api/casework/rules/",
+        None,
+        None,
+        id="review-rules-list",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "get_rule", "rule_id": 2},
+        "GET",
+        "/api/casework/rules/2/",
+        None,
+        None,
+        id="review-rules-get",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "get_config"},
+        "GET",
+        "/api/casework/config/",
+        None,
+        None,
+        id="review-config-get",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "update_config", "body": {"pass_threshold": 85}},
+        "PUT",
+        "/api/casework/config/",
+        None,
+        {"pass_threshold": 85},
+        id="review-config-update",
+    ),
+    pytest.param(
+        ManageCaseworkReviewsTool(),
+        {"action": "regrade_all"},
+        "POST",
+        "/api/casework/reviews/regrade-all/",
+        None,
+        {},
+        id="reviews-regrade",
+    ),
+    pytest.param(
+        ManageJobsTool(),
+        {"action": "list", "kind": "case_review", "limit": 20},
+        "GET",
+        "/api/jobs/",
+        {"kind": "case_review", "limit": 20},
+        None,
+        id="jobs-list",
+    ),
+    pytest.param(
+        ManageJobsTool(),
+        {"action": "enqueue", "body": {"kind": "case_review"}},
+        "POST",
+        "/api/jobs/",
+        None,
+        {"kind": "case_review"},
+        id="jobs-enqueue",
+    ),
+    pytest.param(
+        ManageJobsTool(),
+        {"action": "claim", "body": {"kinds": ["case_review"]}},
+        "POST",
+        "/api/jobs/claim/",
+        None,
+        {"kinds": ["case_review"]},
+        id="jobs-claim",
+    ),
+    pytest.param(
+        ManageJobsTool(),
+        {"action": "stage", "job_id": 9, "body": {"stage": "fetching"}},
+        "POST",
+        "/api/jobs/9/stage/",
+        None,
+        {"stage": "fetching"},
+        id="jobs-stage",
+    ),
+    pytest.param(
+        ManageJobsTool(),
+        {
+            "action": "result",
+            "job_id": 9,
+            "body": {"status": "done", "result": {"count": 1}},
+        },
+        "POST",
+        "/api/jobs/9/result/",
+        None,
+        {"status": "done", "result": {"count": 1}},
+        id="jobs-result",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "arguments", "method", "path", "params", "body"),
+    ACTION_ROUTE_CASES,
+)
+async def test_all_control_plane_actions_map_to_bounded_routes(
+    tool, arguments, method, path, params, body
+):
+    Draft202012Validator(tool.input_schema).validate(arguments)
+    request, payload = await _call(tool, arguments)
+
+    request.assert_awaited_once_with(
+        method,
+        path,
+        params=params,
+        json_body=body,
+        headers=None,
+    )
+    assert payload["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_unified_search_maps_repeatable_filters():
+    request, payload = await _call(
+        SearchControlPlaneTool(),
+        {
+            "q": "court",
+            "type": ["case", "courtcase"],
+            "tags": ["procurement", "appeal"],
+            "page_size": 25,
+        },
+    )
+
+    request.assert_awaited_once_with(
+        "GET",
+        "/api/search/",
+        params={
+            "q": "court",
+            "type": ["case", "courtcase"],
+            "tags": ["procurement", "appeal"],
+            "page_size": 25,
+        },
+        json_body=None,
+        headers=None,
+    )
+    assert payload["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_entity_history_encodes_full_iri_as_one_reference():
+    request, _ = await _call(
+        GetNESEntityVersionsTool(),
+        {
+            "entity_id": "https://jawafdehi.org/entity/person/a",
+            "limit": 10,
+        },
+    )
+    assert request.await_args.args == (
+        "GET",
+        "/api/entities/https%3A%2F%2Fjawafdehi.org%2Fentity%2Fperson%2Fa/versions",
+    )
+    assert request.await_args.kwargs["params"] == {"limit": 10}
+
+
+@pytest.mark.asyncio
+async def test_entity_delete_uses_control_plane_permission_boundary():
+    request, _ = await _call(
+        DeleteNESEntityTool(),
+        {"entity_id": "person/ram"},
+    )
+    assert request.await_args.args == (
+        "DELETE",
+        "/api/entities/https%3A%2F%2Fjawafdehi.org%2Fentity%2Fperson%2Fram",
+    )
+
+
+@pytest.mark.asyncio
+async def test_entity_reference_is_canonicalized_before_path_encoding():
+    request, _ = await _call(
+        GetNESEntityVersionsTool(),
+        {"entity_id": "http://foreign.example/entity/person/ram"},
+    )
+    assert request.await_args.args == (
+        "GET",
+        "/api/entities/https%3A%2F%2Fjawafdehi.org%2Fentity%2Fperson%2Fram/versions",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool",
+    [GetNESEntityVersionsTool(), DeleteNESEntityTool()],
+    ids=lambda tool: tool.name,
+)
+async def test_invalid_entity_reference_returns_stable_tool_error(tool):
+    result = await tool.execute({"entity_id": "missing-prefix"})
+
+    assert result.is_error is True
+    assert json.loads(result[0].text) == {
+        "success": False,
+        "error": "entity reference must be an IRI or prefix/slug.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_material_read_and_conditional_patch_mapping():
+    read_request, _ = await _call(
+        BrowseMaterialsTool(),
+        {"action": "get", "iri": "https://jawafdehi.org/material/court/x"},
+    )
+    assert read_request.await_args.kwargs["params"] == {
+        "iri": "https://jawafdehi.org/material/court/x"
+    }
+
+    patch_request, _ = await _call(
+        ManageMaterialTool(),
+        {
+            "action": "patch",
+            "iri": "https://jawafdehi.org/material/court/x",
+            "patch_ops": [{"op": "add", "path": "/name", "value": "Order"}],
+            "if_match": '"abc"',
+        },
+    )
+    assert patch_request.await_args.args == ("PATCH", "/api/materials/")
+    assert patch_request.await_args.kwargs["headers"] == {"If-Match": '"abc"'}
+    assert patch_request.await_args.kwargs["json_body"]["patch_ops"][0]["op"] == ("add")
+
+
+@pytest.mark.asyncio
+async def test_court_browse_and_ingestion_mapping():
+    browse_request, _ = await _call(
+        BrowseCourtDataTool(),
+        {
+            "action": "list_hearings",
+            "court": "special",
+            "case_number": "082-CR-1",
+        },
+    )
+    assert browse_request.await_args.args == (
+        "GET",
+        "/api/courtcases/special/082-CR-1/hearings/",
+    )
+
+    ingestion_request, _ = await _call(
+        ManageCourtDataTool(),
+        {"action": "register_documents", "items": [{"case_number": "1"}]},
+    )
+    assert ingestion_request.await_args.args == (
+        "POST",
+        "/api/ingestion/documents/",
+    )
+    assert ingestion_request.await_args.kwargs["json_body"] == {
+        "items": [{"case_number": "1"}]
+    }
+
+    firms_request, _ = await _call(
+        BrowseCourtDataTool(),
+        {"action": "list_firms", "name": "builders", "nes_id": "entity-1"},
+    )
+    assert firms_request.await_args.kwargs["params"] == {
+        "name": "builders",
+        "nes_id": "entity-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_firm_create_and_update_map_to_control_plane_routes():
+    create_request, _ = await _call(
+        ManageCourtDataTool(),
+        {"action": "create_firm", "body": {"firm_name": "Acme"}},
+    )
+    assert create_request.await_args.args == ("POST", "/api/firms/")
+
+    update_request, _ = await _call(
+        ManageCourtDataTool(),
+        {
+            "action": "update_firm",
+            "firm_id": 7,
+            "body": {"reason": "settled"},
+            "partial": False,
+        },
+    )
+    assert update_request.await_args.args == ("PATCH", "/api/firms/7/")
+
+
+def test_court_management_schema_does_not_advertise_put_semantics():
+    assert "partial" not in ManageCourtDataTool().input_schema["properties"]
+
+
+@pytest.mark.asyncio
+async def test_proposal_review_and_job_actions_map_to_bounded_routes():
+    proposal_request, _ = await _call(
+        ManageCaseUpdateProposalsTool(),
+        {"action": "approve", "proposal_id": 7, "body": {"notes": "verified"}},
+    )
+    assert proposal_request.await_args.args == (
+        "POST",
+        "/api/case-update-proposals/7/approve/",
+    )
+
+    reject_request, _ = await _call(
+        ManageCaseUpdateProposalsTool(),
+        {"action": "reject", "proposal_id": 8},
+    )
+    assert reject_request.await_args.args == (
+        "POST",
+        "/api/case-update-proposals/8/reject/",
+    )
+    assert reject_request.await_args.kwargs["json_body"] == {}
+
+    review_request, _ = await _call(
+        ManageCaseworkReviewsTool(),
+        {"action": "submit", "body": {"slug": "case-a"}},
+    )
+    assert review_request.await_args.args == (
+        "POST",
+        "/api/casework/reviews/submit/",
+    )
+
+    job_request, _ = await _call(
+        ManageJobsTool(),
+        {
+            "action": "result",
+            "job_id": 9,
+            "body": {"status": "done", "result": {"count": 1}},
+        },
+    )
+    assert job_request.await_args.args == (
+        "POST",
+        "/api/jobs/9/result/",
+    )
+
+
+@pytest.mark.asyncio
+async def test_action_validation_does_not_issue_request():
+    request = AsyncMock()
+    with patch(
+        "jawafdehi_mcp.tools.control_plane.request_control_plane",
+        new=request,
+    ):
+        result = await ManageMaterialTool().execute({"action": "patch", "iri": "x"})
+
+    assert request.await_count == 0
+    assert json.loads(result[0].text)["success"] is False

--- a/tests/mcp/test_dev_query_token.py
+++ b/tests/mcp/test_dev_query_token.py
@@ -1,0 +1,62 @@
+"""Security contract for the Zitadel-free E2E query token."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def dev_query_auth(settings, monkeypatch):
+    from courts.views import IngestionCasesView, QueryView
+    from jawafdehi_shared.auth.dev_service import (
+        DevelopmentQueryTokenAuthentication,
+    )
+    from jawafdehi_shared.auth.oidc import OIDCAuthentication
+
+    settings.TESTING = True
+    settings.DEV_AUTH = True
+    settings.DEV_NGM_QUERY_TOKEN = "query-only"
+    settings.DEV_NGM_QUERY_USERNAME = "mcp-query-e2e"
+    settings.REST_FRAMEWORK = {
+        **settings.REST_FRAMEWORK,
+        "DEFAULT_AUTHENTICATION_CLASSES": [
+            "jawafdehi_shared.auth.dev_service."
+            "DevelopmentQueryTokenAuthentication",
+            "jawafdehi_shared.auth.oidc.OIDCAuthentication",
+        ],
+    }
+    authentication_classes = [
+        DevelopmentQueryTokenAuthentication,
+        OIDCAuthentication,
+    ]
+    monkeypatch.setattr(
+        QueryView,
+        "authentication_classes",
+        authentication_classes,
+    )
+    monkeypatch.setattr(
+        IngestionCasesView,
+        "authentication_classes",
+        authentication_classes,
+    )
+    get_user_model().objects.create(username="mcp-query-e2e")
+    return APIClient()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_dev_query_token_can_only_reach_read_plane(dev_query_auth):
+    dev_query_auth.credentials(HTTP_AUTHORIZATION="Bearer query-only")
+
+    query = dev_query_auth.post(
+        "/api/query/",
+        {"query": "SELECT 1"},
+        format="json",
+    )
+    ingestion = dev_query_auth.post(
+        "/api/ingestion/cases/",
+        {"items": []},
+        format="json",
+    )
+
+    assert query.status_code == 200
+    assert ingestion.status_code == 401

--- a/tests/mcp/test_document_converter.py
+++ b/tests/mcp/test_document_converter.py
@@ -1,0 +1,742 @@
+"""Tests for the unified DocumentConverterTool."""
+
+import asyncio
+import socket
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from jsonschema import Draft202012Validator
+from markitdown import StreamInfo
+
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.tools.document_converter import (
+    DocumentConverterTool,
+    _PinnedNetworkBackend,
+    _ResolvedRemoteTarget,
+    _run_bounded_conversion,
+    _run_isolated_stream_conversion,
+)
+
+
+def _remote_document():
+    return (
+        b"%PDF-1.4 bounded",
+        StreamInfo(
+            mimetype="application/pdf",
+            extension=".pdf",
+            url="https://example.com/document.pdf",
+        ),
+    )
+
+
+class TestDocumentConverterTool:
+    """Test DocumentConverterTool properties and execution."""
+
+    def setup_method(self):
+        self.tool = DocumentConverterTool()
+
+    @pytest.fixture(autouse=True)
+    def _local_stdio_transport(self):
+        token = current_transport.set("stdio")
+        try:
+            yield
+        finally:
+            current_transport.reset(token)
+
+    def test_tool_name(self):
+        assert self.tool.name == "convert_to_markdown"
+
+    def test_tool_has_description(self):
+        assert "MarkItDown" in self.tool.description
+        assert "plugins disabled" in self.tool.description
+        assert "opt-in" in self.tool.description
+
+    def test_input_schema_has_all_fields(self):
+        schema = self.tool.input_schema
+        expected_fields = [
+            "file_path",
+            "uri",
+            "output_path",
+            "pages",
+            "enable_plugins",
+        ]
+        for field in expected_fields:
+            assert field in schema["properties"]
+
+        assert "doc_type" not in schema["properties"]
+        assert "title" not in schema["properties"]
+
+    def test_input_schema_requires_exactly_one_source(self):
+        schema = self.tool.input_schema
+        validator = Draft202012Validator(schema)
+
+        assert schema["required"] == []
+        assert validator.is_valid({"file_path": "/tmp/input.pdf"})
+        assert validator.is_valid({"uri": "https://example.com/input.pdf"})
+        assert not validator.is_valid({})
+        assert not validator.is_valid(
+            {
+                "file_path": "/tmp/input.pdf",
+                "uri": "https://example.com/input.pdf",
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_both_file_path_and_uri(self):
+        result = await self.tool.execute({})
+        assert len(result) == 1
+        assert "Error" in result[0].text
+        assert "file_path" in result[0].text or "uri" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_both_file_path_and_uri_provided(self):
+        result = await self.tool.execute(
+            {"file_path": "/tmp/test.pdf", "uri": "https://example.com/doc.pdf"}
+        )
+        assert len(result) == 1
+        assert "Error" in result[0].text
+        assert "both" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file(self, tmp_path):
+        result = await self.tool.execute(
+            {"file_path": str(tmp_path / "nonexistent_unified_test.pdf")}
+        )
+        assert len(result) == 1
+        assert "File not found" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_path_is_directory(self, tmp_path):
+        result = await self.tool.execute({"file_path": str(tmp_path)})
+        assert len(result) == 1
+        assert "not a file" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_local_pdf_uses_markitdown_without_plugins_by_default(self, tmp_path):
+        """Local PDFs should route through MarkItDown and return markdown by default."""
+        pdf_file = tmp_path / "ciaa.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake content")
+
+        fake_markdown = "# Converted with plugin\n"
+        mock_result = MagicMock()
+        mock_result.markdown = fake_markdown
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            result = await self.tool.execute({"file_path": str(pdf_file)})
+
+        assert len(result) == 1
+        assert "Converted with MarkItDown\n\n" in result[0].text
+        assert fake_markdown in result[0].text
+        mock_markitdown.assert_called_once_with(enable_plugins=False)
+        mock_converter.convert_uri.assert_called_once_with(pdf_file.resolve().as_uri())
+
+    @pytest.mark.asyncio
+    async def test_markitdown_direct_with_file_path(self, tmp_path):
+        """Non-PDF local files should still use MarkItDown and return markdown."""
+        docx_file = tmp_path / "document.docx"
+        docx_file.write_bytes(b"fake docx content")
+
+        fake_markdown = "# Document Title\n\nContent\n"
+        mock_result = MagicMock()
+        mock_result.markdown = fake_markdown
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_markitdown.return_value = mock_converter
+            mock_converter.convert_uri.return_value = mock_result
+
+            result = await self.tool.execute({"file_path": str(docx_file)})
+
+        assert len(result) == 1
+        assert "Converted with MarkItDown\n\n" in result[0].text
+        assert fake_markdown in result[0].text
+        mock_converter.convert_uri.assert_called_once()
+        call_args = mock_converter.convert_uri.call_args[0][0]
+        assert call_args == docx_file.resolve().as_uri()
+
+    @pytest.mark.asyncio
+    async def test_legacy_doc_uses_unified_plugin_enabled_path(self, tmp_path):
+        """Legacy DOC files should be accepted by the unified MarkItDown path."""
+        doc_file = tmp_path / "legacy.doc"
+        doc_file.write_bytes(b"fake doc content")
+
+        fake_markdown = "# Legacy Doc\n"
+        mock_result = MagicMock()
+        mock_result.markdown = fake_markdown
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+
+            result = await self.tool.execute(
+                {"file_path": str(doc_file), "enable_plugins": True}
+            )
+
+        assert len(result) == 1
+        assert fake_markdown in result[0].text
+        mock_markitdown.assert_called_once_with(enable_plugins=True)
+        mock_converter.convert_uri.assert_called_once_with(doc_file.resolve().as_uri())
+
+    @pytest.mark.asyncio
+    async def test_markitdown_with_uri(self):
+        """Remote bytes are passed to the isolated conversion worker."""
+        fake_markdown = "# Web Document\n"
+
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter."
+                "_run_isolated_stream_conversion",
+                new=AsyncMock(return_value=fake_markdown),
+            ) as mock_convert,
+            patch(
+                "jawafdehi_mcp.tools.document_converter._fetch_remote_document",
+                new=AsyncMock(return_value=_remote_document()),
+            ) as mock_fetch,
+        ):
+            result = await self.tool.execute(
+                {"uri": "https://example.com/document.pdf"}
+            )
+
+        assert len(result) == 1
+        assert "Converted with MarkItDown\n\n" in result[0].text
+        assert fake_markdown in result[0].text
+        mock_fetch.assert_awaited_once_with("https://example.com/document.pdf")
+        mock_convert.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_output_path_writing(self, tmp_path):
+        """Test that output_path writes markdown to disk without including content in response."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+        output_file = tmp_path / "output" / "result.md"
+
+        fake_markdown = "# Test\n"
+
+        mock_result = MagicMock()
+        mock_result.markdown = fake_markdown
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            token = current_transport.set("stdio")
+            try:
+                result = await self.tool.execute(
+                    {"file_path": str(pdf_file), "output_path": str(output_file)}
+                )
+            finally:
+                current_transport.reset(token)
+
+        assert len(result) == 1
+        assert "written to" in result[0].text.lower()
+        assert fake_markdown not in result[0].text
+        assert output_file.exists()
+        assert output_file.read_text(encoding="utf-8") == fake_markdown
+
+    @pytest.mark.asyncio
+    async def test_enable_plugins_defaults_to_false_for_remote_input(self):
+        fake_markdown = "# Test\n"
+
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter."
+                "_run_isolated_stream_conversion",
+                new=AsyncMock(return_value=fake_markdown),
+            ) as mock_convert,
+            patch(
+                "jawafdehi_mcp.tools.document_converter._fetch_remote_document",
+                new=AsyncMock(return_value=_remote_document()),
+            ),
+        ):
+            await self.tool.execute({"uri": "https://example.com/doc.pdf"})
+
+        mock_convert.assert_awaited_once()
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_enable_plugins_true_is_rejected_for_remote_input(self):
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter."
+                "_run_isolated_stream_conversion",
+                new=AsyncMock(),
+            ) as mock_convert,
+            patch(
+                "jawafdehi_mcp.tools.document_converter._fetch_remote_document",
+                new=AsyncMock(),
+            ) as mock_fetch,
+        ):
+            result = await self.tool.execute(
+                {"uri": "https://example.com/doc.pdf", "enable_plugins": True}
+            )
+
+        assert "supported only for trusted local stdio" in result[0].text
+        mock_fetch.assert_not_awaited()
+        mock_convert.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_file_uri_conversion(self, tmp_path):
+        """Test that file:// URIs are converted and returned directly."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+
+        fake_markdown = "# Test\n"
+
+        mock_result = MagicMock()
+        mock_result.markdown = fake_markdown
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            result = await self.tool.execute({"uri": pdf_file.resolve().as_uri()})
+
+        assert len(result) == 1
+        assert "Converted with MarkItDown\n\n" in result[0].text
+        assert "Error" not in result[0].text
+        assert fake_markdown in result[0].text
+        mock_converter.convert_uri.assert_called_once_with(pdf_file.resolve().as_uri())
+
+    @pytest.mark.asyncio
+    async def test_rejects_output_path_on_http_transport(self, tmp_path):
+        """HTTP-hosted MCP servers must not write markdown files."""
+        output_file = tmp_path / "result.md"
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute(
+                    {
+                        "uri": "https://example.com/document.pdf",
+                        "output_path": str(output_file),
+                    }
+                )
+            finally:
+                current_transport.reset(token)
+
+        assert len(result) == 1
+        assert "only supported by local stdio" in result[0].text
+        assert "must not write files" in result[0].text
+        assert not output_file.exists()
+        mock_markitdown.assert_not_called()
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_file_path_on_http_transport(self):
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter.Path.exists",
+                side_effect=AssertionError("must not inspect server paths"),
+            ),
+            patch(
+                "jawafdehi_mcp.tools.document_converter.MarkItDown"
+            ) as mock_markitdown,
+        ):
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute({"file_path": "/etc/passwd"})
+            finally:
+                current_transport.reset(token)
+
+        assert "only supported by local stdio" in result[0].text
+        assert "cannot read server filesystem paths" in result[0].text
+        mock_markitdown.assert_not_called()
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_file_uri_on_http_transport(self):
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter.Path.exists",
+                side_effect=AssertionError("must not inspect server paths"),
+            ),
+            patch(
+                "jawafdehi_mcp.tools.document_converter.MarkItDown"
+            ) as mock_markitdown,
+        ):
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute({"uri": "file:///etc/passwd"})
+            finally:
+                current_transport.reset(token)
+
+        assert "only supported by local stdio" in result[0].text
+        mock_markitdown.assert_not_called()
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_bare_path_supplied_as_uri_on_http_transport(self):
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter.Path.exists",
+                side_effect=AssertionError("must not inspect server paths"),
+            ),
+            patch(
+                "jawafdehi_mcp.tools.document_converter.MarkItDown"
+            ) as mock_markitdown,
+        ):
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute({"uri": "/etc/passwd"})
+            finally:
+                current_transport.reset(token)
+
+        assert "Bare paths are not valid URIs" in result[0].text
+        mock_markitdown.assert_not_called()
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_loopback_remote_uri(self):
+        token = current_transport.set("http")
+        try:
+            result = await self.tool.execute({"uri": "http://127.0.0.1/secret"})
+        finally:
+            current_transport.reset(token)
+
+        assert "public IP address" in result[0].text
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_hostname_resolving_to_private_address(self):
+        private_answer = [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("10.0.0.8", 443),
+            )
+        ]
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.socket.getaddrinfo",
+            return_value=private_answer,
+        ):
+            result = await self.tool.execute(
+                {"uri": "https://metadata.example/document"}
+            )
+
+        assert "public IP addresses" in result[0].text
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_pinned_backend_connects_to_validated_ip_without_new_dns_lookup(self):
+        stream = object()
+        backend = AsyncMock()
+        backend.connect_tcp.return_value = stream
+        pinned = _PinnedNetworkBackend(
+            backend,
+            _ResolvedRemoteTarget(
+                hostname="documents.example",
+                port=443,
+                addresses=("93.184.216.34",),
+            ),
+        )
+
+        result = await pinned.connect_tcp(
+            "documents.example",
+            443,
+            timeout=5,
+            local_address=None,
+            socket_options=[],
+        )
+
+        assert result is stream
+        backend.connect_tcp.assert_awaited_once_with(
+            "93.184.216.34",
+            443,
+            timeout=5,
+            local_address=None,
+            socket_options=[],
+        )
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_pinned_backend_rejects_a_changed_connection_host(self):
+        backend = AsyncMock()
+        pinned = _PinnedNetworkBackend(
+            backend,
+            _ResolvedRemoteTarget(
+                hostname="documents.example",
+                port=443,
+                addresses=("93.184.216.34",),
+            ),
+        )
+
+        with pytest.raises(Exception, match="connection target changed"):
+            await pinned.connect_tcp("metadata.internal", 443)
+
+        backend.connect_tcp.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_remote_fetch_holds_document_capacity_slot(self):
+        limiter = asyncio.Semaphore(1)
+
+        async def fetch_while_slot_is_held(_uri):
+            assert limiter.locked()
+            return _remote_document()
+
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter._conversion_limiter",
+                return_value=limiter,
+            ),
+            patch(
+                "jawafdehi_mcp.tools.document_converter._fetch_remote_document",
+                side_effect=fetch_while_slot_is_held,
+            ),
+            patch(
+                "jawafdehi_mcp.tools.document_converter."
+                "_run_isolated_stream_conversion",
+                new=AsyncMock(return_value="# Remote\n"),
+            ),
+        ):
+            result = await self.tool.execute(
+                {"uri": "https://example.com/document.pdf"}
+            )
+
+        assert "# Remote" in result[0].text
+        assert not limiter.locked()
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_data_uri(self, monkeypatch):
+        monkeypatch.setenv("MCP_DOCUMENT_MAX_INPUT_BYTES", "4")
+        result = await self.tool.execute({"uri": "data:text/plain,12345"})
+        assert "exceeds the 4-byte limit" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_http_transport_allows_remote_uri(self):
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter."
+                "_run_isolated_stream_conversion",
+                new=AsyncMock(return_value="# Remote\n"),
+            ) as mock_convert,
+            patch(
+                "jawafdehi_mcp.tools.document_converter._fetch_remote_document",
+                new=AsyncMock(return_value=_remote_document()),
+            ) as mock_fetch,
+        ):
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute(
+                    {"uri": "https://example.com/document.pdf"}
+                )
+            finally:
+                current_transport.reset(token)
+
+        assert "# Remote" in result[0].text
+        mock_fetch.assert_awaited_once_with("https://example.com/document.pdf")
+        mock_convert.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_output_path_matching_source_file(self, tmp_path):
+        """Explicit output_path must not overwrite the source file."""
+        markdown_file = tmp_path / "already.md"
+        markdown_file.write_text("# Existing\n", encoding="utf-8")
+
+        fake_markdown = "# Converted\n"
+        mock_result = MagicMock()
+        mock_result.markdown = fake_markdown
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+
+            token = current_transport.set("stdio")
+            try:
+                result = await self.tool.execute(
+                    {
+                        "file_path": str(markdown_file),
+                        "output_path": str(markdown_file),
+                    }
+                )
+            finally:
+                current_transport.reset(token)
+
+        assert len(result) == 1
+        assert "output_path must differ from the source file" in result[0].text
+        assert markdown_file.read_text(encoding="utf-8") == "# Existing\n"
+
+    @pytest.mark.asyncio
+    async def test_localhost_file_uri_conversion(self, tmp_path):
+        """file://localhost URIs should resolve to local filesystem paths."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+        localhost_uri = f"file://localhost{pdf_file.resolve().as_uri()[7:]}"
+
+        mock_result = MagicMock()
+        mock_result.markdown = "# Test\n"
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            result = await self.tool.execute({"uri": localhost_uri})
+
+        assert len(result) == 1
+        assert "Error" not in result[0].text
+        mock_converter.convert_uri.assert_called_once_with(pdf_file.resolve().as_uri())
+
+    @pytest.mark.asyncio
+    async def test_uppercase_file_uri_conversion(self, tmp_path):
+        """FILE:// URIs should be treated as file URIs."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+        uppercase_uri = pdf_file.resolve().as_uri().replace("file://", "FILE://", 1)
+
+        mock_result = MagicMock()
+        mock_result.markdown = "# Test\n"
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            result = await self.tool.execute({"uri": uppercase_uri})
+
+        assert len(result) == 1
+        assert "Error" not in result[0].text
+        mock_converter.convert_uri.assert_called_once_with(pdf_file.resolve().as_uri())
+
+    @pytest.mark.asyncio
+    async def test_uppercase_https_uri_uses_markitdown(self):
+        """HTTPS:// URIs should still be treated as web URIs."""
+        fake_markdown = "# Web Document\n"
+
+        with (
+            patch(
+                "jawafdehi_mcp.tools.document_converter."
+                "_run_isolated_stream_conversion",
+                new=AsyncMock(return_value=fake_markdown),
+            ) as mock_convert,
+            patch(
+                "jawafdehi_mcp.tools.document_converter._fetch_remote_document",
+                new=AsyncMock(return_value=_remote_document()),
+            ) as mock_fetch,
+        ):
+            result = await self.tool.execute(
+                {"uri": "HTTPS://example.com/document.pdf"}
+            )
+
+        assert len(result) == 1
+        assert "MarkItDown" in result[0].text
+        mock_fetch.assert_awaited_once_with("HTTPS://example.com/document.pdf")
+        mock_convert.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_remote_file_uri_netloc(self):
+        """Remote file URIs should be rejected before path validation."""
+        result = await self.tool.execute({"uri": "file://example.com/test.pdf"})
+
+        assert len(result) == 1
+        assert "Unsupported file URI" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_pages_kwarg_passed_to_convert_uri(self, tmp_path):
+        """Pages parameter should be passed through to MarkItDown as a kwarg."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake content")
+
+        mock_result = MagicMock()
+        mock_result.markdown = "# First page\n"
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            result = await self.tool.execute(
+                {"file_path": str(pdf_file), "pages": "1-3"}
+            )
+
+        assert len(result) == 1
+        assert "Converted with MarkItDown\n\n" in result[0].text
+        mock_converter.convert_uri.assert_called_once_with(
+            pdf_file.resolve().as_uri(), pages="1-3"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pages_not_passed_when_omitted(self, tmp_path):
+        """When pages is not provided, convert_uri should be called without it."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake content")
+
+        mock_result = MagicMock()
+        mock_result.markdown = "# All pages\n"
+
+        with patch(
+            "jawafdehi_mcp.tools.document_converter.MarkItDown"
+        ) as mock_markitdown:
+            mock_converter = MagicMock()
+            mock_converter.convert_uri.return_value = mock_result
+            mock_markitdown.return_value = mock_converter
+            result = await self.tool.execute({"file_path": str(pdf_file)})
+
+        assert len(result) == 1
+        mock_converter.convert_uri.assert_called_once_with(pdf_file.resolve().as_uri())
+
+
+@pytest.mark.security
+@pytest.mark.asyncio
+async def test_isolated_conversion_drains_results_larger_than_pipe_buffer():
+    payload = b"x" * 200_000
+
+    markdown = await _run_isolated_stream_conversion(
+        payload,
+        StreamInfo(mimetype="text/plain", charset="utf-8", extension=".txt"),
+        {},
+    )
+
+    assert markdown.rstrip() == payload.decode()
+
+
+@pytest.mark.asyncio
+async def test_timed_out_thread_failure_is_consumed_and_releases_capacity(
+    monkeypatch,
+):
+    monkeypatch.setenv("MCP_DOCUMENT_CONVERT_TIMEOUT", "0.01")
+    limiter = asyncio.Semaphore(1)
+    await limiter.acquire()
+    loop = asyncio.get_running_loop()
+    unhandled = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+
+    def fail_late():
+        time.sleep(0.03)
+        raise RuntimeError("late parser failure")
+
+    try:
+        with pytest.raises(ValueError, match="timed out"):
+            await _run_bounded_conversion(fail_late, limiter)
+        await asyncio.sleep(0.05)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert limiter._value == 1
+    assert unhandled == []

--- a/tests/mcp/test_http_integration.py
+++ b/tests/mcp/test_http_integration.py
@@ -15,13 +15,11 @@ from jawafdehi_mcp.http_server import (
     _bearer_from_headers,
     _canonical_base_url,
     _max_request_body_size,
-    _mode_from_headers,
     _protected_resource_metadata,
     _resource_metadata_url,
 )
 from jawafdehi_mcp.identity import (
-    PUBLIC_HOST_TOOL_NAMES,
-    current_request_mode,
+    ANONYMOUS_TOOL_NAMES,
     current_user_identity,
 )
 from jawafdehi_mcp.oidc import OIDCError
@@ -84,7 +82,6 @@ def captured(mcp_server, monkeypatch):
     async def _recorder(scope, receive, send):
         seen["identity"] = current_user_identity.get()
         seen["bearer"] = jawafdehi_bearer_token.get()
-        seen["mode"] = current_request_mode.get()
         seen["transport"] = current_transport.get()
         seen["allowed_tools"] = {tool.name for tool in _get_allowed_tools()}
 
@@ -144,19 +141,17 @@ class TestMiddleware:
         assert current_user_identity.get() is None
 
     async def test_no_bearer_is_anonymous(self, mcp_server, captured, monkeypatch):
-        monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
         monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
         scope = _make_scope([])
         await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
         assert captured["identity"] is None
         assert captured["bearer"] is None
         assert captured["transport"] == "http"
-        assert captured["allowed_tools"] == PUBLIC_HOST_TOOL_NAMES
+        assert captured["allowed_tools"] == ANONYMOUS_TOOL_NAMES
 
     async def test_no_bearer_hides_sql_without_query_token(
         self, mcp_server, captured, monkeypatch
     ):
-        monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
         monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
 
         await mcp_server._handle_http(
@@ -165,9 +160,58 @@ class TestMiddleware:
             _SendRecorder(),
         )
 
-        assert captured["allowed_tools"] == PUBLIC_HOST_TOOL_NAMES - {
+        assert captured["allowed_tools"] == ANONYMOUS_TOOL_NAMES - {
             "ngm_query_judicial"
         }
+
+    @pytest.mark.security
+    async def test_anonymous_cannot_reach_the_document_converter(
+        self, mcp_server, captured, monkeypatch
+    ):
+        """convert_to_markdown needs authentication; no /api/ route gates it."""
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
+
+        await mcp_server._handle_http(
+            _make_scope([]),
+            _dummy_receive,
+            _SendRecorder(),
+        )
+
+        assert "convert_to_markdown" not in captured["allowed_tools"]
+
+    async def test_roleless_bearer_reaches_the_document_converter(
+        self, mcp_server, captured, monkeypatch
+    ):
+        """...but any verified bearer does, with no role required."""
+
+        async def _resolve(token):
+            return {"sub": "u2", "email": "noroles@x.org", "roles": []}
+
+        monkeypatch.setattr(http_server, "resolve_bearer_identity", _resolve)
+
+        await mcp_server._handle_http(
+            _make_scope([(b"authorization", b"Bearer good-token")]),
+            _dummy_receive,
+            _SendRecorder(),
+        )
+
+        assert "convert_to_markdown" in captured["allowed_tools"]
+
+    @pytest.mark.security
+    async def test_spoofed_mode_header_has_no_effect(
+        self, mcp_server, captured, monkeypatch
+    ):
+        """The doors are gone: x-mcp-mode is now just an unknown header."""
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
+
+        await mcp_server._handle_http(
+            _make_scope([(b"x-mcp-mode", b"internal")]),
+            _dummy_receive,
+            _SendRecorder(),
+        )
+
+        assert captured["identity"] is None
+        assert captured["allowed_tools"] == ANONYMOUS_TOOL_NAMES
 
     @pytest.mark.security
     async def test_hostile_host_is_rejected(self, mcp_server):
@@ -241,26 +285,13 @@ class TestMiddleware:
         await mcp_server._handle_http(scope, _dummy_receive, send)
         assert send.status == 200
 
-    async def test_internal_health_requires_canonical_resource(
-        self, mcp_server, monkeypatch
-    ):
-        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
-        monkeypatch.setenv("MCP_DEFAULT_MODE", "internal")
-        mcp_server._ready = True
-        send = _SendRecorder()
-
-        await mcp_server._handle_http(
-            _make_scope([], path="/health", method="GET"),
-            _dummy_receive,
-            send,
-        )
-
-        assert send.status == 503
-        assert send.body == b"not ready"
-
     async def test_protected_resource_metadata(self, mcp_server, monkeypatch):
         monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
         monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
+        # Required now: the single door advertises one canonical resource URL.
+        # There is no longer an audience-identifier fallback, which RFC 9728 did
+        # not permit anyway (``resource`` must be the resource's URL).
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
         send = _SendRecorder()
         scope = _make_scope(
             [],
@@ -270,7 +301,7 @@ class TestMiddleware:
         await mcp_server._handle_http(scope, _dummy_receive, send)
         assert send.status == 200
         meta = json.loads(send.body)
-        assert meta["resource"] == "proj-1"
+        assert meta["resource"] == "https://api.jawafdehi.org/mcp"
         assert meta["authorization_servers"] == ["https://auth.x.org"]
 
     @pytest.mark.parametrize(
@@ -334,29 +365,12 @@ class TestProtectedResourceMetadata:
 
 
 class TestHeaderHelpers:
-    def test_mode_from_headers(self):
-        assert _mode_from_headers({b"x-mcp-mode": b"internal"}) == "internal"
-        assert _mode_from_headers({b"x-mcp-mode": b"Public"}) == "public"
-        assert _mode_from_headers({}) is None
-
-    def test_mode_defaults_to_env_floor(self, monkeypatch):
-        monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
-        # Missing header falls back to the deployment floor...
-        assert _mode_from_headers({}) == "public"
-        # ...but an explicit ingress-injected stricter mode still wins.
-        assert _mode_from_headers({b"x-mcp-mode": b"internal"}) == "internal"
-
-    @pytest.mark.security
-    def test_internal_default_cannot_be_downgraded_by_header(self, monkeypatch):
-        monkeypatch.setenv("MCP_DEFAULT_MODE", "internal")
-        assert _mode_from_headers({b"x-mcp-mode": b"public"}) == "internal"
-        assert _mode_from_headers({b"x-mcp-mode": b"legacy"}) == "internal"
-        assert _mode_from_headers({b"x-mcp-mode": b"\xff"}) == "internal"
-
-    @pytest.mark.security
-    def test_invalid_default_mode_fails_closed(self, monkeypatch):
-        monkeypatch.setenv("MCP_DEFAULT_MODE", "legacy")
-        assert _mode_from_headers({}) == "public"
+    def test_no_mode_resolver_exists(self):
+        """The two doors are gone, and so is anything that resolved between them."""
+        assert not hasattr(http_server, "_mode_from_headers")
+        assert not hasattr(http_server, "MODE_HEADER")
+        assert not hasattr(http_server, "MCP_DEFAULT_MODE")
+        assert not hasattr(http_server, "VALID_MODES")
 
     def test_canonical_base_prefers_configured_over_client_host(self, monkeypatch):
         monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.jawafdehi.org/mcp")
@@ -391,121 +405,162 @@ class TestHeaderHelpers:
         assert _max_request_body_size() == 4 * 10 + 1024 * 1024
 
 
-class TestModeDoors:
+class TestSingleDoor:
+    """One endpoint, no header-selected doors.
+
+    The behavioral pivot from the two-door design: an anonymous request is
+    SERVED the read-only catalog rather than challenged, so the metadata document
+    below becomes the only way a client discovers how to authenticate.
+    """
+
     pytestmark = pytest.mark.asyncio(loop_scope="function")
 
-    async def test_internal_anonymous_gets_401_challenge(self, mcp_server, monkeypatch):
-        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.x.org/mcp")
+    async def test_anonymous_is_served_not_challenged(self, mcp_server, captured):
         send = _SendRecorder()
-        scope = _make_scope([(b"x-mcp-mode", b"internal")])
-        await mcp_server._handle_http(scope, _dummy_receive, send)
+        await mcp_server._handle_http(_make_scope([]), _dummy_receive, send)
+        # Reached the session manager instead of short-circuiting on a 401.
+        assert send.status is None
+        assert captured["identity"] is None
+
+    async def test_metadata_is_always_served(self, mcp_server, monkeypatch):
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
+        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope(
+                [],
+                path="/.well-known/oauth-protected-resource",
+                method="GET",
+            ),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 200
+        meta = json.loads(send.body)
+        assert meta["resource"] == "https://api.jawafdehi.org/mcp"
+        assert meta["authorization_servers"] == ["https://auth.x.org"]
+
+    async def test_metadata_requires_canonical_resource(self, mcp_server, monkeypatch):
+        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope(
+                [(b"x-forwarded-host", b"evil.example")],
+                path="/.well-known/oauth-protected-resource",
+                method="GET",
+            ),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 503
+        assert json.loads(send.body)["error"] == "server_configuration_error"
+        assert b"evil.example" not in send.body
+
+    @pytest.mark.security
+    async def test_metadata_ignores_spoofed_host(self, mcp_server, monkeypatch):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
+        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope(
+                [(b"x-forwarded-host", b"evil.example")],
+                path="/.well-known/oauth-protected-resource",
+                method="GET",
+            ),
+            _dummy_receive,
+            send,
+        )
+        assert json.loads(send.body)["resource"] == "https://api.jawafdehi.org/mcp"
+
+    async def test_health_does_not_depend_on_oidc_resource(
+        self, mcp_server, monkeypatch
+    ):
+        """A pod serving anonymous reads is ready even with OAuth unconfigured."""
+        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+        mcp_server._ready = True
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([], path="/health", method="GET"),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 200
+        assert send.body == b"ready"
+
+    async def test_invalid_token_challenge_points_at_metadata(
+        self, mcp_server, monkeypatch
+    ):
+        """A broken bearer is still rejected — and told where to authenticate."""
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
+
+        async def _resolve(token):
+            raise OIDCError("expired")
+
+        monkeypatch.setattr(http_server, "resolve_bearer_identity", _resolve)
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"authorization", b"Bearer stale")]),
+            _dummy_receive,
+            send,
+        )
         assert send.status == 401
-        wa = dict(
+        challenge = dict(
             (k.decode(), v.decode())
             for k, v in next(
                 m["headers"]
                 for m in send.messages
                 if m["type"] == "http.response.start"
             )
-        )
-        assert "resource_metadata=" in wa["www-authenticate"]
-        assert "mcp-internal.x.org" in wa["www-authenticate"]
-
-    async def test_internal_mode_requires_canonical_resource(
-        self, mcp_server, monkeypatch
-    ):
-        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
-        send = _SendRecorder()
-        scope = _make_scope(
-            [
-                (b"x-mcp-mode", b"internal"),
-                (b"x-forwarded-host", b"evil.example"),
-            ]
-        )
-        await mcp_server._handle_http(scope, _dummy_receive, send)
-        assert send.status == 503
-        assert json.loads(send.body)["error"] == "server_configuration_error"
-        assert b"evil.example" not in send.body
-
-    async def test_public_anonymous_proceeds(self, mcp_server, captured):
-        scope = _make_scope([(b"x-mcp-mode", b"public")])
-        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
-        assert captured["identity"] is None
-        assert captured["mode"] == "public"
-        # contextvar reset after request
-        assert current_request_mode.get() is None
-
-    async def test_legacy_anonymous_proceeds(self, mcp_server, captured):
-        scope = _make_scope([])
-        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
-        assert captured["identity"] is None
-        assert captured["mode"] is None
+        )["www-authenticate"]
+        assert 'error="invalid_token"' in challenge
+        assert "resource_metadata=" in challenge
+        assert "api.jawafdehi.org" in challenge
 
     @pytest.mark.security
-    async def test_invalid_mode_is_restricted_to_public(self, mcp_server, captured):
-        scope = _make_scope([(b"x-mcp-mode", b"legacy")])
-        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+    @pytest.mark.parametrize(
+        "authorization",
+        [b"Token abc", b"Bearer", b"Bearer   ", b"garbage", b"Basic dXNlcjpwdw=="],
+    )
+    async def test_malformed_authorization_is_rejected_not_downgraded(
+        self, mcp_server, monkeypatch, authorization
+    ):
+        """A caller that tried to authenticate is told it failed.
+
+        The regression this guards: ``_bearer_from_headers`` returns None for
+        both "absent" and "unparseable", so without an explicit check a wrong
+        scheme silently received the ANONYMOUS catalog and a 200.
+        """
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"authorization", authorization)]),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 401
+        assert json.loads(send.body)["error"] == "invalid_request"
+
+    async def test_absent_authorization_is_still_anonymous(self, mcp_server, captured):
+        """The other half: no header at all is anonymous, not an error."""
+        send = _SendRecorder()
+        await mcp_server._handle_http(_make_scope([]), _dummy_receive, send)
+        assert send.status is None
         assert captured["identity"] is None
-        assert captured["mode"] == "public"
 
-    async def test_metadata_ignores_spoofed_host_when_configured(
-        self, mcp_server, monkeypatch
-    ):
-        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.jawafdehi.org/mcp")
-        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
-        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
-        send = _SendRecorder()
-        scope = _make_scope(
-            [
-                (b"x-mcp-mode", b"internal"),
-                (b"x-forwarded-host", b"evil.example"),
-            ],
-            path="/.well-known/oauth-protected-resource",
-            method="GET",
-        )
-        await mcp_server._handle_http(scope, _dummy_receive, send)
-        meta = json.loads(send.body)
-        assert meta["resource"] == "https://mcp-internal.jawafdehi.org/mcp"
-
-    async def test_public_hides_oauth_metadata(self, mcp_server):
-        send = _SendRecorder()
-        scope = _make_scope(
-            [(b"x-mcp-mode", b"public")],
-            path="/.well-known/oauth-protected-resource",
-            method="GET",
-        )
-        await mcp_server._handle_http(scope, _dummy_receive, send)
-        assert send.status == 404
-
-    async def test_internal_serves_canonical_metadata(self, mcp_server, monkeypatch):
-        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
-        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
-        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.x.org/mcp")
-        send = _SendRecorder()
-        scope = _make_scope(
-            [(b"x-mcp-mode", b"internal")],
-            path="/.well-known/oauth-protected-resource",
-            method="GET",
-        )
-        await mcp_server._handle_http(scope, _dummy_receive, send)
-        assert send.status == 200
-        meta = json.loads(send.body)
-        assert meta["resource"] == "https://mcp-internal.x.org/mcp"
-        assert meta["authorization_servers"] == ["https://auth.x.org"]
-
-    async def test_internal_valid_token_proceeds(
-        self, mcp_server, captured, monkeypatch
-    ):
-        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.x.org/mcp")
+    async def test_valid_token_proceeds(self, mcp_server, captured, monkeypatch):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
         identity = {"sub": "u1", "email": "cw@x.org", "roles": ["contributor"]}
 
         async def _resolve(token):
             return identity
 
         monkeypatch.setattr(http_server, "resolve_bearer_identity", _resolve)
-        scope = _make_scope(
-            [(b"x-mcp-mode", b"internal"), (b"authorization", b"Bearer good")]
+        await mcp_server._handle_http(
+            _make_scope([(b"authorization", b"Bearer good")]),
+            _dummy_receive,
+            _SendRecorder(),
         )
-        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
         assert captured["identity"] == identity
-        assert captured["mode"] == "internal"
+        assert captured["allowed_tools"] == ALL_TOOL_NAMES

--- a/tests/mcp/test_http_integration.py
+++ b/tests/mcp/test_http_integration.py
@@ -1,0 +1,511 @@
+"""Integration tests for the jawafdehi-mcp HTTP server bearer auth.
+
+Exercises the ASGI middleware: bearer extraction, OIDC verification (mocked),
+ContextVar lifecycle, 401 on bad tokens, anonymous fallback, and the health /
+protected-resource-metadata endpoints.
+"""
+
+import json
+
+import pytest
+
+from jawafdehi_mcp import http_server
+from jawafdehi_mcp.http_server import (
+    JawafdehiMCPServer,
+    _bearer_from_headers,
+    _canonical_base_url,
+    _max_request_body_size,
+    _mode_from_headers,
+    _protected_resource_metadata,
+    _resource_metadata_url,
+)
+from jawafdehi_mcp.identity import (
+    PUBLIC_HOST_TOOL_NAMES,
+    current_request_mode,
+    current_user_identity,
+)
+from jawafdehi_mcp.oidc import OIDCError
+from jawafdehi_mcp.request_context import current_transport, jawafdehi_bearer_token
+from jawafdehi_mcp.server import ALL_TOOL_NAMES, _get_allowed_tools
+
+
+def _make_scope(headers=None, path="/", method="POST"):
+    headers = list(headers or [])
+    if not any(name.lower() == b"host" for name, _value in headers):
+        headers.insert(0, (b"host", b"testserver"))
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "http_version": "1.1",
+        "headers": headers,
+        "query_string": b"",
+        "server": ("127.0.0.1", 8000),
+        "client": ("127.0.0.1", 12345),
+    }
+
+
+async def _dummy_receive():
+    return {"type": "http.disconnect"}
+
+
+class _SendRecorder:
+    def __init__(self):
+        self.messages = []
+
+    async def __call__(self, message):
+        self.messages.append(message)
+
+    @property
+    def status(self):
+        for m in self.messages:
+            if m["type"] == "http.response.start":
+                return m["status"]
+        return None
+
+    @property
+    def body(self):
+        for m in self.messages:
+            if m["type"] == "http.response.body":
+                return m["body"]
+        return b""
+
+
+@pytest.fixture
+def mcp_server():
+    return JawafdehiMCPServer()
+
+
+@pytest.fixture
+def captured(mcp_server, monkeypatch):
+    """Replace handle_request with a recorder of the in-request context."""
+    seen = {}
+
+    async def _recorder(scope, receive, send):
+        seen["identity"] = current_user_identity.get()
+        seen["bearer"] = jawafdehi_bearer_token.get()
+        seen["mode"] = current_request_mode.get()
+        seen["transport"] = current_transport.get()
+        seen["allowed_tools"] = {tool.name for tool in _get_allowed_tools()}
+
+    monkeypatch.setattr(mcp_server.session_manager, "handle_request", _recorder)
+    return seen
+
+
+class TestBearerHelper:
+    def test_extracts_bearer(self):
+        assert _bearer_from_headers({b"authorization": b"Bearer abc"}) == "abc"
+
+    def test_ignores_non_bearer(self):
+        assert _bearer_from_headers({b"authorization": b"Token abc"}) is None
+
+    def test_none_when_absent(self):
+        assert _bearer_from_headers({}) is None
+
+
+class TestMiddleware:
+    pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+    async def test_valid_bearer_sets_identity_and_full_catalog(
+        self, mcp_server, captured, monkeypatch
+    ):
+        identity = {"sub": "u1", "email": "a@x.org", "roles": []}
+
+        async def _resolve(token):
+            assert token == "good-token"
+            return identity
+
+        monkeypatch.setattr(http_server, "resolve_bearer_identity", _resolve)
+
+        scope = _make_scope([(b"authorization", b"Bearer good-token")])
+        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+
+        assert captured["identity"] == identity
+        assert captured["bearer"] == "good-token"
+        assert captured["transport"] == "http"
+        assert captured["allowed_tools"] == ALL_TOOL_NAMES
+        # contextvars reset after the request
+        assert current_user_identity.get() is None
+        assert current_transport.get() is None
+        assert jawafdehi_bearer_token.get() is None
+
+    async def test_invalid_bearer_returns_401(self, mcp_server, monkeypatch):
+        async def _resolve(token):
+            raise OIDCError("invalid token or signature")
+
+        monkeypatch.setattr(http_server, "resolve_bearer_identity", _resolve)
+
+        send = _SendRecorder()
+        scope = _make_scope([(b"authorization", b"Bearer bad")])
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+
+        assert send.status == 401
+        assert json.loads(send.body)["error"] == "invalid_token"
+        assert current_user_identity.get() is None
+
+    async def test_no_bearer_is_anonymous(self, mcp_server, captured, monkeypatch):
+        monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
+        scope = _make_scope([])
+        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+        assert captured["identity"] is None
+        assert captured["bearer"] is None
+        assert captured["transport"] == "http"
+        assert captured["allowed_tools"] == PUBLIC_HOST_TOOL_NAMES
+
+    async def test_no_bearer_hides_sql_without_query_token(
+        self, mcp_server, captured, monkeypatch
+    ):
+        monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
+        monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+
+        await mcp_server._handle_http(
+            _make_scope([]),
+            _dummy_receive,
+            _SendRecorder(),
+        )
+
+        assert captured["allowed_tools"] == PUBLIC_HOST_TOOL_NAMES - {
+            "ngm_query_judicial"
+        }
+
+    @pytest.mark.security
+    async def test_hostile_host_is_rejected(self, mcp_server):
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"host", b"attacker.example")]),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 421
+
+    @pytest.mark.security
+    async def test_hostile_origin_is_rejected(self, mcp_server):
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"origin", b"https://attacker.example")]),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 403
+
+    @pytest.mark.parametrize(
+        "host",
+        [b"localhost", b"localhost:48000", b"127.0.0.1:48000", b"[::1]:48000"],
+    )
+    async def test_local_hosts_are_allowed(self, mcp_server, monkeypatch, host):
+        called = False
+
+        async def recorder(scope, receive, send):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(mcp_server.session_manager, "handle_request", recorder)
+        await mcp_server._handle_http(
+            _make_scope([(b"host", host)]),
+            _dummy_receive,
+            _SendRecorder(),
+        )
+        assert called is True
+
+    async def test_canonical_host_and_origin_are_allowed(self, monkeypatch):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp.example/mcp")
+        server = JawafdehiMCPServer()
+        called = False
+
+        async def recorder(scope, receive, send):
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(server.session_manager, "handle_request", recorder)
+        await server._handle_http(
+            _make_scope(
+                [
+                    (b"host", b"mcp.example"),
+                    (b"origin", b"https://mcp.example"),
+                ]
+            ),
+            _dummy_receive,
+            _SendRecorder(),
+        )
+        assert called is True
+
+    async def test_health_endpoint_reflects_lifespan_readiness(self, mcp_server):
+        send = _SendRecorder()
+        scope = _make_scope([], path="/health", method="GET")
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 503
+
+        mcp_server._ready = True
+        send = _SendRecorder()
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 200
+
+    async def test_internal_health_requires_canonical_resource(
+        self, mcp_server, monkeypatch
+    ):
+        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+        monkeypatch.setenv("MCP_DEFAULT_MODE", "internal")
+        mcp_server._ready = True
+        send = _SendRecorder()
+
+        await mcp_server._handle_http(
+            _make_scope([], path="/health", method="GET"),
+            _dummy_receive,
+            send,
+        )
+
+        assert send.status == 503
+        assert send.body == b"not ready"
+
+    async def test_protected_resource_metadata(self, mcp_server, monkeypatch):
+        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
+        send = _SendRecorder()
+        scope = _make_scope(
+            [],
+            path="/.well-known/oauth-protected-resource",
+            method="GET",
+        )
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 200
+        meta = json.loads(send.body)
+        assert meta["resource"] == "proj-1"
+        assert meta["authorization_servers"] == ["https://auth.x.org"]
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/health", "/.well-known/oauth-protected-resource"],
+    )
+    async def test_auxiliary_endpoints_reject_non_get_methods(self, mcp_server, path):
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([], path=path, method="POST"),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 405
+
+    async def test_lifespan_starts_and_stops_session_manager(self, mcp_server):
+        messages = iter(
+            [
+                {"type": "lifespan.startup"},
+                {"type": "lifespan.shutdown"},
+            ]
+        )
+        sent = []
+
+        async def receive():
+            return next(messages)
+
+        async def send(message):
+            sent.append(message)
+
+        await mcp_server._handle_lifespan({}, receive, send)
+
+        assert [message["type"] for message in sent] == [
+            "lifespan.startup.complete",
+            "lifespan.shutdown.complete",
+        ]
+
+    async def test_session_manager_is_stateless(self, mcp_server):
+        assert mcp_server.session_manager.stateless is True
+
+
+class TestProtectedResourceMetadata:
+    def test_resource_defaults_to_audience(self, monkeypatch):
+        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "aud-1")
+        monkeypatch.setenv("OIDC_ISSUER", "https://iss.x.org")
+        meta = _protected_resource_metadata()
+        assert meta["resource"] == "aud-1"
+        assert meta["bearer_methods_supported"] == ["header"]
+
+    def test_host_aware_resource_and_scopes(self, monkeypatch):
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-9")
+        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
+        meta = _protected_resource_metadata("https://mcp-internal.x.org")
+        assert meta["resource"] == "https://mcp-internal.x.org"
+        # Design 1a: point at Zitadel directly.
+        assert meta["authorization_servers"] == ["https://auth.x.org"]
+        # Refresh + project-audience scopes advertised.
+        assert "offline_access" in meta["scopes_supported"]
+        assert "urn:zitadel:iam:org:project:id:proj-9:aud" in meta["scopes_supported"]
+
+
+class TestHeaderHelpers:
+    def test_mode_from_headers(self):
+        assert _mode_from_headers({b"x-mcp-mode": b"internal"}) == "internal"
+        assert _mode_from_headers({b"x-mcp-mode": b"Public"}) == "public"
+        assert _mode_from_headers({}) is None
+
+    def test_mode_defaults_to_env_floor(self, monkeypatch):
+        monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
+        # Missing header falls back to the deployment floor...
+        assert _mode_from_headers({}) == "public"
+        # ...but an explicit ingress-injected stricter mode still wins.
+        assert _mode_from_headers({b"x-mcp-mode": b"internal"}) == "internal"
+
+    @pytest.mark.security
+    def test_internal_default_cannot_be_downgraded_by_header(self, monkeypatch):
+        monkeypatch.setenv("MCP_DEFAULT_MODE", "internal")
+        assert _mode_from_headers({b"x-mcp-mode": b"public"}) == "internal"
+        assert _mode_from_headers({b"x-mcp-mode": b"legacy"}) == "internal"
+        assert _mode_from_headers({b"x-mcp-mode": b"\xff"}) == "internal"
+
+    @pytest.mark.security
+    def test_invalid_default_mode_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("MCP_DEFAULT_MODE", "legacy")
+        assert _mode_from_headers({}) == "public"
+
+    def test_canonical_base_prefers_configured_over_client_host(self, monkeypatch):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.jawafdehi.org/mcp")
+        # A spoofed X-Forwarded-Host / Host must NOT steer the advertised URL.
+        base = _canonical_base_url(
+            {b"x-forwarded-host": b"evil.example", b"host": b"evil.example"}
+        )
+        assert base == "https://mcp-internal.jawafdehi.org/mcp"
+
+    def test_canonical_base_ignores_host_when_unset(self, monkeypatch):
+        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+        base = _canonical_base_url({b"host": b"mcp-internal.x.org"})
+        assert base is None
+
+    def test_canonical_base_rejects_invalid_config(self, monkeypatch):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://user:pass@mcp.example/mcp")
+        assert _canonical_base_url({}) is None
+
+    def test_path_resource_uses_rfc9728_metadata_location(self):
+        assert _resource_metadata_url("https://mcp-internal.x.org/mcp") == (
+            "https://mcp-internal.x.org/.well-known/oauth-protected-resource/mcp"
+        )
+
+    def test_default_request_body_limit_covers_encoded_document(self, monkeypatch):
+        monkeypatch.delenv("MCP_DOCUMENT_MAX_INPUT_BYTES", raising=False)
+        monkeypatch.delenv("MCP_HTTP_MAX_REQUEST_BODY_BYTES", raising=False)
+        assert _max_request_body_size() == 105_906_176
+
+    def test_request_body_limit_tracks_document_limit(self, monkeypatch):
+        monkeypatch.setenv("MCP_DOCUMENT_MAX_INPUT_BYTES", "10")
+        monkeypatch.delenv("MCP_HTTP_MAX_REQUEST_BODY_BYTES", raising=False)
+        assert _max_request_body_size() == 4 * 10 + 1024 * 1024
+
+
+class TestModeDoors:
+    pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+    async def test_internal_anonymous_gets_401_challenge(self, mcp_server, monkeypatch):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.x.org/mcp")
+        send = _SendRecorder()
+        scope = _make_scope([(b"x-mcp-mode", b"internal")])
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 401
+        wa = dict(
+            (k.decode(), v.decode())
+            for k, v in next(
+                m["headers"]
+                for m in send.messages
+                if m["type"] == "http.response.start"
+            )
+        )
+        assert "resource_metadata=" in wa["www-authenticate"]
+        assert "mcp-internal.x.org" in wa["www-authenticate"]
+
+    async def test_internal_mode_requires_canonical_resource(
+        self, mcp_server, monkeypatch
+    ):
+        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+        send = _SendRecorder()
+        scope = _make_scope(
+            [
+                (b"x-mcp-mode", b"internal"),
+                (b"x-forwarded-host", b"evil.example"),
+            ]
+        )
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 503
+        assert json.loads(send.body)["error"] == "server_configuration_error"
+        assert b"evil.example" not in send.body
+
+    async def test_public_anonymous_proceeds(self, mcp_server, captured):
+        scope = _make_scope([(b"x-mcp-mode", b"public")])
+        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+        assert captured["identity"] is None
+        assert captured["mode"] == "public"
+        # contextvar reset after request
+        assert current_request_mode.get() is None
+
+    async def test_legacy_anonymous_proceeds(self, mcp_server, captured):
+        scope = _make_scope([])
+        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+        assert captured["identity"] is None
+        assert captured["mode"] is None
+
+    @pytest.mark.security
+    async def test_invalid_mode_is_restricted_to_public(self, mcp_server, captured):
+        scope = _make_scope([(b"x-mcp-mode", b"legacy")])
+        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+        assert captured["identity"] is None
+        assert captured["mode"] == "public"
+
+    async def test_metadata_ignores_spoofed_host_when_configured(
+        self, mcp_server, monkeypatch
+    ):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.jawafdehi.org/mcp")
+        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
+        send = _SendRecorder()
+        scope = _make_scope(
+            [
+                (b"x-mcp-mode", b"internal"),
+                (b"x-forwarded-host", b"evil.example"),
+            ],
+            path="/.well-known/oauth-protected-resource",
+            method="GET",
+        )
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        meta = json.loads(send.body)
+        assert meta["resource"] == "https://mcp-internal.jawafdehi.org/mcp"
+
+    async def test_public_hides_oauth_metadata(self, mcp_server):
+        send = _SendRecorder()
+        scope = _make_scope(
+            [(b"x-mcp-mode", b"public")],
+            path="/.well-known/oauth-protected-resource",
+            method="GET",
+        )
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 404
+
+    async def test_internal_serves_canonical_metadata(self, mcp_server, monkeypatch):
+        monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-1")
+        monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
+        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.x.org/mcp")
+        send = _SendRecorder()
+        scope = _make_scope(
+            [(b"x-mcp-mode", b"internal")],
+            path="/.well-known/oauth-protected-resource",
+            method="GET",
+        )
+        await mcp_server._handle_http(scope, _dummy_receive, send)
+        assert send.status == 200
+        meta = json.loads(send.body)
+        assert meta["resource"] == "https://mcp-internal.x.org/mcp"
+        assert meta["authorization_servers"] == ["https://auth.x.org"]
+
+    async def test_internal_valid_token_proceeds(
+        self, mcp_server, captured, monkeypatch
+    ):
+        monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.x.org/mcp")
+        identity = {"sub": "u1", "email": "cw@x.org", "roles": ["contributor"]}
+
+        async def _resolve(token):
+            return identity
+
+        monkeypatch.setattr(http_server, "resolve_bearer_identity", _resolve)
+        scope = _make_scope(
+            [(b"x-mcp-mode", b"internal"), (b"authorization", b"Bearer good")]
+        )
+        await mcp_server._handle_http(scope, _dummy_receive, _SendRecorder())
+        assert captured["identity"] == identity
+        assert captured["mode"] == "internal"

--- a/tests/mcp/test_http_integration.py
+++ b/tests/mcp/test_http_integration.py
@@ -5,6 +5,7 @@ ContextVar lifecycle, 401 on bad tokens, anonymous fallback, and the health /
 protected-resource-metadata endpoints.
 """
 
+import inspect
 import json
 
 import pytest
@@ -378,22 +379,27 @@ class TestHeaderHelpers:
         assert not hasattr(http_server, "MCP_DEFAULT_MODE")
         assert not hasattr(http_server, "VALID_MODES")
 
-    def test_canonical_base_prefers_configured_over_client_host(self, monkeypatch):
+    def test_canonical_base_comes_from_configuration(self, monkeypatch):
         monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.jawafdehi.org/mcp")
-        # A spoofed X-Forwarded-Host / Host must NOT steer the advertised URL.
-        base = _canonical_base_url(
-            {b"x-forwarded-host": b"evil.example", b"host": b"evil.example"}
-        )
-        assert base == "https://mcp-internal.jawafdehi.org/mcp"
+        assert _canonical_base_url() == "https://mcp-internal.jawafdehi.org/mcp"
 
-    def test_canonical_base_ignores_host_when_unset(self, monkeypatch):
+    def test_canonical_base_accepts_no_request_input(self):
+        """Header immunity is structural, not a policy this function applies.
+
+        Nothing about a request can reach the advertised security metadata,
+        because there is no parameter through which it could. The behavioural
+        counterpart is ``test_metadata_ignores_spoofed_host``, which proves it
+        end to end over the real handler.
+        """
+        assert not inspect.signature(_canonical_base_url).parameters
+
+    def test_canonical_base_is_none_when_unset(self, monkeypatch):
         monkeypatch.delenv("OIDC_RESOURCE", raising=False)
-        base = _canonical_base_url({b"host": b"mcp-internal.x.org"})
-        assert base is None
+        assert _canonical_base_url() is None
 
     def test_canonical_base_rejects_invalid_config(self, monkeypatch):
         monkeypatch.setenv("OIDC_RESOURCE", "https://user:pass@mcp.example/mcp")
-        assert _canonical_base_url({}) is None
+        assert _canonical_base_url() is None
 
     def test_path_resource_uses_rfc9728_metadata_location(self):
         assert _resource_metadata_url("https://mcp-internal.x.org/mcp") == (

--- a/tests/mcp/test_http_integration.py
+++ b/tests/mcp/test_http_integration.py
@@ -344,19 +344,25 @@ class TestMiddleware:
 
 
 class TestProtectedResourceMetadata:
-    def test_resource_defaults_to_audience(self, monkeypatch):
-        monkeypatch.delenv("OIDC_RESOURCE", raising=False)
+    def test_resource_is_the_url_never_the_audience(self, monkeypatch):
+        """RFC 9728 `resource` is a URL; the old audience fallback is gone.
+
+        It was unreachable anyway — the only caller 503s on a falsy base — but it
+        was still documented and asserted, which is how a non-conformant document
+        would have come back.
+        """
         monkeypatch.setenv("OIDC_API_AUDIENCE", "aud-1")
         monkeypatch.setenv("OIDC_ISSUER", "https://iss.x.org")
-        meta = _protected_resource_metadata()
-        assert meta["resource"] == "aud-1"
+        meta = _protected_resource_metadata("https://api.jawafdehi.org/mcp")
+        assert meta["resource"] == "https://api.jawafdehi.org/mcp"
+        assert meta["resource"] != "aud-1"
         assert meta["bearer_methods_supported"] == ["header"]
 
     def test_host_aware_resource_and_scopes(self, monkeypatch):
         monkeypatch.setenv("OIDC_API_AUDIENCE", "proj-9")
         monkeypatch.setenv("OIDC_ISSUER", "https://auth.x.org")
-        meta = _protected_resource_metadata("https://mcp-internal.x.org")
-        assert meta["resource"] == "https://mcp-internal.x.org"
+        meta = _protected_resource_metadata("https://api.jawafdehi.org/mcp")
+        assert meta["resource"] == "https://api.jawafdehi.org/mcp"
         # Design 1a: point at Zitadel directly.
         assert meta["authorization_servers"] == ["https://auth.x.org"]
         # Refresh + project-audience scopes advertised.
@@ -473,6 +479,52 @@ class TestSingleDoor:
             send,
         )
         assert json.loads(send.body)["resource"] == "https://api.jawafdehi.org/mcp"
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            b"10.42.3.17:8080",  # k8s httpGet defaults Host to the pod IP
+            b"jawafdehi-api-7d9f.default.svc",
+            b"portal.jawafdehi.org",  # some other name fronting the same pod
+        ],
+    )
+    async def test_health_answers_any_host(self, mcp_server, monkeypatch, host):
+        """A readiness probe must not have to satisfy the Host allowlist.
+
+        The regression this guards: the Host check used to run first, so a k8s
+        probe (Host = pod IP) got 421 and the pod was never marked ready. Invisible
+        locally, because the Dockerfile and compose healthchecks both use localhost.
+        """
+        monkeypatch.setenv("OIDC_RESOURCE", "https://api.jawafdehi.org/mcp")
+        mcp_server._ready = True
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"host", host)], path="/health", method="GET"),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 200
+        assert send.body == b"ready"
+
+    @pytest.mark.security
+    async def test_host_allowlist_still_guards_the_protocol_endpoint(self, mcp_server):
+        """Exempting /health must not have exempted anything else."""
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"host", b"10.42.3.17:8080")]),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 421
+
+    async def test_health_rejects_non_get(self, mcp_server):
+        send = _SendRecorder()
+        await mcp_server._handle_http(
+            _make_scope([(b"host", b"10.42.3.17:8080")], path="/health", method="POST"),
+            _dummy_receive,
+            send,
+        )
+        assert send.status == 405
 
     async def test_health_does_not_depend_on_oidc_resource(
         self, mcp_server, monkeypatch

--- a/tests/mcp/test_identity.py
+++ b/tests/mcp/test_identity.py
@@ -1,9 +1,7 @@
 """Tests for authentication-aware MCP tool catalogs."""
 
 from jawafdehi_mcp.identity import (
-    PUBLIC_HOST_TOOL_NAMES,
-    PUBLIC_READ_ONLY_TOOL_NAMES,
-    anonymous_tool_names,
+    ANONYMOUS_TOOL_NAMES,
     get_allowed_tool_names,
 )
 
@@ -18,9 +16,9 @@ class TestGetAllowedToolNames:
         "submit_nes_change",
     }
 
-    def test_none_identity_returns_public_tools(self):
+    def test_none_identity_returns_anonymous_tools(self):
         result = get_allowed_tool_names(None, self.ALL_TOOLS)
-        assert result == PUBLIC_READ_ONLY_TOOL_NAMES & self.ALL_TOOLS
+        assert result == ANONYMOUS_TOOL_NAMES & self.ALL_TOOLS
 
     def test_authenticated_identity_returns_all_tools(self):
         identity = {"sub": "1", "email": "cw@x.org", "roles": ["contributor"]}
@@ -48,10 +46,10 @@ class TestGetAllowedToolNames:
         result = get_allowed_tool_names(identity, limited_tools)
         assert result == limited_tools
 
-    def test_get_current_user_is_public(self):
-        assert "get_current_user" in PUBLIC_READ_ONLY_TOOL_NAMES
+    def test_get_current_user_is_anonymous(self):
+        assert "get_current_user" in ANONYMOUS_TOOL_NAMES
 
-    def test_public_tools_set_does_not_include_write_tools(self):
+    def test_anonymous_set_does_not_include_write_tools(self):
         write_tools = {
             "create_jawafdehi_case",
             "patch_jawafdehi_case",
@@ -59,51 +57,23 @@ class TestGetAllowedToolNames:
             "upload_material_file",
             "ngm_extract_case_data",
         }
-        assert PUBLIC_READ_ONLY_TOOL_NAMES.isdisjoint(write_tools)
+        assert ANONYMOUS_TOOL_NAMES.isdisjoint(write_tools)
 
 
-class TestPublicHostToolSet:
-    def test_public_host_drops_ocr(self):
-        assert "convert_to_markdown" not in PUBLIC_HOST_TOOL_NAMES
+class TestAnonymousToolSet:
+    """One catalog, no request modes: the header-selected doors are gone."""
 
-    def test_public_host_keeps_reads(self):
-        assert "search_jawafdehi_cases" in PUBLIC_HOST_TOOL_NAMES
-        assert "get_jawafdehi_case" in PUBLIC_HOST_TOOL_NAMES
-        assert "ngm_query_judicial" in PUBLIC_HOST_TOOL_NAMES
+    def test_document_converter_requires_authentication(self):
+        # No /api/ route backs this tool, so the catalog is its only gate.
+        assert "convert_to_markdown" not in ANONYMOUS_TOOL_NAMES
 
-    def test_public_host_is_subset_of_read_only(self):
-        assert PUBLIC_HOST_TOOL_NAMES < PUBLIC_READ_ONLY_TOOL_NAMES
+    def test_anonymous_keeps_public_reads(self):
+        assert "search_jawafdehi_cases" in ANONYMOUS_TOOL_NAMES
+        assert "get_jawafdehi_case" in ANONYMOUS_TOOL_NAMES
+        # Public court record over a SELECT-gated plane.
+        assert "ngm_query_judicial" in ANONYMOUS_TOOL_NAMES
 
-    def test_anonymous_tool_names_public_mode(self):
-        assert anonymous_tool_names("public") == PUBLIC_HOST_TOOL_NAMES
-
-    def test_anonymous_tool_names_internal_mode_full_readonly(self):
-        assert anonymous_tool_names("internal") == PUBLIC_READ_ONLY_TOOL_NAMES
-
-    def test_anonymous_tool_names_legacy_mode_full_readonly(self):
-        assert anonymous_tool_names(None) == PUBLIC_READ_ONLY_TOOL_NAMES
-
-
-class TestModeAwareGating:
-    ALL_TOOLS = {
-        "search_jawafdehi_cases",
-        "convert_to_markdown",
-        "ngm_query_judicial",
-        "create_jawafdehi_case",
-    }
-
-    def test_anonymous_public_mode_excludes_ocr_keeps_sql(self):
-        result = get_allowed_tool_names(None, self.ALL_TOOLS, "public")
-        assert "convert_to_markdown" not in result
-        assert "ngm_query_judicial" in result
-        assert "search_jawafdehi_cases" in result
-
-    def test_anonymous_internal_mode_keeps_ocr_sql(self):
-        result = get_allowed_tool_names(None, self.ALL_TOOLS, "internal")
-        assert "convert_to_markdown" in result
-        assert "ngm_query_judicial" in result
-
-    def test_authenticated_identity_unaffected_by_public_mode(self):
+    def test_document_converter_needs_no_role_beyond_authentication(self):
+        all_tools = ANONYMOUS_TOOL_NAMES | {"convert_to_markdown"}
         identity = {"sub": "1", "roles": []}
-        result = get_allowed_tool_names(identity, self.ALL_TOOLS, "public")
-        assert result == self.ALL_TOOLS
+        assert "convert_to_markdown" in get_allowed_tool_names(identity, all_tools)

--- a/tests/mcp/test_identity.py
+++ b/tests/mcp/test_identity.py
@@ -1,0 +1,109 @@
+"""Tests for authentication-aware MCP tool catalogs."""
+
+from jawafdehi_mcp.identity import (
+    PUBLIC_HOST_TOOL_NAMES,
+    PUBLIC_READ_ONLY_TOOL_NAMES,
+    anonymous_tool_names,
+    get_allowed_tool_names,
+)
+
+
+class TestGetAllowedToolNames:
+    ALL_TOOLS = {
+        "get_current_user",
+        "search_jawafdehi_cases",
+        "get_jawafdehi_case",
+        "create_jawafdehi_case",
+        "patch_jawafdehi_case",
+        "submit_nes_change",
+    }
+
+    def test_none_identity_returns_public_tools(self):
+        result = get_allowed_tool_names(None, self.ALL_TOOLS)
+        assert result == PUBLIC_READ_ONLY_TOOL_NAMES & self.ALL_TOOLS
+
+    def test_authenticated_identity_returns_all_tools(self):
+        identity = {"sub": "1", "email": "cw@x.org", "roles": ["contributor"]}
+        result = get_allowed_tool_names(identity, self.ALL_TOOLS)
+        assert result == self.ALL_TOOLS
+
+    def test_authenticated_identity_with_empty_roles_returns_all_tools(self):
+        identity = {"sub": "2", "email": "pub@x.org", "roles": []}
+        result = get_allowed_tool_names(identity, self.ALL_TOOLS)
+        assert result == self.ALL_TOOLS
+
+    def test_authenticated_identity_with_unknown_role_returns_all_tools(self):
+        identity = {"sub": "2", "email": "pub@x.org", "roles": ["unknown"]}
+        result = get_allowed_tool_names(identity, self.ALL_TOOLS)
+        assert result == self.ALL_TOOLS
+
+    def test_identity_with_no_roles_key(self):
+        identity = {"sub": "3", "email": "x@x.org"}
+        result = get_allowed_tool_names(identity, self.ALL_TOOLS)
+        assert result == self.ALL_TOOLS
+
+    def test_respects_all_tool_names_boundary(self):
+        limited_tools = {"search_jawafdehi_cases", "get_jawafdehi_case"}
+        identity = {"sub": "4", "email": "cw@x.org", "roles": ["admin"]}
+        result = get_allowed_tool_names(identity, limited_tools)
+        assert result == limited_tools
+
+    def test_get_current_user_is_public(self):
+        assert "get_current_user" in PUBLIC_READ_ONLY_TOOL_NAMES
+
+    def test_public_tools_set_does_not_include_write_tools(self):
+        write_tools = {
+            "create_jawafdehi_case",
+            "patch_jawafdehi_case",
+            "submit_nes_change",
+            "upload_material_file",
+            "ngm_extract_case_data",
+        }
+        assert PUBLIC_READ_ONLY_TOOL_NAMES.isdisjoint(write_tools)
+
+
+class TestPublicHostToolSet:
+    def test_public_host_drops_ocr(self):
+        assert "convert_to_markdown" not in PUBLIC_HOST_TOOL_NAMES
+
+    def test_public_host_keeps_reads(self):
+        assert "search_jawafdehi_cases" in PUBLIC_HOST_TOOL_NAMES
+        assert "get_jawafdehi_case" in PUBLIC_HOST_TOOL_NAMES
+        assert "ngm_query_judicial" in PUBLIC_HOST_TOOL_NAMES
+
+    def test_public_host_is_subset_of_read_only(self):
+        assert PUBLIC_HOST_TOOL_NAMES < PUBLIC_READ_ONLY_TOOL_NAMES
+
+    def test_anonymous_tool_names_public_mode(self):
+        assert anonymous_tool_names("public") == PUBLIC_HOST_TOOL_NAMES
+
+    def test_anonymous_tool_names_internal_mode_full_readonly(self):
+        assert anonymous_tool_names("internal") == PUBLIC_READ_ONLY_TOOL_NAMES
+
+    def test_anonymous_tool_names_legacy_mode_full_readonly(self):
+        assert anonymous_tool_names(None) == PUBLIC_READ_ONLY_TOOL_NAMES
+
+
+class TestModeAwareGating:
+    ALL_TOOLS = {
+        "search_jawafdehi_cases",
+        "convert_to_markdown",
+        "ngm_query_judicial",
+        "create_jawafdehi_case",
+    }
+
+    def test_anonymous_public_mode_excludes_ocr_keeps_sql(self):
+        result = get_allowed_tool_names(None, self.ALL_TOOLS, "public")
+        assert "convert_to_markdown" not in result
+        assert "ngm_query_judicial" in result
+        assert "search_jawafdehi_cases" in result
+
+    def test_anonymous_internal_mode_keeps_ocr_sql(self):
+        result = get_allowed_tool_names(None, self.ALL_TOOLS, "internal")
+        assert "convert_to_markdown" in result
+        assert "ngm_query_judicial" in result
+
+    def test_authenticated_identity_unaffected_by_public_mode(self):
+        identity = {"sub": "1", "roles": []}
+        result = get_allowed_tool_names(identity, self.ALL_TOOLS, "public")
+        assert result == self.ALL_TOOLS

--- a/tests/mcp/test_jawafdehi_search_tool.py
+++ b/tests/mcp/test_jawafdehi_search_tool.py
@@ -1,0 +1,126 @@
+"""Tests for the Jawafdehi case search / read tools.
+
+Focus: BB-03 — the search tool must not force a case_type=CORRUPTION filter
+(which hid tax-evasion and other non-corruption cases), and read tools must
+surface the API's error body (e.g. an expired forwarded token) rather than a
+bare status string.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from jawafdehi_mcp.tools.jawafdehi_cases import (
+    GetJawafdehiCaseTool,
+    SearchJawafdehiCasesTool,
+)
+
+_PATCH_TARGET = "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient"
+
+
+def _mock_async_client(response):
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = client
+    context_manager.__aexit__.return_value = False
+    return context_manager, client
+
+
+def _query_of(client):
+    """Parsed query dict of the URL the tool issued its GET against."""
+    args, _ = client.get.await_args
+    return parse_qs(urlparse(args[0]).query)
+
+
+class TestSearchJawafdehiCasesTool:
+    def setup_method(self):
+        self.tool = SearchJawafdehiCasesTool()
+
+    def test_metadata_is_not_corruption_scoped(self):
+        assert self.tool.name == "search_jawafdehi_cases"
+        # Must not advertise itself as corruption-only (BB-03).
+        assert "(corruption)" not in self.tool.description.lower()
+        assert "case_type" in self.tool.input_schema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_default_search_sends_no_case_type(self):
+        response = MagicMock()
+        response.is_success = True
+        response.json.return_value = {"count": 3, "page": 1, "results": []}
+        context_manager, client = _mock_async_client(response)
+
+        with patch(_PATCH_TARGET, return_value=context_manager):
+            await self.tool.execute({"search": "Ncell"})
+
+        query = _query_of(client)
+        assert query["type"] == ["case"]
+        assert query["q"] == ["Ncell"]
+        # BB-03: no case_type filter unless the caller explicitly asks for one.
+        assert "case_type" not in query
+
+    @pytest.mark.asyncio
+    async def test_case_type_filter_is_passed_through(self):
+        response = MagicMock()
+        response.is_success = True
+        response.json.return_value = {"count": 1, "page": 1, "results": []}
+        context_manager, client = _mock_async_client(response)
+
+        with patch(_PATCH_TARGET, return_value=context_manager):
+            await self.tool.execute({"search": "tax", "case_type": "TAX_EVASION"})
+
+        assert _query_of(client)["case_type"] == ["TAX_EVASION"]
+
+    @pytest.mark.asyncio
+    async def test_error_body_is_surfaced(self):
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 401
+        response.json.return_value = {"detail": "Token has expired."}
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(_PATCH_TARGET, return_value=context_manager):
+            result = await self.tool.execute({"search": "Ncell"})
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 401
+        assert payload["details"] == {"detail": "Token has expired."}
+
+
+class TestGetJawafdehiCaseTool:
+    def setup_method(self):
+        self.tool = GetJawafdehiCaseTool()
+
+    @pytest.mark.asyncio
+    async def test_missing_slug_errors(self):
+        result = await self.tool.execute({})
+        assert "slug" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_not_found_is_friendly(self):
+        response = MagicMock()
+        response.status_code = 404
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(_PATCH_TARGET, return_value=context_manager):
+            result = await self.tool.execute({"slug": "missing-case"})
+
+        assert "not found" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_error_body_is_surfaced(self):
+        response = MagicMock()
+        response.status_code = 401
+        response.is_success = False
+        response.json.return_value = {"detail": "Token has expired."}
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(_PATCH_TARGET, return_value=context_manager):
+            result = await self.tool.execute({"slug": "some-case"})
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 401
+        assert payload["details"] == {"detail": "Token has expired."}

--- a/tests/mcp/test_jawafdehi_write_tools.py
+++ b/tests/mcp/test_jawafdehi_write_tools.py
@@ -1,0 +1,816 @@
+"""Tests for Jawafdehi MCP create/patch write tools."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from jsonschema import Draft202012Validator
+
+from jawafdehi_mcp.request_context import (
+    current_transport,
+    jawafdehi_bearer_token,
+)
+from jawafdehi_mcp.server import TOOL_MAP
+from jawafdehi_mcp.tools.jawafdehi_cases import (
+    CASE_CREATE_FIELDS,
+    CASE_TYPE_VALUES,
+    CreateJawafdehiCaseTool,
+    DeleteJawafdehiCaseTool,
+    GetJawafdehiCaseTool,
+    PatchJawafdehiCaseTool,
+    UploadMaterialFileTool,
+    MAX_MATERIAL_UPLOAD_BYTES,
+    _get_auth_headers,
+    _has_upstream_auth,
+)
+from cases.caseworker_serializers import CaseCreateSerializer
+from cases.models import CaseState, CaseType
+
+TEST_SLUG = "ciaa-081-cr-0123-sample-case-abc123"
+
+
+@pytest.fixture(autouse=True)
+def _local_stdio_transport():
+    token = current_transport.set("stdio")
+    try:
+        yield
+    finally:
+        current_transport.reset(token)
+
+
+def _mock_async_client(response):
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    client.post = AsyncMock(return_value=response)
+    client.patch = AsyncMock(return_value=response)
+    client.delete = AsyncMock(return_value=response)
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = client
+    context_manager.__aexit__.return_value = False
+    return context_manager, client
+
+
+class TestTransportAuthBoundary:
+    @pytest.mark.security
+    def test_http_does_not_fall_back_to_service_token(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "service-token")
+        transport_token = current_transport.set("http")
+        bearer_token = jawafdehi_bearer_token.set(None)
+        try:
+            assert _get_auth_headers() == {}
+            assert _has_upstream_auth() is False
+        finally:
+            jawafdehi_bearer_token.reset(bearer_token)
+            current_transport.reset(transport_token)
+
+    def test_http_forwards_verified_caller_bearer(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "service-token")
+        transport_token = current_transport.set("http")
+        bearer_token = jawafdehi_bearer_token.set("caller-token")
+        try:
+            assert _get_auth_headers() == {"Authorization": "Bearer caller-token"}
+            assert _has_upstream_auth() is True
+        finally:
+            jawafdehi_bearer_token.reset(bearer_token)
+            current_transport.reset(transport_token)
+
+
+class TestCreateJawafdehiCaseTool:
+    def setup_method(self):
+        self.tool = CreateJawafdehiCaseTool()
+
+    def test_tool_metadata(self):
+        assert self.tool.name == "create_jawafdehi_case"
+        assert "draft Jawafdehi case" in self.tool.description
+        assert self.tool.input_schema["required"] == ["title", "case_type"]
+
+    def test_case_type_schema_matches_the_control_plane(self):
+        assert CASE_TYPE_VALUES == [value for value, _label in CaseType.choices]
+        assert self.tool.input_schema["properties"]["case_type"]["enum"] == (
+            CASE_TYPE_VALUES
+        )
+
+    def test_schema_field_set_matches_create_serializer(self):
+        serializer_fields = {
+            name
+            for name, field in CaseCreateSerializer().fields.items()
+            if not field.read_only
+        }
+
+        assert set(CASE_CREATE_FIELDS) == serializer_fields
+        assert set(self.tool.input_schema["properties"]) == serializer_fields
+        assert self.tool.input_schema["properties"]["state"]["enum"] == [
+            CaseState.DRAFT
+        ]
+
+    @pytest.mark.asyncio
+    async def test_requires_token(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+
+        result = await self.tool.execute({"title": "Case", "case_type": "CORRUPTION"})
+
+        assert "JAWAFDEHI_API_TOKEN" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_create_success(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.is_success = True
+        response.json.return_value = {"id": 7, "title": "Road contract case"}
+
+        context_manager, client = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "title": "Road contract case",
+                    "case_type": "CORRUPTION",
+                    "short_description": "Tender irregularities",
+                    "tags": ["procurement"],
+                    "key_allegations": ["Bid steering"],
+                    "notes": "Internal lead",
+                    "public_notes": "Source attribution",
+                    "alleged_entities": ["https://jawafdehi.org/entity/person/example"],
+                    "court_cases": ["https://jawafdehi.org/courtcase/special/082-cr-1"],
+                    "bigo": 17,
+                }
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["id"] == 7
+        client.post.assert_awaited_once()
+        _, kwargs = client.post.await_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert kwargs["json"]["title"] == "Road contract case"
+        assert kwargs["json"]["case_type"] == "CORRUPTION"
+        assert kwargs["json"]["short_description"] == "Tender irregularities"
+        assert kwargs["json"]["tags"] == ["procurement"]
+        assert kwargs["json"]["key_allegations"] == ["Bid steering"]
+        assert kwargs["json"]["notes"] == "Internal lead"
+        assert kwargs["json"]["public_notes"] == "Source attribution"
+        assert kwargs["json"]["bigo"] == 17
+
+    @pytest.mark.asyncio
+    async def test_create_422_passthrough(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 422
+        response.json.return_value = {
+            "title": ["Ensure this field has no more than 200 characters."]
+        }
+
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {"title": "x" * 201, "case_type": "CORRUPTION"}
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 422
+        assert payload["details"]["title"] == [
+            "Ensure this field has no more than 200 characters."
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_403_passthrough(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 403
+        response.json.return_value = {"detail": "Permission denied."}
+
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {"title": "Case", "case_type": "CORRUPTION"}
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 403
+        assert payload["details"]["detail"] == "Permission denied."
+
+
+class TestPatchJawafdehiCaseTool:
+    def setup_method(self):
+        self.tool = PatchJawafdehiCaseTool()
+
+    def test_tool_metadata(self):
+        assert self.tool.name == "patch_jawafdehi_case"
+        assert "RFC 6902" in self.tool.description
+        assert self.tool.input_schema["required"] == ["slug", "operations"]
+
+    def test_schema_enforces_json_patch_operation_contract(self):
+        validator = Draft202012Validator(self.tool.input_schema)
+        base = {"slug": TEST_SLUG}
+
+        assert validator.is_valid(
+            {
+                **base,
+                "operations": [
+                    {"op": "move", "from": "/old", "path": "/new"},
+                    {"op": "replace", "path": "/title", "value": "Updated"},
+                ],
+            }
+        )
+        assert not validator.is_valid({**base, "operations": []})
+        assert not validator.is_valid(
+            {**base, "operations": [{"op": "move", "path": "/new"}]}
+        )
+        assert not validator.is_valid(
+            {**base, "operations": [{"op": "replace", "path": "/title"}]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_requires_token(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+
+        result = await self.tool.execute(
+            {
+                "slug": TEST_SLUG,
+                "operations": [{"op": "replace", "path": "/title", "value": "Updated"}],
+            }
+        )
+
+        assert "JAWAFDEHI_API_TOKEN" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_requires_operations_list(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        result = await self.tool.execute({"slug": TEST_SLUG, "operations": {}})
+
+        assert "operations must be a non-empty JSON Patch array" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_patch_success(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.is_success = True
+        response.json.return_value = {"id": 3, "title": "Updated title"}
+        response.headers = {"etag": '"v2"'}
+
+        context_manager, client = _mock_async_client(response)
+
+        ops = [{"op": "replace", "path": "/title", "value": "Updated title"}]
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "slug": TEST_SLUG,
+                    "operations": ops,
+                    "if_match": '"v1"',
+                    "transition_reason": "Evidence verified",
+                }
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["title"] == "Updated title"
+        assert payload["etag"] == '"v2"'
+        client.patch.assert_awaited_once()
+        args, kwargs = client.patch.await_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert kwargs["headers"]["If-Match"] == '"v1"'
+        assert kwargs["headers"]["X-Transition-Reason"] == "Evidence verified"
+        assert kwargs["json"] == ops
+        assert TEST_SLUG in args[0]
+
+    @pytest.mark.asyncio
+    async def test_patch_404_passthrough(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 404
+        response.json.return_value = {"detail": "Not found."}
+
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "slug": TEST_SLUG,
+                    "operations": [{"op": "replace", "path": "/title", "value": "x"}],
+                }
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 404
+        assert payload["details"]["detail"] == "Not found."
+
+    @pytest.mark.asyncio
+    async def test_patch_422_passthrough(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.is_success = False
+        response.status_code = 422
+        response.json.return_value = {
+            "detail": "Patching path '/state' is not allowed."
+        }
+
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "slug": TEST_SLUG,
+                    "operations": [
+                        {
+                            "op": "replace",
+                            "path": "/state",
+                            "value": "PUBLISHED",
+                        }
+                    ],
+                }
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 422
+        assert "/state" in payload["details"]["detail"]
+
+
+class TestGetJawafdehiCaseTool:
+    @pytest.mark.asyncio
+    async def test_returns_etag_and_optional_transition_history(self):
+        detail = MagicMock(
+            is_success=True,
+            status_code=200,
+            headers={"etag": '"v1"'},
+        )
+        detail.json.return_value = {"slug": TEST_SLUG, "state": "IN_REVIEW"}
+        history = MagicMock(is_success=True, status_code=200, headers={})
+        history.json.return_value = {
+            "results": [{"from_state": "DRAFT", "to_state": "IN_REVIEW"}]
+        }
+        context_manager, client = _mock_async_client(detail)
+        client.get.side_effect = [detail, history]
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await GetJawafdehiCaseTool().execute(
+                {"slug": TEST_SLUG, "include_history": True}
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["etag"] == '"v1"'
+        assert payload["history"] == history.json.return_value
+        assert (
+            client.get.await_args_list[1]
+            .args[0]
+            .endswith(f"/api/cases/{TEST_SLUG}/history/")
+        )
+
+
+class TestDeleteJawafdehiCaseTool:
+    @pytest.mark.asyncio
+    async def test_soft_delete_uses_authoritative_case_endpoint(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock(is_success=True, status_code=204, headers={})
+        context_manager, client = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await DeleteJawafdehiCaseTool().execute({"slug": TEST_SLUG})
+
+        assert json.loads(result[0].text) == {
+            "success": True,
+            "status_code": 204,
+        }
+        client.delete.assert_awaited_once()
+        args, kwargs = client.delete.await_args
+        assert args[0].endswith(f"/api/cases/{TEST_SLUG}/")
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+
+
+class TestSubmitNESChangeTool:
+    def setup_method(self):
+        from jawafdehi_mcp.tools.jawafdehi_cases import SubmitNESChangeTool
+
+        self.tool = SubmitNESChangeTool()
+
+    def test_tool_metadata(self):
+        assert self.tool.name == "submit_nes_change"
+        assert self.tool.input_schema["required"] == ["action", "change_description"]
+
+    def test_schema_requires_action_specific_write_payloads(self):
+        validator = Draft202012Validator(self.tool.input_schema)
+
+        assert validator.is_valid(
+            {
+                "action": "CREATE",
+                "change_description": "create",
+                "document": {"@type": "Person"},
+            }
+        )
+        assert validator.is_valid(
+            {
+                "action": "UPDATE",
+                "change_description": "update",
+                "ref": "person/ram",
+                "patch_ops": [{"op": "remove", "path": "/description"}],
+            }
+        )
+        assert not validator.is_valid(
+            {"action": "CREATE", "change_description": "missing document"}
+        )
+        assert not validator.is_valid(
+            {
+                "action": "UPDATE",
+                "change_description": "missing patch",
+                "ref": "person/ram",
+            }
+        )
+        assert not validator.is_valid(
+            {
+                "action": "UPDATE",
+                "change_description": "empty patch",
+                "ref": "person/ram",
+                "patch_ops": [],
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_requires_auth(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+
+        result = await self.tool.execute(
+            {"action": "CREATE", "change_description": "x", "document": {}}
+        )
+
+        assert "JAWAFDEHI_API_TOKEN" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_create_posts_document(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.status_code = 201
+        response.json.return_value = {"@id": "https://jawafdehi.org/entity/person/ram"}
+
+        context_manager, client = _mock_async_client(response)
+        client.request = AsyncMock(return_value=response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "action": "CREATE",
+                    "change_description": "seed",
+                    "document": {"prefix": "person", "slug": "ram", "type": "Person"},
+                }
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["@id"].endswith("/entity/person/ram")
+        client.request.assert_awaited_once()
+        args, kwargs = client.request.await_args
+        assert args[0] == "POST"
+        assert args[1].endswith("/api/entities")
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert kwargs["json"]["change_description"] == "seed"
+
+    @pytest.mark.asyncio
+    async def test_update_patches_ref_with_ops(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"@id": "https://jawafdehi.org/entity/person/ram"}
+
+        context_manager, client = _mock_async_client(response)
+        client.request = AsyncMock(return_value=response)
+
+        ops = [{"op": "add", "path": "/name/en", "value": "Ram"}]
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "action": "UPDATE",
+                    "ref": "person/ram",
+                    "patch_ops": ops,
+                    "change_description": "add name",
+                }
+            )
+
+        assert "@id" in json.loads(result[0].text)
+        args, kwargs = client.request.await_args
+        assert args[0] == "PATCH"
+        assert args[1].endswith(
+            "/api/entities/https%3A%2F%2Fjawafdehi.org%2Fentity%2Fperson%2Fram"
+        )
+        assert kwargs["json"]["patch_ops"] == ops
+
+    @pytest.mark.asyncio
+    async def test_update_full_iri_ref_is_encoded_as_one_segment(self, monkeypatch):
+        # A full @id IRI ref must be url-encoded as a single opaque path segment
+        # (safe=''), NOT left with its scheme '//' and path slashes as route
+        # separators — otherwise the detail route can't match it.
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"@id": "x"}
+
+        context_manager, client = _mock_async_client(response)
+        client.request = AsyncMock(return_value=response)
+
+        iri = "https://portal.jawafdehi.org/entity/person/ram-chandra-poudel"
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            await self.tool.execute(
+                {
+                    "action": "UPDATE",
+                    "ref": iri,
+                    "patch_ops": [{"op": "add", "path": "/name/en", "value": "R"}],
+                    "change_description": "x",
+                }
+            )
+
+        args, _ = client.request.await_args
+        # The IRI is one encoded segment: no bare '//' from the scheme survives.
+        assert args[1].endswith(
+            "/api/entities/https%3A%2F%2Fjawafdehi.org%2Fentity%2Fperson%2Fram-chandra-poudel"
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_without_document_errors(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        result = await self.tool.execute(
+            {"action": "CREATE", "change_description": "x"}
+        )
+
+        assert "document" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_update_without_ops_errors(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        result = await self.tool.execute(
+            {"action": "UPDATE", "ref": "person/ram", "change_description": "x"}
+        )
+
+        assert "patch_ops" in result[0].text
+
+
+class TestUploadMaterialFileTool:
+    def setup_method(self):
+        self.tool = UploadMaterialFileTool()
+
+    def test_tool_metadata(self):
+        assert self.tool.name == "upload_material_file"
+        assert "Material" in self.tool.description
+        assert self.tool.input_schema["required"] == ["source", "ident", "file_path"]
+
+    @pytest.mark.asyncio
+    async def test_requires_token(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+
+        result = await self.tool.execute(
+            {"source": "nkp", "ident": "2080-order-1", "file_path": "/tmp/o.pdf"}
+        )
+
+        assert "JAWAFDEHI_API_TOKEN" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_requires_fields(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        result = await self.tool.execute({"source": "nkp", "ident": "x"})
+
+        assert "Missing required arguments" in result[0].text
+        assert "file_path" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_invalid_file_path(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        result = await self.tool.execute(
+            {"source": "nkp", "ident": "x", "file_path": "/nonexistent/broken.pdf"}
+        )
+
+        assert "Could not read file" in result[0].text
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_file_input_on_http_transport(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        with (
+            patch(
+                "jawafdehi_mcp.tools.jawafdehi_cases.Path",
+                side_effect=AssertionError("must not inspect server paths"),
+            ),
+            patch(
+                "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient"
+            ) as mock_client,
+        ):
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute(
+                    {
+                        "source": "nkp",
+                        "ident": "x",
+                        "file_path": "/etc/passwd",
+                    }
+                )
+            finally:
+                current_transport.reset(token)
+
+        assert "only supported by local stdio" in result[0].text
+        assert "cannot read server filesystem paths" in result[0].text
+        mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_success(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        pdf_file = tmp_path / "order.pdf"
+        pdf_file.write_bytes(b"pdf-content")
+
+        response = MagicMock()
+        response.status_code = 201
+        response.json.return_value = {
+            "@id": "https://jawafdehi.org/material/nkp/2080-order-1"
+        }
+
+        context_manager, client = _mock_async_client(response)
+        uploaded = {}
+
+        async def capture_upload(*args, **kwargs):
+            file_handle = kwargs["files"]["file"][1]
+            uploaded["content"] = file_handle.read()
+            uploaded["handle"] = file_handle
+            return response
+
+        client.post.side_effect = capture_upload
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {
+                    "source": "nkp",
+                    "ident": "2080-order-1",
+                    "role": "RAW",
+                    "material_type": "court_order",
+                    "source_url": "https://court.example/order/1",
+                    "skip_convert": True,
+                    "file_path": str(pdf_file),
+                }
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["@id"].endswith("/material/nkp/2080-order-1")
+        client.post.assert_awaited_once()
+        args, kwargs = client.post.await_args
+        assert args[0].endswith("/api/materials/nkp/2080-order-1/file")
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert kwargs["data"]["role"] == "RAW"
+        assert kwargs["data"]["material_type"] == "court_order"
+        assert kwargs["data"]["source_url"] == "https://court.example/order/1"
+        assert kwargs["data"]["skip_convert"] == "true"
+        assert kwargs["files"]["file"][0] == "order.pdf"
+        assert uploaded["content"] == b"pdf-content"
+        assert uploaded["handle"].closed is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_file_before_opening_or_request(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        oversized = tmp_path / "oversized.pdf"
+        with oversized.open("wb") as handle:
+            handle.truncate(MAX_MATERIAL_UPLOAD_BYTES + 1)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient"
+        ) as mock_client:
+            result = await self.tool.execute(
+                {
+                    "source": "nkp",
+                    "ident": "oversized",
+                    "file_path": str(oversized),
+                }
+            )
+
+        assert result.is_error is True
+        assert "100 MB" in result[0].text
+        mock_client.assert_not_called()
+
+    def test_upload_schema_matches_material_api_options(self):
+        properties = self.tool.input_schema["properties"]
+        assert {"MARKDOWN", "SOURCE_PAGE"}.issubset(properties["role"]["enum"])
+        assert "source_url" in properties
+        assert "skip_convert" in properties
+
+    @pytest.mark.asyncio
+    async def test_upload_defaults_role_to_raw_when_omitted(
+        self, monkeypatch, tmp_path
+    ):
+        # The schema advertises role default RAW, but that's metadata only — the
+        # tool must send RAW when the caller omits role.
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        pdf_file = tmp_path / "order.pdf"
+        pdf_file.write_bytes(b"pdf-content")
+
+        response = MagicMock()
+        response.status_code = 201
+        response.json.return_value = {"@id": "x"}
+
+        context_manager, client = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            await self.tool.execute(
+                {
+                    "source": "nkp",
+                    "ident": "2080-order-1",
+                    "material_type": "court_order",
+                    "file_path": str(pdf_file),
+                }
+            )
+
+        _, kwargs = client.post.await_args
+        assert kwargs["data"]["role"] == "RAW"
+
+    @pytest.mark.asyncio
+    async def test_upload_error_passthrough(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        pdf_file = tmp_path / "big.pdf"
+        pdf_file.write_bytes(b"small-content")
+
+        response = MagicMock()
+        response.status_code = 413
+        response.json.return_value = {
+            "detail": "Uploaded file exceeds the 100 MB limit."
+        }
+
+        context_manager, _ = _mock_async_client(response)
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            return_value=context_manager,
+        ):
+            result = await self.tool.execute(
+                {"source": "nkp", "ident": "oversize", "file_path": str(pdf_file)}
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status_code"] == 413
+        assert "100 MB" in payload["details"]["detail"]
+
+    @pytest.mark.asyncio
+    async def test_upload_http_error(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+
+        pdf_file = tmp_path / "evidence.pdf"
+        pdf_file.write_bytes(b"file-content")
+
+        with patch(
+            "jawafdehi_mcp.tools.jawafdehi_cases.httpx.AsyncClient",
+            side_effect=httpx.HTTPError("network down"),
+        ):
+            result = await self.tool.execute(
+                {"source": "nkp", "ident": "x", "file_path": str(pdf_file)}
+            )
+
+        assert "Unexpected error uploading material" in result[0].text
+
+
+def test_new_tools_registered_in_server_tool_map():
+    assert "upload_material_file" in TOOL_MAP
+    assert "submit_nes_change" in TOOL_MAP
+    assert "create_jawaf_entity" not in TOOL_MAP

--- a/tests/mcp/test_metrics.py
+++ b/tests/mcp/test_metrics.py
@@ -3,7 +3,7 @@
 import pytest
 from mcp.types import CallToolResult
 
-from jawafdehi_mcp.identity import current_request_mode, current_user_identity
+from jawafdehi_mcp.identity import current_user_identity
 from jawafdehi_mcp.request_context import current_transport
 from jawafdehi_mcp.server import TOOL_CALLS, TOOL_DURATION, call_tool
 
@@ -32,7 +32,6 @@ async def test_completed_tool_call_records_count_and_duration():
     )
 
     identity_token = current_user_identity.set(None)
-    mode_token = current_request_mode.set("public")
     transport_token = current_transport.set("http")
     try:
         result = await call_tool(
@@ -41,7 +40,6 @@ async def test_completed_tool_call_records_count_and_duration():
         )
     finally:
         current_transport.reset(transport_token)
-        current_request_mode.reset(mode_token)
         current_user_identity.reset(identity_token)
 
     assert "Converted AD 2023-01-15 to BS" in result[0].text
@@ -73,13 +71,11 @@ async def test_error_result_records_failed_outcome():
     )
 
     identity_token = current_user_identity.set(None)
-    mode_token = current_request_mode.set("public")
     transport_token = current_transport.set("http")
     try:
         result = await call_tool("convert_date", {})
     finally:
         current_transport.reset(transport_token)
-        current_request_mode.reset(mode_token)
         current_user_identity.reset(identity_token)
 
     assert isinstance(result, CallToolResult)

--- a/tests/mcp/test_metrics.py
+++ b/tests/mcp/test_metrics.py
@@ -1,0 +1,95 @@
+"""Prometheus instrumentation for embedded MCP tool execution."""
+
+import pytest
+from mcp.types import CallToolResult
+
+from jawafdehi_mcp.identity import current_request_mode, current_user_identity
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.server import TOOL_CALLS, TOOL_DURATION, call_tool
+
+
+def _sample_value(metric, sample_name, labels):
+    for family in metric.collect():
+        for sample in family.samples:
+            if sample.name == sample_name and sample.labels == labels:
+                return sample.value
+    return 0
+
+
+@pytest.mark.asyncio
+async def test_completed_tool_call_records_count_and_duration():
+    labels = {"tool": "convert_date", "outcome": "completed"}
+    duration_labels = {"tool": "convert_date"}
+    count_before = _sample_value(
+        TOOL_CALLS,
+        "jawafdehi_mcp_tool_calls_total",
+        labels,
+    )
+    duration_count_before = _sample_value(
+        TOOL_DURATION,
+        "jawafdehi_mcp_tool_duration_seconds_count",
+        duration_labels,
+    )
+
+    identity_token = current_user_identity.set(None)
+    mode_token = current_request_mode.set("public")
+    transport_token = current_transport.set("http")
+    try:
+        result = await call_tool(
+            "convert_date",
+            {"dates": ["2023-01-15"], "mode": "ad_to_bs"},
+        )
+    finally:
+        current_transport.reset(transport_token)
+        current_request_mode.reset(mode_token)
+        current_user_identity.reset(identity_token)
+
+    assert "Converted AD 2023-01-15 to BS" in result[0].text
+    assert (
+        _sample_value(
+            TOOL_CALLS,
+            "jawafdehi_mcp_tool_calls_total",
+            labels,
+        )
+        == count_before + 1
+    )
+    assert (
+        _sample_value(
+            TOOL_DURATION,
+            "jawafdehi_mcp_tool_duration_seconds_count",
+            duration_labels,
+        )
+        == duration_count_before + 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_error_result_records_failed_outcome():
+    labels = {"tool": "convert_date", "outcome": "failed"}
+    count_before = _sample_value(
+        TOOL_CALLS,
+        "jawafdehi_mcp_tool_calls_total",
+        labels,
+    )
+
+    identity_token = current_user_identity.set(None)
+    mode_token = current_request_mode.set("public")
+    transport_token = current_transport.set("http")
+    try:
+        result = await call_tool("convert_date", {})
+    finally:
+        current_transport.reset(transport_token)
+        current_request_mode.reset(mode_token)
+        current_user_identity.reset(identity_token)
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert "required parameters" in result.content[0].text
+    assert (
+        _sample_value(
+            TOOL_CALLS,
+            "jawafdehi_mcp_tool_calls_total",
+            labels,
+        )
+        == count_before + 1
+    )

--- a/tests/mcp/test_monolith_integration.py
+++ b/tests/mcp/test_monolith_integration.py
@@ -1,0 +1,367 @@
+"""Integration coverage for MCP running inside the platform ASGI process."""
+
+import json
+
+import pytest
+from asgiref.testing import ApplicationCommunicator
+from mcp.shared.version import LATEST_PROTOCOL_VERSION
+
+from config.asgi import PlatformASGIApplication, application, django_application
+from jawafdehi_mcp import __version__
+from jawafdehi_mcp import http_server
+from jawafdehi_mcp.api_transport import (
+    configure_embedded_api,
+    embedded_api_client_kwargs,
+)
+from jawafdehi_mcp.configuration import get_oidc_config
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.tools.nes import GetNESEntityPrefixesTool
+from search.service import SearchService
+
+MCP_HEADERS = [(b"accept", b"application/json, text/event-stream")]
+
+
+async def _asgi_request(
+    method,
+    path,
+    payload=None,
+    extra_headers=None,
+    asgi_application=application,
+):
+    body = json.dumps(payload).encode() if payload is not None else b""
+    headers = [(b"host", b"testserver"), *MCP_HEADERS]
+    headers.extend(extra_headers or [])
+    if payload is not None:
+        headers.append((b"content-type", b"application/json"))
+    communicator = ApplicationCommunicator(
+        asgi_application,
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "root_path": "",
+            "headers": headers,
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+        },
+    )
+    await communicator.send_input(
+        {"type": "http.request", "body": body, "more_body": False}
+    )
+    start = await communicator.receive_output(timeout=5)
+    chunks = []
+    while True:
+        message = await communicator.receive_output(timeout=5)
+        chunks.append(message.get("body", b""))
+        if not message.get("more_body", False):
+            break
+    await communicator.wait(timeout=5)
+    return start["status"], b"".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_composite_asgi_serves_django_and_mcp(monkeypatch):
+    monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+    monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
+    monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "http://testserver")
+    monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.example/mcp")
+    monkeypatch.setenv("OIDC_ISSUER", "https://auth.example")
+    monkeypatch.setenv("OIDC_API_AUDIENCE", "test-project")
+    monkeypatch.setattr(
+        SearchService,
+        "search",
+        lambda self, **kwargs: {
+            "count": 0,
+            "counts": {},
+            "results": [],
+            "page": 1,
+            "page_size": kwargs["page_size"],
+            "next_cursor": None,
+        },
+    )
+
+    lifespan = ApplicationCommunicator(
+        application,
+        {
+            "type": "lifespan",
+            "asgi": {"version": "3.0", "spec_version": "2.0"},
+            "state": {},
+        },
+    )
+    await lifespan.send_input({"type": "lifespan.startup"})
+    assert (await lifespan.receive_output(timeout=5))["type"] == (
+        "lifespan.startup.complete"
+    )
+    try:
+        mcp_health = await _asgi_request("GET", "/mcp/health")
+        api_health = await _asgi_request(
+            "GET",
+            "/api/health",
+            extra_headers=[(b"x-mcp-mode", b"internal")],
+        )
+        metadata = await _asgi_request(
+            "GET",
+            "/.well-known/oauth-protected-resource/mcp",
+            extra_headers=[(b"x-mcp-mode", b"internal")],
+        )
+        initialize = await _asgi_request(
+            "POST",
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": LATEST_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "1.0"},
+                },
+            },
+        )
+        tools = await _asgi_request(
+            "POST",
+            "/mcp",
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+        date_call = await _asgi_request(
+            "POST",
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "convert_date",
+                    "arguments": {
+                        "dates": ["2023-01-15"],
+                        "mode": "ad_to_bs",
+                    },
+                },
+            },
+        )
+        control_plane_call = await _asgi_request(
+            "POST",
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_control_plane",
+                    "arguments": {"q": "accountability"},
+                },
+            },
+        )
+        traversal_call = await _asgi_request(
+            "POST",
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "browse_court_data",
+                    "arguments": {
+                        "action": "get_court",
+                        "court": "%252e%252e",
+                    },
+                },
+            },
+        )
+    finally:
+        await lifespan.send_input({"type": "lifespan.shutdown"})
+        assert (await lifespan.receive_output(timeout=5))["type"] == (
+            "lifespan.shutdown.complete"
+        )
+        await lifespan.wait(timeout=5)
+
+    assert mcp_health[0] == 200
+    assert json.loads(api_health[1]) == {"status": "ok", "service": "jawafdehi-api"}
+    assert application._is_mcp_request({"path": "/mcp/not-a-route"}) is False
+    assert json.loads(metadata[1])["resource"] == ("https://mcp-internal.example/mcp")
+    assert initialize[0] == 200
+    server_info = json.loads(initialize[1])["result"]["serverInfo"]
+    assert server_info["name"] == "jawafdehi-mcp"
+    assert server_info["version"] == __version__
+
+    tool_names = {tool["name"] for tool in json.loads(tools[1])["result"]["tools"]}
+    assert "search_jawafdehi_cases" in tool_names
+    assert "create_jawafdehi_case" not in tool_names
+    assert "convert_to_markdown" not in tool_names
+    assert "search_control_plane" in tool_names
+
+    assert (
+        "Converted AD 2023-01-15 to BS"
+        in (json.loads(date_call[1])["result"]["content"][0]["text"])
+    )
+    control_result = json.loads(
+        json.loads(control_plane_call[1])["result"]["content"][0]["text"]
+    )
+    assert control_result["success"] is True
+    assert control_result["status_code"] == 200
+    assert control_result["data"]["count"] == 0
+    traversal_envelope = json.loads(traversal_call[1])["result"]
+    assert traversal_envelope["isError"] is True
+    traversal_result = json.loads(traversal_envelope["content"][0]["text"])
+    assert traversal_result["success"] is False
+    assert "traversal" in traversal_result["error"]
+
+
+@pytest.mark.asyncio
+async def test_roleless_bearer_gets_catalog_but_django_rejects_write(monkeypatch):
+    class EmptyGroups:
+        def values_list(self, *args, **kwargs):
+            return []
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def exists(self):
+            return False
+
+    class RolelessUser:
+        is_authenticated = True
+        is_superuser = False
+        is_staff = False
+        username = "roleless"
+        groups = EmptyGroups()
+
+    async def resolve_identity(token):
+        assert token == "verified-token"
+        return {"sub": "roleless", "roles": []}
+
+    monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "http://testserver")
+    monkeypatch.setenv("MCP_DEFAULT_MODE", "internal")
+    monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.example/mcp")
+    monkeypatch.setattr(http_server, "resolve_bearer_identity", resolve_identity)
+    monkeypatch.setattr(
+        "jawafdehi_shared.auth.oidc.OIDCAuthentication.authenticate",
+        lambda self, request: (RolelessUser(), {"sub": "roleless"}),
+    )
+
+    roleless_application = PlatformASGIApplication(
+        django_application,
+        http_server.JawafdehiMCPServer(stateless=True),
+    )
+    lifespan = ApplicationCommunicator(
+        roleless_application,
+        {
+            "type": "lifespan",
+            "asgi": {"version": "3.0", "spec_version": "2.0"},
+            "state": {},
+        },
+    )
+    await lifespan.send_input({"type": "lifespan.startup"})
+    assert (await lifespan.receive_output(timeout=5))["type"] == (
+        "lifespan.startup.complete"
+    )
+    try:
+        response = await _asgi_request(
+            "POST",
+            "/mcp",
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "manage_material",
+                    "arguments": {
+                        "action": "delete",
+                        "iri": "https://jawafdehi.org/material/court/test",
+                    },
+                },
+            },
+            extra_headers=[
+                (b"x-mcp-mode", b"internal"),
+                (b"authorization", b"Bearer verified-token"),
+            ],
+            asgi_application=roleless_application,
+        )
+    finally:
+        await lifespan.send_input({"type": "lifespan.shutdown"})
+        assert (await lifespan.receive_output(timeout=5))["type"] == (
+            "lifespan.shutdown.complete"
+        )
+        await lifespan.wait(timeout=5)
+
+    tool_envelope = json.loads(response[1])["result"]
+    assert tool_envelope["isError"] is True
+    tool_result = json.loads(tool_envelope["content"][0]["text"])
+    assert tool_result["success"] is False
+    assert tool_result["status_code"] == 403
+
+
+@pytest.mark.asyncio
+async def test_anonymous_http_tool_does_not_forward_service_token(monkeypatch):
+    seen = {}
+
+    async def fake_django(scope, receive, send):
+        seen["path"] = scope["path"]
+        seen["authorization"] = dict(scope["headers"]).get(b"authorization")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": json.dumps({"prefixes": [{"prefix": "person"}]}).encode(),
+            }
+        )
+
+    configure_embedded_api(fake_django)
+    transport_token = current_transport.set("http")
+    monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "http://testserver")
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "service-token")
+    try:
+        result = await GetNESEntityPrefixesTool().execute({})
+    finally:
+        current_transport.reset(transport_token)
+        configure_embedded_api(django_application)
+
+    assert json.loads(result[0].text)["prefixes"][0]["prefix"] == "person"
+    assert seen == {
+        "path": "/api/entity_prefixes",
+        "authorization": None,
+    }
+
+
+def test_non_http_transport_keeps_remote_client_behavior():
+    token = current_transport.set("stdio")
+    try:
+        assert embedded_api_client_kwargs() == {}
+    finally:
+        current_transport.reset(token)
+
+
+def test_mcp_oidc_config_falls_back_to_django(monkeypatch, settings):
+    monkeypatch.delenv("OIDC_API_AUDIENCE", raising=False)
+    monkeypatch.delenv("OIDC_JWKS_URL", raising=False)
+    settings.OIDC_AUDIENCE = ["project-a", "project-b"]
+    settings.OIDC_JWKS_URI = "https://auth.example/oauth/v2/keys"
+
+    assert get_oidc_config("OIDC_API_AUDIENCE") == ["project-a", "project-b"]
+    assert get_oidc_config("OIDC_JWKS_URL") == settings.OIDC_JWKS_URI
+
+
+def test_mcp_oidc_config_does_not_override_django_with_legacy_env(
+    monkeypatch, settings
+):
+    settings.OIDC_ISSUER = "https://authoritative.example"
+    settings.OIDC_AUDIENCE = "authoritative-project"
+    settings.OIDC_JWKS_URI = "https://authoritative.example/keys"
+    monkeypatch.setenv("OIDC_ISSUER", "https://legacy-override.example")
+    monkeypatch.setenv("OIDC_API_AUDIENCE", "legacy-project")
+    monkeypatch.setenv("OIDC_JWKS_URL", "https://legacy-override.example/keys")
+
+    assert get_oidc_config("OIDC_ISSUER") == settings.OIDC_ISSUER
+    assert get_oidc_config("OIDC_API_AUDIENCE") == settings.OIDC_AUDIENCE
+    assert get_oidc_config("OIDC_JWKS_URL") == settings.OIDC_JWKS_URI

--- a/tests/mcp/test_monolith_integration.py
+++ b/tests/mcp/test_monolith_integration.py
@@ -67,9 +67,8 @@ async def _asgi_request(
 @pytest.mark.asyncio
 async def test_composite_asgi_serves_django_and_mcp(monkeypatch):
     monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
-    monkeypatch.setenv("MCP_DEFAULT_MODE", "public")
     monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "http://testserver")
-    monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.example/mcp")
+    monkeypatch.setenv("OIDC_RESOURCE", "https://api.example/mcp")
     monkeypatch.setenv("OIDC_ISSUER", "https://auth.example")
     monkeypatch.setenv("OIDC_API_AUDIENCE", "test-project")
     monkeypatch.setattr(
@@ -183,7 +182,7 @@ async def test_composite_asgi_serves_django_and_mcp(monkeypatch):
     assert mcp_health[0] == 200
     assert json.loads(api_health[1]) == {"status": "ok", "service": "jawafdehi-api"}
     assert application._is_mcp_request({"path": "/mcp/not-a-route"}) is False
-    assert json.loads(metadata[1])["resource"] == ("https://mcp-internal.example/mcp")
+    assert json.loads(metadata[1])["resource"] == ("https://api.example/mcp")
     assert initialize[0] == 200
     server_info = json.loads(initialize[1])["result"]["serverInfo"]
     assert server_info["name"] == "jawafdehi-mcp"
@@ -236,8 +235,7 @@ async def test_roleless_bearer_gets_catalog_but_django_rejects_write(monkeypatch
         return {"sub": "roleless", "roles": []}
 
     monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "http://testserver")
-    monkeypatch.setenv("MCP_DEFAULT_MODE", "internal")
-    monkeypatch.setenv("OIDC_RESOURCE", "https://mcp-internal.example/mcp")
+    monkeypatch.setenv("OIDC_RESOURCE", "https://api.example/mcp")
     monkeypatch.setattr(http_server, "resolve_bearer_identity", resolve_identity)
     monkeypatch.setattr(
         "jawafdehi_shared.auth.oidc.OIDCAuthentication.authenticate",

--- a/tests/mcp/test_nes_tools.py
+++ b/tests/mcp/test_nes_tools.py
@@ -1,0 +1,208 @@
+"""Tests for NES-backed MCP tools."""
+
+import json
+
+import httpx
+import pytest
+
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.server import TOOL_MAP
+from jawafdehi_mcp.tools.nes import (
+    GetNESEntitiesTool,
+    GetNESEntityPrefixesTool,
+    SearchNESEntitiesTool,
+)
+
+
+class _FakeAsyncClient:
+    def __init__(self, get_impl):
+        self._get_impl = get_impl
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, headers=None, timeout=None):
+        return await self._get_impl(url, timeout, headers)
+
+
+class TestSearchNESEntitiesTool:
+    def setup_method(self):
+        self.tool = SearchNESEntitiesTool()
+
+    def test_schema_matches_supported_entity_filters(self):
+        schema = self.tool.input_schema
+
+        assert schema["required"] == []
+        assert set(schema["properties"]) == {
+            "entity_type",
+            "entity_prefix",
+            "query",
+            "tags",
+            "limit",
+            "offset",
+        }
+        assert "sub_type" not in schema["properties"]
+        assert schema["properties"]["limit"]["maximum"] == 100
+
+    @pytest.mark.asyncio
+    async def test_entity_type_is_optional_and_supported_filters_are_forwarded(
+        self, monkeypatch
+    ):
+        seen = {}
+
+        async def fake_get(url, timeout, headers=None):
+            seen["url"] = httpx.URL(url)
+            return httpx.Response(
+                200,
+                json={"entities": [], "total": 0, "limit": 25, "offset": 10},
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "https://api.example")
+        monkeypatch.setattr(
+            "jawafdehi_mcp.tools.nes.httpx.AsyncClient",
+            lambda **_kwargs: _FakeAsyncClient(fake_get),
+        )
+
+        result = await self.tool.execute(
+            {
+                "entity_prefix": "organization/political_party",
+                "query": "party",
+                "tags": "national,registered",
+                "limit": 25,
+                "offset": 10,
+            }
+        )
+
+        assert json.loads(result[0].text)["total"] == 0
+        assert dict(seen["url"].params) == {
+            "limit": "25",
+            "query": "party",
+            "entity_prefix": "organization/political_party",
+            "tags": "national,registered",
+            "offset": "10",
+        }
+
+
+def test_get_entities_schema_documents_canonical_iris():
+    description = (
+        GetNESEntitiesTool()
+        .input_schema["properties"]["entity_ids"]["description"]
+    )
+
+    assert "https://jawafdehi.org/entity/person/" in description
+    assert "entity:person/" not in description
+
+
+class TestGetNESEntityPrefixesTool:
+    def setup_method(self):
+        self.tool = GetNESEntityPrefixesTool()
+
+    def test_tool_name(self):
+        assert self.tool.name == "get_nes_entity_prefixes"
+
+    def test_input_schema_is_empty_object(self):
+        assert self.tool.input_schema == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    def test_tool_registered_with_server(self):
+        assert "get_nes_entity_prefixes" in TOOL_MAP
+
+    @pytest.mark.asyncio
+    async def test_successful_response(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "https://api.example")
+
+        async def fake_get(url, timeout, headers=None):
+            assert url == "https://api.example/api/entity_prefixes"
+            assert timeout == 30.0
+            return httpx.Response(
+                200,
+                json={
+                    "prefixes": [
+                        {"prefix": "person", "entity_type": "person"},
+                        {
+                            "prefix": "organization/political_party",
+                            "entity_type": "organization",
+                        },
+                    ]
+                },
+            )
+
+        monkeypatch.setattr(
+            "jawafdehi_mcp.tools.nes.httpx.AsyncClient",
+            lambda **_kwargs: _FakeAsyncClient(fake_get),
+        )
+
+        result = await self.tool.execute({})
+
+        assert len(result) == 1
+        parsed = json.loads(result[0].text)
+        assert parsed["prefixes"][0]["prefix"] == "person"
+
+    @pytest.mark.asyncio
+    async def test_non_200_response_includes_http_code(self, monkeypatch):
+        async def fake_get(url, timeout, headers=None):
+            return httpx.Response(503, json={"detail": "NES unavailable"})
+
+        monkeypatch.setattr(
+            "jawafdehi_mcp.tools.nes.httpx.AsyncClient",
+            lambda: _FakeAsyncClient(fake_get),
+        )
+
+        result = await self.tool.execute({})
+
+        assert "HTTP 503" in result[0].text
+        assert "NES unavailable" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_service_token_fallback_when_no_caller_bearer(self, monkeypatch):
+        # No forwarded caller bearer → the service token is sent as Bearer, so
+        # token-only (stdio) flows keep authenticating once NES requires auth.
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "svc-token")
+        captured = {}
+
+        async def fake_get(url, timeout, headers=None):
+            captured["headers"] = headers or {}
+            return httpx.Response(200, json={"prefixes": []})
+
+        monkeypatch.setattr(
+            "jawafdehi_mcp.tools.nes.httpx.AsyncClient",
+            lambda: _FakeAsyncClient(fake_get),
+        )
+
+        token = current_transport.set("stdio")
+        try:
+            await self.tool.execute({})
+        finally:
+            current_transport.reset(token)
+
+        assert captured["headers"].get("Authorization") == "Bearer svc-token"
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_http_does_not_fall_back_to_service_token(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "svc-token")
+        captured = {}
+
+        async def fake_get(url, timeout, headers=None):
+            captured["headers"] = headers or {}
+            return httpx.Response(200, json={"prefixes": []})
+
+        monkeypatch.setattr(
+            "jawafdehi_mcp.tools.nes.httpx.AsyncClient",
+            lambda **_kwargs: _FakeAsyncClient(fake_get),
+        )
+
+        token = current_transport.set("http")
+        try:
+            await self.tool.execute({})
+        finally:
+            current_transport.reset(token)
+
+        assert "Authorization" not in captured["headers"]

--- a/tests/mcp/test_ngm_proxy.py
+++ b/tests/mcp/test_ngm_proxy.py
@@ -1,0 +1,107 @@
+"""Tests for the NGM court-data query helper (gated SQL plane)."""
+
+import httpx
+import pytest
+
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.tools.ngm_proxy import (
+    execute_ngm_proxy_query,
+    get_jawafdehi_api_config,
+)
+
+
+class _FakeAsyncClient:
+    """Minimal async client stub whose .post returns a preset httpx.Response."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    async def post(self, url, json, headers, timeout):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_posts_to_query_plane_with_timeout_seconds():
+    resp = httpx.Response(
+        200, json={"columns": ["a"], "rows": [[1]], "row_count": 1, "query_time_ms": 7}
+    )
+    client = _FakeAsyncClient(resp)
+
+    out = await execute_ngm_proxy_query(
+        client, "https://portal.jawafdehi.org", "svc-token", "SELECT 1", timeout=9
+    )
+
+    # Path + renamed param + Bearer auth.
+    assert client.calls[0]["url"] == "https://portal.jawafdehi.org/api/query/"
+    assert client.calls[0]["json"] == {"query": "SELECT 1", "timeout_seconds": 9}
+    assert client.calls[0]["headers"]["Authorization"] == "Bearer svc-token"
+    # Flat response normalized back into the legacy {success, data} envelope.
+    assert out["success"] is True
+    assert out["data"] == {"columns": ["a"], "rows": [[1]], "row_count": 1}
+    assert out["query_time_ms"] == 7
+
+
+@pytest.mark.asyncio
+async def test_error_status_raises_with_payload():
+    resp = httpx.Response(400, json={"detail": "forbidden: SELECT-only"})
+    client = _FakeAsyncClient(resp)
+
+    with pytest.raises(RuntimeError, match="NGM query failed"):
+        await execute_ngm_proxy_query(
+            client, "https://x", None, "DROP TABLE court_cases"
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_json_on_success_raises_not_silently_empty():
+    # A 200 with a non-JSON body (empty / HTML proxy page) must raise, not return
+    # an empty successful result.
+    resp = httpx.Response(200, text="<html>gateway timeout</html>")
+    client = _FakeAsyncClient(resp)
+
+    with pytest.raises(RuntimeError, match="Non-JSON response from query endpoint"):
+        await execute_ngm_proxy_query(client, "https://x", None, "SELECT 1")
+
+
+@pytest.mark.asyncio
+async def test_non_json_on_error_status_raises_query_failed():
+    resp = httpx.Response(502, text="<html>bad gateway</html>")
+    client = _FakeAsyncClient(resp)
+
+    with pytest.raises(RuntimeError, match="NGM query failed"):
+        await execute_ngm_proxy_query(client, "https://x", None, "SELECT 1")
+
+
+def test_http_query_uses_only_dedicated_query_token(monkeypatch):
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "full-stdio-token")
+    monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+    transport = current_transport.set("http")
+    try:
+        _base_url, token = get_jawafdehi_api_config()
+    finally:
+        current_transport.reset(transport)
+
+    assert token is None
+
+
+def test_stdio_query_can_fall_back_to_full_local_token(monkeypatch):
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "full-stdio-token")
+    monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+    transport = current_transport.set("stdio")
+    try:
+        _base_url, token = get_jawafdehi_api_config()
+    finally:
+        current_transport.reset(transport)
+
+    assert token == "full-stdio-token"
+
+
+def test_dedicated_query_token_wins_in_all_transports(monkeypatch):
+    monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "full-stdio-token")
+    monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
+
+    _base_url, token = get_jawafdehi_api_config()
+
+    assert token == "query-only-token"

--- a/tests/mcp/test_ngm_proxy.py
+++ b/tests/mcp/test_ngm_proxy.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 
-from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.request_context import current_transport, jawafdehi_bearer_token
 from jawafdehi_mcp.tools.ngm_proxy import (
     execute_ngm_proxy_query,
     get_jawafdehi_api_config,
@@ -33,9 +33,15 @@ async def test_posts_to_query_plane_with_timeout_seconds():
         client, "https://portal.jawafdehi.org", "svc-token", "SELECT 1", timeout=9
     )
 
-    # Path + renamed param + Bearer auth.
+    # Path + renamed param + Bearer auth. `public_projection` is present because
+    # no caller bearer was forwarded and the transport is not stdio — see
+    # TestPublicProjectionFlag below.
     assert client.calls[0]["url"] == "https://portal.jawafdehi.org/api/query/"
-    assert client.calls[0]["json"] == {"query": "SELECT 1", "timeout_seconds": 9}
+    assert client.calls[0]["json"] == {
+        "query": "SELECT 1",
+        "timeout_seconds": 9,
+        "public_projection": True,
+    }
     assert client.calls[0]["headers"]["Authorization"] == "Bearer svc-token"
     # Flat response normalized back into the legacy {success, data} envelope.
     assert out["success"] is True
@@ -105,3 +111,60 @@ def test_dedicated_query_token_wins_in_all_transports(monkeypatch):
     _base_url, token = get_jawafdehi_api_config()
 
     assert token == "query-only-token"
+
+
+class TestPublicProjectionFlag:
+    """The anonymous SQL path must ASK for the narrow plane, not infer it.
+
+    ``ngm_query_judicial`` is reachable anonymously and authenticates upstream with
+    a shared service account. The API decides disclosure from role membership, so
+    provisioning that account with ReadOnly (or any NGM role) would have handed the
+    unprojected internal plane — soft-deleted rows, ``is_deleted``, every internal
+    column — to the open internet. These pin that the request no longer depends on
+    how the account is configured.
+    """
+
+    @staticmethod
+    def _client():
+        return _FakeAsyncClient(
+            httpx.Response(
+                200,
+                json={"columns": [], "rows": [], "row_count": 0, "query_time_ms": 1},
+            )
+        )
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_anonymous_http_forces_the_public_projection(self):
+        client = self._client()
+        token = current_transport.set("http")
+        try:
+            await execute_ngm_proxy_query(client, "https://x", "svc-token", "SELECT 1")
+        finally:
+            current_transport.reset(token)
+        assert client.calls[0]["json"]["public_projection"] is True
+
+    @pytest.mark.asyncio
+    async def test_forwarded_caller_bearer_does_not_force_it(self):
+        """A real user's own bearer decides its own disclosure, as before."""
+        client = self._client()
+        transport = current_transport.set("http")
+        bearer = jawafdehi_bearer_token.set("caller-token")
+        try:
+            await execute_ngm_proxy_query(client, "https://x", "svc-token", "SELECT 1")
+        finally:
+            jawafdehi_bearer_token.reset(bearer)
+            current_transport.reset(transport)
+        assert "public_projection" not in client.calls[0]["json"]
+        assert client.calls[0]["headers"]["Authorization"] == "Bearer caller-token"
+
+    @pytest.mark.asyncio
+    async def test_stdio_service_token_keeps_the_internal_plane(self):
+        """A trusted local operator is entitled to it; this must not change."""
+        client = self._client()
+        token = current_transport.set("stdio")
+        try:
+            await execute_ngm_proxy_query(client, "https://x", "svc-token", "SELECT 1")
+        finally:
+            current_transport.reset(token)
+        assert "public_projection" not in client.calls[0]["json"]

--- a/tests/mcp/test_oidc.py
+++ b/tests/mcp/test_oidc.py
@@ -1,0 +1,323 @@
+"""Tests for OIDC bearer-token verification and identity resolution."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from jawafdehi_shared.auth import oidc as platform_oidc
+from jawafdehi_mcp import oidc
+
+ISSUER = "https://auth.test.invalid"
+AUDIENCE = "test-project-id"
+
+
+@pytest.fixture(autouse=True)
+def _oidc_settings(settings):
+    settings.OIDC_ISSUER = ISSUER
+    settings.OIDC_AUDIENCE = AUDIENCE
+    settings.OIDC_JWKS_URI = "https://auth.test.invalid/keys"
+    settings.OIDC_OP_USER_ENDPOINT = "https://auth.test.invalid/userinfo"
+    settings.OIDC_ALGORITHMS = ["RS256"]
+    settings.OIDC_LEEWAY = 30
+    # Reset module caches between tests.
+    platform_oidc.reset_jwks_client()
+    oidc._userinfo_cache.clear()
+    yield
+    platform_oidc.reset_jwks_client()
+
+
+@pytest.fixture
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(autouse=True)
+def _fake_jwks(monkeypatch, rsa_key):
+    """Make verify use our test key instead of fetching a real JWKS."""
+
+    class _SigningKey:
+        key = rsa_key.public_key()
+        key_id = "test-key"
+
+    class _FakeClient:
+        def get_signing_keys(self, refresh=False):
+            return [_SigningKey()]
+
+        @staticmethod
+        def match_kid(signing_keys, kid):
+            return next(
+                (key for key in signing_keys if key.key_id == kid),
+                None,
+            )
+
+    monkeypatch.setattr(platform_oidc, "_get_jwks_client", lambda: _FakeClient())
+
+
+def _mint(rsa_key, *, missing=(), headers=None, **overrides):
+    now = int(time.time())
+    payload = {
+        "sub": "user-123",
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "exp": now + 300,
+        "iat": now,
+        "jti": "jti-1",
+    }
+    payload.update(overrides)
+    for claim in missing:
+        payload.pop(claim, None)
+    return jwt.encode(
+        payload,
+        rsa_key,
+        algorithm="RS256",
+        headers=headers or {"kid": "test-key"},
+    )
+
+
+class TestVerifyBearerToken:
+    def test_valid_token(self, rsa_key):
+        claims = oidc.verify_bearer_token(_mint(rsa_key))
+        assert claims["sub"] == "user-123"
+
+    def test_jwe_rejected(self):
+        with pytest.raises(oidc.OIDCError):
+            oidc.verify_bearer_token("a.b.c.d.e")
+
+    def test_wrong_audience(self, rsa_key):
+        with pytest.raises(oidc.OIDCError):
+            oidc.verify_bearer_token(_mint(rsa_key, aud="other"))
+
+    def test_wrong_issuer(self, rsa_key):
+        with pytest.raises(oidc.OIDCError):
+            oidc.verify_bearer_token(_mint(rsa_key, iss="https://evil.invalid"))
+
+    def test_expired(self, rsa_key):
+        # Beyond the clock-skew leeway (_CLOCK_SKEW_LEEWAY) so it's unambiguously
+        # expired.
+        with pytest.raises(oidc.OIDCError):
+            oidc.verify_bearer_token(_mint(rsa_key, exp=int(time.time()) - 3600))
+
+    def test_expired_within_clock_skew_leeway_is_allowed(self, rsa_key):
+        # A token just past exp (within leeway) is tolerated for clock drift.
+        skew = 25
+        claims = oidc.verify_bearer_token(_mint(rsa_key, exp=int(time.time()) - skew))
+        assert claims["sub"] == "user-123"
+
+    @pytest.mark.parametrize("claim", ["iat", "sub"])
+    def test_requires_same_identity_claims_as_django(self, rsa_key, claim):
+        with pytest.raises(oidc.OIDCError):
+            oidc.verify_bearer_token(_mint(rsa_key, missing=(claim,)))
+
+    def test_missing_issuer_config(self, rsa_key, settings):
+        settings.OIDC_ISSUER = ""
+        with pytest.raises(oidc.OIDCError):
+            oidc.verify_bearer_token(_mint(rsa_key))
+
+
+class TestSigningKeyRefetch:
+    """The kid-miss JWKS refetch is rate-limited so forged/unknown kids can't
+    force a fetch per request (DoS / cache-bust)."""
+
+    def test_refetch_is_rate_limited(self, monkeypatch, rsa_key):
+        calls = []
+
+        class _AlwaysMiss:
+            def get_signing_keys(self, refresh=False):
+                calls.append(refresh)
+                return []
+
+            @staticmethod
+            def match_kid(signing_keys, kid):
+                return None
+
+        monkeypatch.setattr(platform_oidc, "_get_jwks_client", lambda: _AlwaysMiss())
+        platform_oidc._jwks_last_refresh = 0.0
+        token = _mint(rsa_key, headers={"kid": "unknown"})
+
+        # First miss checks the cache and then performs one forced refresh.
+        with pytest.raises(jwt.exceptions.PyJWKClientError):
+            platform_oidc._signing_key_for(token)
+        assert calls == [False, True]
+
+        # An immediate second miss checks the cache but cannot force network I/O.
+        with pytest.raises(jwt.exceptions.PyJWKClientError):
+            platform_oidc._signing_key_for(token)
+        assert calls == [False, True, False]
+
+    def test_refetch_allowed_after_interval(self, monkeypatch, rsa_key):
+        calls = []
+
+        class _AlwaysMiss:
+            def get_signing_keys(self, refresh=False):
+                calls.append(refresh)
+                return []
+
+            @staticmethod
+            def match_kid(signing_keys, kid):
+                return None
+
+        monkeypatch.setattr(platform_oidc, "_get_jwks_client", lambda: _AlwaysMiss())
+        # Pretend the last refetch was long enough ago.
+        platform_oidc._jwks_last_refresh = (
+            time.monotonic() - platform_oidc._JWKS_MIN_REFRESH_INTERVAL - 1
+        )
+        with pytest.raises(jwt.exceptions.PyJWKClientError):
+            platform_oidc._signing_key_for(
+                _mint(rsa_key, headers={"kid": "still-unknown"})
+            )
+        assert calls == [False, True]
+
+
+class TestBuildIdentity:
+    def test_builds_from_userinfo(self):
+        claims = {"sub": "abc"}
+        info = {
+            "email": "Jane@Example.ORG",
+            "name": "Jane Doe",
+            "roles": ["contributor", "staff"],
+        }
+        identity = oidc.build_identity(claims, info)
+        assert identity == {
+            "sub": "abc",
+            "email": "jane@example.org",
+            "name": "Jane Doe",
+            "roles": ["contributor", "staff"],
+        }
+
+    def test_name_falls_back_to_given_family(self):
+        identity = oidc.build_identity(
+            {"sub": "x"},
+            {"given_name": "Ram", "family_name": "Sharma", "email": "r@x.org"},
+        )
+        assert identity["name"] == "Ram Sharma"
+
+    def test_non_list_roles_become_empty(self):
+        identity = oidc.build_identity({"sub": "x"}, {"roles": "contributor"})
+        assert identity["roles"] == []
+
+
+class TestDevelopmentIdentity:
+    def test_requires_both_testing_and_dev_auth(self, settings):
+        settings.TESTING = True
+        settings.DEV_AUTH = False
+        settings.DEV_NGM_QUERY_TOKEN = "e2e-token"
+
+        assert oidc._development_identity("e2e-token") is None
+
+        settings.TESTING = False
+        settings.DEV_AUTH = True
+        assert oidc._development_identity("e2e-token") is None
+
+    def test_rejects_a_different_token(self, settings):
+        settings.TESTING = True
+        settings.DEV_AUTH = True
+        settings.DEV_NGM_QUERY_TOKEN = "e2e-token"
+
+        assert oidc._development_identity("wrong-token") is None
+
+    @pytest.mark.asyncio
+    async def test_resolves_guarded_e2e_token_without_jwks(
+        self, monkeypatch, settings
+    ):
+        settings.TESTING = True
+        settings.DEV_AUTH = True
+        settings.DEV_NGM_QUERY_TOKEN = "e2e-token"
+        settings.DEV_NGM_QUERY_USERNAME = "mcp-query-e2e"
+        verify = MagicMock(side_effect=AssertionError("JWKS must not be used"))
+        monkeypatch.setattr(oidc, "verify_bearer_token", verify)
+
+        identity = await oidc.resolve_bearer_identity("e2e-token")
+
+        assert identity == {
+            "sub": "mcp-query-e2e",
+            "email": None,
+            "name": "mcp-query-e2e",
+            "roles": [],
+        }
+        verify.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestFetchUserinfo:
+    async def test_caches_per_token(self, monkeypatch):
+        calls = {"n": 0}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"email": "a@x.org", "roles": ["admin"]}
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, *a, **k):
+                calls["n"] += 1
+                return _Resp()
+
+        monkeypatch.setattr(oidc.httpx, "AsyncClient", lambda *a, **k: _Client())
+
+        claims = {"jti": "t1", "exp": time.time() + 300}
+        first = await oidc.fetch_userinfo("tok", claims)
+        second = await oidc.fetch_userinfo("tok", claims)
+        assert first == second
+        assert calls["n"] == 1
+
+    async def test_cache_key_is_token_specific_without_jti(self, monkeypatch):
+        calls = {"n": 0}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"email": "a@x.org"}
+
+        class _Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, *args, **kwargs):
+                calls["n"] += 1
+                return _Resp()
+
+        monkeypatch.setattr(oidc.httpx, "AsyncClient", lambda *a, **k: _Client())
+        claims = {"sub": "same-user", "exp": time.time() + 300}
+
+        await oidc.fetch_userinfo("token-a", claims)
+        await oidc.fetch_userinfo("token-b", claims)
+
+        assert calls["n"] == 2
+
+    async def test_verified_token_survives_userinfo_failure(self, monkeypatch):
+        claims = {
+            "sub": "machine-user",
+            "email": "machine@example.org",
+            "roles": ["contributor"],
+        }
+        monkeypatch.setattr(oidc, "verify_bearer_token", lambda token: claims)
+        monkeypatch.setattr(
+            oidc,
+            "fetch_userinfo",
+            AsyncMock(side_effect=oidc.OIDCError("userinfo unavailable")),
+        )
+
+        identity = await oidc.resolve_bearer_identity("verified-token")
+
+        assert identity == {
+            "sub": "machine-user",
+            "email": "machine@example.org",
+            "name": None,
+            "roles": ["contributor"],
+        }

--- a/tests/mcp/test_oidc.py
+++ b/tests/mcp/test_oidc.py
@@ -137,15 +137,20 @@ class TestSigningKeyRefetch:
         platform_oidc._jwks_last_refresh = 0.0
         token = _mint(rsa_key, headers={"kid": "unknown"})
 
-        # First miss checks the cache and then performs one forced refresh.
+        # Two cached reads per miss: one outside _jwks_lock (kept out of it so a
+        # slow JWKS endpoint cannot serialise every authentication) and one
+        # re-check inside it, so a kid a concurrent refresh just landed is found
+        # instead of being rejected by the rate limit below.
         with pytest.raises(jwt.exceptions.PyJWKClientError):
             platform_oidc._signing_key_for(token)
-        assert calls == [False, True]
+        assert calls == [False, False, True]
 
         # An immediate second miss checks the cache but cannot force network I/O.
         with pytest.raises(jwt.exceptions.PyJWKClientError):
             platform_oidc._signing_key_for(token)
-        assert calls == [False, True, False]
+        assert calls == [False, False, True, False, False]
+        # The property that matters: exactly one forced refresh across both.
+        assert calls.count(True) == 1
 
     def test_refetch_allowed_after_interval(self, monkeypatch, rsa_key):
         calls = []
@@ -168,7 +173,7 @@ class TestSigningKeyRefetch:
             platform_oidc._signing_key_for(
                 _mint(rsa_key, headers={"kid": "still-unknown"})
             )
-        assert calls == [False, True]
+        assert calls == [False, False, True]
 
 
 class TestBuildIdentity:

--- a/tests/mcp/test_package_metadata.py
+++ b/tests/mcp/test_package_metadata.py
@@ -1,0 +1,26 @@
+"""Packaging contract for the embedded MCP component."""
+
+from importlib.metadata import version
+from pathlib import Path
+
+import jawafdehi_mcp
+from jawafdehi_mcp.server import app
+
+
+def test_mcp_version_comes_from_monolith_package_metadata():
+    assert jawafdehi_mcp.__version__ == version("jawafdehi")
+
+
+def test_mcp_server_info_reports_monolith_package_version():
+    options = app.create_initialization_options()
+
+    assert options.server_name == "jawafdehi-mcp"
+    assert options.server_version == jawafdehi_mcp.__version__
+
+
+def test_mcp_license_is_packaged_with_the_module():
+    license_path = Path(jawafdehi_mcp.__file__).with_name("LICENSE")
+    assert license_path.is_file()
+    assert license_path.read_text(encoding="utf-8").startswith(
+        "Hippocratic License Version 3.0"
+    )

--- a/tests/mcp/test_server_profile.py
+++ b/tests/mcp/test_server_profile.py
@@ -16,6 +16,7 @@ from jawafdehi_mcp.server import (
     _get_allowed_tools,
     _has_api_token,
     _is_tool_allowed,
+    call_tool,
 )
 
 
@@ -151,6 +152,60 @@ class TestAllowedTools:
             assert len(tools) == len(TOOL_MAP)
         finally:
             current_user_identity.set(None)
+
+
+class TestCallToolEnforcesTheCatalog:
+    """The catalog must gate INVOCATION, not just what `tools/list` advertises.
+
+    These go through ``call_tool`` rather than asserting ``_is_tool_allowed``,
+    because the predicate being correct is worth nothing if the dispatcher stops
+    consulting it. Deleting the check in ``call_tool`` previously left the whole
+    suite green — for ``convert_to_markdown``, which no ``/api/`` permission backs,
+    that check is the only thing standing between an anonymous caller and the tool.
+    """
+
+    pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+    @pytest.mark.security
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["convert_to_markdown", "create_jawafdehi_case", "manage_jobs"],
+    )
+    async def test_anonymous_invocation_is_refused(self, monkeypatch, tool_name):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        token = current_user_identity.set(None)
+        try:
+            with pytest.raises(ValueError, match=tool_name):
+                await call_tool(tool_name, {})
+        finally:
+            current_user_identity.reset(token)
+
+    @pytest.mark.security
+    async def test_anonymous_invocation_of_unconfigured_query_tool_is_refused(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+        token = current_user_identity.set(None)
+        try:
+            with pytest.raises(ValueError, match="ngm_query_judicial"):
+                await call_tool("ngm_query_judicial", {"query": "SELECT 1"})
+        finally:
+            current_user_identity.reset(token)
+
+    async def test_anonymous_invocation_of_an_allowed_tool_is_not_refused(
+        self, monkeypatch
+    ):
+        """The guard must refuse the right things and only those."""
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        token = current_user_identity.set(None)
+        try:
+            result = await call_tool(
+                "convert_date", {"dates": ["2023-01-15"], "mode": "ad_to_bs"}
+            )
+        finally:
+            current_user_identity.reset(token)
+        assert "Converted AD 2023-01-15 to BS" in result[0].text
 
 
 class TestIsToolAllowed:

--- a/tests/mcp/test_server_profile.py
+++ b/tests/mcp/test_server_profile.py
@@ -5,8 +5,7 @@ from contextlib import contextmanager
 import pytest
 
 from jawafdehi_mcp.identity import (
-    PUBLIC_HOST_TOOL_NAMES,
-    PUBLIC_READ_ONLY_TOOL_NAMES,
+    ANONYMOUS_TOOL_NAMES,
     current_user_identity,
     get_allowed_tool_names,
 )
@@ -64,10 +63,10 @@ class TestHasApiToken:
 
 
 class TestGetAllowedToolNames:
-    def test_no_identity_returns_only_public(self):
+    def test_no_identity_returns_only_anonymous(self):
         all_names = set(TOOL_MAP.keys())
         result = get_allowed_tool_names(None, all_names)
-        assert result == PUBLIC_READ_ONLY_TOOL_NAMES
+        assert result == ANONYMOUS_TOOL_NAMES
 
     def test_authenticated_identity_returns_all(self):
         all_names = set(TOOL_MAP.keys())
@@ -95,16 +94,16 @@ class TestAllowedTools:
         current_user_identity.set(None)
         tools = _get_allowed_tools()
         tool_names = {t.name for t in tools}
-        assert tool_names == PUBLIC_READ_ONLY_TOOL_NAMES - {"ngm_query_judicial"}
+        assert tool_names == ANONYMOUS_TOOL_NAMES - {"ngm_query_judicial"}
 
-    def test_no_identity_with_query_token_returns_full_public_set(self, monkeypatch):
+    def test_no_identity_with_query_token_returns_full_anonymous_set(self, monkeypatch):
         monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
         monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
         current_user_identity.set(None)
 
         tool_names = {tool.name for tool in _get_allowed_tools()}
 
-        assert tool_names == PUBLIC_READ_ONLY_TOOL_NAMES
+        assert tool_names == ANONYMOUS_TOOL_NAMES
 
     def test_token_mode_no_user_returns_all(self, monkeypatch):
         """A stdio service token with no identity receives all tools."""
@@ -129,7 +128,7 @@ class TestAllowedTools:
         current_user_identity.set(None)
         with _using_transport("http"):
             tool_names = {tool.name for tool in _get_allowed_tools()}
-        assert tool_names == PUBLIC_READ_ONLY_TOOL_NAMES - {"ngm_query_judicial"}
+        assert tool_names == ANONYMOUS_TOOL_NAMES - {"ngm_query_judicial"}
 
     def test_authenticated_identity_returns_all(self, monkeypatch):
         """An authenticated identity gets all tools."""
@@ -237,11 +236,11 @@ class TestPublicToolSetIntegrity:
         "convert_to_markdown",
     }
 
-    def test_all_public_tools_exist_in_tool_map(self):
-        for name in PUBLIC_READ_ONLY_TOOL_NAMES:
-            assert name in TOOL_MAP, f"Public tool '{name}' not found in TOOL_MAP"
+    def test_all_anonymous_tools_exist_in_tool_map(self):
+        for name in ANONYMOUS_TOOL_NAMES:
+            assert name in TOOL_MAP, f"Anonymous tool '{name}' not found in TOOL_MAP"
 
-    def test_public_tools_are_read_only(self):
+    def test_anonymous_tools_are_read_only(self):
         write_tool_names = {
             "create_jawafdehi_case",
             "delete_nes_entity",
@@ -255,10 +254,10 @@ class TestPublicToolSetIntegrity:
             "upload_material_file",
             "ngm_extract_case_data",
         }
-        assert PUBLIC_READ_ONLY_TOOL_NAMES.isdisjoint(write_tool_names)
+        assert ANONYMOUS_TOOL_NAMES.isdisjoint(write_tool_names)
 
-    def test_private_tools_not_in_public_set(self):
-        private_tools = set(TOOL_MAP.keys()) - PUBLIC_READ_ONLY_TOOL_NAMES
+    def test_private_tools_not_in_anonymous_set(self):
+        private_tools = set(TOOL_MAP.keys()) - ANONYMOUS_TOOL_NAMES
         assert len(private_tools) > 0
         assert "create_jawafdehi_case" in private_tools
         assert "upload_material_file" in private_tools
@@ -267,8 +266,8 @@ class TestPublicToolSetIntegrity:
         assert ALL_TOOL_NAMES == self.EXPECTED_ALL_TOOL_NAMES
         assert len(ALL_TOOL_NAMES) == 26
 
-    def test_private_tool_set(self):
-        assert ALL_TOOL_NAMES - PUBLIC_READ_ONLY_TOOL_NAMES == {
+    def test_authentication_required_tool_set(self):
+        assert ALL_TOOL_NAMES - ANONYMOUS_TOOL_NAMES == {
             "ngm_extract_case_data",
             "create_jawafdehi_case",
             "patch_jawafdehi_case",
@@ -281,16 +280,17 @@ class TestPublicToolSetIntegrity:
             "manage_case_update_proposals",
             "manage_casework_reviews",
             "manage_jobs",
+            # Authentication required, but no role beyond it — no /api/ route
+            # backs this tool, so the catalog is its only gate.
+            "convert_to_markdown",
         }
 
-    def test_public_tools_count(self):
+    def test_anonymous_tools_count(self):
         assert {
             "search_control_plane",
             "get_nes_entity_versions",
             "browse_materials",
             "browse_court_data",
-        }.issubset(PUBLIC_READ_ONLY_TOOL_NAMES)
-        assert len(PUBLIC_READ_ONLY_TOOL_NAMES) == 14
-        assert PUBLIC_HOST_TOOL_NAMES == PUBLIC_READ_ONLY_TOOL_NAMES - {
-            "convert_to_markdown"
-        }
+        }.issubset(ANONYMOUS_TOOL_NAMES)
+        assert len(ANONYMOUS_TOOL_NAMES) == 13
+        assert "convert_to_markdown" not in ANONYMOUS_TOOL_NAMES

--- a/tests/mcp/test_server_profile.py
+++ b/tests/mcp/test_server_profile.py
@@ -1,0 +1,296 @@
+"""Tests for authentication-aware tool catalogs in jawafdehi-mcp."""
+
+from contextlib import contextmanager
+
+import pytest
+
+from jawafdehi_mcp.identity import (
+    PUBLIC_HOST_TOOL_NAMES,
+    PUBLIC_READ_ONLY_TOOL_NAMES,
+    current_user_identity,
+    get_allowed_tool_names,
+)
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.server import (
+    ALL_TOOL_NAMES,
+    TOOL_MAP,
+    _get_allowed_tools,
+    _has_api_token,
+    _is_tool_allowed,
+)
+
+
+@contextmanager
+def _using_transport(name: str | None):
+    token = current_transport.set(name)
+    try:
+        yield
+    finally:
+        current_transport.reset(token)
+
+
+class TestHasApiToken:
+    def test_has_token_when_set(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token-123")
+        with _using_transport("stdio"):
+            assert _has_api_token() is True
+
+    def test_has_no_token_when_unset(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        with _using_transport("stdio"):
+            assert _has_api_token() is False
+
+    def test_has_no_token_when_empty(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "")
+        with _using_transport("stdio"):
+            assert _has_api_token() is False
+
+    def test_has_no_token_when_whitespace(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "   ")
+        with _using_transport("stdio"):
+            assert _has_api_token() is False
+
+    @pytest.mark.security
+    def test_http_transport_cannot_use_service_token(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token-123")
+        with _using_transport("http"):
+            assert _has_api_token() is False
+
+    @pytest.mark.security
+    def test_unknown_transport_cannot_use_service_token(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token-123")
+        with _using_transport(None):
+            assert _has_api_token() is False
+
+
+class TestGetAllowedToolNames:
+    def test_no_identity_returns_only_public(self):
+        all_names = set(TOOL_MAP.keys())
+        result = get_allowed_tool_names(None, all_names)
+        assert result == PUBLIC_READ_ONLY_TOOL_NAMES
+
+    def test_authenticated_identity_returns_all(self):
+        all_names = set(TOOL_MAP.keys())
+        identity = {"user_id": 1, "username": "test", "roles": ["Contributor"]}
+        result = get_allowed_tool_names(identity, all_names)
+        assert result == all_names
+
+    def test_authenticated_identity_with_empty_roles_returns_all(self):
+        all_names = set(TOOL_MAP.keys())
+        identity = {"user_id": 2, "username": "public", "roles": []}
+        result = get_allowed_tool_names(identity, all_names)
+        assert result == all_names
+
+    def test_authenticated_identity_without_roles_key_returns_all(self):
+        all_names = set(TOOL_MAP.keys())
+        identity = {"user_id": 3, "username": "noroles"}
+        result = get_allowed_tool_names(identity, all_names)
+        assert result == all_names
+
+
+class TestAllowedTools:
+    def test_no_identity_no_token_hides_unconfigured_query_tool(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+        current_user_identity.set(None)
+        tools = _get_allowed_tools()
+        tool_names = {t.name for t in tools}
+        assert tool_names == PUBLIC_READ_ONLY_TOOL_NAMES - {"ngm_query_judicial"}
+
+    def test_no_identity_with_query_token_returns_full_public_set(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", "query-only-token")
+        current_user_identity.set(None)
+
+        tool_names = {tool.name for tool in _get_allowed_tools()}
+
+        assert tool_names == PUBLIC_READ_ONLY_TOOL_NAMES
+
+    def test_token_mode_no_user_returns_all(self, monkeypatch):
+        """A stdio service token with no identity receives all tools."""
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        current_user_identity.set(None)
+        with _using_transport("stdio"):
+            tools = _get_allowed_tools()
+        assert len(tools) == len(TOOL_MAP)
+
+    def test_token_only_no_identity_returns_all(self, monkeypatch):
+        """A stdio service token remains usable without a forwarded identity."""
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        current_user_identity.set(None)
+        with _using_transport("stdio"):
+            tools = _get_allowed_tools()
+        assert len(tools) == len(TOOL_MAP)
+
+    @pytest.mark.security
+    def test_http_service_token_does_not_expand_tool_list(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+        current_user_identity.set(None)
+        with _using_transport("http"):
+            tool_names = {tool.name for tool in _get_allowed_tools()}
+        assert tool_names == PUBLIC_READ_ONLY_TOOL_NAMES - {"ngm_query_judicial"}
+
+    def test_authenticated_identity_returns_all(self, monkeypatch):
+        """An authenticated identity gets all tools."""
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        identity = {"user_id": 1, "username": "worker", "roles": ["Contributor"]}
+        current_user_identity.set(identity)
+        try:
+            tools = _get_allowed_tools()
+            assert len(tools) == len(TOOL_MAP)
+        finally:
+            current_user_identity.set(None)
+
+    def test_roleless_authenticated_identity_returns_all(self, monkeypatch):
+        """A verified identity does not need a role to receive all tools."""
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        identity = {"user_id": 2, "username": "public", "roles": []}
+        current_user_identity.set(identity)
+        try:
+            tools = _get_allowed_tools()
+            assert len(tools) == len(TOOL_MAP)
+        finally:
+            current_user_identity.set(None)
+
+
+class TestIsToolAllowed:
+    def test_public_tool_allowed_without_token(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        current_user_identity.set(None)
+        assert _is_tool_allowed("search_jawafdehi_cases") is True
+
+    def test_write_tool_blocked_without_token(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        current_user_identity.set(None)
+        assert _is_tool_allowed("create_jawafdehi_case") is False
+
+    def test_query_tool_blocked_without_anonymous_query_token(self, monkeypatch):
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+        current_user_identity.set(None)
+
+        assert _is_tool_allowed("ngm_query_judicial") is False
+
+    def test_write_tool_allowed_for_authenticated_identity(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        identity = {"user_id": 1, "username": "cw", "roles": ["Contributor"]}
+        current_user_identity.set(identity)
+        try:
+            assert _is_tool_allowed("create_jawafdehi_case") is True
+        finally:
+            current_user_identity.set(None)
+
+    def test_write_tool_allowed_for_roleless_authenticated_identity(self, monkeypatch):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        identity = {"user_id": 2, "username": "pub", "roles": []}
+        current_user_identity.set(identity)
+        try:
+            assert _is_tool_allowed("create_jawafdehi_case") is True
+        finally:
+            current_user_identity.set(None)
+
+    def test_write_tool_allowed_with_token_only(self, monkeypatch):
+        """A stdio service token can call write tools without a user identity."""
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        current_user_identity.set(None)
+        with _using_transport("stdio"):
+            assert _is_tool_allowed("create_jawafdehi_case") is True
+
+    @pytest.mark.security
+    def test_write_tool_blocked_for_anonymous_http_with_service_token(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("JAWAFDEHI_API_TOKEN", "test-token")
+        current_user_identity.set(None)
+        with _using_transport("http"):
+            assert _is_tool_allowed("create_jawafdehi_case") is False
+
+
+class TestPublicToolSetIntegrity:
+    EXPECTED_ALL_TOOL_NAMES = {
+        "get_current_user",
+        "search_control_plane",
+        "ngm_query_judicial",
+        "ngm_extract_case_data",
+        "search_jawafdehi_cases",
+        "get_jawafdehi_case",
+        "create_jawafdehi_case",
+        "patch_jawafdehi_case",
+        "delete_jawafdehi_case",
+        "submit_nes_change",
+        "upload_material_file",
+        "search_nes_entities",
+        "get_nes_entities",
+        "get_nes_entity_prefixes",
+        "get_nes_tags",
+        "get_nes_entity_versions",
+        "delete_nes_entity",
+        "browse_materials",
+        "manage_material",
+        "browse_court_data",
+        "manage_court_data",
+        "manage_case_update_proposals",
+        "manage_casework_reviews",
+        "manage_jobs",
+        "convert_date",
+        "convert_to_markdown",
+    }
+
+    def test_all_public_tools_exist_in_tool_map(self):
+        for name in PUBLIC_READ_ONLY_TOOL_NAMES:
+            assert name in TOOL_MAP, f"Public tool '{name}' not found in TOOL_MAP"
+
+    def test_public_tools_are_read_only(self):
+        write_tool_names = {
+            "create_jawafdehi_case",
+            "delete_nes_entity",
+            "manage_material",
+            "manage_court_data",
+            "manage_case_update_proposals",
+            "manage_casework_reviews",
+            "manage_jobs",
+            "patch_jawafdehi_case",
+            "submit_nes_change",
+            "upload_material_file",
+            "ngm_extract_case_data",
+        }
+        assert PUBLIC_READ_ONLY_TOOL_NAMES.isdisjoint(write_tool_names)
+
+    def test_private_tools_not_in_public_set(self):
+        private_tools = set(TOOL_MAP.keys()) - PUBLIC_READ_ONLY_TOOL_NAMES
+        assert len(private_tools) > 0
+        assert "create_jawafdehi_case" in private_tools
+        assert "upload_material_file" in private_tools
+
+    def test_all_tool_names_count(self):
+        assert ALL_TOOL_NAMES == self.EXPECTED_ALL_TOOL_NAMES
+        assert len(ALL_TOOL_NAMES) == 26
+
+    def test_private_tool_set(self):
+        assert ALL_TOOL_NAMES - PUBLIC_READ_ONLY_TOOL_NAMES == {
+            "ngm_extract_case_data",
+            "create_jawafdehi_case",
+            "patch_jawafdehi_case",
+            "delete_jawafdehi_case",
+            "submit_nes_change",
+            "upload_material_file",
+            "delete_nes_entity",
+            "manage_material",
+            "manage_court_data",
+            "manage_case_update_proposals",
+            "manage_casework_reviews",
+            "manage_jobs",
+        }
+
+    def test_public_tools_count(self):
+        assert {
+            "search_control_plane",
+            "get_nes_entity_versions",
+            "browse_materials",
+            "browse_court_data",
+        }.issubset(PUBLIC_READ_ONLY_TOOL_NAMES)
+        assert len(PUBLIC_READ_ONLY_TOOL_NAMES) == 14
+        assert PUBLIC_HOST_TOOL_NAMES == PUBLIC_READ_ONLY_TOOL_NAMES - {
+            "convert_to_markdown"
+        }

--- a/tests/mcp/test_stdio_integration.py
+++ b/tests/mcp/test_stdio_integration.py
@@ -1,0 +1,40 @@
+"""End-to-end contract for the retained local stdio MCP transport."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from jawafdehi_mcp.server import ALL_TOOL_NAMES
+
+
+@pytest.mark.asyncio
+async def test_stdio_subprocess_initialize_list_and_call():
+    project_root = Path(__file__).resolve().parents[2]
+    parameters = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "jawafdehi_mcp.server"],
+        cwd=project_root,
+        env={
+            # A configured local service bearer unlocks the complete stdio
+            # catalog. The local date call does not send it over the network.
+            "JAWAFDEHI_API_TOKEN": "stdio-contract-test",
+            "STRUCTLOG_CONSOLE": "0",
+        },
+    )
+
+    async with stdio_client(parameters) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            initialized = await session.initialize()
+            listed = await session.list_tools()
+            result = await session.call_tool(
+                "convert_date",
+                {"dates": ["2023-01-15"], "mode": "ad_to_bs"},
+            )
+
+    assert initialized.serverInfo.name == "jawafdehi-mcp"
+    assert {tool.name for tool in listed.tools} == ALL_TOOL_NAMES
+    assert result.isError is False
+    assert "Converted AD 2023-01-15 to BS" in result.content[0].text

--- a/tests/mcp/test_tool_schemas.py
+++ b/tests/mcp/test_tool_schemas.py
@@ -1,0 +1,35 @@
+"""Regression tests for MCP tool input schemas."""
+
+from jsonschema import Draft202012Validator
+
+from jawafdehi_mcp.server import TOOLS
+
+
+def test_all_tool_schemas_are_valid_draft_2020_12():
+    for tool in TOOLS:
+        Draft202012Validator.check_schema(tool.input_schema)
+
+
+def test_all_tool_schemas_have_top_level_object_type():
+    for tool in TOOLS:
+        schema = tool.input_schema
+        assert isinstance(schema, dict), f"{tool.name} schema must be a dict"
+        assert schema.get("type") == "object", (
+            f"{tool.name} schema must declare top-level type=object"
+        )
+
+
+def test_empty_properties_object_schemas_have_required_list():
+    for tool in TOOLS:
+        schema = tool.input_schema
+        if schema.get("type") != "object":
+            continue
+
+        properties = schema.get("properties")
+        if properties == {}:
+            assert "required" in schema, (
+                f"{tool.name} empty-properties schema must include required"
+            )
+            assert schema["required"] == [], (
+                f"{tool.name} empty-properties schema must set required to []"
+            )

--- a/tests/mcp/test_validation.py
+++ b/tests/mcp/test_validation.py
@@ -1,0 +1,178 @@
+"""Tests for query validation logic."""
+
+import json
+
+import pytest
+
+from jawafdehi_mcp.tools.ngm_judicial import NGMJudicialTool
+
+
+class TestQueryValidation:
+    """Test query validation rules."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.tool = NGMJudicialTool()
+
+    def test_valid_select_query(self):
+        """Test that valid SELECT queries pass validation."""
+        query = "SELECT * FROM courts"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is True
+        assert error is None
+
+    def test_valid_join_query(self):
+        """Test that valid JOIN queries pass validation."""
+        query = """
+            SELECT c.case_number, co.full_name_nepali
+            FROM court_cases c
+            JOIN courts co ON c.court_identifier = co.identifier
+        """
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is True
+        assert error is None
+
+    def test_reject_insert_query(self):
+        """Test that INSERT queries are rejected."""
+        query = "INSERT INTO courts (identifier) VALUES ('test')"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "only select" in error.lower()
+
+    def test_reject_update_query(self):
+        """Test that UPDATE queries are rejected."""
+        query = "UPDATE courts SET full_name_nepali = 'test'"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "only select" in error.lower()
+
+    def test_reject_delete_query(self):
+        """Test that DELETE queries are rejected."""
+        query = "DELETE FROM courts WHERE identifier = 'test'"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "only select" in error.lower()
+
+    def test_reject_drop_query(self):
+        """Test that DROP queries are rejected."""
+        query = "DROP TABLE courts"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "only select" in error.lower()
+
+    def test_reject_scraped_dates_table(self):
+        """Test that queries to scraped_dates table are rejected."""
+        query = "SELECT * FROM scraped_dates"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "scraped_dates" in error.lower()
+
+    def test_reject_invalid_table(self):
+        """Test that queries to non-allowed tables are rejected."""
+        query = "SELECT * FROM users"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "invalid table" in error.lower()
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT setval('seq', 1)",
+            "SELECT nextval('seq')",
+            "SELECT pg_advisory_lock(1)",
+            "SELECT database_to_xml(true, false, '')",
+            "SELECT pg_sleep_for(interval '1 second')",
+            "SELECT table_to_xmlschema('courts'::regclass, true, false, '')",
+        ],
+    )
+    def test_reuses_api_guard_for_side_effecting_functions(self, query):
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is False
+        assert "forbidden function" in error.lower()
+
+    def test_case_insensitive_validation(self):
+        """Test that validation is case-insensitive."""
+        query = "SELECT * FROM COURTS"
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is True
+        assert error is None
+
+    def test_complex_valid_query(self):
+        """Test complex but valid query."""
+        query = """
+            SELECT
+                cc.case_number,
+                cc.case_type,
+                co.full_name_nepali,
+                COUNT(cch.id) as hearing_count
+            FROM court_cases cc
+            JOIN courts co ON cc.court_identifier = co.identifier
+            LEFT JOIN court_case_hearings cch
+                ON cc.case_number = cch.case_number
+            WHERE cc.case_type LIKE '%भ्रष्टाचार%'
+            GROUP BY cc.case_number, cc.case_type, co.full_name_nepali
+            ORDER BY hearing_count DESC
+            LIMIT 10
+        """
+        is_valid, error = self.tool._validate_query(query)
+        assert is_valid is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_validation_error_is_json_encoded(self, monkeypatch):
+        message = 'invalid table "quoted"\nwith a backslash: \\'
+        monkeypatch.setattr(
+            self.tool,
+            "_validate_query",
+            lambda query: (False, message),
+        )
+
+        result = await self.tool.execute({"query": "SELECT 1"})
+
+        assert result.is_error is True
+        assert json.loads(result[0].text)["error"] == message
+
+
+class TestEnvironmentValidation:
+    """Test environment variable validation."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.tool = NGMJudicialTool()
+
+    def test_missing_api_token_is_ok_in_public_mode(self, monkeypatch):
+        """The public query tool can initialize without a configured credential."""
+        monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "https://portal.jawafdehi.org")
+        monkeypatch.delenv("JAWAFDEHI_API_TOKEN", raising=False)
+        monkeypatch.delenv("MCP_QUERY_API_TOKEN", raising=False)
+
+        base_url, token = self.tool._validate_environment()
+        assert base_url == "https://portal.jawafdehi.org"
+        assert token is None
+
+    def test_invalid_base_url(self, monkeypatch):
+        """Test that non-HTTP URL raises error."""
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", "test-token")
+        monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", "postgresql://example.local")
+
+        with pytest.raises(ValueError, match=r"must be an HTTP\(S\) URL"):
+            self.tool._validate_environment()
+
+    def test_valid_base_url_and_token(self, monkeypatch):
+        """Test that valid API base URL and token pass validation."""
+        url = "https://portal.jawafdehi.org"
+        token = "token-123"
+        monkeypatch.setenv("JAWAFDEHI_API_BASE_URL", url)
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", token)
+
+        result = self.tool._validate_environment()
+        assert result == (url, token)
+
+    def test_default_base_url_is_used(self, monkeypatch):
+        """Test default base URL is used when env var is omitted."""
+        monkeypatch.delenv("JAWAFDEHI_API_BASE_URL", raising=False)
+        monkeypatch.setenv("MCP_QUERY_API_TOKEN", "token-123")
+
+        result = self.tool._validate_environment()
+        assert result[0] == "https://api.jawafdehi.org"
+        assert result[1] == "token-123"

--- a/tests/mcp/test_whoami.py
+++ b/tests/mcp/test_whoami.py
@@ -1,0 +1,41 @@
+"""Tests for the get_current_user tool."""
+
+import json
+
+import pytest
+
+from jawafdehi_mcp.identity import current_user_identity
+from jawafdehi_mcp.tools.whoami import GetCurrentUserTool
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUser:
+    async def test_anonymous(self):
+        token = current_user_identity.set(None)
+        try:
+            result = await GetCurrentUserTool().execute({})
+        finally:
+            current_user_identity.reset(token)
+        payload = json.loads(result[0].text)
+        assert payload["authenticated"] is False
+
+    async def test_authenticated(self):
+        identity = {
+            "sub": "u1",
+            "email": "jane@x.org",
+            "name": "Jane",
+            "roles": ["admin"],
+        }
+        token = current_user_identity.set(identity)
+        try:
+            result = await GetCurrentUserTool().execute({})
+        finally:
+            current_user_identity.reset(token)
+        payload = json.loads(result[0].text)
+        assert payload == {
+            "authenticated": True,
+            "name": "Jane",
+            "email": "jane@x.org",
+            "roles": ["admin"],
+            "sub": "u1",
+        }

--- a/tests/mcp/tools/test_ngm_extract.py
+++ b/tests/mcp/tools/test_ngm_extract.py
@@ -1,0 +1,201 @@
+"""Tests for NGMExtractCaseDataTool."""
+
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from jawafdehi_mcp.request_context import current_transport
+from jawafdehi_mcp.tools.ngm_extract import NGMExtractCaseDataTool
+
+
+class TestNGMExtractCaseDataTool:
+    """Test functionality of NGMExtractCaseDataTool."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.tool = NGMExtractCaseDataTool()
+        self.valid_args = {
+            "court_identifier": "supreme",
+            "case_number": "079-WO-0123",
+            "file_path": "/tmp/test_output.md",
+        }
+
+    @pytest.fixture(autouse=True)
+    def _local_stdio_transport(self):
+        token = current_transport.set("stdio")
+        try:
+            yield
+        finally:
+            current_transport.reset(token)
+
+    def test_missing_arguments(self):
+        """Test missing required arguments."""
+        import asyncio
+
+        arguments = {"court_identifier": "supreme"}
+        result = asyncio.run(self.tool.execute(arguments))
+        assert not result[0].text.startswith('{"success": true')
+        assert "required" in result[0].text
+
+    def test_format_markdown_empty_data(self):
+        """Test format_markdown when no data is found."""
+        md = self.tool._format_markdown({}, {}, [], [])
+        assert "Unknown Court" in md
+        assert "Unknown Case" in md
+        assert "Could not find metadata" in md
+
+    def test_format_markdown_with_data(self):
+        """Test formatting valid case data into markdown."""
+        court_info = {
+            "full_name_english": "Supreme Court",
+            "full_name_nepali": "सर्वोच्च अदालत",
+        }
+        case_info = {
+            "case_number": "079-WO-123",
+            "case_type": "Writ",
+            "case_status": "Pending",
+        }
+        entities = [
+            {"side": "Plaintiff", "name": "Ram", "address": "Kathmandu"},
+            {"side": "Defendant", "name": "Shyam"},
+        ]
+        hearings = [
+            {
+                "hearing_date_ad": "2023-01-01",
+                "decision_type": "Order",
+                "judge_names": "Judge A",
+            }
+        ]
+
+        md = self.tool._format_markdown(court_info, case_info, hearings, entities)
+
+        assert "Supreme Court" in md
+        assert "सर्वोच्च अदालत" in md
+        assert "079-WO-123" in md
+        assert "Writ" in md
+        assert "Pending" in md
+        assert "Ram" in md
+        assert "Kathmandu" in md
+        assert "Shyam" in md
+        assert "2023-01-01" in md
+        assert "Judge A" in md
+
+        # JSON should only appear in the Appendix, not inline among the main sections
+        appendix_idx = md.index("## Appendix: Raw Data")
+        first_json_block = md.index("```json")
+        assert first_json_block > appendix_idx, (
+            "JSON blocks must only appear after the Appendix heading"
+        )
+
+        # No 'Full Case Record Details' or 'Hearing Full Details' headings should exist
+        assert "Full Case Record Details" not in md
+        assert "Hearing Full Details" not in md
+
+    def test_format_markdown_appendix_structure(self):
+        """Appendix with JSON blobs is present when data exists, absent when not."""
+        court_info = {"full_name_english": "Test Court", "full_name_nepali": ""}
+        case_info = {"case_number": "001", "case_type": "Civil"}
+        hearing = {
+            "hearing_date_ad": "2024-03-15",
+            "hearing_date_bs": "2080-12-02",
+            "decision_type": "Order",
+            "judge_names": "Judge B",
+        }
+
+        # With data: Appendix present with both case and hearing JSON
+        md_with_data = self.tool._format_markdown(court_info, case_info, [hearing], [])
+        assert "## Appendix: Raw Data" in md_with_data
+        assert "### Full Case Record" in md_with_data
+        assert "### Hearing Records" in md_with_data
+        assert "#### Hearing 1:" in md_with_data
+
+        # Without data (empty case_info triggers early return): no Appendix
+        md_no_data = self.tool._format_markdown({}, {}, [], [])
+        assert "## Appendix: Raw Data" not in md_no_data
+
+    @patch("os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch(
+        "jawafdehi_mcp.tools.ngm_extract.NGMExtractCaseDataTool._validate_environment"
+    )
+    @patch(
+        "jawafdehi_mcp.tools.ngm_extract.NGMExtractCaseDataTool._execute_proxy_query"
+    )
+    def test_successful_extraction(
+        self,
+        mock_execute_proxy_query,
+        mock_env,
+        mock_file_open,
+        mock_makedirs,
+    ):
+        """Test a full successful extraction flow."""
+        mock_env.return_value = ("https://portal.jawafdehi.org", "test-token")
+        mock_execute_proxy_query.side_effect = [
+            {
+                "success": True,
+                "data": {
+                    "columns": ["full_name_english", "full_name_nepali"],
+                    "rows": [["Test Court", "टेस्ट अदालत"]],
+                },
+            },
+            {
+                "success": True,
+                "data": {
+                    "columns": ["case_number", "case_type", "case_status"],
+                    "rows": [["123", "Writ", "Pending"]],
+                },
+            },
+            {
+                "success": True,
+                "data": {
+                    "columns": ["side", "name", "address"],
+                    "rows": [["Plaintiff", "Ram", "Kathmandu"]],
+                },
+            },
+            {
+                "success": True,
+                "data": {
+                    "columns": ["hearing_date_ad", "decision_type", "judge_names"],
+                    "rows": [["2023-01-01", "Order", "Judge A"]],
+                },
+            },
+        ]
+
+        import asyncio
+
+        result = asyncio.run(self.tool.execute(self.valid_args))
+
+        # Validate successful execution
+        assert '{"success": true' in result[0].text
+        assert mock_makedirs.called
+        mock_file_open.assert_called_with("/tmp/test_output.md", "w", encoding="utf-8")
+
+        # Verify content written includes formatted markdown
+        handle = mock_file_open()
+        written_content = "".join(
+            [call.args[0] for call in handle.write.call_args_list]
+        )
+        assert "Test Court" in written_content
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_rejects_file_output_on_http_transport(self):
+        with (
+            patch.object(
+                self.tool,
+                "_validate_environment",
+                side_effect=AssertionError("must not call the API"),
+            ),
+            patch(
+                "builtins.open",
+                side_effect=AssertionError("must not open server paths"),
+            ),
+        ):
+            token = current_transport.set("http")
+            try:
+                result = await self.tool.execute(self.valid_args)
+            finally:
+                current_transport.reset(token)
+
+        assert '"success": false' in result[0].text
+        assert "only supported by local stdio" in result[0].text

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -11,6 +11,8 @@ authenticator validates against that key. They cover:
       shape and ignoring unknown roles).
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -130,6 +132,93 @@ def _authenticate(token):
     factory = APIRequestFactory()
     request = factory.get("/api/", HTTP_AUTHORIZATION=f"Bearer {token}")
     return oidc_auth.OIDCAuthentication().authenticate(request)
+
+
+class TestSigningKeyResolutionIsConcurrent:
+    """``_signing_key_for`` lives in shared auth and gates EVERY authenticated
+    request, so its concurrency behaviour is pinned here in the platform suite
+    rather than only under tests/mcp/.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_refresh_clock(self):
+        """``_jwks_last_refresh`` is module state; leaving it set would silently
+        suppress a later test's expected refresh depending on ordering."""
+        yield
+        oidc_auth.reset_jwks_client()
+
+    def test_cached_lookup_does_not_serialise_across_threads(self, monkeypatch):
+        """A slow cached JWKS read must not block other threads authenticating.
+
+        Regression guard. Holding ``_jwks_lock`` across the cached read turned N
+        concurrent authentications into a serial queue of N * OIDC_JWKS_TIMEOUT,
+        because on a cold or expired cache PyJWT performs network I/O there.
+
+        Deterministic rather than timing-based: every thread must be inside the
+        lookup simultaneously to clear the barrier, so if the lookups cannot
+        overlap the barrier breaks instead of the test merely running slowly.
+        """
+        concurrency = 4
+        barrier = threading.Barrier(concurrency, timeout=10)
+        key = object()
+        entered = []
+
+        class _ConcurrentClient:
+            def get_signing_keys(self, refresh=False):
+                entered.append(refresh)
+                barrier.wait()
+                return [key]
+
+            @staticmethod
+            def match_kid(signing_keys, kid):
+                return key
+
+        monkeypatch.setattr(
+            oidc_auth, "_get_jwks_client", lambda: _ConcurrentClient()
+        )
+        token = jwt.encode({"sub": "s"}, "x" * 32, headers={"kid": "k1"})
+
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            resolved = list(
+                pool.map(lambda _: oidc_auth._signing_key_for(token), range(concurrency))
+            )
+
+        assert resolved == [key] * concurrency
+        # All four resolved from the cache; none needed a forced refresh.
+        assert entered == [False] * concurrency
+
+    def test_rate_limited_refresh_is_still_mutually_exclusive(self, monkeypatch):
+        """The forced refresh keeps its lock: at most one per interval.
+
+        The fix above narrowed the lock; it must not have widened the refresh
+        budget. Pinned here too because it is the DoS guard for unknown kids.
+        """
+        refreshes = []
+        gate = threading.Barrier(2, timeout=10)
+
+        class _AlwaysMiss:
+            def get_signing_keys(self, refresh=False):
+                if refresh:
+                    refreshes.append(refresh)
+                return []
+
+            @staticmethod
+            def match_kid(signing_keys, kid):
+                return None
+
+        monkeypatch.setattr(oidc_auth, "_get_jwks_client", lambda: _AlwaysMiss())
+        oidc_auth._jwks_last_refresh = 0.0
+        token = jwt.encode({"sub": "s"}, "x" * 32, headers={"kid": "nope"})
+
+        def attempt(_):
+            gate.wait()  # maximise the chance both race for the refresh
+            with pytest.raises(jwt.exceptions.PyJWKClientError):
+                oidc_auth._signing_key_for(token)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            list(pool.map(attempt, range(2)))
+
+        assert len(refreshes) == 1
 
 
 def test_jwks_client_uses_configured_timeout(settings, monkeypatch):

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -132,6 +132,24 @@ def _authenticate(token):
     return oidc_auth.OIDCAuthentication().authenticate(request)
 
 
+def test_jwks_client_uses_configured_timeout(settings, monkeypatch):
+    settings.OIDC_JWKS_TIMEOUT = 4.5
+    captured = {}
+    client = object()
+
+    def build_client(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return client
+
+    oidc_auth.reset_jwks_client()
+    monkeypatch.setattr(oidc_auth, "PyJWKClient", build_client)
+
+    assert oidc_auth._get_jwks_client() is client
+    assert captured["args"] == (settings.OIDC_JWKS_URI,)
+    assert captured["kwargs"]["timeout"] == 4.5
+
+
 # ---------------------------------------------------------------------------
 # (a) valid token -> authed user with groups synced from roles
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -753,6 +753,28 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/62/8fb1fb647d2788c950d69d6a769cd9d55c918ac1fc57be2f90b7e4029787/google_api_core-2.33.0.tar.gz", hash = "sha256:3a36bcc3e319783f4c97da41f6f45ea6ffcaa55848e341de16e09cb70243c2bb", size = 181607, upload-time = "2026-07-22T16:28:28.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/31/5056a347bb934ea04583c8b27916ef1501729c72638629545bce26ff4223/google_api_core-2.33.0-py3-none-any.whl", hash = "sha256:a2e22a0c1d0f03eafff1858b38cf46f832d5902b0c052235bf0ab8402929fbdc", size = 176462, upload-time = "2026-07-22T16:28:22.447Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
@@ -768,6 +790,69 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "google-cloud-appengine-logging"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/b9/fcafc8d2dc68975a65cdff74807547cff9b2a7b00e738d3f5ff0bd112867/google_cloud_appengine_logging-1.10.0.tar.gz", hash = "sha256:b5563e76010a36e6adf1cc489620c29ee4fb3b986b006d237e9a061eb0f0abb7", size = 17744, upload-time = "2026-06-03T14:52:40.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/b3/4eeb9f59c4e7e07e1f08704b6508249eea5760878810014e636026300416/google_cloud_appengine_logging-1.10.0-py3-none-any.whl", hash = "sha256:193675caaf062c41688a3e2c744b73614db82408bc7fb060353b6878d7134492", size = 18143, upload-time = "2026-06-03T14:51:55.174Z" },
+]
+
+[[package]]
+name = "google-cloud-audit-log"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/46/b971191224557091cc865b47d527e61da180e33b9397904bdefdae1dcacd/google_cloud_audit_log-0.6.0.tar.gz", hash = "sha256:4dd343683c0bb31187ebef3426803f13159e950fbea3fe60a864855cfed959b8", size = 44674, upload-time = "2026-06-03T14:52:48.095Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/99/27c70286bfa3503e43f845578ed5c2ab30c0cc68e525c168286f05f9a51c/google_cloud_audit_log-0.6.0-py3-none-any.whl", hash = "sha256:8c5ecbc341ad3b3daf776981f6d7fd7ab5ff5a29c5dce3172c669b570e0f6717", size = 44853, upload-time = "2026-06-03T14:52:03.775Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-logging"
+version = "3.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-appengine-logging" },
+    { name = "google-cloud-audit-log" },
+    { name = "google-cloud-core" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/a5/895a08ddb4b0e1374b291905e36514ca7d2d620542239e8ad5291627fdb2/google_cloud_logging-3.16.1.tar.gz", hash = "sha256:603024ad8257d8194f53c9dfaf27fc2c32111d627bc4c574556584a8150fcace", size = 293629, upload-time = "2026-07-08T17:03:51.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/ab/099478b9d4983e25f6d966e74c2bd2a68e8e33125f2862bdcda573b6ec46/google_cloud_logging-3.16.1-py3-none-any.whl", hash = "sha256:2314db116753d8a449f28d3f60f710885f5c563a47311850415f9e3e0a116970", size = 234182, upload-time = "2026-07-08T17:03:22.965Z" },
 ]
 
 [[package]]
@@ -789,6 +874,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
 ]
 
 [[package]]
@@ -833,6 +949,20 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio-status"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/26/0aa9168c87882381fd810d140c279a2490ed6aee655f0515d6f56c5ca404/grpcio_status-1.81.1.tar.gz", hash = "sha256:9389a03e746017b10f0630c064289201458f3ce01f5d7ef4b0bebc1ef6cf82ad", size = 13923, upload-time = "2026-06-11T12:58:48.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl", hash = "sha256:08072fa9995f4a95c647fc6f4f85e2411573d00087bcabdf30f260114338f232", size = 14638, upload-time = "2026-06-11T12:58:31.982Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -867,6 +997,42 @@ wheels = [
 ]
 
 [[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -879,6 +1045,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -976,15 +1151,22 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
     { name = "duckdb" },
+    { name = "google-cloud-logging" },
     { name = "google-genai" },
     { name = "gunicorn" },
+    { name = "httpcore" },
+    { name = "httpx" },
     { name = "indic-transliteration" },
     { name = "jsonpatch" },
+    { name = "likhit" },
     { name = "lxml" },
     { name = "markdown" },
+    { name = "markitdown", extra = ["docx", "pdf", "pptx", "xlsx"] },
+    { name = "mcp" },
     { name = "mozilla-django-oidc" },
     { name = "nats-py" },
     { name = "nepali" },
+    { name = "nepali-datetime" },
     { name = "openai" },
     { name = "opensearch-py" },
     { name = "psycopg", extra = ["binary"] },
@@ -997,7 +1179,10 @@ dependencies = [
     { name = "requests" },
     { name = "rules" },
     { name = "sentry-sdk" },
+    { name = "sqlglot" },
     { name = "structlog" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn-worker" },
     { name = "wagtail" },
     { name = "wagtail-headless-preview" },
     { name = "whitenoise" },
@@ -1036,17 +1221,24 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.16" },
     { name = "drf-spectacular", specifier = ">=0.29" },
     { name = "duckdb", specifier = ">=1.4.0" },
+    { name = "google-cloud-logging", specifier = ">=3.12" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "gunicorn", specifier = ">=23.0" },
+    { name = "httpcore", specifier = ">=1.0,<2" },
+    { name = "httpx", specifier = ">=0.28" },
     { name = "indic-transliteration", specifier = ">=2.3.82" },
     { name = "jsonpatch", specifier = ">=1.33" },
-    { name = "likhit", marker = "extra == 'bigo-enrichment'", git = "https://github.com/Jawafdehi/likhit.git?rev=main" },
+    { name = "likhit", git = "https://github.com/Jawafdehi/likhit.git?rev=e98eb446437f8a086e1e8da409d413ca81106532" },
+    { name = "likhit", marker = "extra == 'bigo-enrichment'", git = "https://github.com/Jawafdehi/likhit.git?rev=e98eb446437f8a086e1e8da409d413ca81106532" },
     { name = "lxml", specifier = ">=5.0" },
     { name = "markdown", specifier = ">=3.5" },
+    { name = "markitdown", extras = ["docx", "pdf", "pptx", "xlsx"], specifier = ">=0.1.5" },
     { name = "markitdown", extras = ["docx", "pdf", "pptx", "xlsx"], marker = "extra == 'bigo-enrichment'", specifier = ">=0.1.5" },
+    { name = "mcp", specifier = ">=1.26,<2" },
     { name = "mozilla-django-oidc", specifier = ">=5.0.2" },
     { name = "nats-py", specifier = ">=2.9" },
     { name = "nepali", specifier = ">=1.2.0" },
+    { name = "nepali-datetime", specifier = ">=1.0.8.4" },
     { name = "openai", specifier = ">=2.30,<3" },
     { name = "opensearch-py", specifier = ">=2.4" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
@@ -1059,7 +1251,10 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32" },
     { name = "rules", specifier = ">=3.5" },
     { name = "sentry-sdk", specifier = ">=2.0" },
+    { name = "sqlglot", specifier = ">=26.33,<28" },
     { name = "structlog", specifier = ">=25.5" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
+    { name = "uvicorn-worker", specifier = ">=0.3,<1" },
     { name = "wagtail", specifier = ">=7.4,<7.5" },
     { name = "wagtail-headless-preview", specifier = ">=0.9,<0.10" },
     { name = "whitenoise", specifier = ">=6.11" },
@@ -1221,7 +1416,7 @@ wheels = [
 [[package]]
 name = "likhit"
 version = "0.1.7"
-source = { git = "https://github.com/Jawafdehi/likhit.git?rev=main#8809c174cc3eb72e20dac56143623ca597b4baa7" }
+source = { git = "https://github.com/Jawafdehi/likhit.git?rev=e98eb446437f8a086e1e8da409d413ca81106532#e98eb446437f8a086e1e8da409d413ca81106532" }
 dependencies = [
     { name = "fonttools" },
     { name = "markitdown", extra = ["docx", "pdf"] },
@@ -1434,6 +1629,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1495,6 +1715,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/42/6e/26c0f7b544c978ec7b9d12ee1219023213e2dd14f3ea18e4f1665b1b945f/nepali-1.2.0.tar.gz", hash = "sha256:75a9d0bd4b3e95d72c7045539b63e84077686ffa12dff5db3fffe6579cbb511d", size = 63658, upload-time = "2026-02-02T15:06:34.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/e5/4aea4554803da821bce158b14ca66f7622f11daa281e9e720e4b97861b3f/nepali-1.2.0-py3-none-any.whl", hash = "sha256:1f9244b2fcb51e6b9e710cc1c483024f8600954d545a9a12a2accf53213911b1", size = 69502, upload-time = "2026-02-02T15:06:32.689Z" },
+]
+
+[[package]]
+name = "nepali-datetime"
+version = "1.0.8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/25/dac3e744b0a6af03e05a25ab868a032d51993d0e91be70ea38b814b4c047/nepali_datetime-1.0.8.5.tar.gz", hash = "sha256:745093e929cfe164e1062058221e9a9eac25d89083b1b43b3bb2aa8e854f2884", size = 20357, upload-time = "2026-05-07T13:26:18.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/41/6ef290b5ab1671a0d421d105ee59d3d02b5c96004ba77f2ccb0b99a55e8f/nepali_datetime-1.0.8.5-py3-none-any.whl", hash = "sha256:adec683e06333482d31543d0d2bdf195cef12505615eaf747bcae0b82e5f6ad2", size = 18638, upload-time = "2026-05-07T13:26:17.237Z" },
 ]
 
 [[package]]
@@ -1650,6 +1879,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/9e/e77844cb2d625ca32331bfdd28930113b3778399c01dd5f1c350ceb55e65/opensearch_py-3.2.0.tar.gz", hash = "sha256:f40fb3a295275422df2ad6d9459f667af94472d5a9e567072e9ecf163eb22613", size = 259927, upload-time = "2026-04-27T18:17:50.467Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/63/7abb96bf2e3619acbd27de99e60619bfacfb7c55b68c4792a258e6d92871/opensearch_py-3.2.0-py3-none-any.whl", hash = "sha256:721a0d3b13fbed9e82278aed748285cf63a1855354ab7e73e3d4992d1b93418b", size = 387286, upload-time = "2026-04-27T18:17:48.658Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1889,6 +2130,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/3e/29e0d6a2c5adde6ab5772253fd16ab346324026b89a66e354689c86d0584/proto_plus-1.28.2.tar.gz", hash = "sha256:26d843eb99c1e32fdf1d20ff0faae56607f7748fe774acf9ecd5cfe6c6472501", size = 58063, upload-time = "2026-07-22T16:28:29.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/84/4e9a53a062d4073c74897a6bd20fff74d55307341b3e85c081002462b3ef/proto_plus-1.28.2-py3-none-any.whl", hash = "sha256:b874236fcac2358f601e4330bcb76cb8b89c851303ccf4078408b3d4774d1c52", size = 50693, upload-time = "2026-07-22T16:28:24.059Z" },
 ]
 
 [[package]]
@@ -2135,6 +2388,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2321,6 +2588,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -2732,12 +3018,47 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlglot"
+version = "27.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/50/766692a83468adb1bde9e09ea524a01719912f6bc4fdb47ec18368320f6e/sqlglot-27.29.0.tar.gz", hash = "sha256:2270899694663acef94fa93497971837e6fadd712f4a98b32aee1e980bc82722", size = 5503507, upload-time = "2025-10-29T13:50:24.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/70/20c1912bc0bfebf516d59d618209443b136c58a7cff141afa7cf30969988/sqlglot-27.29.0-py3-none-any.whl", hash = "sha256:9a5ea8ac61826a7763de10cad45a35f0aa9bfcf7b96ee74afb2314de9089e1cb", size = 526060, upload-time = "2025-10-29T13:50:22.061Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -2889,6 +3210,74 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.52.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gunicorn" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/59/9101b9c0680fd80e9d26c07deb822a5d18a324339fcf9cd017885ee808ad/uvicorn_worker-0.4.0.tar.gz", hash = "sha256:8ee5306070d8f38dce124adce488c3c0b50f20cf0c0222b12c66188da7214493", size = 9361, upload-time = "2025-09-20T10:47:01.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/25/09cd7a90c8bb7fb693be0d6704fccd5f9778d5513214b7a01cc4a94ff314/uvicorn_worker-0.4.0-py3-none-any.whl", hash = "sha256:e2ed952cef976f5e9e429d7269640bbcafbd36c80aa80f1003c8c77a6797abde", size = 5364, upload-time = "2025-09-20T10:46:59.776Z" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2942,6 +3331,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/c4/5fe6d6c0df1a11be144d6cc9e0f951fb871490208b93237eeda75f8a1bd5/wagtail_headless_preview-0.9.0.tar.gz", hash = "sha256:dbabbb614bd1689f048738c46034c557a3ee426e0ef80feb4831bcfc93a24e15", size = 14887, upload-time = "2026-06-13T10:49:37.597Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/80/0cc32c5192f875d5556487cc71e7280bbfd734b5d6bf24156c5f15e23c92/wagtail_headless_preview-0.9.0-py3-none-any.whl", hash = "sha256:9047701345323d77938c07685279770646c92545bed851c6608f026ac645f16d", size = 12781, upload-time = "2026-06-13T10:49:35.969Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **User description**
Runs the MCP server inside this deployment instead of as a separately deployed
sidecar, and serves it from **one** endpoint — in production
`https://api.jawafdehi.org/mcp`.

Five commits, deliberately separate:

| | commit | what |
|---|---|---|
| 1 | `feat(mcp)` | the migration — a faithful port of the deployed server |
| 2 | `refactor(mcp)!` | collapse the public/internal doors into one |
| 3 | `fix(mcp)` | unbreak the k8s readiness probe; test the gate that had none |
| 4 | `fix(courts/mcp)` | stop inferring SQL disclosure from a shared account's roles |
| 5 | `fix(auth/courts/mcp)` | act on a self-review of this diff |

Review #2 on its own merits; it is a design change, and it is revertible without
touching the migration. #3–#5 are each self-contained fixes with their reasoning
in the commit message.

## Runtime

`config.asgi.application` routes the MCP protocol, health, and OAuth
protected-resource paths to `jawafdehi_mcp` and everything else to Django, so a
single Gunicorn ASGI deployment serves both. Stateless streamable HTTP, so any
worker or pod can serve any request without session affinity.

Tools keep consuming the `/api/` plane rather than reaching into the ORM, so the
existing contracts, authentication, permission checks, and serializers stay the
boundary — including the rules `docs/security/authz-model.md` pins on MCP as a
principal (the `ngm.query` scope-only bypass §5.4, the service-account subject
allowlist on `/api/caseworker/me` §5.5). In the embedded runtime a bounded
`httpx.ASGITransport` wrapper dispatches those calls to Django in memory, with a
wall-clock deadline and shared concurrency cap that stock `ASGITransport` does
not provide; the caller's verified bearer is forwarded. The stdio runner remains
a remote API client.

## Access control, in one table

| Caller | Catalog |
|---|---|
| Anonymous (no `Authorization` header) | read-only `ANONYMOUS_TOOL_NAMES`, 13 tools |
| Any verified bearer — **any role, including none** | all 26 tools |
| stdio with `JAWAFDEHI_API_TOKEN` | all 26 (the service token is authentication) |

Catalog visibility is **not** an authorization grant. Tools forward the caller's
bearer to Django, whose API permissions decide what the call may actually do.

A caller that *attempted* authentication is always told it failed, in two cases
that must not collapse into "anonymous":

- header present but unparseable as a Bearer credential → `401 invalid_request`
- credential parses but fails OIDC verification → `401 invalid_token`

Both carry `WWW-Authenticate` with `resource_metadata`.

## ⚠️ Reviewer attention — two things to ratify

**1. An anonymous request is served, not challenged.** The rationale: every tool
in the anonymous set wraps a REST route that is already `AllowAny` —
`/api/entities`, `/api/search/`, `/api/materials/`, `/api/courts/` — so serving
those through MCP grants nothing the API does not already serve without a token,
and 401-ing `get_nes_entities` while `GET /api/entities` returns the same bytes
would be an inconsistency rather than a security gain.

**The cost, stated plainly:** MCP clients begin an OAuth flow only on a 401, so a
client sending no credential is never prompted to log in — it silently receives
the smaller catalog. `get_current_user` reports `authenticated: false`, and
`GET /.well-known/oauth-protected-resource/mcp` is how authenticating stays
discoverable. That auto-prompt is what the removed `internal` door bought, and
this trades it away. If that trade is wrong, the fix is small and local: challenge
when no credential is present.

**2. Persistent database connections are turned off platform-wide.** This needs
whoever owns the deployment, not an MCP reviewer. `config/settings.py` moves every
Postgres database from `CONN_MAX_AGE = 60` + `CONN_HEALTH_CHECKS = True` to `0` /
`False`, so each request opens a fresh connection to all three.

The reason is that connection lifetime is not dependable under ASGI: `connections`
is a `thread_critical` `Local` (`django.db.utils.ConnectionHandler`), while the
`request_finished` signal that runs `close_old_connections` is sent from the event
loop — so the handler need not see the connection that served the request, and a
nonzero `CONN_MAX_AGE` risks idle backends nothing reclaims. `ASGI_LIMIT_CONCURRENCY`
bounds how many connections can be in flight per worker.

**What to check:** whether the extra connect per request is acceptable at your
Postgres, or whether a pooler should front it first. Earlier revisions of this
branch asserted in comments that production already runs PgBouncer; that was never
established, so the claim is gone rather than load-bearing.

## Breaking changes

- **`convert_to_markdown` now requires authentication** (no particular role). It
  was in the legacy-door anonymous set, so the in-cluster OWUI deployment loses it
  anonymously and must present a bearer or run stdio with a service token. It is
  one of the few tools with no `/api/` route behind it, so the catalog is its only
  gate — enforced in `call_tool`, not merely `tools/list`, with a security test on
  both halves.
- **`OIDC_RESOURCE` is now required.** The metadata document is the only
  auth-discovery path, so it is always served and returns `503` without the
  variable. This drops the old fallback that advertised the OIDC *audience* as
  `resource`; RFC 9728 requires that field to be the resource's URL, so the old
  document was non-conformant.
- **`POST /api/query/` accepts a new `public_projection` boolean.** It can only
  *narrow* disclosure — never widen it — so honouring it from an untrusted body is
  safe, and a test pins the one-way property. It exists because "is this caller
  entitled to internal columns?" and "is this request on someone's behalf?" are
  different questions, and only the client knows the second. This is a contract
  addition to a `courts/` endpoint and deserves a `courts/` owner's eye rather
  than riding through on an MCP review.
- **Deployment, outside this repo:** retire the `mcp` / `mcp-internal` hostnames
  and the Traefik `X-MCP-Mode` header-injection middleware. `X-MCP-Mode` is now an
  unrecognized header with no effect, and a test pins that.
- `GET /mcp/health` reports lifespan readiness only. A missing `OIDC_RESOURCE` is
  not "unready" — the anonymous read catalog still serves, and failing the probe
  would evict a working pod.

## A note for whoever owns the lint config

`jawafdehi_mcp/**` is annotated to satisfy `ANN` rather than being added to
`per-file-ignores`, so it joins `lakehouse` as a directory the annotation gate
actually covers — `pyproject.toml` is explicit that an ignores entry is how a
directory opts *out*, and that "a per-file-ignores entry that is always violated
is not a gate." The 12 deliberate broad catches carry `# noqa: BLE001` plus a
reason.

One snag in the documented opt-in procedure, worth fixing separately: it says to
add a directory "once its `ruff check <dir> --select ANN` count is 0", but that
command re-enables `ANN401`, which the project disables tree-wide — so it never
reads 0 for *any* directory. `lakehouse`, the stated fully-annotated beachhead,
reads 4; `jawafdehi_mcp` reads 28. Both are clean under the real config. The
procedure needs `--ignore ANN401`, or a reviewer following it literally will
reject correct work.

## Found by reviewing this diff, fixed in it

Each was reproduced before being fixed, and each new guard was mutation-tested —
the control was neutralised to confirm the test fails, then restored.

- **`_bearer_from_headers` returned `None` for both "absent" and "malformed"**, so
  a wrong auth scheme silently received the anonymous catalog and a `200`. Hence
  the `invalid_request` branch above; a parametrized test covers five malformed
  shapes plus the absent-header counterpart.
- **`/mcp/health` returned `421` to every Kubernetes probe** — the Host allowlist
  ran first and a probe defaults `Host` to the pod IP. Readiness is now answered
  before that check, which is safe because it takes no credential and returns one
  of two fixed strings.
- **`call_tool`'s catalog enforcement had no test.** Confirmed by neutralising the
  guard and watching 2,906 tests still pass. Four now cover it.
- **`ngm_query_judicial` inferred disclosure from a shared account's roles.** It
  serves anonymous callers with a service token, so provisioning that account with
  `ReadOnly` or any NGM role would have handed the unprojected plane to the open
  internet. It now sets `public_projection` explicitly, so the guarantee no longer
  depends on how the account happens to be configured.
- **The JWKS kid-miss rate limiter serialised every authentication on the
  platform.** It held `_jwks_lock` across the *cached* key read, and on a cold or
  expired cache PyJWT falls through from that read to a network fetch — so the lock
  spanned I/O. Measured against a 1s JWKS endpoint, six concurrent requests took
  1,2,3,4,5,6s (6.00s) where `main` took 1.00s; with `OIDC_JWKS_TIMEOUT` defaulting
  to 10s that is a 60s tail during a JWKS brownout, for every authenticated request
  rather than only MCP. The cached read moved outside the lock, restoring parity
  with `main`. The regression guard is a `threading.Barrier` rather than a timing
  threshold, so it fails deterministically if the lock scope ever comes back.

## Verification

Local gate at `67d180c`:

- `uv run ruff check .` — clean
- `pytest --ignore=integration-tests` — **4,288 passed, 4 skipped, 47 subtests, 0
  failures**
- `uv run ty check` — 38 diagnostics tree-wide, unchanged from `main`'s baseline;
  the 4 inside `jawafdehi_mcp` were verified pre-existing by reverting each
  annotation and re-measuring

CI was green on the preceding head `d75865a` (`test-and-lint`, `e2e`).


___
### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Embed MCP in Django ASGI

- Add MCP control-plane tools

- Add case/NES/material write tools

- Cover MCP auth, routing, schemas


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCP endpoint"] -- "routes" --> B["Django ASGI"]
  B["Django ASGI"] -- "dispatches" --> C["Embedded API transport"]
  C["Embedded API transport"] -- "calls" --> D["Control-plane APIs"]
  D["Control-plane APIs"] -- "serve" --> E["MCP tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>jawafdehi_cases.py</strong><dd><code>Add Jawafdehi case write tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-2ae7e0b52c2cc2b63ebca45536751c4b828596fa21ee1164afa93930db57ecd4">+1097/-0</a></td>

</tr>

<tr>
  <td><strong>document_converter.py</strong><dd><code>Add document conversion MCP tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-a665b36d2992f3b4a1650646d7da2e503e99d2bebfd78d839bcbf02efd07b9b7">+861/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>control_plane.py</strong><dd><code>Add aggregate control-plane MCP tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-dcb573b7e1cfbd72b160d72402c78b12b7b9153b36ad617f4d426d1258130ffb">+722/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>control_plane_schemas.py</strong><dd><code>Define control-plane JSON schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-3a48c28d2e44f9cca6a309b9adcae65da585c1faf88b24a79be1c00999499d17">+681/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>http_server.py</strong><dd><code>Add ASGI HTTP MCP server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-45fb9dbb563e5244793620eddb1e06c012bfc571e45170344e48cb7b59d1d34a">+439/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ngm_extract.py</strong><dd><code>Add NGM extraction tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4040c357b6550d1f085f96673a95e7025dc2dc56e5d8d6a85861f1083ad0e106">+382/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>nes.py</strong><dd><code>Add NES lookup tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-895711099a82c82cbad1a642e1899d13abb288e6a66c3b1fc1a3223d583ccd4d">+363/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ngm_judicial.py</strong><dd><code>Add NGM judicial query tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-c2f277594fd306fa10854eb974a2b679250306f46584ce41d8ad67da7d395caf">+181/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>server.py</strong><dd><code>Register MCP server tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-283cf3ff35bc5e7163cd4154a20136be3d153e63e405b1583a2739c353bef7af">+225/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>test_jawafdehi_write_tools.py</strong><dd><code>Cover Jawafdehi write tool contracts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4fa53ad21bffb4fea6dea08daeee23e4be4d8deeed0cceb7fd47bfadb00753a1">+816/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_control_plane_tools.py</strong><dd><code>Cover control-plane tool route mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b341ea666cf3da6de012323caf7422db16a8e169a7aa05f9e4a0a507d6d896ec">+970/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_document_converter.py</strong><dd><code>Test document converter tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-dc51ea3c2371ef322695e2dadbbd863b73efa5ef3738e2c06e686afc0e84768e">+742/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_http_integration.py</strong><dd><code>Test hosted MCP HTTP behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-dfaf1a2d42d1af289a2b1d80c326dc62d4c137b6b84606601fb1934056267d48">+566/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_monolith_integration.py</strong><dd><code>Test Django monolith MCP routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4bdcf9b9004f05cad7a54bb82dcf61b96b6cba16158036b181922226784265d6">+365/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_server_profile.py</strong><dd><code>Test MCP server profile selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b980a7917ca3e2479bc4828e0e12903b40a0f748d2e94e72b2cc6419bdd0431b">+296/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_oidc.py</strong><dd><code>Test MCP OIDC authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-004683447d36dba8078d8c3225d3862a8f1daece3fe311093fb9b8c1fc51fea0">+323/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_ngm_extract.py</strong><dd><code>Test NGM extraction tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-3c7bd6c83c0feb99bfec416dc4584acfacfaf002816ccbab480f09c820ffd11d">+201/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_validation.py</strong><dd><code>Test MCP input validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-f824aa3b708d1ce6a569ab9e2fc5c943bb82b8044fe5cf26f05257e0eb22b41e">+178/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_nes_tools.py</strong><dd><code>Test NES tool behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-7dafd709e0e4adedb3ea67054e542b8d794cd31620ca189d22b8253cbe87dbd5">+208/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>configuration.py</strong><dd><code>Add Django OIDC config bridge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b20d7bf3bc8955aa289ed6cce0b31e9528d3e2473ccbca33523c269ea62171a2">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>63 files</summary><table>
<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci.yml</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-publish-platform.yml</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-6fe97b10300d8a58a533a31ed6f5a00409b97f8c0ccf3a4d8d83a64606b6656b">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration.yml</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b">+28/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+42/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.consumer</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-8873e849979e504d3fe654525e4380f652ad5923d619e7f2264b6abbd24a3fd5">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>seed_dev.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-bcf6b6f5803e02d97002cfa3b5fed05c2ea1231bc8b2e8d4fad0fc081cf95804">+14/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>asgi.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-e6351d76c95e05b7cf6c87dc62446cff8b8116141018417e22cbaddd3bcad742">+71/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>asgi_worker.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-3876eb60054128410d38b16e32f1faddca34c7e43f553e1f695d13ac98448052">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>settings.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193">+40/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>permissions.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-e2b1dee6de7a304549647088048a62ab3fed73f9e92ccca1bdcf5def4eb2d759">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>query_guard.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-ce8526c0c77622b67dc26a0f2e5b14a071de8e6bb788e6471e54aec28e0f35f8">+294/-117</a></td>

</tr>

<tr>
  <td><strong>test_api.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-bd6ca112fa37369abbd24f3fceb9ad814842274d138643146a86a15f62ee5185">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_query_guard_security.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-5d401a87a80645fc0897464e85c2c9b26083f909cd3ceafbf0c497edcb899382">+228/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>views.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-635672874c677d86a724601f0a7635942040a13c2eea9cd21805d3102670dce2">+72/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.e2e.env</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b9fb9d9f0755977bb39b81b1c3fd8be23ae70440de834b769437bfb00a7f9e47">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.e2e.yml</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-29d8d8c569345f7e4339e3bab5342fa39d73d2293303d372c0f00cd04ad242eb">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+53/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ARCHITECTURE.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1">+14/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DOC-STATUS.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-154b32979eb1fc2741d5dca55a30cefb078dd5362d805e8cfca30dae77492c5b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ADDING_TOOLS.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-e6ebb9a4e441c554bbfb23a904186f727fab7b55c8967b5115e5558c0c71ee1a">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-cf0c322274418ac59edaa13045ac7ce0d67373c38de9127e5fd526733e3d9aa6">+159/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>authz-model.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-81dd296e1cec1658469f7490f498306419e50b4da54bff62a925f8c5a392896b">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>authz-v3-change-map.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-37958f6f62460c84cf62188338fa1c92437be8519fc01d82192b26c4522c3ab6">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>threat-model.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-b3de0d56557601861e5bbd8541f6466fcd1b7543a61cca03e6864002d11a179a">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>testing.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245">+17/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-11def896777c09de84c2afa5687d3b1be20fa4a1a63899bbc0b31066dd003ef1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_mcp_smoke.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-116c8f1856b8367eae5a5bce03ae3a0d322884c295586928db9a4e558161406e">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LICENSE</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4e40eaf54e82b4b6ddc335d92b1eaa39818d61d0e5b48d48f637119b64597d2d">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-7e1f890a5d3bbb51e5aa620239d9756b068b5a8d129cede90070c4fd0ca33df8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api_transport.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-8b3d953cc433c700bc68b59a1717962b2b19cc0bb6bdcf973becdc58511e11e7">+155/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>control_plane.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4c11acbc4b05e4b525c63c5e7374f90a1dab4d0e3adf8492377de8bd9e92f5b2">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>identity.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-d49ff76439ef9e54e4e3a579f39184fb86e80e701b3f45451989be245af87983">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>logging_setup.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-2a3500da1a11eeed0b11d7703d56089ee8c712a751cab967beed9a1b57339f08">+147/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>oidc.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-f265f62eddc30ecc23e12b982a2ceba58b1679c5d8f41c8d78d2d237e843e8e5">+173/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>path_safety.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-9f14f8f23c75f92fdbffbebbb9acfc39f84f49c6d5979b3a75fdd4cd3aac3c98">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>request_context.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-be721f4f27ab0b58861fdfbbe74fc8cab3dcd1846f9e7b12c06e68080ce27d8b">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-e5525c45fb9b8fd7779ea593b543772687beaef34e6faafeb8b9300ec90ca6eb">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4d81345b3f66878500c55d4636783f0fa51290014ea1aa54f634a7f3565234fb">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>date_converter.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-fd00bf93f82dbec19e1ee77ec22ff28258535f2bd04c954bdef2fedc3b195fcd">+116/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ngm_proxy.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-58e09a13436c53b0e806758a8b87922f3a8c1db9264f63b282619b650b44b375">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>whoami.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-923b0824a0c9c02655a8a35158b56a8c91dd3ea8b6d857910ddb1f8fe96e69ee">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dev_service.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-0509d4ae0f02460467ed31b6922901b9c17f0a35b949e170367402e308b2ee26">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>oidc.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4c9f98097dd3f0ddf747fed6c43c981dd7a9aa166878668cf1c5c67265f09858">+68/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>logging_config.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-68661cf67e2ec7fb1fb3057d3f1586d5084971d4ac32cab52357f97e1bb8016d">+23/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+33/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>views.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-f724e243dd9c26fddecf50dee8a641cbe950f8ff4622dd06985e00cb8d0cea51">+14/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_reviews_grouped.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-e835e11a84ff54b40ebe8ff659e7ae9a6ab9b07b051b232f05ea98c4b58573d8">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-51c83e25f09b54ea59123e8fd21de91e00599b2ee07cf1ecde817ef3b915f27b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>conftest.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-5172148353a6228395be5b64b90bcbdf312cdcb21a81e8acdded388c871f5d14">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_asgi_worker.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-8c67cdde5cb3bcfb20fb900ae01105cb7ba2bf8906f72387e9dcaa4a4c4d2488">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_control_plane_client.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-24aa35ff06ae88f1fc80a120af4afa05a96c2b1ce1904468f962ca93fd948a9d">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_dev_query_token.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-4f4f0172dd275a524f07de73ca3faa14c9194c8c568dec203da3bc4dd7096ea0">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_identity.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-306d454462eced666304cc210c3e2983df26c39b7f952160c7ee61c508675de5">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_jawafdehi_search_tool.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-a4d6b44fe5c4f5a523aa9f62cc5f1ab0fb0d796ab276f6ca04123595c2596916">+126/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_metrics.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-020023b311721115d4286884bb138351b87d5836b3db0110edee28cfc322095f">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_ngm_proxy.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-0eaf2866f370e83e18135f62a7b18528f0f8bd430aa51d968d46c0574fd5dd7f">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_package_metadata.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-ff456c7c496581aeb19dddc8a53c1897b5730ee274005e1ae009b26580bd9539">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_stdio_integration.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-5df48b61dd670e66fadcd0fc9db33ac205750eb96c882b30d14b3cc9c90d1c6c">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tool_schemas.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-97aaa089286346b1397281e3141c977cc9fd0dd5ce6dfd409faf6ec1f53c9ad1">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_whoami.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-25c337dfac63f7779c665a6dcae817f101e3532735614d137ae70c4e20ba70d7">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_oidc_auth.py</strong></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/427/files#diff-8ad9f7e5c1411fa5703fd0a460d58251e71b23ba1eace31c5650eb4ed965bb05">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embedded MCP server at `/mcp` with health checks, tool discovery, authentication, and authorization.
  * Added tools for case management, judicial queries, entity search, document and date conversion, materials, reviews, jobs, and user identity.
  * Added stateless HTTP and stdio access with configurable limits and timeouts.
  * Improved SQL query safety, response limits, public data filtering, and read-only execution.
* **Documentation**
  * Added MCP architecture, usage, security, testing, and tool-development documentation.
* **Bug Fixes**
  * Normalized review slug filtering and improved OIDC key-refresh handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
