### PR TITLE
chore(typing): make `ty` a blocking gate, not advisory output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,20 @@ jobs:
       - name: Lint (ruff check)
         run: uv run ruff check .
 
-      # Type check, ADVISORY: reports into the log but never fails the build
-      # (`|| true`). ty is pre-1.0 and has no Django plugin, so it cannot see
-      # through the model metaclass — at adoption that was ~800 of 1304
-      # diagnostics on this tree. pyproject.toml's [tool.ty.rules] silences those
-      # families, leaving 30 real ones. Drop the `|| true` and make this a gate
-      # once those reach 0; see the staged plan in pyproject.toml.
-      - name: Type check (ty, advisory — does not fail the build)
-        run: uv run ty check || true
+      # Type check — a real GATE now (note: no `|| true`).
+      #
+      # What changed: ty still has no Django plugin, but django-stubs +
+      # djangorestframework-stubs close most of the metaclass blind spot from stub
+      # data alone, which a plugin was never needed for. That took the "all
+      # families on" count from 1560 to a tree this gate passes clean, and let four
+      # previously-silenced families (invalid-argument-type, not-subscriptable,
+      # unsupported-operator, invalid-assignment) become enforced.
+      #
+      # Still exempt, each with its measured cost written down in
+      # pyproject.toml's [tool.ty.rules]: `unresolved-attribute` (the one real
+      # plugin gap) and `unresolved-import` (optional lazy deps, permanent).
+      - name: Type check (ty)
+        run: uv run ty check
 
       # ``integration-tests/`` is a separate live-stack E2E suite (own pyproject + Makefile) that
       # hits a running monolith at PLATFORM_BASE_URL — it belongs in its own stack-up job, not this

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,29 @@ repos:
       - id: check-toml
       - id: check-yaml
 
-# ty (astral-sh) is deliberately NOT a hook yet. It is installed in the `dev`
-# group and configured in pyproject.toml under [tool.ty]; run it with
-# `uv run ty check`. At adoption it reported 1304 diagnostics on this tree, ~800
-# of them Django metaclass blind spots (`Model.objects`, DRF
-# `force_authenticate`) that ty cannot yet see through. The [tool.ty.rules]
-# block silences those families and leaves 30 real ones. Wire it in here only
-# once those 30 are at 0 and the silenced families can be re-enabled — see the
-# staged plan in pyproject.toml.
+  # ty is now a hook, and a `local` one — deliberately unlike the pinned ruff
+  # mirror above. That is not inconsistency: ty has to RESOLVE this project's
+  # third-party types (django-stubs, drf-stubs, django, DRF, wagtail, every
+  # runtime dep) to say anything useful, and a pre-commit-managed isolated env
+  # contains none of them. A mirror hook would report the whole tree as
+  # unresolved imports. Hermeticity is simply not on offer here; the project venv
+  # is the only environment in which the answer is correct.
+  #
+  # `pass_filenames: false` because the check is whole-project: ty needs the
+  # cross-module view, and the per-path scoping in [tool.ty.overrides] is keyed on
+  # paths it discovers itself.
+  #
+  # `files` covers pyproject.toml as well as sources, and that is not incidental.
+  # The obvious `types: [python]` looks right and is subtly wrong: pyproject.toml
+  # HOLDS the [tool.ty] config, so under a python-only trigger a commit that
+  # loosens a rule, widens an override, or drops a whole block skips the very
+  # check it just weakened. Verified by staging pyproject.toml alone — the hook
+  # reported "no files to check" and passed.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check
+        entry: uv run ty check
+        language: system
+        files: '(\.pyi?$|^pyproject\.toml$)'
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ that look like bugs but are load-bearing.
 ```bash
 uv sync                                    # install app + dev tools
 uv run ruff check .                        # the lint gate (exactly what CI runs)
-uv run ty check                            # type check — ADVISORY, not a gate
+uv run ty check                            # type check — a GATE, must be clean
 uv run python manage.py check
 DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true \
   uv run pytest -q --ignore=integration-tests    # full suite, ~2.3 min, no services
@@ -26,12 +26,17 @@ databases, one per router alias. Do not stand up Postgres/OpenSearch/MinIO to ru
 it. `--ignore=integration-tests` matters: `integration-tests/` is a separate live-stack
 suite that *errors* rather than skips when the stack is down.
 
-Expect **3297 passed · 4 skipped · 1 warning** (measured 2026-08-04). The 4 skips
-are `materials/tests/test_patch_concurrency_postgres.py`, which needs a real
-Postgres `ngm` alias AND `DJANGO_SETTINGS_MODULE=config.settings` — see that
+**Baseline the suite on your untouched branch and compare against that**, rather
+than against a number written down here — the totals move whenever upstream lands
+tests, and a stale figure here would just make a green run look wrong. What is
+stable is the shape: green, a handful of skips, exactly one warning.
+
+The skips are `materials/tests/test_patch_concurrency_postgres.py`, which needs a
+real Postgres `ngm` alias AND `DJANGO_SETTINGS_MODULE=config.settings` — see that
 module's docstring; `settings_test` hardcodes sqlite, so they can never run on the
-default gate. The 1 warning is upstream's own un-awaited `_drain_tasks` coroutine
-in `case_events`, not something this tree introduced.
+default gate. The one warning is upstream's own un-awaited `_drain_tasks`
+coroutine in `case_events`, not something this tree introduced. **A second
+warning is a real signal** — see the note under Conventions.
 
 Run one test: `uv run pytest tests/api/test_public_api.py -k name`. Security suite
 only: `uv run pytest -m security`.
@@ -47,12 +52,42 @@ primitive — so a directory opts *in* by deleting its line there, and only once
 its `ruff check <dir> --select ANN` count is already 0. Tests are exempt
 permanently.
 
-**`ty` is advisory, not a gate** — `uv run ty check`, and CI runs it with
-`|| true`. It is pre-1.0 with no Django plugin, so it cannot see through the
-model metaclass: at adoption it reported 1304 diagnostics of which ~800 were
-`Model.objects` / DRF `force_authenticate` false positives.
-`[tool.ty.rules]` silences those families, leaving **30 real ones** — worth
-reading, and the list to drive to zero before making it a gate.
+**`ty` IS a gate now** — `uv run ty check`, no `|| true` in CI, and a
+`local` pre-commit hook (local because ty needs the project venv to resolve
+django-stubs et al; a hermetic mirror env would report the tree as unresolved
+imports).
+
+It is still pre-1.0 with no Django plugin, but that stopped mattering:
+`django-stubs` + `djangorestframework-stubs` (dev group, exact-pinned, type-only)
+close the metaclass blind spot from stub data, which needs no plugin. Enforced
+now, beyond ty's defaults: `invalid-argument-type`, `not-subscriptable`,
+`unsupported-operator`, `invalid-assignment` (all four were silenced before),
+plus `possibly-unresolved-reference` and `possibly-missing-import`, which ty
+ships OFF and which found real bugs.
+
+Two families remain exempt: `unresolved-attribute` (the one genuine plugin gap —
+implicit FK `_id`, reverse accessors, `get_user_model()`) and `unresolved-import`
+(optional lazily-imported deps; permanent). Tests and a list of named source
+files are scoped out of the four new families via `[[tool.ty.overrides]]` —
+**deleting an entry from that list is how a file opts in**, and only once
+`ty check <file>` is already 0.
+
+**The measured cost of every exemption lives in `pyproject.toml`, next to the
+config it justifies — not here.** That is deliberate: a number is only useful
+where you can act on it, and a count in this file rots silently while a count
+beside the `include =` list is read by whoever is about to delete an entry. Each
+block records how it was measured, so re-derive rather than trust.
+
+**The gate's diagnostic set is a function of the resolved DEPENDENCY set.** This
+is the trap most likely to waste your afternoon. Families like
+`unresolved-import` are exempt, so before a package resolves, everything
+downstream of it infers as `Unknown` and no rule can fire on it. Promote that
+package into the main dependency set and its consumers become checked code
+overnight — so `ty check` can go red in files nobody edited. It happened here:
+PR #427 moved `markitdown`, `httpcore` and `likhit` out of extras, which
+surfaced findings in `review/converter.py` and `materials/sourcing/ppmo/ocr.py`,
+both untouched for weeks. **Re-measure after a dependency change; do not assume
+a merge broke something.**
 
 ## Traps — things that look wrong and are not
 
@@ -185,12 +220,36 @@ do not push to it.
   `tests/e2e/test_public_api_e2e.py:101` E/34 (a test, low value to split), and
   `casework/enrich_related_entities.py:364` `main` E/33.
   `cases/api_views.py` is still a 1989-line module even after the split.
-- **`ty`'s 30 real diagnostics** (`uv run ty check`). Mostly Django-shaped and
-  low-value (`__str__` returning `CharField` not `str`, `QuerySet.as_manager`),
-  but read them before dismissing: two genuine bugs came out of the first pass —
-  `case_scraper.py` called `len()` on an Optional `response.text` (TypeError on a
-  blocked Gemini candidate), and `ciaa_draft_case_service.convert_bs_to_ad` was
-  annotated `Optional[datetime]` while `bs_to_ad` returns `date`.
+- **`ty` is clean and gated** — the debt this bullet used to list is gone. The
+  `__str__`-returning-`CharField` family evaporated with django-stubs; the rest
+  were fixed. Keep reading its output rather than dismissing it, because that pass
+  found more real bugs: a SECOND Optional-`response.text` in `case_scraper.py` (the
+  phase-2 structuring call, one function below the phase-1 one already fixed);
+  `build_convert_payload` annotated `Optional[dict]` while all three of its failure
+  paths `raise`; `_die()` missing `-> NoReturn`, which made six reads genuinely
+  possibly-unbound; a `get_form` override silently dropping Django's `change`; and
+  `case_events.bus` passing a possibly-None loop *after* building the coroutine,
+  orphaning it.
+- **Two real defects sit behind the MCP type debt** (found 2026-08-05 while
+  gating ty over PR #427; each wants its own PR, neither is a typing fix):
+  `jawafdehi_mcp/tools/ngm_extract.py` `_validate_environment` is annotated
+  `-> tuple[str, str]` but returns `get_jawafdehi_api_config()`, whose token can
+  be `None` — and that token goes straight into an `Authorization` header. And
+  `sql_quote` is `value.replace("'", "''")`, applied to `arguments.get(...)`
+  straight off the MCP wire, then f-string-interpolated into `SELECT`s. The
+  `''`-doubling is correct for Postgres with `standard_conforming_strings` on, so
+  this is not trivially injectable, but a non-`str` argument (JSON number, list)
+  reaches `.replace` and raises. The `if not all([a, b, c])` guard above it is
+  also why ty reports most of that file — `all()` does not narrow.
+- **The remaining type debt is enumerated, not vague** — read the
+  `[[tool.ty.overrides]]` blocks in `pyproject.toml`, which name every file and
+  carry the per-block measurement and reasoning. The THIRD block is source files
+  predating the gate (the first is `urls.py`, the second tests); the FOURTH is
+  everything PR #427 brought in. Nearly all of it is two shapes: bs4 attribute
+  values (`str | AttributeValueList | None`) used as plain `str`, and unnarrowed
+  Optionals. The `dict(...)`-splat lever — annotating a heterogeneous carrier dict
+  `dict[str, Any]` so a typed constructor stops unioning every field — is the
+  biggest single win available and is mostly spent.
 - **`ANN` is enforced in `lakehouse/` only.** Per-directory source-only counts,
   cheapest first (re-measured after the 2026-08-04 upstream rebase): `newsletter`
   5, `discovery` 31, `jobs` 34, `content` 57, `case_proposals` 78, `case_events`

--- a/case_events/bus.py
+++ b/case_events/bus.py
@@ -226,11 +226,33 @@ class _Bus:
         if envelope.get("dedup_key"):
             headers["Nats-Msg-Id"] = envelope["dedup_key"]
 
-        try:
-            future = asyncio.run_coroutine_threadsafe(
-                self._js.publish(subject, body, headers=headers or None), self._loop
+        # Both of the next two blocks exist to keep a failed publish from ALSO
+        # orphaning a coroutine. `self._js.publish(...)` builds one eagerly, and a
+        # coroutine that is created and never awaited emits a "coroutine was never
+        # awaited" RuntimeWarning when it is collected. The suite is held at exactly
+        # one warning (see AGENTS.md), so a second one is a real signal and must not
+        # come from here.
+        #
+        # `_loop` is None until the bus starts, so check it BEFORE constructing the
+        # coroutine — there is nothing to clean up if we never build it.
+        loop = self._loop
+        if loop is None:
+            logger.warning(
+                "case_events.publish_failed", subject=subject, error="bus not started"
             )
+            return False
+
+        # A non-None loop can still be closed under us, and `call_soon_threadsafe`
+        # then raises before `run_coroutine_threadsafe` ever wraps the coroutine in a
+        # task — so nothing will await it and we have to close it by hand. Hence the
+        # separate name: an inline `self._js.publish(...)` argument leaves no handle
+        # to close. (The test helper in case_events/tests/test_bus.py already closes
+        # the coroutine in its `run_coroutine_threadsafe` stub for this same reason.)
+        coro = self._js.publish(subject, body, headers=headers or None)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
         except Exception as exc:  # noqa: BLE001 - loop may have died under us
+            coro.close()
             logger.warning("case_events.publish_failed", subject=subject, error=str(exc))
             return False
 

--- a/case_events/consumers/__init__.py
+++ b/case_events/consumers/__init__.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import structlog
 
@@ -239,6 +239,15 @@ def select(only: list[str] | None = None) -> list[ConsumerSpec]:
 # reason jobs.registry guards its own consumer import: a broken handler module
 # should not make the registry itself unimportable, which would take down the
 # management command that reports the problem.
+if TYPE_CHECKING:
+    # The guarded import below binds `handlers` only when it succeeds, so to a
+    # type checker every `from case_events.consumers import handlers` (the tests
+    # do exactly that) reads as a possibly-missing member. Declare it
+    # unconditionally here: in any healthy build the name IS bound, and the
+    # try/except exists for the catastrophic case, not the normal one. This
+    # changes nothing at runtime — the guard below is still the real contract.
+    from . import handlers
+
 try:  # pragma: no cover - defensive import wiring
     from . import handlers  # noqa: F401,E402
 except Exception:  # noqa: BLE001

--- a/case_events/tests/test_bus.py
+++ b/case_events/tests/test_bus.py
@@ -7,6 +7,7 @@ even try.
 """
 
 import asyncio
+import inspect
 import json
 import threading
 import time
@@ -336,6 +337,42 @@ class TestPublishMechanics:
         with mock.patch.object(bus.logger, "warning") as warn:
             bus._log_result(ok, "s")
         warn.assert_not_called()
+
+    @override_settings(NATS_URL="nats://localhost:4222")
+    def test_a_loop_that_died_under_us_does_not_orphan_the_coroutine(self):
+        """A failed schedule must close the coroutine it already built.
+
+        ``js.publish(...)`` is eager, but ``run_coroutine_threadsafe`` raises on a
+        closed loop *before* wrapping it in a task, so nothing will ever await it and
+        it emits "coroutine was never awaited" when collected. That would be a SECOND
+        suite warning, which AGENTS.md treats as a real signal.
+
+        Asserted on the coroutine's own state rather than by catching the warning,
+        because the warning only fires at GC time and would make this flaky.
+        """
+        built = {}
+
+        async def real_publish(*_args, **_kwargs):  # a genuine coroutine, not a Mock
+            return None
+
+        def capture(*args, **kwargs):
+            built["coro"] = real_publish(*args, **kwargs)
+            return built["coro"]
+
+        with mock.patch.object(bus._bus, "_ensure_started", return_value=True), \
+             mock.patch.object(bus._bus, "_js") as js, \
+             mock.patch.object(bus._bus, "_loop", mock.Mock()), \
+             mock.patch(
+                 "case_events.bus.asyncio.run_coroutine_threadsafe",
+                 side_effect=RuntimeError("Event loop is closed"),
+             ), \
+             mock.patch.object(bus.logger, "warning") as warn:
+            js.publish.side_effect = capture
+            result = bus._bus.publish("jaw.case.update.approved", {"payload": {}})
+
+        assert result is False
+        assert warn.call_args.kwargs["error"] == "Event loop is closed"
+        assert inspect.getcoroutinestate(built["coro"]) == inspect.CORO_CLOSED
 
 
 class TestOnlyOneThreadPaysTheConnectCost:

--- a/case_events/tests/test_producers.py
+++ b/case_events/tests/test_producers.py
@@ -445,7 +445,9 @@ class TestMaterialProducer:
             "court_order",
             data={"@id": "https://jawafdehi.org/material/court_order/abc", "isPartOf": {"@id": case_iri}},
         )
-        _, payload, refs, _ = material_producer.signal_for(m)
+        signal = material_producer.signal_for(m)
+        assert signal is not None, "a court_order with isPartOf must emit a signal"
+        _, payload, refs, _ = signal
 
         assert payload["part_of"] == case_iri
         assert case_iri in refs
@@ -457,7 +459,9 @@ class TestMaterialProducer:
 
     def test_a_press_release_with_no_case_still_emits(self):
         """CIAA releases generally name no docket; that is not a broken signal."""
-        _, payload, refs, _ = material_producer.signal_for(self.material("ciaa_press_release"))
+        signal = material_producer.signal_for(self.material("ciaa_press_release"))
+        assert signal is not None, "a press release with no docket must still emit"
+        _, payload, refs, _ = signal
         assert payload["part_of"] == ""
         assert refs  # its own IRI is still a ref
 

--- a/case_proposals/job_kind.py
+++ b/case_proposals/job_kind.py
@@ -248,7 +248,11 @@ def on_result(job, result: dict) -> None:
         return _validation_failure(job, "intent type not draftable by a model", intent_type=str(itype)[:60])
 
     try:
-        confidence = float(result.get("confidence"))
+        # Passing a missing key's None into float() is the INTENT here: the
+        # `except (TypeError, ValueError)` immediately below is what handles both
+        # "absent" and "not a number", in one place. Narrowing first would just
+        # duplicate that branch.
+        confidence = float(result.get("confidence"))  # ty: ignore[invalid-argument-type]
     except (TypeError, ValueError):
         return _validation_failure(job, "confidence is missing or not a number")
     if not 0.0 <= confidence <= 1.0:

--- a/cases/admin.py
+++ b/cases/admin.py
@@ -240,8 +240,18 @@ class CaseAdminForm(forms.ModelForm):
             new_state = cleaned_data.get("state")
 
             if old_state != new_state and self.request:
+                # `cleaned_data.get("state")` is Optional and deliberately passed
+                # through unnarrowed: short-circuiting on None here would SKIP the
+                # permission check entirely, which is the one outcome that must not
+                # happen. Note it does not *refuse* on None either —
+                # `can_transition_case_state` never reads `to_state` at all (see
+                # cases/rules/predicates.py), so its verdict is the caller's role
+                # and nothing else. None is therefore harmless to pass and unsafe
+                # to branch on, which is why the value goes through as-is.
                 if not can_transition_case_state(
-                    self.request.user, self.instance, new_state
+                    self.request.user,
+                    self.instance,
+                    new_state,  # ty: ignore[invalid-argument-type]
                 ):
                     errors["state"] = (
                         f"You do not have permission to transition from {old_state} to {new_state}. "
@@ -649,11 +659,22 @@ class CaseAdmin(UserFullNameAdminMixin, admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
-    def get_form(self, request, obj=None, **kwargs):
-        """Pass request to form for role-based field customization."""
-        form_class = super().get_form(request, obj, **kwargs)
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        """Pass request to form for role-based field customization.
 
-        class FormWithRequest(form_class):
+        `change` is named explicitly to match `ModelAdmin.get_form`. Django passes
+        it as a keyword, so it previously arrived inside `**kwargs` and was
+        forwarded that way — which means capturing it here makes forwarding it
+        below mandatory, not optional. Dropping it would silently hand `super()`
+        a default `change=False` on every edit-form render.
+        """
+        form_class = super().get_form(request, obj, change=change, **kwargs)
+
+        # Subclassing a base held in a variable is genuinely beyond static
+        # modelling — `form_class` is whatever `super().get_form()` built for this
+        # request. The dynamic subclass is the mechanism by which `request` reaches
+        # the form, so there is no static shape to rewrite this into.
+        class FormWithRequest(form_class):  # ty: ignore[unsupported-base]
             def __new__(cls, *args, **kwargs):
                 kwargs["request"] = request
                 return form_class(*args, **kwargs)

--- a/cases/fields.py
+++ b/cases/fields.py
@@ -7,6 +7,7 @@ plus ``HttpsURLField`` (a Django-6-ready ``URLField``).
 
 import re
 from datetime import datetime
+from typing import Any
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -37,7 +38,11 @@ class HttpsURLField(models.URLField):
     """
 
     def formfield(self, **kwargs):
-        return super().formfield(**{"assume_scheme": "https", **kwargs})
+        # Bound with an explicit `dict[str, Any]` rather than splatted inline: the
+        # merged literal otherwise infers a `str`-ish value type and every one of
+        # `formfield`'s differently-typed parameters is reported against it.
+        merged: dict[str, Any] = {"assume_scheme": "https", **kwargs}
+        return super().formfield(**merged)
 
 
 class TextListField(models.JSONField):

--- a/cases/management/commands/refresh_statistics.py
+++ b/cases/management/commands/refresh_statistics.py
@@ -40,7 +40,6 @@ class Command(BaseCommand):
             route_reads_to_replica(attempt < _MAX_ATTEMPTS)
             try:
                 stats = refresh_statistics()
-                break
             except OperationalError as exc:
                 if attempt == _MAX_ATTEMPTS:
                     raise
@@ -50,10 +49,24 @@ class Command(BaseCommand):
                     f"{attempt}/{_MAX_ATTEMPTS} ({exc}); retrying in {backoff}s"
                 )
                 time.sleep(backoff)
+            else:
+                # Report on the success path rather than after the loop. The
+                # previous shape (`break`, then read `stats` below the loop) was
+                # correct only because the final attempt re-raises, so the loop
+                # can never fall through — a non-local invariant that a type
+                # checker flags as a possibly-unbound read, and that a later edit
+                # to _MAX_ATTEMPTS or the raise could quietly turn into a real
+                # NameError. Here `stats` is read only where it is provably bound.
+                #
+                # `finally` still runs before this returns, so the routing flag is
+                # cleared exactly as before; the only change is that the flag reset
+                # now happens after this write instead of before it, which nothing
+                # observes (it is a ContextVar, and this write does not read it).
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Statistics snapshot refreshed (last_updated={stats['last_updated']})"
+                    )
+                )
+                return
             finally:
                 route_reads_to_replica(False)
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Statistics snapshot refreshed (last_updated={stats['last_updated']})"
-            )
-        )

--- a/cases/services/case_scraper.py
+++ b/cases/services/case_scraper.py
@@ -341,8 +341,19 @@ class CaseScraper:
             ),
         )
 
+        # Same Optional-`response.text` trap as the phase-1 extraction above, which
+        # was already fixed there and not here: a blocked/empty candidate yields
+        # None, and `model_validate_json(None)` fails with a pydantic type error
+        # about the *schema* rather than saying the model returned nothing.
+        text = response.text
+        if text is None:
+            raise RuntimeError(
+                "Gemini returned no text for the phase-2 structuring "
+                "(blocked or empty candidate)."
+            )
+
         # Parse and validate the case
-        case = Case.model_validate_json(response.text)
+        case = Case.model_validate_json(text)
 
         self.log("  Validation successful")
         return case

--- a/casework/common/cli.py
+++ b/casework/common/cli.py
@@ -214,7 +214,12 @@ def _utc_iso_now() -> str:
 
 class _UTCFormatter(logging.Formatter):
     """Formatter whose %(asctime)s is UTC, not local time."""
-    converter = time.gmtime
+    # `converter = time.gmtime` is the idiom the stdlib logging cookbook
+    # prescribes for UTC timestamps. typeshed declares `Formatter.converter` as a
+    # plain callable attribute while `time.gmtime` is an overloaded builtin, so
+    # the assignment reads as an incompatible method override. Idiom is correct;
+    # the checker cannot line the two shapes up.
+    converter = time.gmtime  # ty: ignore[invalid-method-override]
 
 
 class _RunContextFilter(logging.Filter):

--- a/casework/enrich_missing_bigo.py
+++ b/casework/enrich_missing_bigo.py
@@ -29,7 +29,7 @@ import logging
 import re
 import sys
 import time
-from typing import Optional
+from typing import NoReturn, Optional
 
 from casework.common.api import CaseworkApi
 from casework.common.cli import (
@@ -512,8 +512,15 @@ def main(argv=None):
         f"allow_remote_writes={args.allow_remote_writes}",
     )
 
-    def _die(step, exc):
-        """Record a pre-loop failure in the run log, then exit non-zero."""
+    def _die(step, exc) -> NoReturn:
+        """Record a pre-loop failure in the run log, then exit non-zero.
+
+        `NoReturn` is load-bearing, not decoration: every caller below is an
+        `except` handler whose *only* statement is `_die(...)`, so without it a
+        type checker reads `api`/`all_cases` as possibly-unbound at each later
+        use and reports six findings. It also states the contract the callers
+        already rely on — `_die` never falls through.
+        """
         detail = f"{type(exc).__name__}: {exc}"
         _run_event(logger, paths, run_id, step, "error", detail, level=logging.ERROR)
         log_run_footer(

--- a/casework/enrich_tags.py
+++ b/casework/enrich_tags.py
@@ -903,8 +903,11 @@ def _collect_case_text(case: dict) -> str:
         for cc in case.get("court_cases") or []:
             if isinstance(cc, str):
                 parts.append(cc)
-    if case.get("description"):
-        parts.append(case.get("description"))
+    # Bind once, then test: the previous shape called `.get` twice, so the value
+    # joined below was not provably the non-empty one the guard checked.
+    description = case.get("description")
+    if description:
+        parts.append(description)
     return " ".join(parts).lower()
 
 

--- a/casework/entity_resolver.py
+++ b/casework/entity_resolver.py
@@ -769,7 +769,14 @@ def qualified_siblings(extracted: str, candidates: list[dict],
             continue
         title = result.get("title") or {}
         for form in (title.get("ne"), title.get("en")):
-            longer = name_tokens(form or "")
+            # Skip a missing form up front. Previously `name_tokens(form or "")`
+            # gave a falsy form an empty token list, which `len(longer) <= len(small)`
+            # below then always dropped (0 <= len(small) holds for any small) — so
+            # this is the same outcome reached directly instead of via the length
+            # test. `out` is a list[str]; keep None out of it explicitly.
+            if not form:
+                continue
+            longer = name_tokens(form)
             if len(longer) <= len(small):
                 continue
             if all(tokens_equal(a, b) for a, b in zip(small, longer)):

--- a/config/settings.py
+++ b/config/settings.py
@@ -499,18 +499,24 @@ def _sqlite_alias(file_name: str, test_name: str) -> dict:
     }
 
 
+# Read once each, rather than calling `os.getenv` twice per alias (once to test and
+# once to pass). Two calls mean the value handed to `parse()` is not provably the
+# non-empty one the test checked.
+_NES_DB_URL = os.getenv("NES_DB_URL")
+_NGM_DB_URL = os.getenv("NGM_DATABASE_URL")
+
 DATABASES = {
     "default": dj_database_url.config(default="sqlite:///db.sqlite3"),
     # nes DB — the NES entity store.
     "nes": (
-        dj_database_url.parse(os.getenv("NES_DB_URL"))
-        if os.getenv("NES_DB_URL")
+        dj_database_url.parse(_NES_DB_URL)
+        if _NES_DB_URL
         else _sqlite_alias("db_nes.sqlite3", "test_nes.sqlite3")
     ),
     # ngm DB — courts/materials.
     "ngm": (
-        dj_database_url.parse(os.getenv("NGM_DATABASE_URL"))
-        if os.getenv("NGM_DATABASE_URL")
+        dj_database_url.parse(_NGM_DB_URL)
+        if _NGM_DB_URL
         else _sqlite_alias("db_ngm.sqlite3", "test_ngm.sqlite3")
     ),
 }

--- a/content/models.py
+++ b/content/models.py
@@ -61,7 +61,11 @@ class ArticleIndexPage(Page):
     api_fields = [APIField("intro")]
 
 
-class ArticlePage(HeadlessPreviewMixin, Page):
+# The `serve_preview` signatures of `HeadlessPreviewMixin` (wagtail-headless-preview)
+# and Wagtail's own `PreviewableMixin` genuinely disagree upstream. Overriding it is
+# the entire reason the mixin is here and it must come FIRST in the MRO — see the
+# docstring below. Nothing in this repo can reconcile the two declarations.
+class ArticlePage(HeadlessPreviewMixin, Page):  # ty: ignore[invalid-method-override]
     """An update or news article, delivered headless via the API v2.
 
     ``HeadlessPreviewMixin`` overrides ``serve_preview`` so the edit-screen

--- a/courts/case_status.py
+++ b/courts/case_status.py
@@ -537,8 +537,14 @@ def outcome_from_hearings(hearings) -> HearingOutcome | None:
                 (v for k, v in _HEARING_DECISION_MAP.items() if _order_key(k) in decision),
                 None,
             )
-            if verdict is None:
-                continue
+        # Hoisted out of the fallback branch so it guards BOTH paths with one check.
+        # `classify_order_type` only sets a verdict for the terminal/compound buckets
+        # (its docstring says so, and both arms return a dict hit), so on the
+        # non-fallback path this never fires — but the invariant lives in that
+        # function's prose, not its `tuple[str, str | None]` return type. Checking it
+        # here is what keeps a verdict-less HearingOutcome unconstructable.
+        if verdict is None:
+            continue
         date_bs = _ws(hearing.get("date") or hearing.get("hearing_date"))
         date_ad = None
         if date_bs:

--- a/courts/scraper/high.py
+++ b/courts/scraper/high.py
@@ -76,7 +76,17 @@ def parse_bench_list(html: str) -> list[dict[str, str]]:
         cells = row.find_all("td")
         if len(cells) < 2:
             continue
-        match = _SEND_DATA_RE.search(row.get("onclick", ""))
+        # bs4 types an attribute value as `str | list[str]`, because multi-valued
+        # attributes (class, rel) parse to a list. `onclick` is never multi-valued,
+        # but join rather than assume: a malformed page should not raise TypeError
+        # out of the middle of a cause-list parse.
+        raw_onclick = row.get("onclick", "")
+        onclick = (
+            raw_onclick
+            if isinstance(raw_onclick, str)
+            else " ".join(raw_onclick or [])
+        )
+        match = _SEND_DATA_RE.search(onclick)
         if not match:
             continue
         benches.append(
@@ -106,7 +116,10 @@ def parse_bench_page(
     soup = BeautifulSoup(html, "html.parser")
     hearing_date_ad = bs_to_ad(date_bs)
 
-    bench_type_elem = soup.find("h4", string=lambda x: x and "इजलास" in x)
+    # `bool(x) and ...` rather than `x and ...`: the latter evaluates to `x` (a
+    # str) when falsy, and bs4's string matcher is a predicate returning bool.
+    # Same truthiness for bs4, honest type for the reader.
+    bench_type_elem = soup.find("h4", string=lambda x: bool(x) and "इजलास" in x)
     bench_type = (
         normalize_whitespace(bench_type_elem.get_text()) if bench_type_elem else ""
     )

--- a/courts/scraper/special.py
+++ b/courts/scraper/special.py
@@ -104,8 +104,10 @@ def parse_bench_page(
     soup = BeautifulSoup(html, "html.parser")
     hearing_date_ad = bs_to_ad(date_bs)
 
+    # `bool(x)` not `x` — see the note in courts/scraper/high.py: bs4's string
+    # matcher is a bool predicate, and `x and ...` yields the str when falsy.
     court_number_elem = soup.find(
-        "font", string=lambda x: x and "इजलास" in x and "नं" in x
+        "font", string=lambda x: bool(x) and "इजलास" in x and "नं" in x
     )
     court_number = (
         normalize_whitespace(court_number_elem.get_text()) if court_number_elem else ""
@@ -254,7 +256,7 @@ def parse_detail(html: str) -> ParsedEnrichment:
 
 def _parse_hearing_section(soup: BeautifulSoup) -> list[dict]:
     """Rows of the 'पेशी को विवरण' (hearing schedule) ``utivtbl`` table."""
-    heading = soup.find(string=lambda x: x and "पेशी को विवरण" in x)
+    heading = soup.find(string=lambda x: bool(x) and "पेशी को विवरण" in x)
     if not heading:
         return []
     parent_row = heading.find_parent("tr")

--- a/courts/tests/test_import_courtcases.py
+++ b/courts/tests/test_import_courtcases.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 from io import StringIO
+from typing import Any
 from unittest import mock
 
 from django.core.management import call_command
@@ -74,7 +75,12 @@ def _hearing(**over):
 
 
 def _copy(rows, **cfg):
-    options = dict(
+    # `dict[str, Any]`, not inferred: a heterogeneous dict infers its value type as
+    # the union of every entry, and `ImportConfig(**options)` then sees EVERY field
+    # as `ImportMode | list[str] | ... | int`. That one splat accounted for 55 of
+    # the tree's type diagnostics. `Any` is correct here — the dict is a kwargs
+    # carrier whose values are deliberately of differing types.
+    options: dict[str, Any] = dict(
         mode=ImportMode.COPY, courts=["supreme"], source_rows=rows, batch_size=10
     )
     options.update(cfg)
@@ -334,7 +340,7 @@ class VerdictJudgeDeriveTests(_NgmTestCase):
             decision_type="अन्तिम आदेश", judge_names="मा. न्या. श्री एकमा. न्या. श्री दुई",
             scraped_at=_SCRAPED,
         )
-        cfg = dict(mode=ImportMode.INPLACE, courts=["special"])
+        cfg: dict[str, Any] = dict(mode=ImportMode.INPLACE, courts=["special"])
         first = CourtCaseImporter(ImportConfig(**cfg)).run()
         self.assertEqual(first.dq_verdict_judge_derived, 1)
         case = CourtCase.objects.using("ngm").get(case_number="082-CR-0007")
@@ -398,7 +404,7 @@ class InplaceModeTests(_NgmTestCase):
             court=court, case_number="081-CR-0400", status="enriched",
             case_type="080-cp-1852 लेनदेन",
         )
-        cfg = dict(mode=ImportMode.INPLACE, courts=["supreme"])
+        cfg: dict[str, Any] = dict(mode=ImportMode.INPLACE, courts=["supreme"])
         first = CourtCaseImporter(ImportConfig(**cfg)).run()
         self.assertEqual(first.dq_case_type_normalized, 1)
         case = CourtCase.objects.using("ngm").get(

--- a/discovery/resourcesync.py
+++ b/discovery/resourcesync.py
@@ -59,7 +59,9 @@ def _rs_md(capability: str, *, at: datetime | None = None, extra: dict | None = 
     """One ``<rs:md>`` element with a ``capability`` (+ optional attrs)."""
     attrs = [f'capability={quoteattr(capability)}']
     if at is not None:
-        attrs.append(f'at={quoteattr(_iso(at))}')
+        # `at` is already known non-None here, so format it directly: `_iso` exists
+        # to accept an Optional and returns one, which would only re-widen it.
+        attrs.append(f'at={quoteattr(at.isoformat())}')
     for key, value in (extra or {}).items():
         attrs.append(f"{key}={quoteattr(str(value))}")
     return f"  <rs:md {' '.join(attrs)}/>"

--- a/jobs/tests/test_review_supersede.py
+++ b/jobs/tests/test_review_supersede.py
@@ -114,7 +114,11 @@ def test_regrade_all_targets_only_the_latest_review_per_slug():
     with mock.patch.object(
         views.HasContributorRole, "has_permission", return_value=True
     ):
-        response = views.regrade_all(request)
+        # drf-stubs types an `@api_view`-decorated function as a zero-parameter
+        # view callable, so calling it directly with a request — which is exactly
+        # how APIRequestFactory tests invoke function views — reads as an arity
+        # error. The call is correct DRF usage.
+        response = views.regrade_all(request)  # ty: ignore[too-many-positional-arguments]
 
     assert response.data["review_ids"] == [latest.pk]
     old.refresh_from_db()

--- a/lakehouse/engine.py
+++ b/lakehouse/engine.py
@@ -72,15 +72,20 @@ def build_s3_secret_sql(
     no endpoint is the AWS-S3 path).
     """
     s3 = settings.s3
-    if not s3.is_configured:
+    # Bound to locals so the credentials actually NARROW. `S3Settings.is_configured`
+    # is exactly `bool(access_key_id and secret_access_key)` (see lakehouse/config.py),
+    # but it is a property, so testing it tells a type checker nothing about the two
+    # fields. The condition below is that same one, spelled where it narrows.
+    key_id, secret = s3.access_key_id, s3.secret_access_key
+    if not (key_id and secret):
         raise RuntimeError(
             "S3/R2 credentials not configured (set AWS_ACCESS_KEY_ID / "
             "AWS_SECRET_ACCESS_KEY); see ngm.lakehouse.config."
         )
     parts = [
         "TYPE s3",
-        f"KEY_ID {_quote(s3.access_key_id)}",
-        f"SECRET {_quote(s3.secret_access_key)}",
+        f"KEY_ID {_quote(key_id)}",
+        f"SECRET {_quote(secret)}",
         f"REGION {_quote(s3.region)}",
         f"URL_STYLE {_quote(s3.url_style)}",
         f"USE_SSL {'true' if s3.use_ssl else 'false'}",
@@ -108,11 +113,15 @@ def build_catalog_secret_sql(
             "ICEBERG_WAREHOUSE); see ngm.lakehouse.config."
         )
     parts = ["TYPE iceberg"]
-    if cat.uses_oauth2:
+    # Inlined rather than `if cat.uses_oauth2:` for the narrowing reason above —
+    # `uses_oauth2` is defined as exactly this conjunction (lakehouse/config.py).
+    client_id, client_secret = cat.client_id, cat.client_secret
+    oauth2_server_uri = cat.oauth2_server_uri
+    if client_id and client_secret and oauth2_server_uri:
         parts += [
-            f"CLIENT_ID {_quote(cat.client_id)}",
-            f"CLIENT_SECRET {_quote(cat.client_secret)}",
-            f"OAUTH2_SERVER_URI {_quote(cat.oauth2_server_uri)}",
+            f"CLIENT_ID {_quote(client_id)}",
+            f"CLIENT_SECRET {_quote(client_secret)}",
+            f"OAUTH2_SERVER_URI {_quote(oauth2_server_uri)}",
         ]
         if cat.oauth2_scope:
             parts.append(f"OAUTH2_SCOPE {_quote(cat.oauth2_scope)}")
@@ -135,13 +144,16 @@ def build_attach_sql(
 ) -> str:
     """Render the ``ATTACH ... (TYPE iceberg, SECRET ..., ENDPOINT ...)`` call."""
     cat = settings.catalog
-    if not cat.is_configured:
+    # `CatalogSettings.is_configured` is exactly `bool(uri and warehouse)`; bind both
+    # so they narrow (same reasoning as build_s3_secret_sql above).
+    uri, warehouse = cat.uri, cat.warehouse
+    if not (uri and warehouse):
         raise RuntimeError("Iceberg catalog not configured; see ngm.lakehouse.config.")
     return (
-        f"ATTACH {_quote(cat.warehouse)} AS {alias} (\n"
+        f"ATTACH {_quote(warehouse)} AS {alias} (\n"
         f"    TYPE iceberg,\n"
         f"    SECRET {secret_name},\n"
-        f"    ENDPOINT {_quote(cat.uri)}\n"
+        f"    ENDPOINT {_quote(uri)}\n"
         f");"
     )
 

--- a/llm/providers/proxy.py
+++ b/llm/providers/proxy.py
@@ -1,5 +1,7 @@
 """OpenAI-compatible llm-proxy provider."""
 
+from typing import Any
+
 from django.conf import settings
 
 from llm.providers.base import Provider, strip_code_fence
@@ -23,7 +25,11 @@ class ProxyProvider(Provider):
         if _proxy is None:
             from openai import OpenAI
 
-            kwargs = dict(
+            # `dict[str, Any]`: a heterogeneous kwargs carrier infers its value type
+            # as the union of every entry, so `OpenAI(**kwargs)` below would see
+            # EVERY one of its parameters as `str | int | ...` — 16 diagnostics from
+            # this one splat. The values are deliberately of differing types.
+            kwargs: dict[str, Any] = dict(
                 base_url=settings.LLM_PROXY_BASE_URL,
                 api_key=settings.LLM_PROXY_API_KEY or "unused",
                 timeout=120,

--- a/materials/conversion.py
+++ b/materials/conversion.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from . import jsonld
 from . import provenance
@@ -105,7 +105,7 @@ def enqueue_material_convert(material_iri: str, *, priority: int = 100):
     )
 
 
-def build_convert_payload(job) -> Optional[dict]:
+def build_convert_payload(job) -> dict:
     """``build_payload`` hook: resolve the source URLs for a claimed convert job.
 
     Reads the Material row named by ``payload['material_iri']`` and returns the

--- a/materials/sourcing/ciaa/parse.py
+++ b/materials/sourcing/ciaa/parse.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 from bs4 import BeautifulSoup
@@ -34,7 +35,13 @@ from materials.sourcing.nkp.normalizer import (
 #: class matching is membership (``col-sm-8`` among the element's classes), which
 #: is slightly more lenient than the legacy ``@class="col-sm-8"`` xpath and so
 #: strictly more robust to an added utility class.
-_CONTAINER_ATTRS = {"class": "col-sm-8"}
+# Annotated `Any`-valued rather than left to infer `dict[str, str]`: bs4 types
+# `find(attrs=...)` as a dict over its own wide "strainable" union, and `dict` is
+# INVARIANT in its value type, so `dict[str, str]` is not assignable to it even
+# though `str` is a member of that union. `Any` on a handle to an untyped
+# third-party shape is the documented house style (see the ANN401 note in
+# pyproject.toml, which names BeautifulSoup explicitly).
+_CONTAINER_ATTRS: dict[str, Any] = {"class": "col-sm-8"}
 
 #: Link/UI label text that is page chrome, never body text (the download badge and
 #: the social buttons), dropped from the extracted full text.

--- a/materials/tests/test_single_source_ingest.py
+++ b/materials/tests/test_single_source_ingest.py
@@ -14,6 +14,7 @@ repo root:
 from __future__ import annotations
 
 from datetime import date
+from typing import Any
 
 from django.test import TestCase
 
@@ -116,7 +117,10 @@ class MaterializeOrdersViaImporterTests(_NgmTestCase):
         }
 
     def _run(self, **over):
-        cfg = dict(
+        # Annotated for the same reason as courts/tests/test_import_courtcases.py
+        # ::_copy — an unannotated heterogeneous kwargs dict makes every splatted
+        # field the union of all its value types.
+        cfg: dict[str, Any] = dict(
             mode=ImportMode.COPY, courts=["supreme"], source_rows=[self._row()],
             materialize_orders=True, batch_size=10,
         )

--- a/materials/views.py
+++ b/materials/views.py
@@ -843,12 +843,23 @@ def _list_materials(request) -> Response:
 
     paginator = PlatformCursorPagination()
     page = paginator.paginate_queryset(qs, request)
+
     # Authed callers get the cached visibility + policy per row (for the admin
     # table); anon callers get the raw JSON-LD unchanged.
-    docs = [
-        _with_admin_visibility(row) if can_see_nonpublic else row.data for row in page
-    ]
-    return paginator.get_paginated_response(docs)
+    def _render(rows):
+        return [
+            _with_admin_visibility(row) if can_see_nonpublic else row.data
+            for row in rows
+        ]
+
+    # `paginate_queryset` is Optional-returning: DRF returns None when a paginator
+    # declines to paginate. PlatformCursorPagination (a CursorPagination) never
+    # does, so this is unreachable today — but `get_paginated_response` REQUIRES a
+    # completed paginate_queryset, so the None branch cannot just fall through to
+    # it. Same shape as courts/views.py::_paginated, which is the house pattern.
+    if page is None:
+        return Response(_render(qs))
+    return paginator.get_paginated_response(_render(page))
 
 
 @api_view(["GET", "POST", "PATCH", "DELETE"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,34 +166,67 @@ dev = [
     "pytest-asyncio>=0.24",
     "pre-commit>=4.6.0",
     "ty>=0.0.66",
+    # Type-only stubs for the Django/DRF surface. EXACT pins, deliberately: a
+    # stub bump silently changes the diagnostic set the type gate is measured
+    # against, exactly as a ruff bump changes the lint gate (same reasoning as
+    # the pinned ruff mirror in .pre-commit-config.yaml). Bump these
+    # intentionally and re-measure, never incidentally.
+    #
+    # These do the heavy lifting that makes a type GATE possible at all — see
+    # the [tool.ty.rules] block below for the measurement. They are stubs, so
+    # they carry no runtime code and are dev-group only: they never enter the
+    # image. Verified inert: the full suite is unchanged with them installed.
+    "django-stubs==6.0.7",
+    "djangorestframework-stubs==3.17.1",
 ]
 
 # ---------------------------------------------------------------------------
-# ty (astral-sh) — type checking, ADVISORY, not yet a gate.
+# ty (astral-sh) — type checking, and a GATE.
 #
 # Run it:  uv run ty check
 #
-# ty is pre-1.0 (0.0.66 here) and has NO Django plugin, so it cannot see what
-# Django's model metaclass adds at runtime. Measured on this tree at the time of
-# adoption: 1304 diagnostics, of which ~800 (61%) are that blind spot —
-# 640 `X has no attribute objects` (the default Manager, injected by ModelBase)
-# and 110 `has no attribute force_authenticate` (DRF's APIClient). Those are
-# tool limitations, not defects in this code.
+# ty is a GATE: CI runs `uv run ty check` with no `|| true`, and
+# .pre-commit-config.yaml runs it too. It is still pre-1.0 (0.0.66; 0.0.67 is the
+# latest) and still has NO Django plugin.
 #
-# So the rules below are OFF for now, and ty is ADVISORY rather than a gate: CI
-# runs it with `|| true` (see ci.yml) and pre-commit does not run it at all. A
-# gate that reports 800 false positives trains people to ignore it. What IS
-# useful today is the 30 that remain once those families are silenced, which is
-# why the checker is installed and configured rather than skipped.
+# That last point used to be the blocker, and the reason it no longer is:
+# the metaclass blind spot turned out to be closable from STUB DATA, which needs
+# no plugin. django-stubs types field access through `__get__` overloads and
+# declares `objects`, so adding django-stubs + djangorestframework-stubs to the
+# dev group moved this tree, measured:
 #
-# The path to a real gate, in order:
-#   1. keep `unresolved-attribute` off until ty ships Django support (track
-#      astral-sh/ty#255 "django plugin"), or add django-stubs and re-measure;
-#   2. turn the small families on one at a time (`not-iterable`,
-#      `missing-argument`, `invalid-method-override` are single digits today);
-#   3. only then drop the `|| true` in ci.yml and add the hook to
-#      .pre-commit-config.yaml.
-# ---------------------------------------------------------------------------
+#     all families on, no stubs .............. 1560   (1174 unresolved-attribute,
+#                                                      of which 809 `objects`
+#                                                      and 110 force_authenticate)
+#     all families on, with stubs ..............676   (pre-fix; the same
+#                                                      measurement on the SHIPPED
+#                                                      tree is 551)
+#     ...after the fixes in this change .........0 against the config below
+#
+# Provenance, so the next person can re-derive rather than trust. Only the 0 and
+# the 551 are reproducible as-is; 1560 and 676 are historical, read off single
+# `ty check` runs before the fixes landed, so do not expect 676 back. To redo the
+# "all families on" number without editing this file:
+#
+#     uv run ty check --config-file <a ty.toml holding only [environment]+[src]>
+#
+# and for one family, `uv run ty check -c "rules.<name>='error'"` (which is how
+# the 314 below was taken). Note `-c "overrides=[]"` does NOT clear the override
+# blocks — arrays do not replace, so it silently no-ops; use --config-file.
+# 1560 is the sum of the then-baseline (31) plus each silenced family measured on
+# its own via `--error <rule>`; the families are independent.
+#
+# `__str__` returning `CharField` went from 12 to 1 for the same reason. The
+# stubs cost 24 false `path()`/`re_path()` overload reports in URLconfs, handled
+# by the first override block below.
+#
+# django-stubs targets mypy and says so, so expect occasional friction of exactly
+# that kind rather than none. It is type-only, dev-group, never in the image, and
+# verified inert against the suite.
+#
+# The remaining exemptions are `unresolved-attribute` and `unresolved-import`;
+# both are argued, with their measured cost, in [tool.ty.rules] below. Track
+# astral-sh/ty#255 ("django plugin") — landing it is what closes the first one.
 # ---------------------------------------------------------------------------
 # ruff — the lint gate (CI runs exactly `uv run ruff check .`).
 #
@@ -279,19 +312,228 @@ exclude = [
 ]
 
 [tool.ty.rules]
-# --- Django/DRF blind spots: off until ty understands the metaclass. ---
+# --- The ONE family still off tree-wide. -----------------------------------
+# `unresolved-attribute` is the django-stubs *plugin* gap, and it is the only
+# thing django-stubs cannot close from stubs alone. What remains after the stubs
+# land (measured on this tree): 109 in source, 205 in tests. The source ones are
+# dominated by things a mypy plugin synthesises and a stub file cannot —
+# implicit FK id columns (`court_id` x17, `case_id` x8), reverse relation
+# accessors (`courtcase_references`, `material_references`), and the custom-User
+# surface (`groups`, `is_superuser`) reached through `get_user_model()`, which is
+# typed `type[AbstractBaseUser]`.
+#
+# Closing it needs one of: ty gaining a Django plugin (track astral-sh/ty#255 —
+# still absent as of 0.0.67), hand-declaring every FK's `_id` and every
+# `related_name` on the 26 models, or abandoning `get_user_model()` across 38
+# call sites. The first is free and coming; the other two trade a documented
+# Django practice for type purity. So: off, with the cost written down.
 unresolved-attribute = "ignore"
-# `Model.objects.filter(...)` returns Any to ty, so anything derived from a
-# queryset trips these three.
+
+# `unresolved-import` is off for a different and permanent reason: this tree
+# imports genuinely OPTIONAL dependencies lazily inside function bodies, guarded
+# by try/except ImportError, and they are absent from the base image on purpose.
+# The full set as of this change: markitdown, playwright.sync_api, pymupdf,
+# fitz, likhit.converters, npttf2utf, cloudpathlib, markdownify. Two more are
+# django-stubs re-export gaps rather than optional deps
+# (`django.template.loader.engines`, `django.test.testcases.
+# DatabaseOperationForbidden`) — both resolve fine at runtime.
+unresolved-import = "ignore"
+
+# --- Bug-shaped rules, explicitly ON (ty ships them off by default). ---
+# These two ask "can this name actually be unbound here?", which is a runtime
+# NameError/ImportError question rather than a typing-purity one, so they are
+# worth having even while the Django-shaped families above are still settling.
+# They earned their place: the 7 + 3 they reported were a missing `NoReturn` on
+# `casework.enrich_missing_bigo._die` (6), a genuinely non-local possibly-unbound
+# read in `refresh_statistics` (1), and `case_events.consumers.handlers` being
+# bound only inside a defensive try/except (3). All fixed at the definition site
+# rather than suppressed at the call sites.
+possibly-unresolved-reference = "error"
+possibly-missing-import = "error"
+
+# NOTE what is NOT listed here: `invalid-argument-type`, `not-subscriptable`,
+# `unsupported-operator` and `invalid-assignment` were all `"ignore"` before this
+# change and are now at ty's default (error), i.e. GATED. They were silenced as
+# "queryset returns Any" collateral; with django-stubs installed that premise
+# mostly evaporated, and what was left turned out to be four real fix families —
+# unnarrowed Optionals, and heterogeneous `dict(...)` splatted into a typed
+# constructor (six annotated lines accounted for 91 diagnostics across
+# `ImportConfig`, `OpenAI` and `Field.formfield`). Of that 91, **26 are
+# source-side**, each verified by reverting the annotation and re-running:
+# `OpenAI` 16, `Field.formfield` 9, bs4 `find(attrs=...)` 1. The remainder was
+# `ImportConfig` in test files, which the tests block below now exempts anyway —
+# so those four test-side annotations are documentation, not gate-load-bearing.
+#
+# They are enforced everywhere EXCEPT the tests and source-file override blocks
+# below, which name the places not yet converted (the urls.py block below governs
+# a different rule and is unrelated). That list is meant to shrink; deleting an entry
+# is how a file opts in, exactly as deleting a `per-file-ignores` line is how a
+# directory opts into ANN.
+
+# ---------------------------------------------------------------------------
+# Per-path rule overrides. ty DOES have a select-for-one-path primitive (unlike
+# ruff, which is why the ANN gate above has to be inverted through
+# per-file-ignores). Prefer an override here over scattering inline
+# `# ty: ignore` comments across a whole family.
+# ---------------------------------------------------------------------------
+[[tool.ty.overrides]]
+# django-stubs types `path()`/`re_path()` with overloads whose `view` must be
+# `Callable[..., HttpResponseBase]`. Neither DRF's `@api_view`-decorated
+# functions nor `.as_view()` results match any overload, so EVERY route in the
+# tree gets reported — 24 findings, all confined to URLconfs (review 8,
+# discovery 6, jobs 4, entities 3, materials 3).
+#
+# Verified false, not deferred: `path("auth/me/", views.me_view)` in
+# review/urls.py is valid Django that runs in production and is covered by the
+# suite. This is django-stubs/ty friction (django-stubs targets mypy, and says
+# so), not a defect in these files.
+#
+# The suppression is per-FILE rather than per-line because a URLconf is
+# essentially nothing but `path()` calls — there is no other call shape here for
+# it to mask. Re-check this on a django-stubs bump; if the overloads gain an
+# `Any`-tolerant arm, delete the whole block.
+include = ["**/urls.py"]
+
+[tool.ty.overrides.rules]
+no-matching-overload = "ignore"
+
+# ---------------------------------------------------------------------------
+[[tool.ty.overrides]]
+# TESTS: the four newly-gated families are off here — 168 findings' worth,
+# re-derived on the shipped tree: 93 invalid-argument-type, 47 not-subscriptable,
+# 18 unsupported-operator, 10 invalid-assignment.
+#
+# This mirrors the ANN policy above, which exempts tests permanently, and for a
+# related reason: a test double's whole job is to stand in for a shape it does
+# not statically have. Concretely, within THESE four families it is Optional
+# helper returns used without a guard (all 47 not-subscriptable are "cannot
+# subscript None") and `None`/double stand-ins passed where the real type is
+# declared — `ModelAdmin(site=None)` 15, `Job | None` into `finalize` 12,
+# `HTTPError.__init__` 9. tests/casework/test_enrich_timeline.py (28) and
+# materials/tests/test_nkp_parse.py (15) are the two biggest files.
+#
+# NOT this block: the double-attribute noise (`_casework_run_paths`, `calls`) and
+# most of the `APIClient`/`get_user_model()` surface are `unresolved-attribute`,
+# which is off tree-wide above — 205 of its 314 are in tests.
+#
+# `not-iterable` is here for the same reason and is NOT one of the four: unittest
+# `Mock.await_args`/`call_args` are typed `None` until the mock is called, so the
+# standard `args, kwargs = m.await_args` unpack after an
+# `assert_awaited_once()` reads as "unpacking None". It is the exact same
+# stand-in-shape argument as the 47 "cannot subscript None" above, just a
+# different rule name. 3 findings, all in tests/mcp/test_jawafdehi_write_tools.py.
+#
+# This is a deliberate trade, not an oversight: it does mean a genuine type
+# mistake in a test body goes unreported. Judged worth it because the same
+# mistake almost always shows up as a FAILING test, which is a louder signal
+# than a diagnostic — whereas in source there is no such backstop.
+include = [
+    "tests/**",
+    "**/tests/**",
+    "**/test_*.py",
+    "**/conftest.py",
+    "conftest.py",
+]
+
+[tool.ty.overrides.rules]
 invalid-argument-type = "ignore"
 not-subscriptable = "ignore"
 unsupported-operator = "ignore"
-# Django settings are assembled dynamically (`from config.settings import *`),
-# and test doubles are assigned over typed attributes on purpose.
 invalid-assignment = "ignore"
-# Optional third-party imports guarded by try/except ImportError (markitdown,
-# indic_transliteration) legitimately do not resolve in every environment.
-unresolved-import = "ignore"
+not-iterable = "ignore"
+
+# ---------------------------------------------------------------------------
+[[tool.ty.overrides]]
+# SOURCE files not yet converted to the four gated families — 30 findings across
+# 14 files, enumerated rather than blanketed so the remaining work is visible and
+# countable. DELETE AN ENTRY TO OPT THE FILE IN; do that only once
+# `ty check <file>` is actually 0, or the gate goes red for everyone.
+#
+# Roughly what is in here, so the next person does not have to re-triage:
+#   * discovery/views.py (9) — Django's `sitemap`/`Sitemap` generics plus
+#     decorator-application artifacts (`Expected TypeVar, found def ...`).
+#   * courts/scraper/{special,district,orders}.py (7) — bs4 attribute values are
+#     `str | AttributeValueList`, so `in`/`get` on them needs coercing first;
+#     same family as the fixes already made in high.py.
+#   * content/management/commands/seed_updates.py (3) — front-matter dict values
+#     are `str | list | dict` and are passed straight to `str` parameters.
+#   * the remaining singles are unnarrowed Optionals and one `Mapping` being
+#     subscript-assigned (cases/serializers.py).
+include = [
+    "cases/api_views.py",
+    "cases/serializers.py",
+    "cases/services/ciaa_draft_case_service.py",
+    "cases/widgets.py",
+    "case_events/consumers/runner.py",
+    "content/management/commands/seed_updates.py",
+    "courts/importer.py",
+    "courts/management/commands/scrape_court_orders.py",
+    "courts/scraper/district.py",
+    "courts/scraper/orders.py",
+    "courts/scraper/special.py",
+    "discovery/views.py",
+    "jawafdehi_shared/search/transliterate.py",
+    "llm/providers/base.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+not-subscriptable = "ignore"
+unsupported-operator = "ignore"
+invalid-assignment = "ignore"
+
+# ---------------------------------------------------------------------------
+[[tool.ty.overrides]]
+# ARRIVED WITH PR #427 (MCP server into the monolith), which merged while ty was
+# still advisory — so this code was never checked against the gated families. 16
+# findings across 5 files, kept SEPARATE from the block above rather than folded
+# into it, because clearing them needs two extra rules off
+# (`invalid-return-type`, `no-matching-overload`) and the 14 files above must not
+# silently acquire that wider exemption. Same opt-in rule: delete an entry once
+# `ty check <file>` is 0.
+#
+# Two of these files are NOT new, and that is the interesting part. #427
+# promoted `markitdown`, `httpcore` and `likhit` from extras into the main
+# dependency set. They had been UNRESOLVED imports before — a family this config
+# exempts permanently — so everything downstream of them inferred as `Unknown`
+# and nothing could fire. Now they resolve, the types are real, and genuine
+# mismatches surface in files nobody touched:
+#   * review/converter.py (1) — monkeypatches markitdown's
+#     `nepali_pdf._run_full_page_ocr`; the replacement is unannotated, so it is
+#     `-> Unknown` against a declared `-> DocumentConverterResult`.
+#   * materials/sourcing/ppmo/ocr.py (2) — page-index Optional used as a list
+#     subscript and in a `tuple[int, bytes]`.
+# The lesson worth keeping: THIS GATE'S DIAGNOSTIC SET IS A FUNCTION OF THE
+# RESOLVED DEPENDENCY SET. Adding a dependency can turn previously-`Unknown`
+# code into checked code, so a red gate after a dep bump is not necessarily
+# anyone's edit. Re-measure, do not assume a merge broke something.
+#
+# The genuinely new code:
+#   * jawafdehi_mcp/tools/ngm_extract.py (7) — 6 of the 7 are one root cause:
+#     `arguments.get()` is `Any | None` and the guard is `if not all([a, b, c])`,
+#     which ty does not treat as narrowing. Fixing it is a 3-line change and
+#     WORTH DOING, but not in a tooling PR — see the note in AGENTS.md; two real
+#     defects hide behind it (`_validate_environment` is annotated
+#     `tuple[str, str]` while its source can yield a None token, and `sql_quote`
+#     assumes `str` but gets whatever JSON the MCP client sent).
+#   * jawafdehi_mcp/tools/document_converter.py (5) — `SpawnProcess` passed where
+#     `Process` is declared (3), a `str | int` header value, and a private
+#     `_network_backend` monkeypatch on httpcore's pool.
+#   * jawafdehi_mcp/configuration.py (1) — module-level `None` assigned to a
+#     `LazySettings`-typed name.
+include = [
+    "jawafdehi_mcp/configuration.py",
+    "jawafdehi_mcp/tools/document_converter.py",
+    "jawafdehi_mcp/tools/ngm_extract.py",
+    "materials/sourcing/ppmo/ocr.py",
+    "review/converter.py",
+]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+invalid-return-type = "ignore"
+no-matching-overload = "ignore"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"

--- a/tests/api/test_auditlog_actor.py
+++ b/tests/api/test_auditlog_actor.py
@@ -10,6 +10,8 @@ Regression tests for two defects on ``CaseViewSet.partial_update``:
    API-driven ``LogEntry`` was written with ``actor=NULL``. See ``AuditlogActorMixin``.
 """
 
+from typing import TYPE_CHECKING
+
 import pytest
 from auditlog.models import LogEntry
 from django.contrib.auth import get_user_model
@@ -24,7 +26,14 @@ from cases.models import (
 )
 from tests.conftest import create_user_with_role
 
-User = get_user_model()
+if TYPE_CHECKING:
+    # `get_user_model()` is typed `type[AbstractBaseUser]`, which cannot be used
+    # as an annotation. AUTH_USER_MODEL is not overridden in this project, so the
+    # concrete class below IS what `get_user_model()` returns at runtime — the
+    # runtime path keeps the indirection, the checker gets the real class.
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
 
 URL = "/api/cases/{}/"
 

--- a/tests/api/test_caseworker_patch.py
+++ b/tests/api/test_caseworker_patch.py
@@ -2,6 +2,7 @@
 Tests for PATCH /api/cases/{id}/ (RFC 6902 JSON Patch endpoint).
 """
 
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -18,7 +19,13 @@ from cases.models import (
 )
 from tests.conftest import create_user_with_role
 
-User = get_user_model()
+if TYPE_CHECKING:
+    # See the note in tests/api/test_auditlog_actor.py: `get_user_model()` is
+    # typed `type[AbstractBaseUser]` and so is not usable as an annotation, while
+    # AUTH_USER_MODEL here is the default `User`.
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
 
 URL = "/api/cases/{}/"
 

--- a/tests/casework/test_enrich_card.py
+++ b/tests/casework/test_enrich_card.py
@@ -1158,7 +1158,10 @@ def test_a_failed_detail_fetch_skips_the_case_and_never_writes(monkeypatch):
     `if_match=None`, because the failed fetch is what left the ETag unset.
     """
     class _FetchFails(_StubApi):
-        def get_case_with_etag(self, slug):
+        # `timeout` is carried even though this override ignores it: dropping a
+        # parameter the base accepts makes the double break on any caller that
+        # passes it, which is a bug the double would hide rather than expose.
+        def get_case_with_etag(self, slug, timeout=60):
             raise RuntimeError("HTTP Error 502: Bad Gateway")
 
     api = _FetchFails([CASE_STUB_BOTH])

--- a/tests/casework/test_enrich_timeline.py
+++ b/tests/casework/test_enrich_timeline.py
@@ -461,6 +461,7 @@ class TestParseTimelineResponse:
             {"date": "2020-01-01", "title": "पहिलो"},
         ])
         result = _parse_timeline_response(body)
+        assert result is not None
         assert [e["date"] for e in result] == ["2020-01-01", "2024-06-01"]
 
     def test_drops_invalid_entries_keeps_valid_ones(self):

--- a/tests/test_dev_auth.py
+++ b/tests/test_dev_auth.py
@@ -50,7 +50,13 @@ def test_dev_auth_forced_off_in_production():
     import sys
 
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    env = {
+    # Annotated, not inferred: ty widens an unannotated dict to
+    # `dict[Unknown | str, None | str]` after the `env.pop("TESTING", None)` below
+    # (the None default leaks into the VALUE type), which then fails to satisfy
+    # `subprocess.run(env=...)`'s `Mapping[str, str]`. The annotation states the
+    # type the dict actually has. Isolated against ty 0.0.66 — a `.pop` with a
+    # None default should not affect the mapping's own type.
+    env: dict[str, str] = {
         **os.environ,
         "DEV_AUTH": "true",
         "DEBUG": "False",

--- a/uv.lock
+++ b/uv.lock
@@ -530,6 +530,21 @@ wheels = [
 ]
 
 [[package]]
+name = "django-stubs"
+version = "6.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/90/087c6e424e705e05182e543ef6b366a59eb5c92ab008b0dbbba55f357a40/django_stubs-6.0.7.tar.gz", hash = "sha256:bc55431c0af745a64e39cf33a8d36c87dccbedeae2fe26fab47dd355270e8538", size = 282293, upload-time = "2026-07-14T10:08:27.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/86/230ae6056221b543d63f7710d73967fe1c6840693540e99ea3c54f45859c/django_stubs-6.0.7-py3-none-any.whl", hash = "sha256:7ed9a14c438e589272ca04e966dee82a4d1ff7ca5c2171bc986c50a0d03ec35b", size = 547460, upload-time = "2026-07-14T10:08:25.626Z" },
+]
+
+[[package]]
 name = "django-stubs-ext"
 version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -602,6 +617,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/d7/c016e69fac19ff8afdc89db9d31d9ae43ae031e4d1993b20aca179b8301a/djangorestframework-3.17.1.tar.gz", hash = "sha256:a6def5f447fe78ff853bff1d47a3c59bf38f5434b031780b351b0c73a62db1a5", size = 905742, upload-time = "2026-03-24T16:58:33.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/e1/2c516bdc83652b1a60c6119366ac2c0607b479ed05cd6093f916ca8928f8/djangorestframework-3.17.1-py3-none-any.whl", hash = "sha256:c3c74dd3e83a5a3efc37b3c18d92bd6f86a6791c7b7d4dff62bb068500e76457", size = 898844, upload-time = "2026-03-24T16:58:31.845Z" },
+]
+
+[[package]]
+name = "djangorestframework-stubs"
+version = "3.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django-stubs" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/4b/1bee065c6c87ee04b905732deb53acdfc43d0e5673f43a5f75ec4deb7f6f/djangorestframework_stubs-3.17.1.tar.gz", hash = "sha256:5b67655090e2976b778bad572840b732a87ab2911402530d0dca2fbf72f891c5", size = 33470, upload-time = "2026-07-28T21:27:52.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/38/6a04ffca56e24220bf37494fe9f75ce9abe8115776a90c924732bb37823a/djangorestframework_stubs-3.17.1-py3-none-any.whl", hash = "sha256:40f1f22ec1965d1caff17c66794b87799eb8f42e0628ea46b501dcd565d8a803", size = 57562, upload-time = "2026-07-28T21:27:50.58Z" },
 ]
 
 [[package]]
@@ -1196,6 +1225,8 @@ bigo-enrichment = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "django-stubs" },
+    { name = "djangorestframework-stubs" },
     { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1263,6 +1294,8 @@ provides-extras = ["bigo-enrichment"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "django-stubs", specifier = "==6.0.7" },
+    { name = "djangorestframework-stubs", specifier = "==3.17.1" },
     { name = "hypothesis", specifier = ">=6.0" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -3159,6 +3192,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **User description**
## What

`ty` ran as `uv run ty check || true`, so its output was advisory and, predictably, unread. This makes it a **blocking gate**: no `|| true` in CI, plus a pre-commit hook.

## Why this is possible now

The stated blocker was "ty is pre-1.0 and has no Django plugin". That turned out not to be the real obstacle. The Django model-metaclass blind spot — 1174 `unresolved-attribute`, of which **809 were `Model.objects`** and 110 DRF `force_authenticate` — closes from **stub data alone**, which needs no plugin: `django-stubs` types field access through `__get__` overloads and declares `objects`.

Adding `django-stubs` + `djangorestframework-stubs` took "all candidate families on" from **1560 → 676**. Those two are historical — read off single runs *before* the fixes landed, so don't expect 676 back; the reproducible figure on this branch is 551, and `pyproject.toml` records the recipe for re-deriving each. Both stub packages are exact-pinned, type-only, dev-group: present in CI (`uv sync --frozen` installs the group) and absent from both images (`--no-dev` in `Dockerfile` and `Dockerfile.consumer`).

## Bugs this actually found

Four families are newly enforced tree-wide (`invalid-argument-type`, `not-subscriptable`, `unsupported-operator`, `invalid-assignment` — all four were previously silenced), plus `possibly-unresolved-reference` and `possibly-missing-import`, which ty ships **off**. They are not cosmetic:

| Site | Bug |
|---|---|
| `cases/admin.py` | A `get_form` override silently dropped Django's `change` argument. **⚠️ Behaviour-affecting** — see reviewer note below. |
| `cases/services/case_scraper.py` | A *second* Optional `response.text`, in the phase-2 structuring call one function below the phase-1 one already fixed. |
| `casework/enrich_missing_bigo.py` | `_die()` lacked `-> NoReturn`, which made six later reads genuinely possibly-unbound. |
| `case_events/bus.py` | A possibly-None loop passed *after* the coroutine was built, orphaning it. Review then caught the **sibling** path — a loop closed under us makes `call_soon_threadsafe` raise before the coroutine is wrapped in a task, so that one needs an explicit `coro.close()` too. Both now pinned by a test. |
| `materials/conversion.py` | `build_convert_payload` annotated `Optional[dict]` while all three of its failure paths `raise`. |

## Remaining debt is enumerated, not vague

Four `[[tool.ty.overrides]]` blocks, each carrying its own measurement and reasoning in the config rather than here:

1. `**/urls.py` — `no-matching-overload` only. django-stubs types `path()` with overloads that neither DRF's `@api_view` functions nor `.as_view()` results match, so every route in the tree reports. Verified false, not deferred.
2. **Tests** — the four families plus `not-iterable`. Same rationale as the existing permanent `ANN` exemption for tests: a test double's whole job is to stand in for a shape it does not statically have.
3. **14 pre-existing source files** — the four families.
4. **Everything PR #427 brought in** — 5 files, kept *separate* from block 3 because clearing it needs two extra rules off (`invalid-return-type`, `no-matching-overload`) and the 14 files above must not silently acquire that wider exemption.

**Deleting a file's entry is how it opts in**, and only once `ty check <file>` is already 0 — the same beachhead pattern this repo already uses for ruff's `ANN`.

Two families stay exempt, each argued with its measured cost in `[tool.ty.rules]`:
- `unresolved-attribute` — the one genuine plugin gap (implicit FK `_id`, reverse accessors, `get_user_model()`). Tracking astral-sh/ty#255.
- `unresolved-import` — optional lazily-imported deps; permanent.

## The trap worth reading even if you skim the rest

**This gate's diagnostic set is a function of the resolved *dependency* set.** `unresolved-import` is exempt, so before a package resolves, everything downstream of it infers as `Unknown` and no rule can fire on it. #427 promoted `markitdown`, `httpcore` and `likhit` out of extras — so two files that #427 never touched (`review/converter.py`, `materials/sourcing/ppmo/ocr.py`, both untouched for weeks) became checked code overnight and reported real mismatches. A red `ty` after a dependency change is not necessarily anyone's edit. Re-measure before assuming a merge broke something. Written up in `AGENTS.md` and in block 4's comment.

## Two real defects found, deliberately NOT fixed here

Both sit behind the MCP type debt in block 4, and both want their own PR — a tooling change is the wrong place to make a security-relevant behaviour change:

- `jawafdehi_mcp/tools/ngm_extract.py` `_validate_environment` is annotated `-> tuple[str, str]` but returns `get_jawafdehi_api_config()`, whose token can be `None` — and that token goes straight into an `Authorization` header.
- `sql_quote` is `value.replace("'", "''")`, applied to `arguments.get(...)` straight off the MCP wire and then f-string-interpolated into `SELECT`s. The `''`-doubling is correct for Postgres with `standard_conforming_strings` on, so this is not trivially injectable — but a non-`str` argument (a JSON number or list) reaches `.replace` and raises. The `if not all([a, b, c])` guard above it is also why `ty` reports most of that file: `all()` does not narrow.

Both are recorded under Known debt in `AGENTS.md`. Happy to take either as a follow-up.

## Reviewer note — please look here

**`CaseAdmin.get_form` is the one behaviour change, and it is untested.** Restoring the dropped `change` argument is load-bearing: Django's `options.py` uses `if change and not self.has_change_permission(...)` to exclude every field, and this admin's `has_change_permission` returns `False` unconditionally, so `change` is precisely what gates that branch. Nothing in the suite covers it. I'd take a follow-up adding a regression test, or push it into this PR if you'd rather it not merge uncovered.

## A note on counts

Counts were **removed** from `AGENTS.md` rather than updated. They now live in `pyproject.toml` next to the `include =` lists they justify, where whoever is about to delete an entry will actually read them. The suite total in this PR went stale inside a single rebase, which is the argument in miniature. Each block records how it was measured, so re-derive rather than trust — including the trap that `-c "overrides=[]"` **silently no-ops** because arrays don't replace, so `--config-file` is the only way to neutralize an override block.

## Verification

Run at `72da447`, rebased onto `6af88d5`:

```bash
uv run ruff check .    # clean
uv run ty check        # clean — and it bites: every inline `ty: ignore`
                       # here is load-bearing (verified with
                       # unused-ignore-comment='error' plus a positive control)
uv lock --check        # consistent
DJANGO_SETTINGS_MODULE=config.settings_test TESTING=true \
  uv run pytest -q --ignore=integration-tests
# 4304 passed, 4 skipped, 1 warning, 47 subtests
```

All 4 skips are `materials/tests/test_patch_concurrency_postgres.py`, which needs a real Postgres `ngm` alias; the 1 warning is the pre-existing un-awaited `_drain_tasks` coroutine. Neither is introduced here.

**A datapoint on whether this gate will block other people's work.** The rebase picked up #425, whose `case_proposals/` source had never been type-checked — `ty` is advisory on `main`, so nothing there had to pass. It passes unmodified, and no override block was added to make that true. Worth stating how that was checked, because zero diagnostics is also exactly what an *unchecked* file looks like: forcing `unresolved-attribute` and `possibly-unresolved-reference` to error on `apply.py` still gave zero, which proves nothing on its own, so I dropped a throwaway `case_proposals/_ty_probe.py` containing `x: int = "definitely not an int"` and confirmed ty flags it. That establishes the directory really is analyzed and that `invalid-assignment` fires there. One clean PR isn't evidence the gate never blocks anyone — but it does show the gate isn't reliant on `case_proposals` being quietly exempt.

The pre-commit `ty` hook is triggered by `files: '(\.pyi?$|^pyproject\.toml$)'`, not `types: [python]`, and that is deliberate: `pyproject.toml` *holds* the `[tool.ty]` config, so under a Python-only trigger a commit that loosens a rule or drops a whole override block would skip the very check it just weakened. Found by hitting it — an earlier amend staging only `pyproject.toml` reported "no files to check ... Skipped". Verified after the fix with a positive control (`pyproject.toml` alone → Passed) and a negative one (`README.md` → correctly Skipped).


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Make `ty` blocking

- Add Django/DRF stubs

- Fix surfaced runtime bugs

- Document typed-gate policy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ci["CI"] -- "runs" --> ty["ty check"]
  stubs["Django/DRF stubs"] -- "reduce noise" --> ty
  fixes["Type fixes"] -- "make clean" --> ty
  docs["Docs/hooks"] -- "enforce" --> ty
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>bus.py</strong><dd><code>Close publish coroutine on scheduling failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-dc92eb12d22aefaf168f1e7e89c65623028302d58141a03615ce17bc834c82e9">+25/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>admin.py</strong><dd><code>Preserve admin `change` argument forwarding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-b7a3f0177d3be7adf3139695169d6e588e824f82e4fca55261caf3cc41eb3453">+26/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>refresh_statistics.py</strong><dd><code>Return from bound statistics success path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-af674569a5fe811fbfe8a0601fbe431bc80425270f026a932fcf2b77a3ff5b76">+19/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>case_scraper.py</strong><dd><code>Reject empty Gemini phase-two response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-a89d08ed15840363211f721352c185462019addeac182d262eff2324b95c2f43">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entity_resolver.py</strong><dd><code>Skip missing sibling title forms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-a0442a61bee19311460dae16304d48ce1dbfcbce304ae01a717b9aa0fd913a67">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>case_status.py</strong><dd><code>Guard verdict construction across branches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-8bf1463436bf52616a4c94fcc833984531ee8ca5f1f864322fbdb345eee6a5aa">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>high.py</strong><dd><code>Coerce bs4 attributes and predicates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-c6abc8235239aea5c5ba3f93c28927047d69ebea22875f9b11e0f715eee51bff">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>special.py</strong><dd><code>Use boolean bs4 string predicates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-b62abb053fff3f652c693b6210044237bf76490f11e27902ed25248221d35206">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>views.py</strong><dd><code>Handle optional pagination fallback safely</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-bb0520fbd404cf66f66a369c0858842aa915fa4b2d6d368008d4a4ee5208970e">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Declare handler import for type checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-d9d263a82f86eff9534188cc2d8055f30f0a198e4b8f2fc67446094c77fca62e">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fields.py</strong><dd><code>Type heterogeneous `formfield` kwargs merge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-010510942afeb13aea9bd053b324861774c202279333e53cb375c2a0872d02e0">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli.py</strong><dd><code>Suppress valid UTC formatter override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-10d5ea401a4ba97c7ae79547175e565c3b7733fa1028b64dc098719fb7f8561d">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_missing_bigo.py</strong><dd><code>Mark fatal bootstrap helper `NoReturn`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-8f467def65557fd5e08bab577f4cd249c274ae9d7530a0496af808b55a52345b">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_tags.py</strong><dd><code>Narrow description before appending text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-af4eb9ddc030080dacdf3b7d770be8c6c6e92cea1d157c4c799d7452be584ca3">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Ignore upstream preview signature mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-9ba6beaf306484d6e23bd60611b6b6ce4695187bc0b586931c0ad1dfd490eca8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resourcesync.py</strong><dd><code>Format narrowed ResourceSync timestamp directly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-d1aa513a846b6a1c862013446e62a82a6971e4b5ad5adc73190e57c862c6288a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>engine.py</strong><dd><code>Narrow configured lakehouse credentials locally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-0f2c03d89c9ab9bc4c5c019f7c24648f792f822436654a7a90818e0c73f33ee5">+22/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proxy.py</strong><dd><code>Type OpenAI client kwargs carrier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-10514b2bd96ff2bc69722affec68714d63e0aecd8e66216ae287b7fb85272704">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>conversion.py</strong><dd><code>Tighten convert payload return type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-18adc24b809cd55a6c92a8f907ef455cf3fb040f3e7c94ce534b6405aeeb79a5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>parse.py</strong><dd><code>Type BeautifulSoup attrs handle broadly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-c2734910333cded3a8f1fd84a33570a156d2572efb53dccdf37bb658b926d3ff">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>test_bus.py</strong><dd><code>Test coroutine closure on dead loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-f8e20eef689e0e56d5c15aa6890b0d212802a58fbc46f4f2ca3333393f9bcf5f">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_producers.py</strong><dd><code>Guard optional material producer signals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-e2e831df7650b7864a164eda61e0b2409b270de733dd6963ff964d4b37370e8b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_import_courtcases.py</strong><dd><code>Type importer kwargs carriers in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-60700ab5ba12ea6b7819beb0b7385999396a899b945dd2025ec9628892f9aab5">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_review_supersede.py</strong><dd><code>Suppress valid direct DRF view call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-638ddf5257934fd6bcd3ba2c5cc47dbb09f55fcf2368e2c961d15e3f4b41c1e4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_single_source_ingest.py</strong><dd><code>Type single-source importer config carrier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-62abb52310ce4d97539ac410136a2e864b969e41adb7c64cd0bb9087bc5336ea">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_auditlog_actor.py</strong><dd><code>Split runtime user model from annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-7c97f9e937e6f0375b3206c9e30680a0a70c06b5114ea705e1348338f5f95e07">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_caseworker_patch.py</strong><dd><code>Split patch test user typing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-e45f77bc9eda9e7e0bcf61f6c288174c37c9803d0c31ecedcaa0b5b20b5a124d">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_enrich_card.py</strong><dd><code>Match stub API timeout signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-26c411973b810c922c00a3eb504211375a734a2e7cd32ff4d41eaaf10b1ef9eb">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_enrich_timeline.py</strong><dd><code>Assert parsed timeline is present</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-db8336e41bfc2aba584dc70ea94393987e8b501e7bfff34ad20dc68cf67d43cb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_dev_auth.py</strong><dd><code>Type subprocess environment mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-78e7b9cbb1a72499731ac8c97f609dec133d33e3b482cced32926e43782c2e09">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>job_kind.py</strong><dd><code>Document intentional confidence coercion ignore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-3eb9480104e521129e2f2d00d434e81a5c67b23f9fbf8d5c01c35627f8ee711c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>settings.py</strong><dd><code>Bind database URLs before parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci.yml</strong><dd><code>Make `ty check` fail CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+14/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.pre-commit-config.yaml</strong><dd><code>Add local whole-project `ty` hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+26/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add stubs and strict `ty` rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+270/-28</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong><dd><code>Document new gated typing workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/428/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+77/-18</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
