### PR TITLE
casework: create the NES entities a case needs, and gate what may become one

### DIFF
--- a/casework/README.md
+++ b/casework/README.md
@@ -427,8 +427,24 @@ Read `*.created.jsonl` before an apply. Its `outcome` column is the whole story:
 | `created` / `would-create` | A new NES entity, bound to the case |
 | `already-exists` | Someone got there first (409); bound to theirs |
 | `reused` | A second spelling of a name created earlier in this run |
-| `skipped` | No prefix, a prefix whose parent branch does not exist, or no slug |
+| `skipped` | One of the four gates below refused it; the `reason` column says which |
 | `error` | The POST failed; the name stays unmatched, the case keeps its other binds |
+
+#### What is allowed to become an entity
+
+Four gates run in front of every POST, cheapest and most categorical first. A refused
+name still **binds** whatever it matched — these gate creation only.
+
+| Gate | Refuses |
+|------|---------|
+| Section | Anything from the `location` section. NES already holds all 77 districts under official codes (`location/district/jhapa-np0104`), so a location created here is always a duplicate or junk |
+| Name shape | `_name_vetoes`: a composite `Activity - Location`, a lone token, an all-generic institution name |
+| `is_named_entity` | Anything the extraction did not confirm names one specific thing. A **missing** field refuses too |
+| Identity | No prefix, a prefix whose parent branch does not exist, or no slug |
+
+`is_named_entity` fails closed on purpose. A prompt regression that drops the field shows
+up as `0 created` in the summary, which is visible and fixable; defaulting the other way
+fills NES with entries nobody can delete.
 
 Three things to know before you run it:
 
@@ -438,9 +454,11 @@ Three things to know before you run it:
   came from, which is one source, not two.
 - **An already-enriched case creates nothing.** The idempotency gate skips any case
   already holding a `related` bind, before the create step runs. Use `--force`.
-- **The resolver's name vetoes no longer block anything.** Names it judged not to be
-  entities at all — `गैरकानूनी आर्जित घरजग्गा सम्पत्ति - काठमाडौं`, a description of
-  seized property — are created. Filtering them is a later pass.
+- **The slug comes from the English name when there is one.** Most firms in these court
+  orders are English names written in Devanagari, and transliterating them back gives
+  `phareshta-debhalapamenta-enda-indashtrija` for "Forest Development and Industries".
+  The IRI is permanent, so `created.jsonl` carries a `name_en` column worth reading
+  before an apply.
 
 ### 4. Consolidate run logs — `ledger`
 

--- a/casework/README.md
+++ b/casework/README.md
@@ -406,8 +406,9 @@ Most do not: production run `645b1483` (case 078-CR-0038) extracted 13 names and
 matched **none**, because NES holds almost no institution a CIAA court order names.
 
 `--create-entities` creates them, then binds them. It is **off by default and
-independent of `--apply`**, so upgrading the enricher cannot make an existing
-`--apply` run start writing to NES.
+never implied by `--apply`**, so upgrading the enricher cannot make an existing
+`--apply` run start writing to NES. It does not override the dry run either —
+without `--apply` the flag only reports what it would create.
 
 ```bash
 # Dry run: reports every entity it would create, creates nothing
@@ -415,18 +416,22 @@ uv run python -m casework.enrich_related_entities \
     --slug case-078-cr-0038-ciaa-special-court-case-078-cr-9a \
     --create-entities --dry-run
 
-# Write: all four flags together
+# Write to production. --allow-remote-writes is only the guard; the write still
+# needs somewhere to go and something to authenticate with
 uv run python -m casework.enrich_related_entities --batch-csv batch.csv \
-    --create-entities --apply --allow-remote-writes
+    --create-entities --apply \
+    --api-base-url https://api.jawafdehi.org \
+    --api-token "$JAWAFDEHI_API_TOKEN" --allow-remote-writes
 ```
 
 Read `*.created.jsonl` before an apply. Its `outcome` column is the whole story:
 
 | Outcome | Meaning |
 |---------|---------|
-| `created` / `would-create` | A new NES entity, bound to the case |
+| `created` | The POST succeeded and the entity is bound to the case |
+| `would-create` | Dry run: eligible to create, but nothing was POSTed and nothing bound. An `--apply` run would create it |
 | `already-exists` | Someone got there first (409); bound to theirs |
-| `reused` | A second spelling of a name created earlier in this run |
+| `reused` | A name created earlier in this run under the same prefix |
 | `skipped` | One of the four gates below refused it; the `reason` column says which |
 | `error` | The POST failed; the name stays unmatched, the case keeps its other binds |
 

--- a/casework/README.md
+++ b/casework/README.md
@@ -132,7 +132,7 @@ flowchart LR
 | tags | `enrich_tags` | `tags` | `patch_field` | yes ¹ | cheap |
 | timeline | `enrich_timeline` | `timeline` | `patch_field` | yes ¹ | premium |
 | allegations | `enrich_allegations` | `key_allegations` | `patch_field` | yes ¹ | premium |
-| entities | `enrich_related_entities` | `entities` | `patch_field` | yes ¹ | premium |
+| entities | `enrich_related_entities` | `entities` (+ NES entities with `--create-entities`) | `patch_field`, `POST /api/entities` | yes ¹ | premium |
 | ledger | `ledger` | ledger JSON (local file) | none (reads run logs) | local file | — |
 
 ¹ Remote write requires **`--apply` + `--allow-remote-writes` + `--api-token`** together.
@@ -154,6 +154,18 @@ Each run gets a `run_id` and writes two files under `work/enricher-runs/`
 
 - `…-<stage>-<run_id>.log` — human-readable, UTC-timestamped
 - `…-<stage>-<run_id>.events.jsonl` — one JSON event per case/step
+
+`enrich_related_entities` writes five more, sharing that stem. The first two are the
+answer to "what did the model actually find", which the counts in the log do not give
+you — they survive a run that binds nothing:
+
+| File | Holds |
+|------|-------|
+| `.extracted.jsonl` | Every extracted name with its section and notes, per case |
+| `.accused_notes.jsonl` | The `accused_notes` array |
+| `.binds.jsonl` | Each bind, with the candidates that lost |
+| `.created.jsonl` | Each entity created or refused, with the reason |
+| `.nomatch.md` | Names still unmatched, grouped, with a Role column |
 
 `ledger.py` folds all `*.events.jsonl` into a **current-state ledger** keyed by
 `(slug, stage)`, latest-by-timestamp, ignoring non-outcome statuses
@@ -382,10 +394,53 @@ uv run python -m casework.enrich_missing_bigo \
 | tags | `uv run python -m casework.enrich_tags --dry-run` | `… --apply` (add `--no-llm` for rules-only) |
 | timeline | `uv run python -m casework.enrich_timeline --dry-run` | `… --apply` |
 | allegations | `uv run python -m casework.enrich_allegations --dry-run` | `… --apply` |
-| entities | `uv run python -m casework.enrich_related_entities --dry-run` | `… --apply` |
+| entities | `uv run python -m casework.enrich_related_entities --dry-run` | `… --apply` (add `--create-entities` to create missing NES entities) |
 
 For every "Apply (loopback)" cell above, the **remote/production** form adds:
 `--api-base-url https://api.jawafdehi.org --api-token "$JAWAFDEHI_API_TOKEN" --allow-remote-writes`.
+
+#### Creating the NES entities a case needs — `--create-entities`
+
+`enrich_related_entities` binds extracted names to NES entities that already exist.
+Most do not: production run `645b1483` (case 078-CR-0038) extracted 13 names and
+matched **none**, because NES holds almost no institution a CIAA court order names.
+
+`--create-entities` creates them, then binds them. It is **off by default and
+independent of `--apply`**, so upgrading the enricher cannot make an existing
+`--apply` run start writing to NES.
+
+```bash
+# Dry run: reports every entity it would create, creates nothing
+uv run python -m casework.enrich_related_entities \
+    --slug case-078-cr-0038-ciaa-special-court-case-078-cr-9a \
+    --create-entities --dry-run
+
+# Write: all four flags together
+uv run python -m casework.enrich_related_entities --batch-csv batch.csv \
+    --create-entities --apply --allow-remote-writes
+```
+
+Read `*.created.jsonl` before an apply. Its `outcome` column is the whole story:
+
+| Outcome | Meaning |
+|---------|---------|
+| `created` / `would-create` | A new NES entity, bound to the case |
+| `already-exists` | Someone got there first (409); bound to theirs |
+| `reused` | A second spelling of a name created earlier in this run |
+| `skipped` | No prefix, a prefix whose parent branch does not exist, or no slug |
+| `error` | The POST failed; the name stays unmatched, the case keeps its other binds |
+
+Three things to know before you run it:
+
+- **Entities are created with no sources.** `POST /api/entities` validates `@id`,
+  `@type` and `name` and nothing else; the 2-distinct-publisher rule lives in
+  `manage.py bulk_ingest`. Each entity carries a `citation` naming the document it
+  came from, which is one source, not two.
+- **An already-enriched case creates nothing.** The idempotency gate skips any case
+  already holding a `related` bind, before the create step runs. Use `--force`.
+- **The resolver's name vetoes no longer block anything.** Names it judged not to be
+  entities at all — `गैरकानूनी आर्जित घरजग्गा सम्पत्ति - काठमाडौं`, a description of
+  seized property — are created. Filtering them is a later pass.
 
 ### 4. Consolidate run logs — `ledger`
 

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -276,13 +276,20 @@ class CaseworkApi:
                                timeout=timeout) as r:
                 return json.loads(r.read().decode())
         except urllib.error.HTTPError as exc:
-            # 422 covers both a duplicate IRI and a malformed payload. Only the
-            # body separates them, and only the duplicate is recoverable.
+            # A duplicate IRI is 409 ENTITY_EXISTS, NOT 422. The view's 422 is for
+            # validation (`entities/views.py:219`); the duplicate check raises a
+            # ValueError that `_map_service_value_error` turns into 409
+            # (`entities/views.py:420`). Verified against the local harness --
+            # keying this off 422 made every re-run record `error` and rebind
+            # nothing, which no stubbed test caught because the stub chose the
+            # status.
+            if exc.code == 409:
+                raise EntityAlreadyExists(
+                    exc.read().decode(errors="replace")) from exc
             if exc.code == 422:
-                detail = exc.read().decode(errors="replace")
-                if "already exists" in detail:
-                    raise EntityAlreadyExists(detail) from exc
-                raise ValueError(f"entity create rejected: {detail}") from exc
+                raise ValueError(
+                    "entity create rejected: "
+                    f"{exc.read().decode(errors='replace')}") from exc
             raise
 
     # The list endpoint's server-side default is 20 per page, so walking all

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -3,10 +3,24 @@ import base64
 import json
 import logging
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 
 LOOPBACK_HOSTS = ("127.0.0.1", "localhost")
+
+
+class EntityAlreadyExists(Exception):
+    """A create POST hit an entity that is already there.
+
+    Its own type because the caller's response is to BIND the existing entity,
+    not to record an error: someone -- a caseworker, or an earlier run over the
+    same case -- got there first, which is the outcome we wanted. The server
+    reports it as 422 from `PublicationService.create_entity`'s duplicate-`@id`
+    check (`entities/services/publication/service.py:68`), the same status a
+    genuinely malformed payload returns, so the body text is the only thing that
+    separates the two.
+    """
 
 
 class CandidateList(list):
@@ -223,6 +237,53 @@ class CaseworkApi:
             url += ("&" if "?" in url else "?") + urllib.parse.urlencode(params)
         with self._request("GET", url, headers=self._headers(), timeout=timeout) as r:
             return json.loads(r.read().decode())
+
+    def entity_prefixes(self, timeout=60):
+        """Every entity prefix currently in use, from `GET /api/entity_prefixes`.
+
+        A READ, so it is safe against production and unaffected by the write
+        guard. Not a whitelist: the endpoint answers `SELECT DISTINCT prefix`
+        over live entities (`entities/persistence.py:313`), so it reports what
+        exists rather than what is permitted -- which is exactly why
+        `casework.entity_identity.prefix_is_creatable` has to decide, and why an
+        unchecked prefix would ratify itself by appearing here on the next call.
+        """
+        return list(self.get("/entity_prefixes", timeout=timeout).get("prefixes") or ())
+
+    def create_entity(self, payload, timeout=60):
+        """POST one NES entity. Returns the created document (with its `@id`).
+
+        Raises `EntityAlreadyExists` when the IRI is taken, so the caller can
+        bind the existing entity instead of failing the case.
+
+        Goes through `_request` rather than `self.get`/`_patch`, the same way
+        `convert.py`'s `upload_markdown` does, which is what puts it under the
+        host write-guard: a non-loopback POST is refused unless
+        `allow_remote_writes` is set. No second guard to keep in step.
+
+        The payload is the API's authoring form -- `prefix`, `slug`, `type`,
+        `name` plus any schema.org properties, which
+        `normalize_authoring_payload` copies through verbatim
+        (`entities/write_validation.py:113`). It builds the `@id` from
+        prefix+slug itself, so we never send one.
+        """
+        url = self.base_url + "/entities"
+        body = json.dumps(payload).encode("utf-8")
+        headers = dict(self._headers())
+        headers["Content-Type"] = "application/json"
+        try:
+            with self._request("POST", url, data=body, headers=headers,
+                               timeout=timeout) as r:
+                return json.loads(r.read().decode())
+        except urllib.error.HTTPError as exc:
+            # 422 covers both a duplicate IRI and a malformed payload. Only the
+            # body separates them, and only the duplicate is recoverable.
+            if exc.code == 422:
+                detail = exc.read().decode(errors="replace")
+                if "already exists" in detail:
+                    raise EntityAlreadyExists(detail) from exc
+                raise ValueError(f"entity create rejected: {detail}") from exc
+            raise
 
     # The list endpoint's server-side default is 20 per page, so walking all
     # 3,003 cases costs 151 round trips -- ~2m45s against production, paid by

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -16,10 +16,11 @@ class EntityAlreadyExists(Exception):
     Its own type because the caller's response is to BIND the existing entity,
     not to record an error: someone -- a caseworker, or an earlier run over the
     same case -- got there first, which is the outcome we wanted. The server
-    reports it as 422 from `PublicationService.create_entity`'s duplicate-`@id`
-    check (`entities/services/publication/service.py:68`), the same status a
-    genuinely malformed payload returns, so the body text is the only thing that
-    separates the two.
+    answers 409 `ENTITY_EXISTS`: `_map_service_value_error` maps the duplicate
+    `@id` check (`entities/services/publication/service.py:68`) to 409, and
+    reserves 422 for `validate_create_payload` failures (`entities/views.py:220,
+    420`). Keyed on the status alone -- an earlier version keyed on 422, and
+    every re-run then recorded `error` and rebound nothing.
     """
 
 

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -137,6 +137,7 @@ from casework.entity_resolver import (
     NO_MATCH,
     REVIEW,
     Decision,
+    _name_vetoes,
     apply_document_veto,
     normalise_name,
     resolve,
@@ -200,17 +201,21 @@ STRICT RULES:
 - DO NOT extract the location of courts or government inquiry offices.
 - Extract 1 location for simple cases. Extract 2-3 only if the case genuinely spans
   multiple districts.
-- Leave notes BLANK ("") for all location entities.
-- The entity_name should include context in the format: "Organisation/Activity - Location"
+- The entity_name must be the PLACE NAME ALONE. Never combine it with an activity,
+  an organisation, or anything else. The place is the entity; what happened there
+  belongs in notes.
+- Put the activity context in notes instead, in Nepali.
 
-Examples of CORRECT location entity names:
-- "साझा भण्डार सहकारी - सुर्खेत जिल्ला"
-- "स्वास्थ्य उपकरण खरिद - जनकपुरधाम"
-- "भरत ताल निर्माण परियोजना - सर्लाही जिल्ला"
-- "नापी कार्यालय - खैरहनी नगरपालिका"
-- (if no specific activity context, just the location name: "काठमाडौं")
+Examples of CORRECT location entities:
+- "सुर्खेत"      notes: "साझा भण्डार सहकारीको कारोबार भएको जिल्ला"
+- "जनकपुरधाम"    notes: "स्वास्थ्य उपकरण खरिद भएको स्थान"
+- "सर्लाही"      notes: "भरत ताल निर्माण परियोजना रहेको जिल्ला"
+- "खैरहनी नगरपालिका"  notes: "नापी कार्यालयको कारोबार भएको नगरपालिका"
+- "काठमाडौं"     notes: "जग्गा तथा शेयर लगानी रहेको जिल्ला"
 
 Examples of WRONG location names:
+- "स्वास्थ्य उपकरण खरिद - जनकपुरधाम" ← an activity glued to a place, NEVER do this
+- "घरजग्गा सम्पत्ति - काठमाडौं" ← a description of property, not a place
 - "तनहुँ जिल्ला" ← accused home address, SKIP
 - "काठमाडौं" ← if only reason is court/CIAA office, SKIP
 
@@ -243,6 +248,12 @@ Extract ALL of these categories that appear in the documents:
   Only extract named CIAA investigation officers if they are specifically named
   and their investigation is directly relevant.
   Example: "रविन्द्र कुमार बुढाप्रिथी"  notes: "अनुसन्धान अधिकृत, CIAA"
+
+  MEDIA — DO NOT extract a newspaper, portal or broadcaster whose only role was
+  REPORTING the case. It is a source, not a participant.
+  Example of what to SKIP: "नयाँ पत्रिका" (published the story that prompted the
+  complaint). Extract a media organisation only when it is itself accused, owns
+  assets at issue, or received the funds.
 
 Notes must never be blank for related entities. Always describe the specific connection.
 Only extract entities with CONFIRMED connections — not people who were later acquitted.
@@ -286,6 +297,8 @@ Output ONLY this JSON object, no other text:
       "relationship_type": "location", "related", "accused", "alleged" or "witness",
       "entity_prefix": "the category from the list below",
       "entity_type": "Person", "Organization", "GovernmentOrganization" or "Place",
+      "is_named_entity": true or false,
+      "name_en": "the name in English, or \"\" if you cannot give one",
       "notes": "specific description"
     }
   ],
@@ -321,6 +334,38 @@ A district is `location/district`.
 
 Set `entity_type` to match: `Person` for a person, `GovernmentOrganization` for
 a state body, `Organization` for a company or NGO, `Place` for a location.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+IS THIS A NAMED THING? (is_named_entity)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Set `is_named_entity` to true ONLY when the string names ONE SPECIFIC thing that
+exists in the world and could be looked up in a register. Set it to false when
+the string is a CATEGORY of thing, a description, or a phrase.
+
+  true   "विध मानेजमेन्ट प्रा.लि."      one registered company
+  true   "हेम राज विष्ट"                 one person
+  true   "कर्मचारी सञ्चय कोष"            one named state fund
+  false  "सामुदायिक वन उपभोक्ता समूह"   a KIND of group, not one named group
+  false  "घरजग्गा सम्पत्ति"              a description of property
+  false  "ठेक्का प्राप्त गर्ने कम्पनी"    a role, not a name
+
+When false, the entity is still recorded against the case but no new register
+entry is made for it. When you are unsure, answer false.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENGLISH NAME (name_en)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Give the name in English. Many Nepali documents write English company names in
+Devanagari -- convert those BACK to the English they came from rather than
+spelling them out phonetically.
+
+  "फरेष्ट डेभलपमेन्ट एण्ड इण्डष्ट्रिज"  ->  "Forest Development and Industries"
+  "ग्लोवल वाइल्ड फार्मिङ प्रा.लि."      ->  "Global Wild Farming Pvt. Ltd."
+  "कर्मचारी सञ्चय कोष"                  ->  "Employees Provident Fund"
+  "हेम राज विष्ट"                        ->  "Hem Raj Bista"
+
+Return "" if you genuinely cannot give one. Never guess a company's registered
+English name when the document does not support it.
 """
 
 
@@ -352,6 +397,11 @@ RELATIONSHIP_TYPES = (
     "alleged", "accused", "related", "witness", "opposition", "victim",
     "location", "respondent", "petitioner",
 )
+
+#: The one section that never creates. NES holds all 77 districts from a
+#: gazetteer ingest, keyed by official code (`location/district/jhapa-np0104`),
+#: so anything this stage would mint here is a duplicate or junk.
+LOCATION_SECTION = "location"
 
 #: Where a section the API rejects lands. `related` and not a guess at the
 #: intended meaning: it is what the extraction prompt already defaults to
@@ -1020,12 +1070,14 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
         item = items_by_name.get(name) or {}
         prefix = (item.get("entity_prefix") or "").strip().lower()
         etype = (item.get("entity_type") or "").strip()
+        name_en = (item.get("name_en") or "").strip()
         row = {"slug": plan.slug, "extracted": name, "role": section,
                "prefix": prefix, "type": etype, "citation": citation,
-               "nes_id": "", "outcome": "", "reason": ""}
+               "name_en": name_en, "nes_id": "", "outcome": "", "reason": ""}
 
-        slug = entity_slug(name)
-        refusal = _cannot_create(prefix, etype, slug, live_prefixes)
+        slug = entity_slug(name, name_en)
+        refusal = _cannot_create(prefix, etype, slug, live_prefixes,
+                                 section=section, name=name, item=item)
         if refusal:
             row.update(outcome="skipped", reason=refusal)
             rows.append(row)
@@ -1046,7 +1098,7 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
         else:
             try:
                 created = api.create_entity(_authoring_payload(
-                    prefix, slug, etype, name, citation))
+                    prefix, slug, etype, name, citation, name_en))
                 iri = created.get("@id") or iri
                 row.update(outcome="created", nes_id=iri)
             except EntityAlreadyExists:
@@ -1065,13 +1117,40 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
     return bind_items, still_unmatched, rows
 
 
-def _cannot_create(prefix, etype, slug, live_prefixes):
+def _cannot_create(prefix, etype, slug, live_prefixes, *, section, name, item):
     """Why this name cannot become an entity, or "" when it can.
 
     One function so every refusal reads the same way in `created.jsonl`, and so
-    the order is fixed: identity first (is there a prefix and a type at all),
-    then whether the prefix may be used, then whether the name yields a slug.
+    the order is fixed: cheapest and most categorical first.
+
+    1. SECTION. NES already holds all 77 districts under official codes
+       (`location/district/kailali-np0771`), from a gazetteer ingest. A location
+       created here is therefore always a duplicate of a canonical district or
+       junk -- there is no third case. Bind them, never mint them.
+    2. NAME SHAPE. `_name_vetoes` is the resolver's own judgement that a string
+       is too weak to identify anything: a composite `Activity - Location`, a
+       lone token, an all-generic institution name. It no longer blocks binding
+       (2026-08-05), but a string the resolver will not trust to MATCH is not
+       one to CREATE from.
+    3. THE MODEL'S VERDICT. `is_named_entity` is the only gate that can tell
+       `सामुदायिक वन उपभोक्ता समूह` -- a kind of group -- from a named one.
+       `_name_vetoes` cannot: its generic rule needs EVERY word in a 53-word
+       list, and neither सामुदायिक nor समूह is in it.
+
+       ABSENT MEANS NO. A prompt regression that drops the field then surfaces
+       as `0 created` in the summary, which is visible and fixable; defaulting
+       the other way fills NES with entries nobody can delete.
+    4. IDENTITY. Prefix, type, slug -- can we even build an IRI.
     """
+    if section == LOCATION_SECTION:
+        return ("location entities are bind-only: NES already holds the "
+                "canonical districts under official codes")
+    veto = _name_vetoes(name)
+    if veto:
+        return f"name is not creatable: {veto}"
+    if item.get("is_named_entity") is not True:
+        return ("extraction did not confirm this is a specific named entity "
+                "(is_named_entity)")
     if not prefix or not etype:
         return "extraction gave no entity_prefix/entity_type"
     if not prefix_is_creatable(prefix, live_prefixes):
@@ -1083,17 +1162,23 @@ def _cannot_create(prefix, etype, slug, live_prefixes):
     return ""
 
 
-def _authoring_payload(prefix, slug, etype, name, citation):
+def _authoring_payload(prefix, slug, etype, name, citation, name_en=""):
     """The API's authoring form for a create POST.
 
     No `@id`: `normalize_authoring_payload` builds it from prefix+slug and
     validates the shape while doing so (`entities/write_validation.py:113`).
 
     `name` is a language map keyed `ne`, because every name here comes out of a
-    Nepali court document and claiming it as English would be wrong. `citation`
-    is a free-form schema.org property the authoring path copies through
-    verbatim; it is omitted rather than sent empty when the case had no source
-    material to name.
+    Nepali court document. `en` joins it when the extraction supplied one:
+    canonical NES entities carry both (`{"ne": "काठमाडौं", "en": "Kathmandu"}`)
+    and every entity this stage created before 2026-08-06 was missing its
+    English name, so it was invisible to the English UI and to English search.
+    Omitted rather than sent blank -- an empty `en` is a claim that the name has
+    no English form, which is different from not knowing it.
+
+    `citation` is a free-form schema.org property the authoring path copies
+    through verbatim; it is omitted rather than sent empty when the case had no
+    source material to name.
     """
     payload = {
         "prefix": prefix,
@@ -1102,6 +1187,8 @@ def _authoring_payload(prefix, slug, etype, name, citation):
         "name": {"ne": name},
         "change_description": "Created by casework.enrich_related_entities",
     }
+    if name_en:
+        payload["name"]["en"] = name_en
     if citation:
         payload["citation"] = citation
     return payload

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -101,7 +101,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from casework.common.api import CaseworkApi
+from casework.common.api import CaseworkApi, EntityAlreadyExists
 from casework.common.cli import (
     add_common_args,
     basic_auth_from_env,
@@ -113,7 +113,8 @@ from casework.common.cli import (
     setup_logging,
 )
 from casework.common.llm import bootstrap, tier_for
-from casework.common.materials import source_text
+from casework.common.materials import source_chunks, source_text
+from casework.entity_identity import entity_slug, prefix_is_creatable
 from casework.common.parse import parse_extraction_response
 from casework.common.pipeline import (
     COURT_TYPES,
@@ -140,7 +141,7 @@ from casework.entity_resolver import (
     normalise_name,
     resolve,
 )
-from jawafdehi_shared.entities.ids import is_valid_entity_iri
+from jawafdehi_shared.entities.ids import build_entity_iri, is_valid_entity_iri
 
 log = logging.getLogger("casework.enrich_related_entities")
 
@@ -283,6 +284,8 @@ Output ONLY this JSON object, no other text:
     {
       "entity_name": "Name exactly as in document",
       "relationship_type": "location", "related", "accused", "alleged" or "witness",
+      "entity_prefix": "the category from the list below",
+      "entity_type": "Person", "Organization", "GovernmentOrganization" or "Place",
       "notes": "specific description"
     }
   ],
@@ -294,6 +297,45 @@ Output ONLY this JSON object, no other text:
   ]
 }
 """
+
+#: Appended to `SYSTEM_PROMPT` when `--create-entities` is on, carrying the live
+#: category list. Only then: without the flag nothing is created, and asking for
+#: two fields nobody reads would spend prompt budget on a case where the budget
+#: is already the binding constraint (`PROMPT_HARD_MAX`).
+#:
+#: The list arrives from `GET /api/entity_prefixes` rather than being hardcoded,
+#: because it is `SELECT DISTINCT prefix` over live entities and grows. A
+#: hardcoded copy would silently refuse categories that exist.
+PREFIX_PROMPT_TEMPLATE = """
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ENTITY CATEGORY (entity_prefix)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Every entity needs a category. CHOOSE FROM THIS LIST ONLY -- a value not on it
+is discarded and the entity is not created:
+
+{prefixes}
+
+Pick the most specific one that fits. A person is always `person`. A district
+forest office is `organization/government/district/dfo`, not `organization`.
+A district is `location/district`.
+
+Set `entity_type` to match: `Person` for a person, `GovernmentOrganization` for
+a state body, `Organization` for a company or NGO, `Place` for a location.
+"""
+
+
+def prefix_prompt_section(live_prefixes):
+    """The category instructions for `SYSTEM_PROMPT`, or "" with no prefixes.
+
+    Returns "" rather than a template with an empty list: an instruction to
+    choose from nothing would make the model invent values, and every invented
+    value is then discarded by `prefix_is_creatable` -- an expensive way to
+    produce no entities.
+    """
+    if not live_prefixes:
+        return ""
+    listed = "\n".join(f"  {p}" for p in sorted(live_prefixes))
+    return PREFIX_PROMPT_TEMPLATE.format(prefixes=listed)
 
 # Writes are DRAFT-only. This is also what makes the merge safe: the case read
 # BLANKS per-entity `notes` for non-casework viewers
@@ -922,6 +964,149 @@ def apply_entity_plan(api, plan):
                             if_match=plan.if_match)
 
 
+def source_citation_iri(case):
+    """The material IRI to cite on an entity created from this case, or "".
+
+    The first press-release or court-order material with converted text, in that
+    order -- the same documents the extraction read, so the citation names a
+    document that actually mentions the entity. Empty when neither is present,
+    which the caller records rather than papering over: an entity created here
+    has no other provenance, and the API's create path enforces none.
+    """
+    for types in (PRESS_TYPES, COURT_TYPES):
+        chunks, _unmet = source_chunks(case, types=types)
+        for _mtype, iri, _text in chunks:
+            if iri:
+                return iri
+    return ""
+
+
+def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
+                                  citation, *, dry_run, run_entities):
+    """Create an NES entity for each unmatched name, then bind it.
+
+    Returns `(bind_items, still_unmatched, rows)`: the validated bind items to
+    merge into the case, the `plan.nomatch` entries no entity could be made for,
+    and one report row per name for `*.created.jsonl`.
+
+    `run_entities` maps a normalised name to an IRI already created THIS RUN, and
+    is shared across cases on purpose. Case 078-CR-0038 named the Dhangadhi
+    forest directorate twice in one extraction; without it, that case creates two
+    entities on its first run, and two cases naming the same office create two
+    more.
+
+    A dry run POSTs nothing and still reports the IRI it would have used, built
+    from the same prefix and slug, so the printed patch is the one an `--apply`
+    run would send.
+
+    Nothing here raises. A name that cannot become an entity -- no prefix, a
+    prefix with no existing parent, an unslugifiable name, a failed POST -- is
+    recorded and left in `still_unmatched`, so one bad name costs the case
+    nothing else.
+    """
+    bind_items, still_unmatched, rows = [], [], []
+
+    for name, decision, section in plan.nomatch:
+        item = items_by_name.get(name) or {}
+        prefix = (item.get("entity_prefix") or "").strip().lower()
+        etype = (item.get("entity_type") or "").strip()
+        row = {"slug": plan.slug, "extracted": name, "role": section,
+               "prefix": prefix, "type": etype, "citation": citation,
+               "nes_id": "", "outcome": "", "reason": ""}
+
+        slug = entity_slug(name)
+        refusal = _cannot_create(prefix, etype, slug, live_prefixes)
+        if refusal:
+            row.update(outcome="skipped", reason=refusal)
+            rows.append(row)
+            still_unmatched.append((name, decision, section))
+            continue
+
+        key = normalise_name(name)
+        if key in run_entities:
+            # Same office, second spelling. Reuse rather than create a twin.
+            row.update(outcome="reused", nes_id=run_entities[key])
+            rows.append(row)
+            bind_items.append(_created_bind(run_entities[key], section, item))
+            continue
+
+        iri = build_entity_iri(prefix, slug)
+        if dry_run:
+            row.update(outcome="would-create", nes_id=iri)
+        else:
+            try:
+                created = api.create_entity(_authoring_payload(
+                    prefix, slug, etype, name, citation))
+                iri = created.get("@id") or iri
+                row.update(outcome="created", nes_id=iri)
+            except EntityAlreadyExists:
+                # Someone got there first. That is the outcome we wanted.
+                row.update(outcome="already-exists", nes_id=iri)
+            except Exception as exc:  # noqa: BLE001 - one name's failure must not cost the case its other binds
+                row.update(outcome="error", reason=str(exc))
+                rows.append(row)
+                still_unmatched.append((name, decision, section))
+                continue
+
+        run_entities[key] = iri
+        rows.append(row)
+        bind_items.append(_created_bind(iri, section, item))
+
+    return bind_items, still_unmatched, rows
+
+
+def _cannot_create(prefix, etype, slug, live_prefixes):
+    """Why this name cannot become an entity, or "" when it can.
+
+    One function so every refusal reads the same way in `created.jsonl`, and so
+    the order is fixed: identity first (is there a prefix and a type at all),
+    then whether the prefix may be used, then whether the name yields a slug.
+    """
+    if not prefix or not etype:
+        return "extraction gave no entity_prefix/entity_type"
+    if not prefix_is_creatable(prefix, live_prefixes):
+        return (f"prefix {prefix!r} is not in use and its parent branch does not "
+                "exist, so creating it would strand the entity where no search "
+                "filter reaches")
+    if not slug:
+        return "name yields no IRI-legal slug"
+    return ""
+
+
+def _authoring_payload(prefix, slug, etype, name, citation):
+    """The API's authoring form for a create POST.
+
+    No `@id`: `normalize_authoring_payload` builds it from prefix+slug and
+    validates the shape while doing so (`entities/write_validation.py:113`).
+
+    `name` is a language map keyed `ne`, because every name here comes out of a
+    Nepali court document and claiming it as English would be wrong. `citation`
+    is a free-form schema.org property the authoring path copies through
+    verbatim; it is omitted rather than sent empty when the case had no source
+    material to name.
+    """
+    payload = {
+        "prefix": prefix,
+        "slug": slug,
+        "type": etype,
+        "name": {"ne": name},
+        "change_description": "Created by casework.enrich_related_entities",
+    }
+    if citation:
+        payload["citation"] = citation
+    return payload
+
+
+def _created_bind(iri, section, item):
+    """One bind item for a just-created entity, validated like any other."""
+    bind = {"nes_id": iri,
+            "relationship_type": section,
+            "notes": (item.get("notes") or "").strip()}
+    if section == "accused":
+        bind["outcome"] = CHARGED
+    return validate_bind_item(bind)
+
+
 def plan_summary(plan, extracted_items):
     """Reconcile one case's plan against the names it was built from.
 
@@ -1215,6 +1400,14 @@ def main(argv=None):
     )
     add_common_args(ap)
     ap.add_argument(
+        "--create-entities", action="store_true",
+        help="Create an NES entity for each extracted name that matches none, "
+             "then bind it. OFF BY DEFAULT and independent of --apply, so "
+             "upgrading this enricher cannot make an existing --apply run start "
+             "writing to NES. Entities created this way are published with NO "
+             "sources -- the 2-distinct-publisher rule lives in "
+             "`manage.py bulk_ingest`, not on the API's create path.")
+    ap.add_argument(
         "--strict", action="store_true",
         help="Bind only when exactly one NES entity matched and no veto fired; "
              "send ambiguities and vetoed matches to review instead. Off by "
@@ -1290,6 +1483,13 @@ def main(argv=None):
     bind_rows, review_rows, nomatch_rows = [], [], []
     # Collected BEFORE resolution, so they survive a run where nothing binds.
     extracted_rows, accused_notes_rows = [], []
+    created_rows = []
+    # Entities created THIS RUN, keyed by normalised name and shared across
+    # cases: the same district office recurs, and each extra creation is a
+    # duplicate NES entity nobody asked for.
+    run_entities = {}
+    # Fetched on first use, not at startup -- see the call site.
+    live_prefixes = None
 
     for idx, case in enumerate(cases, 1):
         slug = case.get("slug") or "?"
@@ -1386,9 +1586,16 @@ def main(argv=None):
                       detail="empty prompt after truncation", level=logging.WARNING)
             continue
 
+        # The category list rides on the system prompt only when we might create
+        # something. Fetched once per run, here as well as at the create step,
+        # because the prompt is built first.
+        if args.create_entities and live_prefixes is None:
+            live_prefixes = api.entity_prefixes()
+
         try:
             response_text = invoke_text(
-                system=SYSTEM_PROMPT,
+                system=SYSTEM_PROMPT + prefix_prompt_section(
+                    live_prefixes if args.create_entities else None),
                 content=user_prompt,
                 max_tokens=EXTRACTION_MAX_TOKENS,
                 tier=tier_for("entities"),
@@ -1499,6 +1706,35 @@ def main(argv=None):
                                 "role": section,
                                 "reason": decision.reason, "score": decision.score,
                                 "candidates": [list(c) for c in decision.candidates]})
+        # CREATE, then bind. Only reachable with --create-entities; without it
+        # `plan.nomatch` is untouched and this enricher behaves exactly as before.
+        if args.create_entities and plan.nomatch:
+            if live_prefixes is None:
+                # Fetched once per run, lazily: a run that creates nothing (no
+                # unmatched name, or the flag off) must not pay for it.
+                live_prefixes = api.entity_prefixes()
+            created_binds, still_unmatched, created = create_entities_for_unmatched(
+                api, plan, {(i.get("entity_name") or "").strip(): i
+                            for i in valid_items},
+                live_prefixes, source_citation_iri(detail),
+                dry_run=args.dry_run, run_entities=run_entities)
+            created_rows.extend(created)
+            plan.nomatch = still_unmatched
+            for row in created:
+                log_event(logger, paths["events"], run_id=run_id, stage="entities",
+                          slug=slug, step="create", status=row["outcome"],
+                          detail=f"{row['extracted']} -> {row['nes_id'] or row['reason']}",
+                          level=logging.WARNING if row["outcome"] in
+                          ("skipped", "error") else logging.INFO)
+            if created_binds:
+                # `patch_items` is already the merged whole list on a WOULD_PATCH
+                # plan; on a NOOP it is empty and the case's own binds are the
+                # base. Merging against the wrong one would drop every existing
+                # bind, because this PATCH replaces the entire list.
+                base = plan.patch_items or current_entity_binds(fresh)
+                plan.patch_items = merge_entity_binds(base, created_binds)
+                plan.action = "WOULD_PATCH"
+
         for name, decision, section in plan.nomatch:
             nomatch_rows.append((name, slug, decision, section))
 
@@ -1579,6 +1815,7 @@ def main(argv=None):
     write_jsonl(reports["review"], review_rows)
     write_jsonl(reports["extracted"], extracted_rows)
     write_jsonl(reports["accused_notes"], accused_notes_rows)
+    write_jsonl(reports["created"], created_rows)
     write_nomatch_report(reports["nomatch"], nomatch_rows)
 
     print()

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -1102,11 +1102,21 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
     merge into the case, the `plan.nomatch` entries no entity could be made for,
     and one report row per name for `*.created.jsonl`.
 
-    `run_entities` maps a normalised name to an IRI already created THIS RUN, and
-    is shared across cases on purpose. Case 078-CR-0038 named the Dhangadhi
-    forest directorate twice in one extraction; without it, that case creates two
-    entities on its first run, and two cases naming the same office create two
-    more.
+    `run_entities` maps `(prefix, normalised name)` to an IRI already created
+    THIS RUN, and is shared across cases on purpose. Case 078-CR-0038 named the
+    Dhangadhi forest directorate twice in one extraction; without it, that case
+    creates two entities on its first run, and two cases naming the same office
+    create two more.
+
+    THE PREFIX IS PART OF THE KEY, and must stay part of it. A person and an
+    organisation can carry the same name, and they live at different IRIs
+    (`person/ram-bahadur-thapa`, `organization/ram-bahadur-thapa`) that the
+    server will never 409 against each other. Keyed on the name alone, the
+    second case reuses the first's IRI and binds a PERSON as the organisation
+    in a corruption case. The name still carries within a prefix, so two
+    spellings of one office -- or one office whose `name_en` the model wrote
+    differently in two cases, which would otherwise slug apart -- still collapse
+    to one entity.
 
     A dry run POSTs nothing and still reports the IRI it would have used, built
     from the same prefix and slug, so the printed patch is the one an `--apply`
@@ -1137,7 +1147,7 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
             still_unmatched.append((name, decision, section))
             continue
 
-        key = normalise_name(name)
+        key = (prefix, normalise_name(name))
         if key in run_entities:
             # Same office, second spelling. Reuse rather than create a twin.
             row.update(outcome="reused", nes_id=run_entities[key])
@@ -1654,9 +1664,10 @@ def main(argv=None):
     # Collected BEFORE resolution, so they survive a run where nothing binds.
     extracted_rows, accused_notes_rows = [], []
     created_rows = []
-    # Entities created THIS RUN, keyed by normalised name and shared across
-    # cases: the same district office recurs, and each extra creation is a
-    # duplicate NES entity nobody asked for.
+    # Entities created THIS RUN, keyed by `(prefix, normalised name)` and shared
+    # across cases: the same district office recurs, and each extra creation is a
+    # duplicate NES entity nobody asked for. The prefix is in the key so a
+    # shared name cannot collapse two categories -- see the call site.
     run_entities = {}
     # Fetched on first use, not at startup -- see the call site.
     live_prefixes = None

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -46,16 +46,19 @@ namesake. That is the accepted cost of the mode; every such bind is marked
 labelled set: precision 0.872, recall 0.872, and all five wrong binds are
 Election Commission candidate records rather than namesake mix-ups.
 
-TWO REFUSALS SURVIVE THAT MODE, both because they are not "uncertain" at all:
+ONE REFUSAL SURVIVES THAT MODE:
 
-* A CROSS-SCRIPT-ONLY MATCH (`is_cross_script_only`). Overriding the other vetoes
-  accepts a known risk about a name that DID match; overriding this one asserts a
-  match the matcher rejects, because the score exists only through romanisation.
-  कमल थापा scores 0.96 against a `Kamala Thapa` entity and 0.00 against
-  कमला थापा -- binding it names a woman in a case charging a man.
 * AN UNREADABLE ENTITY DOCUMENT (`apply_document_veto`'s fail-closed branch). One
   403 or 502 would otherwise bind whichever namesake sorted first with nothing
   having been checked at all.
+
+A CROSS-SCRIPT-ONLY MATCH USED TO BE THE SECOND, and is now bound (2026-08-05:
+this stage produces no review queue, and which entities are real is a later
+pass). The risk it guarded is real and unmitigated: कमल थापा scores 0.96 against
+a `Kamala Thapa` entity and 0.00 against कमला थापा, so the bind can name a woman
+in a case charging a man. `resolve` still reports the veto, so the reason text
+survives on the bind row in `*.binds.jsonl` -- that file is where such a bind is
+found again.
 
 `--strict` is the conservative pipeline: an ambiguity or a veto goes to the review
 report instead of binding. Same labelled set: precision 1.000, recall 0.846.
@@ -134,7 +137,6 @@ from casework.entity_resolver import (
     REVIEW,
     Decision,
     apply_document_veto,
-    is_cross_script_only,
     normalise_name,
     resolve,
 )
@@ -309,6 +311,12 @@ RELATIONSHIP_TYPES = (
     "location", "respondent", "petitioner",
 )
 
+#: Where a section the API rejects lands. `related` and not a guess at the
+#: intended meaning: it is what the extraction prompt already defaults to
+#: ("PART 2 -- PEOPLE AND ORGANIZATIONS (relationship_type=\"related\" unless
+#: stated)"), so a coerced row claims exactly what an unstated one would.
+DEFAULT_RELATIONSHIP_TYPE = "related"
+
 
 def bind_relationship_type(entity):
     """One bind's relationship type, lowercased and trimmed, from either key.
@@ -439,6 +447,10 @@ class EntityBindPlan:
     # cannot be recovered from the name afterwards, and on a run where nothing
     # resolves this list is the ONLY record of what each name was said to be.
     nomatch: list = field(default_factory=list)  # (name, Decision, section)
+    # Sections the extraction named that the case API will not accept, rewritten
+    # to `related`. Recorded because a silently relabelled section is a section
+    # nobody asserted -- the run log and the reports name the original.
+    coerced: list = field(default_factory=list)  # (name, original, "related")
     patch_items: list = field(default_factory=list)
     reason: str = ""
     # There are no separate accused lists. Every name this planner handles comes
@@ -473,15 +485,6 @@ class EntityBindPlan:
 # testing a reason string by eye is how they would drift apart.
 PROMOTED_PREFIX = "promoted over: "
 
-# Appended to the veto reason of the one REVIEW permissive mode will not promote,
-# so the review row explains itself. See `_promote_top_candidate`.
-NOT_PROMOTED_CROSS_SCRIPT = (
-    "not promoted even in permissive mode: the winning candidate carries no "
-    "Devanagari name, so its score comes from romanisation, which folds a "
-    "masculine name into its feminine form. Binding it would assert a match that "
-    "a same-script comparison refuses outright. Confirm by hand")
-
-
 def is_promoted(decision):
     """True when this bind won by overriding a veto, so it is one to double-check."""
     return decision.reason.startswith(PROMOTED_PREFIX)
@@ -501,50 +504,61 @@ def _bind_row(slug, name, decision, notes, section, written):
 
 
 def _promote_top_candidate(decision, extracted_name):
-    """A vetoed/ambiguous REVIEW -> a BIND on its highest-scoring candidate.
+    """A vetoed/ambiguous REVIEW -> a BIND, verdict flipped on the top candidate.
 
-    This is the whole of "bind every name that matched something". `resolve`
-    returns REVIEW for ambiguity, truncation, name vetoes and province/institution
-    scope, and `apply_document_veto` adds the election-record one. Each of those
-    means "a candidate cleared the score threshold but something ELSE was
-    unproven", so each has a top candidate sitting right there in
-    `decision.candidates`.
+    `resolve` returns REVIEW for ambiguity, truncation, name vetoes,
+    cross-script and province/institution scope, and `apply_document_veto` adds
+    the election-record one. Each means "a candidate cleared the score threshold
+    but something ELSE was unproven", so each has candidates to bind.
+
+    Flips the verdict only. WHICH candidates are bound is `qualifying_binds`'
+    decision, and since 2026-08-05 that is all of them, not just this one --
+    every veto here is now overridden, including the cross-script match this
+    function used to refuse (see the module docstring for the risk that carries).
 
     Deterministic by construction: `resolve` sorts `candidates` by
-    `(-score, nes_id)`, so two entities tied at the same score always resolve to
-    the same one -- a re-run cannot silently pick a different entity than the
-    run before it. NO_MATCH is left alone: nothing scored, so there is nothing
-    to promote, and this module may never create an NES entity.
+    `(-score, nes_id)`, so a re-run binds the same entities in the same order.
+    NO_MATCH is left alone -- nothing scored, so there is nothing to promote, and
+    creating an entity is the create step's job, not this one's.
 
-    ONE REVIEW IS NEVER PROMOTED: a cross-script-only match (see
-    `is_cross_script_only`). There the NAME itself is what is unproven, so
-    promoting does not accept a known risk, it asserts a match the matcher rejects
-    -- कमल थापा scores 0.96 against a `Kamala Thapa` entity and 0.00 against
-    कमला थापा, so the bind would name a woman in a case charging a man. Checked
-    against the candidate rather than against `decision.reason`, because
-    `resolve` reports only the FIRST veto that fires: a name that is both
-    ambiguous and cross-script comes back reading "ambiguous", and a reason-text
-    check would promote it.
-
-    The remaining cost is explicit: a promoted ambiguity is a coin flip between
-    namesakes. `decision.reason` is carried into the bind's note so the row says
-    why it was uncertain, and `*.binds.jsonl` records the runners-up that lost.
+    The cost stays explicit: `decision.reason` is carried onto the bind row so
+    `*.binds.jsonl` says why the bind was uncertain and lists the candidates.
     """
     if decision.verdict != REVIEW or not decision.candidates:
         return decision
     score, nes_id, matched = decision.candidates[0]
     if score < MIN_BIND_SCORE:
         return decision
-    if is_cross_script_only(extracted_name, matched):
-        # Say why this one stayed behind while permissive mode promoted its
-        # neighbours, or the row reads as an ordinary ambiguity that a caseworker
-        # would expect to have been bound like all the others.
-        return Decision(decision.verdict, decision.nes_id, decision.score,
-                        decision.matched_name,
-                        f"{decision.reason}; {NOT_PROMOTED_CROSS_SCRIPT}",
-                        decision.candidates)
     return Decision(BIND, nes_id, score, matched,
                     f"{PROMOTED_PREFIX}{decision.reason}", decision.candidates)
+
+
+def qualifying_binds(decision):
+    """Every candidate on `decision` that may be bound, as its own `Decision`.
+
+    One extracted name can produce SEVERAL binds. `resolve` reports an ambiguity
+    as a single REVIEW naming the top candidate; promoting it used to keep that
+    one and drop the rest. Since 2026-08-05 every candidate at or above
+    `MIN_BIND_SCORE` is bound and the later filtering pass decides -- two NES
+    rows scoring identically are usually one entity entered twice, and when they
+    are two different people sharing a name, both land and a human unpicks it.
+
+    Only candidates at or above the threshold. "Bind every candidate that
+    qualified" is not "bind everything the search returned": a weak near-miss
+    riding along on a strong match would bind an unrelated entity.
+
+    Falls back to `[decision]` when there are no candidates to enumerate, which
+    is what a hand-built BIND looks like.
+    """
+    if decision.verdict != BIND:
+        return []
+    qualifying = [c for c in (decision.candidates or ())
+                  if c[0] >= MIN_BIND_SCORE]
+    if not qualifying:
+        return [decision]
+    return [Decision(BIND, nes_id, score, matched,
+                     decision.reason, decision.candidates)
+            for score, nes_id, matched in qualifying]
 
 
 def _resolve_with_vetoes(api, name, strict=False):
@@ -743,22 +757,19 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
         if not name:
             continue
 
-        # Bind into whatever section the extraction names, so long as the API
-        # accepts that section. This is a validity check, not a scope filter:
-        # `alleged`, `location`, `witness`, `victim` and the rest all bind now.
-        # An unrecognised value, an empty string and a missing key still go to
-        # review, because there is no section to put them in -- guessing one
-        # would file the entity under a relationship nobody asserted.
+        # Bind into whatever section the extraction names. `alleged`, `location`,
+        # `witness`, `victim` and the rest all bind.
+        #
+        # A section the API does not accept is COERCED to `related` rather than
+        # held: `related` is what the prompt itself defaults to, and the coercion
+        # is not cosmetic. `PATCH /entities` validates the whole list, so one
+        # unaccepted section fails every bind on the case rather than only its own
+        # row -- holding the name back would cost the other binds nothing, but
+        # letting it through would cost them everything.
         rel_type = (item.get("relationship_type") or "").strip().lower()
         if rel_type not in RELATIONSHIP_TYPES:
-            plan.review.append((name, Decision(
-                REVIEW, None, 0.0, "",
-                f"relationship_type {item.get('relationship_type')!r} is not one "
-                f"of the {len(RELATIONSHIP_TYPES)} the case API accepts "
-                f"({', '.join(RELATIONSHIP_TYPES)}), so there is no section to "
-                "bind it into. Reported without spending a search request",
-                ()), rel_type))
-            continue
+            plan.coerced.append((name, rel_type, DEFAULT_RELATIONSHIP_TYPE))
+            rel_type = DEFAULT_RELATIONSHIP_TYPE
 
         decision = _resolve_with_vetoes(api, name, strict=strict)
 
@@ -770,61 +781,82 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
             continue
 
         notes = (item.get("notes") or "").strip()
-        item_to_bind = {
-            "nes_id": decision.nes_id,
-            "relationship_type": rel_type,
-            "notes": notes,
-        }
-        if bind_key(item_to_bind) in have:
-            # This entity is already bound to this case IN THIS SECTION (by an
-            # earlier extracted name, or by a pre-existing bind) -- not a new
-            # addition, so it is not counted in `plan.bound` either. Counting it
-            # there would overstate "binds written" on every idempotent re-run.
-            #
-            # Keyed on the pair, so the same entity CAN still be added in a
-            # different section -- see `bind_key`.
-            continue
-
-        # ESCALATION TO `accused` IS NEVER AUTOMATIC. Keying the merge on the pair
-        # means a second section for an already-bound entity now gets written
-        # rather than silently dropped -- correct, and what the DB constraint
-        # allows. But `accused` is not just another section: it names a person as
-        # the subject of a corruption case and carries `outcome=CHARGED`. When the
-        # case already characterises this entity some other way, a human (or an
-        # earlier run) made that call, and upgrading it on an LLM's say-so is the
-        # one bind this module must not make by itself. It goes to review with the
-        # existing characterisation named, so the upgrade is a decision someone
-        # takes rather than a diff someone discovers.
-        if rel_type == "accused" and decision.nes_id in already_characterised:
-            existing = sorted(section for nes_id, section in have
-                              if nes_id == decision.nes_id)
-            plan.review.append((name, Decision(
-                REVIEW, decision.nes_id, decision.score, decision.matched_name,
-                f"would escalate to 'accused' an entity this case already binds as "
-                f"{', '.join(repr(s) for s in existing)}. An accused bind asserts "
-                "the person is the subject of the case and sets outcome=charged, so "
-                "it is not applied on top of an existing characterisation without a "
-                f"human. Original reason: {decision.reason or 'clean match'}",
-                decision.candidates), rel_type))
-            continue
-        # `outcome` is legal ONLY on an accused bind -- the DB enforces it with
-        # the `outcome_only_on_accused` CHECK constraint, and `validate_bind_item`
-        # mirrors that. Every case in this corpus is a Special Court `-CR-` case,
-        # so CIAA filed a charge sheet and 'charged' is true by construction.
-        if rel_type == "accused":
-            item_to_bind["outcome"] = CHARGED
-        # Recorded BEFORE `outcome` is added, so the key matches the one
-        # `bind_key` computed above -- it reads only the two identity fields, but
-        # adding the entry after the mutation would invite that to drift.
-        have.add(bind_key(item_to_bind))
-        additions.append(validate_bind_item(item_to_bind))
-        plan.bound.append((name, decision, notes, rel_type))
+        # One name, possibly several binds -- see `qualifying_binds`.
+        for bind_decision in qualifying_binds(decision):
+            _bind_one(plan, name, bind_decision, rel_type, notes, have,
+                      already_characterised, additions)
 
     merged = merge_entity_binds(current, additions)
     if merged != current:
         plan.action = "WOULD_PATCH"
         plan.patch_items = merged
     return plan
+
+
+def _bind_one(plan, name, decision, rel_type, notes, have,
+              already_characterised, additions):
+    """Add ONE (entity, section) bind to `plan`, or record why it was not added.
+
+    Split out of `plan_case_entities` when one extracted name became able to
+    produce several binds -- the body was a `continue`-driven block inside that
+    loop, and `continue` cannot mean "next candidate" and "next name" at once.
+    Mutates `plan`, `have` and `additions`: the caller's loop owns them, and this
+    is the only writer of a bind row.
+    """
+    item_to_bind = {
+        "nes_id": decision.nes_id,
+        "relationship_type": rel_type,
+        "notes": notes,
+    }
+    if bind_key(item_to_bind) in have:
+        # This entity is already bound to this case IN THIS SECTION (by an
+        # earlier extracted name, or by a pre-existing bind) -- not a new
+        # addition, so it is not counted in `plan.bound` either. Counting it
+        # there would overstate "binds written" on every idempotent re-run.
+        #
+        # Keyed on the pair, so the same entity CAN still be added in a
+        # different section -- see `bind_key`.
+        return
+
+    # ESCALATION TO `accused` IS NEVER AUTOMATIC. Keying the merge on the pair
+    # means a second section for an already-bound entity now gets written
+    # rather than silently dropped -- correct, and what the DB constraint
+    # allows. But `accused` is not just another section: it names a person as
+    # the subject of a corruption case and carries `outcome=CHARGED`. When the
+    # case already characterises this entity some other way, a human (or an
+    # earlier run) made that call, and upgrading it on an LLM's say-so is the
+    # one bind this module must not make by itself. It goes to review with the
+    # existing characterisation named, so the upgrade is a decision someone
+    # takes rather than a diff someone discovers.
+    #
+    # THE ONE REVIEW THIS STAGE STILL PRODUCES. Dropping the review queue
+    # (2026-08-05) did not drop this: the alternative is not "bind it later",
+    # it is "publish a charge on an LLM's say-so".
+    if rel_type == "accused" and decision.nes_id in already_characterised:
+        existing = sorted(section for nes_id, section in have
+                          if nes_id == decision.nes_id)
+        plan.review.append((name, Decision(
+            REVIEW, decision.nes_id, decision.score, decision.matched_name,
+            f"would escalate to 'accused' an entity this case already binds as "
+            f"{', '.join(repr(s) for s in existing)}. An accused bind asserts "
+            "the person is the subject of the case and sets outcome=charged, so "
+            "it is not applied on top of an existing characterisation without a "
+            f"human. Original reason: {decision.reason or 'clean match'}",
+            decision.candidates), rel_type))
+        return
+
+    # `outcome` is legal ONLY on an accused bind -- the DB enforces it with
+    # the `outcome_only_on_accused` CHECK constraint, and `validate_bind_item`
+    # mirrors that. Every case in this corpus is a Special Court `-CR-` case,
+    # so CIAA filed a charge sheet and 'charged' is true by construction.
+    if rel_type == "accused":
+        item_to_bind["outcome"] = CHARGED
+    # Recorded BEFORE `outcome` is added, so the key matches the one
+    # `bind_key` computed above -- it reads only the two identity fields, but
+    # adding the entry after the mutation would invite that to drift.
+    have.add(bind_key(item_to_bind))
+    additions.append(validate_bind_item(item_to_bind))
+    plan.bound.append((name, decision, notes, rel_type))
 
 
 def _check_entity_plan(plan):
@@ -903,19 +935,31 @@ def plan_summary(plan, extracted_items):
 
     Recomputed here rather than threaded through `plan_case_entities`, because
     everything needed is already available to a caller that has both the plan
-    and the `extracted_items` it was built from: the number of extracted names
-    with a non-empty `entity_name` (the same "name" `plan_case_entities` skips
-    a blank of, before it even looks at `relationship_type`) minus how many of
-    those are accounted for in `bound`/`review`/`nomatch` is exactly the count
-    that was dropped as already-bound. No re-resolution, no extra searches --
-    just arithmetic over what the plan already recorded.
+    and the `extracted_items` it was built from. No re-resolution, no extra
+    searches -- just arithmetic over what the plan already recorded.
+
+    THE BUCKETS DO NOT SUM TO `extracted`. `bound` counts bind ROWS, and since
+    2026-08-05 one extracted name can produce several of them, so
+    `bound + review + nomatch` can exceed the number of names. `already_bound`
+    is therefore derived from which NAMES produced no row at all, not by
+    subtracting row counts -- the subtraction reconciled to -1 on the first
+    ambiguity.
     """
-    extracted = sum(
-        1 for item in extracted_items if (item.get("entity_name") or "").strip())
+    names = [(item.get("entity_name") or "").strip() for item in extracted_items]
+    names = [name for name in names if name]
+    extracted = len(names)
     bound = len(plan.bound)
     review = len(plan.review)
     nomatch = len(plan.nomatch)
-    already_bound = extracted - (bound + review + nomatch)
+    # `bound` counts bind ROWS and one name can now produce several of them (see
+    # `qualifying_binds`), so `extracted - (bound + review + nomatch)` goes
+    # NEGATIVE on an ambiguity -- 3 names, 3 binds, 1 no-match reconciled to -1.
+    # A name is "accounted for" when it produced at least one row anywhere; the
+    # rest are the ones the already-bound check dropped.
+    accounted = ({row[0] for row in plan.bound}
+                 | {row[0] for row in plan.review}
+                 | {row[0] for row in plan.nomatch})
+    already_bound = sum(1 for name in names if name not in accounted)
     return {
         "extracted": extracted,
         "bound": bound,

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -638,7 +638,7 @@ def _bind_row(slug, name, decision, notes, section, written):
             "reason": decision.reason, "written": written}
 
 
-def _promote_top_candidate(decision, extracted_name):
+def _promote_top_candidate(decision):
     """A vetoed/ambiguous REVIEW -> a BIND, verdict flipped on the top candidate.
 
     `resolve` returns REVIEW for ambiguity, truncation, name vetoes,
@@ -702,9 +702,10 @@ def _resolve_with_vetoes(api, name, strict=False, *, section=""):
     no role can drift onto a different guard.
 
     `strict=False` (the default) binds the best-scoring candidate whenever one
-    cleared the threshold, even if a veto fired -- with the two exceptions
-    `_promote_top_candidate` and the fail-closed branch below spell out: a
-    cross-script-only match and an unreadable entity document are never promoted.
+    cleared the threshold, even if a veto fired -- with ONE exception, which the
+    fail-closed branch below spells out: an unreadable entity document is never
+    promoted. The cross-script refusal that used to be the second exception was
+    removed on 2026-08-05, so `कमल थापा` can now bind a `Kamala Thapa` entity.
     `strict=True` restores the conservative behaviour: a veto means REVIEW and a
     human decides.
 
@@ -736,7 +737,7 @@ def _resolve_with_vetoes(api, name, strict=False, *, section=""):
         # Promote BEFORE the document read, so a name that `resolve` vetoed still
         # gets its winning candidate checked against its own document below
         # rather than skipping that read entirely.
-        decision = _promote_top_candidate(decision, name)
+        decision = _promote_top_candidate(decision)
         if not decision.is_bind:
             return decision
 
@@ -777,7 +778,7 @@ def _resolve_with_vetoes(api, name, strict=False, *, section=""):
     # with nothing having actually been matched against. Distinguished by whether
     # the document came back, never by parsing the veto's reason text.
     if not strict and readable:
-        decision = _promote_top_candidate(decision, name)
+        decision = _promote_top_candidate(decision)
     return decision
 
 
@@ -849,10 +850,12 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
        nobody ever saw. The exception's own text is folded into the reason (and
        logged), so a misconfigured base URL is diagnosable rather than looking like
        a real veto.
-    2. `_promote_top_candidate`'s CROSS-SCRIPT refusal. A candidate with no
-       Devanagari name only scored through romanisation, which folds a masculine
-       name into its feminine form; there the name itself is what is unproven, so
-       there is no "best-scoring match" to fall back on.
+    THE CROSS-SCRIPT REFUSAL IS GONE. It used to be the second guard: a
+    candidate with no Devanagari name only scored through romanisation, which
+    folds a masculine name into its feminine form. Removed on 2026-08-05 when
+    the review queue was dropped, so a case charging `कमल थापा` can now bind a
+    `Kamala Thapa` entity. Recorded here because this is the function that plans
+    the write, and a reader must not infer a guard that no longer exists.
     """
     slug = case.get("slug")
     state = case.get("state")
@@ -1072,6 +1075,25 @@ def source_citation_iri(case):
     return ""
 
 
+def read_live_prefixes(api):
+    """The live prefix list, or None when it could not be read.
+
+    None, not []: an empty list would look like "no prefix is in use" and make
+    `prefix_is_creatable` refuse every category, so the caller would silently
+    create nothing and report a reason that was never true.
+
+    Every other API call in the per-case loop is wrapped so one case's failure
+    does not cost the run. This one was not, and it is called from inside that
+    loop -- a single 502 aborted the whole batch, and at the create-step call
+    site it did so after entities had already been POSTed.
+    """
+    try:
+        return api.entity_prefixes()
+    except Exception as exc:  # noqa: BLE001 - a transient read must cost one case, not the run
+        log.warning("could not read the live entity prefixes: %s", exc)
+        return None
+
+
 def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
                                   citation, *, dry_run, run_entities):
     """Create an NES entity for each unmatched name, then bind it.
@@ -1141,9 +1163,23 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
                 still_unmatched.append((name, decision, section))
                 continue
 
+        # `_created_bind` VALIDATES, and validation raises. A server answering
+        # with an off-authority `@id` -- a redirect, a differently-configured
+        # `iri_base()` -- escaped the POST's handler above, which wraps only the
+        # request, and the call site has none. That killed the run after
+        # entities had already been created. Same treatment as a failed POST:
+        # the name is recorded and left unmatched, the case keeps its others.
+        try:
+            bind = _created_bind(iri, section, item)
+        except ValueError as exc:
+            row.update(outcome="error", reason=str(exc), nes_id="")
+            rows.append(row)
+            still_unmatched.append((name, decision, section))
+            continue
+
         run_entities[key] = iri
         rows.append(row)
-        bind_items.append(_created_bind(iri, section, item))
+        bind_items.append(bind)
 
     return bind_items, still_unmatched, rows
 
@@ -1724,7 +1760,7 @@ def main(argv=None):
         # something. Fetched once per run, here as well as at the create step,
         # because the prompt is built first.
         if args.create_entities and live_prefixes is None:
-            live_prefixes = api.entity_prefixes()
+            live_prefixes = read_live_prefixes(api)
 
         try:
             response_text = invoke_text(
@@ -1789,7 +1825,7 @@ def main(argv=None):
             })
         for note in accused_notes:
             if isinstance(note, dict):
-                accused_notes_rows.append({"slug": slug, **note})
+                accused_notes_rows.append({**note, "slug": slug})
 
         # Re-read WITH the ETag so the whole-list replace is conditional. `detail`
         # above came from `get_case`, which returns no ETag.
@@ -1846,7 +1882,7 @@ def main(argv=None):
             if live_prefixes is None:
                 # Fetched once per run, lazily: a run that creates nothing (no
                 # unmatched name, or the flag off) must not pay for it.
-                live_prefixes = api.entity_prefixes()
+                live_prefixes = read_live_prefixes(api)
             created_binds, still_unmatched, created = create_entities_for_unmatched(
                 api, plan, {(i.get("entity_name") or "").strip(): i
                             for i in valid_items},

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -359,6 +359,10 @@ RELATIONSHIP_TYPES = (
 #: stated)"), so a coerced row claims exactly what an unstated one would.
 DEFAULT_RELATIONSHIP_TYPE = "related"
 
+#: `created.jsonl` outcomes that yielded an IRI the case can bind. The other two
+#: -- `skipped` and `error` -- leave the name in `nomatch`.
+CREATED_OUTCOMES = frozenset({"created", "would-create", "already-exists", "reused"})
+
 
 def bind_relationship_type(entity):
     """One bind's relationship type, lowercased and trimmed, from either key.
@@ -493,6 +497,12 @@ class EntityBindPlan:
     # to `related`. Recorded because a silently relabelled section is a section
     # nobody asserted -- the run log and the reports name the original.
     coerced: list = field(default_factory=list)  # (name, original, "related")
+    # Names the create step made an entity for. They are REMOVED from `nomatch`
+    # once created, so without this list `plan_summary` sees a name that produced
+    # no row anywhere and counts it as already-bound -- which reported all 12
+    # entities the first production dry run would have created as work that did
+    # not need doing.
+    created: list = field(default_factory=list)  # names
     patch_items: list = field(default_factory=list)
     reason: str = ""
     # There are no separate accused lists. Every name this planner handles comes
@@ -1143,13 +1153,18 @@ def plan_summary(plan, extracted_items):
     # rest are the ones the already-bound check dropped.
     accounted = ({row[0] for row in plan.bound}
                  | {row[0] for row in plan.review}
-                 | {row[0] for row in plan.nomatch})
+                 | {row[0] for row in plan.nomatch}
+                 # A created name left `nomatch` and produced no row in the other
+                 # two either, so it has to be named here or it reads as
+                 # already-bound.
+                 | set(plan.created))
     already_bound = sum(1 for name in names if name not in accounted)
     return {
         "extracted": extracted,
         "bound": bound,
         "review": review,
         "nomatch": nomatch,
+        "created": len(plan.created),
         "already_bound": already_bound,
     }
 
@@ -1720,6 +1735,11 @@ def main(argv=None):
                 dry_run=args.dry_run, run_entities=run_entities)
             created_rows.extend(created)
             plan.nomatch = still_unmatched
+            # Only outcomes that produced an IRI to bind. `skipped` and `error`
+            # stay in `nomatch`, which already accounts for them, and counting
+            # them here would report entities we did not create.
+            plan.created = [row["extracted"] for row in created
+                            if row["outcome"] in CREATED_OUTCOMES]
             for row in created:
                 log_event(logger, paths["events"], run_id=run_id, stage="entities",
                           slug=slug, step="create", status=row["outcome"],
@@ -1821,16 +1841,28 @@ def main(argv=None):
     print()
     print(f"  TOTAL entities extracted across all cases: {total_entities_extracted}")
     print(f"  TOTAL accused notes extracted: {total_accused_notes_extracted}")
+    # "matched an EXISTING entity" and not just "bound": with --create-entities a
+    # created entity is bound too, and it is counted on the create line below.
+    # Reading 0 here while 13 entities reach the case is the kind of misreport
+    # this stage's reporting was rebuilt to stop.
     if args.dry_run:
         # Nothing was written -- say so, so this line can never be mistaken
         # for a record of an actual write the way an unqualified "bound to
         # cases" count could be.
-        print(f"  TOTAL entities that WOULD bind to cases (dry run, nothing "
-              f"written): {total_bound}")
+        print(f"  TOTAL that WOULD bind to an EXISTING NES entity (dry run, "
+              f"nothing written): {total_bound}")
     else:
-        print(f"  TOTAL entities bound to cases: {total_bound}")
+        print(f"  TOTAL bound to an EXISTING NES entity: {total_bound}")
     print(f"  TOTAL reported for human review: {total_review}  -> {reports['review']}")
     print(f"  TOTAL with no NES match: {total_nomatch}  -> {reports['nomatch']}")
+    if created_rows:
+        verb = "WOULD create" if args.dry_run else "created"
+        made = sum(1 for row in created_rows if row["outcome"] in CREATED_OUTCOMES)
+        print(f"  TOTAL NES entities {verb}: {made}  -> {reports['created']}")
+        for outcome in ("skipped", "error"):
+            n = sum(1 for row in created_rows if row["outcome"] == outcome)
+            if n:
+                print(f"    {n} {outcome} (left unmatched)")
     print(f"  TOTAL already bound (nothing to write): {total_already_bound}")
     if total_skipped_enriched:
         # Not necessarily finished, since the section scope widened after those

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -130,7 +130,6 @@ from casework.common.select import select_for_run
 # perfect court record bound zero defendants whenever its press-release PDF lacked a
 # MARKDOWN role, or the LLM call failed). `casework/court_record.py` and its tests
 # are kept intact, unwired, pending a decision on giving it its own CLI.
-from casework.court_record import CHARGED
 from casework.entity_resolver import (
     BIND,
     MIN_BIND_SCORE,
@@ -258,11 +257,13 @@ Extract ALL of these categories that appear in the documents:
 Notes must never be blank for related entities. Always describe the specific connection.
 Only extract entities with CONFIRMED connections — not people who were later acquitted.
 
-USE A MORE SPECIFIC relationship_type INSTEAD OF "related" when the documents make
-the role plain. Only these three; when in doubt use "related".
+DO NOT EXTRACT THE DEFENDANTS. The people the charge sheet (आरोपपत्र) names are
+already held in the court record and are read from there, not from this text.
+Extracting them here would guess at names the court record states exactly.
+Skip them entirely — do not list them under any relationship_type.
 
-  "accused" — a person the charge sheet (आरोपपत्र) names as a defendant.
-  Example: "गजेन्द्र प्रसाद राउत"  notes: "प्रतिवादी"
+USE A MORE SPECIFIC relationship_type INSTEAD OF "related" when the documents make
+the role plain. Only these two; when in doubt use "related".
 
   "alleged" — named as implicated in the documents, but NOT on the charge sheet.
   Example: "नानी काजी थापा"  notes: "घुस लेनदेनमा संलग्न भनी उल्लेख, अभियोग लगाइएको छैन"
@@ -294,7 +295,7 @@ Output ONLY this JSON object, no other text:
   "entities": [
     {
       "entity_name": "Name exactly as in document",
-      "relationship_type": "location", "related", "accused", "alleged" or "witness",
+      "relationship_type": "location", "related", "alleged" or "witness",
       "entity_prefix": "the category from the list below",
       "entity_type": "Person", "Organization", "GovernmentOrganization" or "Place",
       "is_named_entity": true or false,
@@ -397,6 +398,12 @@ RELATIONSHIP_TYPES = (
     "alleged", "accused", "related", "witness", "opposition", "victim",
     "location", "respondent", "petitioner",
 )
+
+#: The section this enricher refuses outright. Defendants come from the NGM
+#: court record (`casework/court_record.py::defendant_names`), which states them
+#: instead of guessing, and an accused bind is the only one that may carry
+#: `outcome`. Confirmed with Gaurav's supervisor on 2026-08-06.
+ACCUSED_SECTION = "accused"
 
 #: The one section that never creates. NES holds all 77 districts from a
 #: gazetteer ingest, keyed by official code (`location/district/jhapa-np0104`),
@@ -517,6 +524,29 @@ def validate_bind_item(item):
     return item
 
 
+def validate_new_bind(item):
+    """`validate_bind_item` plus the one rule that applies only to NEW binds.
+
+    Split deliberately. `apply_entity_plan` validates every row of the
+    whole-list PATCH, and that list carries binds the case ALREADY has -- a
+    human's accused bind, or one the court-record path wrote. Refusing accused
+    there would make any such case unpatchable, which is the opposite of the
+    intent: those binds are the authoritative ones.
+
+    What this module may not do is PROPOSE an accused bind of its own.
+    Defendants come from the NGM court record
+    (`casework/court_record.py::defendant_names`), which states them rather
+    than guessing. `plan_case_entities` drops the section before resolution, so
+    this is the backstop for a caller assembling additions by hand.
+    """
+    validate_bind_item(item)
+    if item.get("relationship_type") == ACCUSED_SECTION:
+        raise ValueError(
+            "this enricher does not propose 'accused' binds: defendants come "
+            "from the NGM court record, not the LLM")
+    return item
+
+
 @dataclass
 class EntityBindPlan:
     slug: str
@@ -553,6 +583,9 @@ class EntityBindPlan:
     # entities the first production dry run would have created as work that did
     # not need doing.
     created: list = field(default_factory=list)  # names
+    #: (name, section) the extraction produced for a section this enricher does
+    #: not own. Only `accused` today -- reported, never bound, never created.
+    court_record_only: list = field(default_factory=list)
     patch_items: list = field(default_factory=list)
     reason: str = ""
     # There are no separate accused lists. Every name this planner handles comes
@@ -877,6 +910,25 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
             plan.coerced.append((name, rel_type, DEFAULT_RELATIONSHIP_TYPE))
             rel_type = DEFAULT_RELATIONSHIP_TYPE
 
+        # THE LLM DOES NOT SUPPLY DEFENDANTS. `GET /courtcases/<court>/<number>/
+        # entities` states them exactly -- for 078-CR-0038, हेम राज विष्ट and
+        # रुबी जि.सी. विष्ट, the same two the extraction guessed at -- and
+        # `casework/court_record.py` already reads it.
+        #
+        # Dropped rather than coerced to `related`. Coercing would bind a
+        # defendant under a section that understates their role, and it would
+        # still bind every namesake the search returned.
+        #
+        # This is also what closes the CHARGED hole: an accused bind carries
+        # `outcome = CHARGED`, and since 2026-08-05 one name binds EVERY
+        # candidate at or above the threshold, so an ambiguous accused name
+        # recorded every namesake as charged -- 13 of them for `संजय प्रसाद
+        # यादव`, per `resolve`'s own docstring. With the section gone the path
+        # does not exist to narrow.
+        if rel_type == ACCUSED_SECTION:
+            plan.court_record_only.append((name, rel_type))
+            continue
+
         decision = _resolve_with_vetoes(api, name, strict=strict,
                                         section=rel_type)
 
@@ -925,44 +977,18 @@ def _bind_one(plan, name, decision, rel_type, notes, have,
         # different section -- see `bind_key`.
         return
 
-    # ESCALATION TO `accused` IS NEVER AUTOMATIC. Keying the merge on the pair
-    # means a second section for an already-bound entity now gets written
-    # rather than silently dropped -- correct, and what the DB constraint
-    # allows. But `accused` is not just another section: it names a person as
-    # the subject of a corruption case and carries `outcome=CHARGED`. When the
-    # case already characterises this entity some other way, a human (or an
-    # earlier run) made that call, and upgrading it on an LLM's say-so is the
-    # one bind this module must not make by itself. It goes to review with the
-    # existing characterisation named, so the upgrade is a decision someone
-    # takes rather than a diff someone discovers.
-    #
-    # THE ONE REVIEW THIS STAGE STILL PRODUCES. Dropping the review queue
-    # (2026-08-05) did not drop this: the alternative is not "bind it later",
-    # it is "publish a charge on an LLM's say-so".
-    if rel_type == "accused" and decision.nes_id in already_characterised:
-        existing = sorted(section for nes_id, section in have
-                          if nes_id == decision.nes_id)
-        plan.review.append((name, Decision(
-            REVIEW, decision.nes_id, decision.score, decision.matched_name,
-            f"would escalate to 'accused' an entity this case already binds as "
-            f"{', '.join(repr(s) for s in existing)}. An accused bind asserts "
-            "the person is the subject of the case and sets outcome=charged, so "
-            "it is not applied on top of an existing characterisation without a "
-            f"human. Original reason: {decision.reason or 'clean match'}",
-            decision.candidates), rel_type))
-        return
-
-    # `outcome` is legal ONLY on an accused bind -- the DB enforces it with
-    # the `outcome_only_on_accused` CHECK constraint, and `validate_bind_item`
-    # mirrors that. Every case in this corpus is a Special Court `-CR-` case,
-    # so CIAA filed a charge sheet and 'charged' is true by construction.
-    if rel_type == "accused":
-        item_to_bind["outcome"] = CHARGED
+    # NO `accused` BRANCH HERE, DELIBERATELY. This used to escalate-guard an
+    # accused bind and stamp `outcome = CHARGED`. `plan_case_entities` now
+    # refuses the section outright, so both were unreachable -- and code that
+    # can stamp CHARGED, sitting in a module that must never write an accused
+    # bind, is a hazard waiting for someone to move the filter. The refusal
+    # that replaced them is at the write boundary in `validate_bind_item`,
+    # where it is reachable and tested.
     # Recorded BEFORE `outcome` is added, so the key matches the one
     # `bind_key` computed above -- it reads only the two identity fields, but
     # adding the entry after the mutation would invite that to drift.
     have.add(bind_key(item_to_bind))
-    additions.append(validate_bind_item(item_to_bind))
+    additions.append(validate_new_bind(item_to_bind))
     plan.bound.append((name, decision, notes, rel_type))
 
 
@@ -1201,12 +1227,13 @@ def _authoring_payload(prefix, slug, etype, name, citation, name_en=""):
 
 def _created_bind(iri, section, item):
     """One bind item for a just-created entity, validated like any other."""
+    # No accused branch: `validate_new_bind` refuses the section outright, so
+    # stamping `outcome = CHARGED` here would only build an item that cannot
+    # pass validation.
     bind = {"nes_id": iri,
             "relationship_type": section,
             "notes": (item.get("notes") or "").strip()}
-    if section == "accused":
-        bind["outcome"] = CHARGED
-    return validate_bind_item(bind)
+    return validate_new_bind(bind)
 
 
 def plan_summary(plan, extracted_items):

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -435,7 +435,10 @@ class EntityBindPlan:
     # from the name afterwards. Carries the raw (lowercased) value for an
     # unrecognised section, which is exactly what a caseworker needs to see.
     review: list = field(default_factory=list)   # (name, Decision, section)
-    nomatch: list = field(default_factory=list)  # (name, Decision)
+    # The section rides here for the same reason it does on `bound`/`review`: it
+    # cannot be recovered from the name afterwards, and on a run where nothing
+    # resolves this list is the ONLY record of what each name was said to be.
+    nomatch: list = field(default_factory=list)  # (name, Decision, section)
     patch_items: list = field(default_factory=list)
     reason: str = ""
     # There are no separate accused lists. Every name this planner handles comes
@@ -763,7 +766,7 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
             plan.review.append((name, decision, rel_type))
             continue
         if decision.verdict == NO_MATCH:
-            plan.nomatch.append((name, decision))
+            plan.nomatch.append((name, decision, rel_type))
             continue
 
         notes = (item.get("notes") or "").strip()
@@ -940,7 +943,14 @@ def report_paths(paths):
     stem = log_path[: -len(suffix)] if log_path.endswith(suffix) else log_path
     return {"binds": f"{stem}.binds.jsonl",
             "review": f"{stem}.review.jsonl",
-            "nomatch": f"{stem}.nomatch.md"}
+            "nomatch": f"{stem}.nomatch.md",
+            # `extracted` and `accused_notes` record the model's own answer
+            # BEFORE resolution, so a run that binds nothing still shows what it
+            # found. Run 645b1483 extracted 13 entities and 2 accused notes and
+            # left no trace of either beyond a count in the log.
+            "extracted": f"{stem}.extracted.jsonl",
+            "accused_notes": f"{stem}.accused_notes.jsonl",
+            "created": f"{stem}.created.jsonl"}
 
 
 def _md_cell(text):
@@ -984,15 +994,21 @@ def write_nomatch_report(path, rows):
     worse candidate than one this run actually saw for the same name.
     """
     grouped = {}
-    for name, slug, decision in rows:
+    for name, slug, decision, section in rows:
         key = normalise_name(name)
         entry = grouped.setdefault(
-            key, {"names": [], "slugs": [], "near": decision.matched_name,
-                  "score": decision.score})
+            key, {"names": [], "slugs": [], "sections": [],
+                  "near": decision.matched_name, "score": decision.score})
         if name not in entry["names"]:
             entry["names"].append(name)
         if slug not in entry["slugs"]:
             entry["slugs"].append(slug)
+        # EVERY section the group appeared under, not the first. A normalised
+        # group collects rows from different cases, and the same name can be
+        # extracted as `accused` in one and `location` in another. Showing only
+        # one tells a caseworker to create the wrong kind of entity.
+        if section and section not in entry["sections"]:
+            entry["sections"].append(section)
         if decision.score > entry["score"]:
             entry["near"] = decision.matched_name
             entry["score"] = decision.score
@@ -1001,12 +1017,13 @@ def write_nomatch_report(path, rows):
     lines = ["# Extracted names with no NES entity", "",
              "Each of these needs an NES entity before a re-run can bind it. "
              "Most-recurring first.", "",
-             "| Cases | Extracted name | Closest NES candidate | Score |",
-             "|---|---|---|---|"]
+             "| Cases | Extracted name | Role | Closest NES candidate | Score |",
+             "|---|---|---|---|---|"]
     for entry in ordered:
         near = _md_cell(entry["near"]) or "—"
         names = " / ".join(_md_cell(name) for name in entry["names"])
-        lines.append(f"| {len(entry['slugs'])} | {names} "
+        roles = " / ".join(_md_cell(s) for s in entry["sections"]) or "—"
+        lines.append(f"| {len(entry['slugs'])} | {names} | {roles} "
                      f"| {near} | {entry['score']:.2f} |")
     Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -1227,6 +1244,8 @@ def main(argv=None):
     # below blames the resolver for a refusal that happened after it.
     total_refused_binds = 0
     bind_rows, review_rows, nomatch_rows = [], [], []
+    # Collected BEFORE resolution, so they survive a run where nothing binds.
+    extracted_rows, accused_notes_rows = [], []
 
     for idx, case in enumerate(cases, 1):
         slug = case.get("slug") or "?"
@@ -1373,6 +1392,20 @@ def main(argv=None):
                   step="extract", status="ok",
                   detail=f"{len(valid_items)} entities + {len(accused_notes)} accused_notes")
 
+        # Record the extraction itself, here, before anything can drop it. Every
+        # later exit -- an ETag failure, a refused plan, a whole case of
+        # no-matches -- leaves these rows already written.
+        for item in valid_items:
+            extracted_rows.append({
+                "slug": slug,
+                "extracted": (item.get("entity_name") or "").strip(),
+                "relationship_type": (item.get("relationship_type") or "").strip().lower(),
+                "notes": (item.get("notes") or "").strip(),
+            })
+        for note in accused_notes:
+            if isinstance(note, dict):
+                accused_notes_rows.append({"slug": slug, **note})
+
         # Re-read WITH the ETag so the whole-list replace is conditional. `detail`
         # above came from `get_case`, which returns no ETag.
         try:
@@ -1422,8 +1455,8 @@ def main(argv=None):
                                 "role": section,
                                 "reason": decision.reason, "score": decision.score,
                                 "candidates": [list(c) for c in decision.candidates]})
-        for name, decision in plan.nomatch:
-            nomatch_rows.append((name, slug, decision))
+        for name, decision, section in plan.nomatch:
+            nomatch_rows.append((name, slug, decision, section))
 
         counts = plan_summary(plan, valid_items)
         total_review += counts["review"]
@@ -1500,6 +1533,8 @@ def main(argv=None):
     reports = report_paths(paths)
     write_jsonl(reports["binds"], bind_rows)
     write_jsonl(reports["review"], review_rows)
+    write_jsonl(reports["extracted"], extracted_rows)
+    write_jsonl(reports["accused_notes"], accused_notes_rows)
     write_nomatch_report(reports["nomatch"], nomatch_rows)
 
     print()

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -782,6 +782,19 @@ def _resolve_with_vetoes(api, name, strict=False, *, section=""):
     return decision
 
 
+def bind_section(item):
+    """The section one extracted item will actually bind into.
+
+    The coercion in one place because two callers must agree on the answer.
+    `plan_case_entities` files the item under this section, and the creation
+    stage looks its metadata back up BY that section -- so a caller that read
+    the raw `relationship_type` instead would miss every coerced item and
+    refuse it for having no prefix.
+    """
+    rel_type = (item.get("relationship_type") or "").strip().lower()
+    return rel_type if rel_type in RELATIONSHIP_TYPES else DEFAULT_RELATIONSHIP_TYPE
+
+
 def plan_case_entities(api, case, etag, extracted_items, strict=False):
     """Resolve every extracted name for one case and build its write plan.
 
@@ -908,10 +921,10 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
         # unaccepted section fails every bind on the case rather than only its own
         # row -- holding the name back would cost the other binds nothing, but
         # letting it through would cost them everything.
-        rel_type = (item.get("relationship_type") or "").strip().lower()
-        if rel_type not in RELATIONSHIP_TYPES:
-            plan.coerced.append((name, rel_type, DEFAULT_RELATIONSHIP_TYPE))
-            rel_type = DEFAULT_RELATIONSHIP_TYPE
+        raw_type = (item.get("relationship_type") or "").strip().lower()
+        rel_type = bind_section(item)
+        if rel_type != raw_type:
+            plan.coerced.append((name, raw_type, rel_type))
 
         # THE LLM DOES NOT SUPPLY DEFENDANTS. `GET /courtcases/<court>/<number>/
         # entities` states them exactly -- for 078-CR-0038, हेम राज विष्ट and
@@ -1094,13 +1107,22 @@ def read_live_prefixes(api):
         return None
 
 
-def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
+def create_entities_for_unmatched(api, plan, items_by_key, live_prefixes,
                                   citation, *, dry_run, run_entities):
     """Create an NES entity for each unmatched name, then bind it.
 
     Returns `(bind_items, still_unmatched, rows)`: the validated bind items to
     merge into the case, the `plan.nomatch` entries no entity could be made for,
     and one report row per name for `*.created.jsonl`.
+
+    `items_by_key` maps `(name, bind_section(item))` back to the extracted item
+    the metadata must come from -- the prefix, the type, the English name, the
+    notes and the `is_named_entity` gate. KEYED ON THE SECTION TOO, because one
+    name can be extracted twice under two sections with contradictory metadata,
+    and keyed on the name alone both `plan.nomatch` entries read whichever the
+    model emitted last. That is not a tie-break, it is a safety gate decided by
+    output order: a contractor extracted as `related` with `is_named_entity:
+    true` was refused because a same-named `witness` row said false.
 
     `run_entities` maps `(prefix, normalised name)` to an IRI already created
     THIS RUN, and is shared across cases on purpose. Case 078-CR-0038 named the
@@ -1130,7 +1152,7 @@ def create_entities_for_unmatched(api, plan, items_by_name, live_prefixes,
     bind_items, still_unmatched, rows = [], [], []
 
     for name, decision, section in plan.nomatch:
-        item = items_by_name.get(name) or {}
+        item = items_by_key.get((name, section)) or {}
         prefix = (item.get("entity_prefix") or "").strip().lower()
         etype = (item.get("entity_type") or "").strip()
         name_en = (item.get("name_en") or "").strip()
@@ -1895,8 +1917,8 @@ def main(argv=None):
                 # unmatched name, or the flag off) must not pay for it.
                 live_prefixes = read_live_prefixes(api)
             created_binds, still_unmatched, created = create_entities_for_unmatched(
-                api, plan, {(i.get("entity_name") or "").strip(): i
-                            for i in valid_items},
+                api, plan, {((i.get("entity_name") or "").strip(),
+                             bind_section(i)): i for i in valid_items},
                 live_prefixes, source_citation_iri(detail),
                 dry_run=args.dry_run, run_entities=run_entities)
             created_rows.extend(created)

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -899,12 +899,10 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
     current = current_entity_binds(case)
     plan.n_current = len(current)
     have = {bind_key(bind) for bind in current}
-    # Which entities the case ALREADY characterises somehow, from the binds that
-    # existed before this run. Used only by the accused-escalation guard below;
-    # deliberately not updated as this run adds binds, because whether one
-    # extracted item precedes another in the LLM's output is arbitrary and must
-    # not decide whether a name is written or reviewed.
-    already_characterised = {nes_id for nes_id, _ in have}
+    # No `already_characterised` set here any more. It existed only to feed the
+    # accused-escalation guard, and the accused section is refused outright now
+    # -- see `_bind_one`. Rebuilding it per case would cost a set build and
+    # leave a future reader hunting for the guard it used to serve.
 
     additions = []
     for item in extracted_items:
@@ -959,7 +957,7 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
         # One name, possibly several binds -- see `qualifying_binds`.
         for bind_decision in qualifying_binds(decision):
             _bind_one(plan, name, bind_decision, rel_type, notes, have,
-                      already_characterised, additions)
+                      additions)
 
     merged = merge_entity_binds(current, additions)
     if merged != current:
@@ -968,8 +966,7 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
     return plan
 
 
-def _bind_one(plan, name, decision, rel_type, notes, have,
-              already_characterised, additions):
+def _bind_one(plan, name, decision, rel_type, notes, have, additions):
     """Add ONE (entity, section) bind to `plan`, or record why it was not added.
 
     Split out of `plan_case_entities` when one extracted name became able to
@@ -1092,8 +1089,10 @@ def read_live_prefixes(api):
     """The live prefix list, or None when it could not be read.
 
     None, not []: an empty list would look like "no prefix is in use" and make
-    `prefix_is_creatable` refuse every category, so the caller would silently
-    create nothing and report a reason that was never true.
+    `prefix_is_creatable` refuse every category. `prefix_is_creatable` itself
+    cannot tell the two apart (`set(live_prefixes or ())`), so the distinction
+    is only worth anything because `_cannot_create` checks for None BEFORE
+    calling it and says what actually happened.
 
     Every other API call in the per-case loop is wrapped so one case's failure
     does not cost the run. This one was not, and it is called from inside that
@@ -1239,7 +1238,10 @@ def _cannot_create(prefix, etype, slug, live_prefixes, *, section, name, item):
        ABSENT MEANS NO. A prompt regression that drops the field then surfaces
        as `0 created` in the summary, which is visible and fixable; defaulting
        the other way fills NES with entries nobody can delete.
-    4. IDENTITY. Prefix, type, slug -- can we even build an IRI.
+    4. IDENTITY. Prefix, type, slug -- can we even build an IRI. An unreadable
+       prefix list is refused here too, but says so in as many words: it is the
+       one refusal that reports a failure to check rather than a check that
+       failed.
     """
     if section == LOCATION_SECTION:
         return ("location entities are bind-only: NES already holds the "
@@ -1252,6 +1254,15 @@ def _cannot_create(prefix, etype, slug, live_prefixes, *, section, name, item):
                 "(is_named_entity)")
     if not prefix or not etype:
         return "extraction gave no entity_prefix/entity_type"
+    if live_prefixes is None:
+        # NOT a judgement on the prefix -- nothing was checked. `read_live_
+        # prefixes` returns None for exactly this case, but `prefix_is_creatable`
+        # folds None and [] to the same empty set, so without this branch a
+        # transient 502 reports every name as having an unusable prefix. That
+        # sentence is false for a prefix as ordinary as `person`, and it sends a
+        # caseworker to fix a prefix that was never the problem.
+        return (f"the live entity prefix list could not be read, so {prefix!r} "
+                "was never checked -- retry this case")
     if not prefix_is_creatable(prefix, live_prefixes):
         return (f"prefix {prefix!r} is not in use and its parent branch does not "
                 "exist, so creating it would strand the entity where no search "
@@ -1604,9 +1615,11 @@ def main(argv=None):
     ap.add_argument(
         "--create-entities", action="store_true",
         help="Create an NES entity for each extracted name that matches none, "
-             "then bind it. OFF BY DEFAULT and independent of --apply, so "
+             "then bind it. OFF BY DEFAULT and never implied by --apply, so "
              "upgrading this enricher cannot make an existing --apply run start "
-             "writing to NES. Entities created this way are published with NO "
+             "writing to NES. It does not override the dry run either: without "
+             "--apply nothing is POSTed and the run only reports what it would "
+             "create. Entities created this way are published with NO "
              "sources -- the 2-distinct-publisher rule lives in "
              "`manage.py bulk_ingest`, not on the API's create path.")
     ap.add_argument(
@@ -1614,7 +1627,9 @@ def main(argv=None):
         help="Bind only when exactly one NES entity matched and no veto fired; "
              "send ambiguities and vetoed matches to review instead. Off by "
              "default: the default binds the best-scoring match for every name, "
-             "except a match that exists only across scripts.")
+             "including a match that exists only across scripts -- that refusal "
+             "was removed on 2026-08-05, so a case charging कमल थापा can bind a "
+             "Kamala Thapa entity.")
     args = ap.parse_args(argv)
 
     setup_logging(args.verbose)

--- a/casework/enrich_related_entities.py
+++ b/casework/enrich_related_entities.py
@@ -663,7 +663,7 @@ def qualifying_binds(decision):
             for score, nes_id, matched in qualifying]
 
 
-def _resolve_with_vetoes(api, name, strict=False):
+def _resolve_with_vetoes(api, name, strict=False, *, section=""):
     """One name -> one `Decision`. THE ONLY resolution path in this module: every
     extracted name and every court-record `accused` name comes through here, so
     no role can drift onto a different guard.
@@ -691,8 +691,12 @@ def _resolve_with_vetoes(api, name, strict=False):
     read failure must never let a BIND survive.
     """
     candidates = api.search_entities(name)
+    # Only the location section prefers the coded gazetteer entry over an
+    # un-coded twin -- see `resolve`. Everywhere else two entities scoring alike
+    # is a real ambiguity.
     decision = resolve(name, candidates,
-                       candidates_complete=getattr(candidates, "complete", True))
+                       candidates_complete=getattr(candidates, "complete", True),
+                       prefer_gazetteer=(section == LOCATION_SECTION))
     if not decision.is_bind:
         if strict:
             return decision
@@ -873,7 +877,8 @@ def plan_case_entities(api, case, etag, extracted_items, strict=False):
             plan.coerced.append((name, rel_type, DEFAULT_RELATIONSHIP_TYPE))
             rel_type = DEFAULT_RELATIONSHIP_TYPE
 
-        decision = _resolve_with_vetoes(api, name, strict=strict)
+        decision = _resolve_with_vetoes(api, name, strict=strict,
+                                        section=rel_type)
 
         if decision.verdict == REVIEW:
             plan.review.append((name, decision, rel_type))

--- a/casework/entity_identity.py
+++ b/casework/entity_identity.py
@@ -1,0 +1,112 @@
+"""Identity for NES entities this package creates: the slug and the prefix rule.
+
+Two pure functions, deliberately apart from `enrich_related_entities`: they take
+strings and return strings, touch no API, and are the only place that decides
+what a created entity is *called* and where it is *filed*.
+
+Both answer questions the case API does not. `validate_jsonld_entity` checks the
+IRI's shape and nothing else, and the prefix list at `/api/entity_prefixes` is
+`SELECT DISTINCT prefix` over live entities (`entities/persistence.py:313`) --
+a report of what exists, not a whitelist. So a POST with an invented prefix
+succeeds, and the prefix then appears in that endpoint's own output. Every
+guard here is ours.
+"""
+
+import re
+
+from jawafdehi_shared.entities.ids import MAX_IRI_LENGTH
+
+# `_colloquial_fold` is private to that module, and imported anyway: it owns the
+# sound-spelling map (ś→sh, ṣ→sh, ṛ→ri) that makes `बिष्ट` read as `bishta`
+# rather than `bista`. Folding the diacritics here instead -- plain NFKD, which
+# is what the rest of that module's public surface would give us -- drops the
+# retroflex dot and yields `bista`, a spelling no NES entity uses. The
+# alternative is copying a phonetic table that must never drift from the one the
+# search index uses. `test_slug_transliterates_a_devanagari_person_name` pins
+# the mapping, so a change on that side fails here rather than silently
+# re-spelling every entity we create.
+from jawafdehi_shared.search.transliterate import _colloquial_fold, to_roman
+
+#: Bound on a generated slug. Far below `MAX_IRI_LENGTH` (300) on purpose: the
+#: prefix, the host and `/entity/` all share that budget, and the deepest live
+#: prefix is already 44 characters. A slug this long is also unreadable, which
+#: matters because a caseworker reads these IRIs in `created.jsonl`.
+MAX_SLUG_LENGTH = 80
+
+#: The prefix grammar, mirroring `_PREFIX` in `jawafdehi_shared.entities.ids`:
+#: 1 to 4 slash-joined segments of lowercase letters, digits and underscores.
+#: Duplicated rather than imported because that module keeps it private, and a
+#: silent drift here would let a malformed prefix reach a POST.
+_PREFIX_RE = re.compile(r"^[a-z0-9_]+(?:/[a-z0-9_]+){0,3}$")
+
+
+def entity_slug(name: str) -> str:
+    """A stable, IRI-legal slug for `name`, or "" if nothing usable survives.
+
+    Returns "" rather than raising: a name of pure punctuation has no slug, and
+    the caller's job is to skip and record it, not to build an invalid IRI.
+
+    Uses `to_roman` and folds the diacritics here, NOT `to_roman_colloquial`.
+    That function returns two spellings joined by a space -- a strict
+    transliteration and a schwa-dropped one, e.g. "hema raja bishta hem raj
+    bisht" -- because it feeds a search index that should match either. Slugging
+    it produces `hema-raja-bishta-hem-raj-bisht`.
+
+    The schwa-dropped spelling alone is closer to how Nepali is written in Latin
+    ("hem raj bisht"), and is still not used: it deletes a trailing vowel it
+    cannot distinguish from an inherent one, turning जिल्ला into `jill`.
+
+    Stability matters more than beauty. The same name must slug identically on
+    every run, or a re-run creates a second entity instead of finding the first.
+    """
+    if not name or not isinstance(name, str):
+        return ""
+
+    # `biṣṭa` -> `bishta`, `dhanagaḍhī` -> `dhanagadhi`: the sound map first, then
+    # the remaining combining marks stripped.
+    ascii_only = _colloquial_fold(to_roman(name))
+
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_only.lower()).strip("-")
+    if len(slug) > MAX_SLUG_LENGTH:
+        # Cut at a hyphen so the slug ends on a whole word rather than mid-name.
+        slug = slug[:MAX_SLUG_LENGTH].rsplit("-", 1)[0].strip("-")
+    # The grammar is `[a-z0-9][a-z0-9-]*`, so a slug starting with a digit is
+    # fine but one starting with a hyphen is not. `strip("-")` covers it.
+    return slug if len(slug) <= MAX_IRI_LENGTH else slug[:MAX_SLUG_LENGTH]
+
+
+def prefix_is_creatable(prefix, live_prefixes) -> bool:
+    """True when we may file a new entity under `prefix`.
+
+    Two ways to qualify: the prefix is already in use, or its IMMEDIATE parent
+    is. So `organization/government/forest` is allowed because
+    `organization/government` exists, while `organizaton/government/police` is
+    not -- its parent is nowhere, which is what a typo in the trunk looks like.
+
+    A brand-new root (`ministry`, `ministry/forest`) never qualifies. A root has
+    no parent to vouch for it, so accepting one would let any single misspelled
+    word become a permanent top-level category.
+
+    The parent must be the immediate one, not any ancestor. Accepting a
+    grandparent would wave through a typo in a middle segment:
+    `organization/government/revnue/customs` would borrow
+    `organization/government`'s legitimacy.
+
+    Known limit: a typo in the LAST segment still passes, because only the
+    parent is checked. `organization/government/polices` has a valid parent.
+    Trunk typos are the ones worth catching -- they strand the entity where no
+    search filter reaches it, and they compound, because the bad prefix then
+    reports as live.
+    """
+    if not prefix or not isinstance(prefix, str):
+        return False
+    if not _PREFIX_RE.match(prefix):
+        return False
+
+    live = set(live_prefixes or ())
+    if prefix in live:
+        return True
+    parent, sep, _leaf = prefix.rpartition("/")
+    if not sep:
+        return False        # a root nobody uses yet
+    return parent in live

--- a/casework/entity_identity.py
+++ b/casework/entity_identity.py
@@ -14,8 +14,6 @@ guard here is ours.
 
 import re
 
-from jawafdehi_shared.entities.ids import MAX_IRI_LENGTH
-
 # `_colloquial_fold` is private to that module, and imported anyway: it owns the
 # sound-spelling map (ś→sh, ṣ→sh, ṛ→ri) that makes `बिष्ट` read as `bishta`
 # rather than `bista`. Folding the diacritics here instead -- plain NFKD, which
@@ -50,7 +48,11 @@ def _slugify(text) -> str:
         slug = slug[:MAX_SLUG_LENGTH].rsplit("-", 1)[0].strip("-")
     # The grammar is `[a-z0-9][a-z0-9-]*`, so a slug starting with a digit is
     # fine but one starting with a hyphen is not. `strip("-")` covers it.
-    return slug if len(slug) <= MAX_IRI_LENGTH else slug[:MAX_SLUG_LENGTH]
+    #
+    # No second length check against MAX_IRI_LENGTH: 80 is already far under
+    # 300, so it could never fire, and reading like an independent cap invites
+    # someone to raise MAX_SLUG_LENGTH and trust a guard that was never there.
+    return slug
 
 
 def entity_slug(name: str, name_en=None) -> str:

--- a/casework/entity_identity.py
+++ b/casework/entity_identity.py
@@ -40,8 +40,33 @@ MAX_SLUG_LENGTH = 80
 _PREFIX_RE = re.compile(r"^[a-z0-9_]+(?:/[a-z0-9_]+){0,3}$")
 
 
-def entity_slug(name: str) -> str:
+def _slugify(text) -> str:
+    """Lowercase, hyphenate, trim to `MAX_SLUG_LENGTH`. "" if nothing survives."""
+    if not text or not isinstance(text, str):
+        return ""
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    if len(slug) > MAX_SLUG_LENGTH:
+        # Cut at a hyphen so the slug ends on a whole word rather than mid-name.
+        slug = slug[:MAX_SLUG_LENGTH].rsplit("-", 1)[0].strip("-")
+    # The grammar is `[a-z0-9][a-z0-9-]*`, so a slug starting with a digit is
+    # fine but one starting with a hyphen is not. `strip("-")` covers it.
+    return slug if len(slug) <= MAX_IRI_LENGTH else slug[:MAX_SLUG_LENGTH]
+
+
+def entity_slug(name: str, name_en=None) -> str:
     """A stable, IRI-legal slug for `name`, or "" if nothing usable survives.
+
+    Prefers `name_en`, the English name the extraction supplies. Most company
+    names in these court orders are English written in Devanagari, and sounding
+    them back out is unusable: `फरेष्ट डेभलपमेन्ट एण्ड इण्डष्ट्रिज` transliterates to
+    `phareshta-debhalapamenta-enda-indashtrija`, where the English name gives
+    `forest-development-and-industries`. The IRI is permanent and a caseworker
+    authoring that firm by hand would write the second, so preferring the
+    English name is what keeps NES from holding the company twice.
+
+    Falls back to transliteration whenever `name_en` yields no slug -- absent,
+    blank, punctuation, or not a string. Falling back beats returning "": ""
+    makes the caller skip an entity it could have created.
 
     Returns "" rather than raising: a name of pure punctuation has no slug, and
     the caller's job is to skip and record it, not to build an invalid IRI.
@@ -59,20 +84,16 @@ def entity_slug(name: str) -> str:
     Stability matters more than beauty. The same name must slug identically on
     every run, or a re-run creates a second entity instead of finding the first.
     """
+    english = _slugify(name_en)
+    if english:
+        return english
+
     if not name or not isinstance(name, str):
         return ""
 
     # `biṣṭa` -> `bishta`, `dhanagaḍhī` -> `dhanagadhi`: the sound map first, then
     # the remaining combining marks stripped.
-    ascii_only = _colloquial_fold(to_roman(name))
-
-    slug = re.sub(r"[^a-z0-9]+", "-", ascii_only.lower()).strip("-")
-    if len(slug) > MAX_SLUG_LENGTH:
-        # Cut at a hyphen so the slug ends on a whole word rather than mid-name.
-        slug = slug[:MAX_SLUG_LENGTH].rsplit("-", 1)[0].strip("-")
-    # The grammar is `[a-z0-9][a-z0-9-]*`, so a slug starting with a digit is
-    # fine but one starting with a hyphen is not. `strip("-")` covers it.
-    return slug if len(slug) <= MAX_IRI_LENGTH else slug[:MAX_SLUG_LENGTH]
+    return _slugify(_colloquial_fold(to_roman(name)))
 
 
 def prefix_is_creatable(prefix, live_prefixes) -> bool:

--- a/casework/entity_resolver.py
+++ b/casework/entity_resolver.py
@@ -913,7 +913,8 @@ def _truncation_veto(candidates, winner_id, candidates_complete) -> str:
 
 
 def resolve(extracted_name: str, candidates: list[dict],
-            candidates_complete: bool = True) -> Decision:
+            candidates_complete: bool = True,
+            prefer_gazetteer: bool = False) -> Decision:
     """Decide what to do with one LLM-extracted name.
 
     BIND only when exactly ONE NES entity scores at or above MIN_BIND_SCORE and
@@ -958,6 +959,29 @@ def resolve(extracted_name: str, candidates: list[dict],
                         scored[0][2] if scored else "",
                         "no NES entity scored at or above the bind threshold",
                         frozen)
+
+    # NES holds some places twice: `झापा` is both `location/district/jhapa-np0104`
+    # and `location/jhapa`, scoring 146.20 each, so run c92ad032 bound one
+    # district onto the case as two rows. Where the coded gazetteer entry is
+    # among the qualifiers, it is the one to keep -- it carries the government
+    # district code, and the un-coded twin is a hand-added duplicate.
+    #
+    # AFTER qualification, never before. Filtering the candidate list up front
+    # would let a coded entry that matched badly take the bind from an un-coded
+    # one that matched well, or drop the name to NO_MATCH outright. Narrowing
+    # the qualifying set can only ever pick between entities already good enough
+    # to bind.
+    #
+    # `frozen` keeps every candidate, so the dropped twin still reaches the
+    # report and the duplicate stays visible.
+    #
+    # Only the location section asks for this. Anywhere else, two entities
+    # scoring alike is the ambiguity it looks like.
+    if prefer_gazetteer and len(qualifying) > 1:
+        coded = {nes_id for nes_id in qualifying if names_a_gazetteer_place(nes_id)}
+        if coded:
+            qualifying = coded
+            scored = [row for row in scored if row[1] in coded]
 
     # Every veto below refuses the SAME way -- downgrade the winning candidate
     # to REVIEW with a reason -- so the construction lives in one place. A new

--- a/casework/entity_resolver.py
+++ b/casework/entity_resolver.py
@@ -697,17 +697,43 @@ def _province_veto(extracted: str, nes_id: str) -> str:
     )
 
 
-def _name_vetoes(extracted: str) -> str:
+#: Prefixes whose name space is a CLOSED, officially-coded gazetteer: 77
+#: districts and 7 provinces, ingested with their government codes
+#: (`location/district/jhapa-np0104`). The bare `location/` prefix is
+#: deliberately absent -- it holds countries and hand-added places with no code,
+#: which is the open name space the single-token veto was written for.
+GAZETTEER_PREFIXES = (
+    "/entity/location/district/",
+    "/entity/location/province/",
+)
+
+
+def names_a_gazetteer_place(nes_id) -> bool:
+    """True when `nes_id` is a district or province from the coded gazetteer."""
+    if not nes_id or not isinstance(nes_id, str):
+        return False
+    return any(marker in nes_id for marker in GAZETTEER_PREFIXES)
+
+
+def _name_vetoes(extracted: str, nes_id=None) -> str:
     """The reason this name can never be auto-bound, or "" if none applies.
 
-    These are properties of the extracted string alone, independent of what NES
-    holds.
+    Every veto here is a property of the extracted string alone. `nes_id` is the
+    winning candidate and buys exactly one exemption, described below; callers
+    with no candidate -- `enrich_related_entities._cannot_create`, deciding
+    whether to CREATE -- pass nothing and get every veto.
     """
     normalised = normalise_name(extracted)
     if _COMPOSITE_SEPARATOR in normalised:
         return "composite 'Activity - Location' name, never split"
     tokens = name_tokens(extracted)
-    if len(tokens) < 2:
+    # THE ONE EXEMPTION. A lone token is a weak anchor in an OPEN name space --
+    # one surname, one word of a firm. A district is the opposite: `काठमाडौं` is
+    # the entire name, the register holds 77 of them, and each carries a
+    # government code. Vetoing those left the location section unable to bind
+    # anything at all, which is what the 2026-08-06 hardening found once the
+    # prompt stopped gluing an activity onto the front of every place name.
+    if len(tokens) < 2 and not (tokens and names_a_gazetteer_place(nes_id)):
         return "single token is too weak an anchor"
     if all(token[1] & GENERIC_TOKENS for token in tokens):
         return "generic institutional name identifies no specific entity"
@@ -945,7 +971,7 @@ def resolve(extracted_name: str, candidates: list[dict],
     truncation = _truncation_veto(candidates, scored[0][1], candidates_complete)
     if truncation:
         return review(truncation)
-    veto = _name_vetoes(extracted_name)
+    veto = _name_vetoes(extracted_name, scored[0][1])
     if veto:
         return review(veto)
     if is_cross_script_only(extracted_name, scored[0][2]):

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -1999,9 +1999,9 @@ def test_nomatch_report_ranks_by_how_many_cases_a_name_appears_in(tmp_path):
     def d():
         return Decision(NM, None, 0.0, "", "no NES entity scored high enough", ())
 
-    rows = [("जिल्ला शिक्षा कार्यालय, दाङ", "case-a", d()),
-            ("जिल्ला शिक्षा कार्यालय, दाङ", "case-b", d()),
-            ("गुल्बा कोरी", "case-c", d())]
+    rows = [("जिल्ला शिक्षा कार्यालय, दाङ", "case-a", d(), "related"),
+            ("जिल्ला शिक्षा कार्यालय, दाङ", "case-b", d(), "related"),
+            ("गुल्बा कोरी", "case-c", d(), "accused")]
     out = tmp_path / "run.nomatch.md"
     write_nomatch_report(out, rows)
     text = out.read_text(encoding="utf-8")
@@ -2019,15 +2019,16 @@ def test_nomatch_report_escapes_table_breaking_characters(tmp_path):
     from casework.entity_resolver import Decision
 
     rows = [("मालपोत | कार्यालय", "case-a",
-             Decision(NM, None, 0.42, "जिल्ला\nकार्यालय", "no match", ()))]
+             Decision(NM, None, 0.42, "जिल्ला\nकार्यालय", "no match", ()),
+             "related")]
     out = tmp_path / "run.nomatch.md"
     write_nomatch_report(out, rows)
 
     row = next(line for line in out.read_text(encoding="utf-8").splitlines()
                if "मालपोत" in line)
-    # Four columns means four separators plus the two bounding ones; an unescaped
-    # pipe or newline would change that count.
-    assert row.count("|") - row.count(r"\|") == 5
+    # Five columns means five separators plus the bounding one; an unescaped pipe
+    # or newline would change that count.
+    assert row.count("|") - row.count(r"\|") == 6
     assert r"मालपोत \| कार्यालय" in row
     assert "जिल्ला कार्यालय" in row      # the newline became a space
     assert "\n" not in row
@@ -2104,8 +2105,8 @@ def test_nomatch_report_keeps_the_best_scoring_candidate_in_a_group(tmp_path):
     weak = Decision(NM, None, 0.40, "कमजोर मिल्दोजुल्दो", "no NES entity scored high enough", ())
     strong = Decision(NM, None, 0.83, "उत्तम मिल्दोजुल्दो", "no NES entity scored high enough", ())
     rows = [
-        ("जिल्ला शिक्षा कार्यालय, दाङ", "case-a", weak),
-        ("जिल्ला शिक्षा कार्यालय, दाङ", "case-b", strong),
+        ("जिल्ला शिक्षा कार्यालय, दाङ", "case-a", weak, "related"),
+        ("जिल्ला शिक्षा कार्यालय, दाङ", "case-b", strong, "related"),
     ]
     out = tmp_path / "run.nomatch.md"
     write_nomatch_report(out, rows)
@@ -2498,3 +2499,134 @@ def test_apply_over_a_case_that_already_has_a_bind_writes_both_rows(
          "notes": "तत्कालीन अध्यक्ष"},
         {"nes_id": ANKUR_IRI, "relationship_type": "related", "notes": "क"},
     ]
+
+
+# --------------------------------------------------------------------------
+# Extraction visibility -- what the model said, for every extracted name.
+#
+# Motivated by production run 645b1483 (2026-08-05, case 078-CR-0038): 13
+# entities extracted, 0 bind, 0 review, 13 no-match. The run recorded COUNTS
+# only, so the one thing a caseworker needed -- what each of the 13 names was
+# said to BE -- reached no file. `bound` and `review` rows already carry their
+# section; `nomatch` dropped it, and nothing recorded the extraction itself.
+# --------------------------------------------------------------------------
+
+
+def _nomatch_decision(score=0.0, near=""):
+    from casework.entity_resolver import NO_MATCH as NM
+    from casework.entity_resolver import Decision
+
+    return Decision(NM, None, score, near, "no NES entity scored high enough", ())
+
+
+def test_nomatch_rows_carry_the_section_they_were_extracted_under():
+    # The section is the most useful triage field on an unresolved row: it says
+    # whether the missing NES entity is an accused person or a district office.
+    # `bound` and `review` carry it for a documented reason -- two extracted
+    # items can name the same person under different sections, so it cannot be
+    # recovered from the name afterwards. That reasoning applies here unchanged.
+    case = {"slug": "case-nomatch-sections", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+         "notes": "क"},
+        {"entity_name": "वन निर्देशनालय, धनगढी", "relationship_type": "location",
+         "notes": "ख"}], strict=True)
+
+    assert [(name, section) for name, _decision, section in plan.nomatch] == [
+        ("हेम राज बिष्ट", "accused"),
+        ("वन निर्देशनालय, धनगढी", "location"),
+    ]
+
+
+def test_nomatch_report_shows_the_section_for_each_unmatched_name(tmp_path):
+    # The report IS the caseworker's queue for creating NES entities. Creating a
+    # person and creating a district office are different jobs, and the queue
+    # could not tell them apart.
+    rows = [("हेम राज बिष्ट", "case-a", _nomatch_decision(), "accused"),
+            ("वन निर्देशनालय, धनगढी", "case-b", _nomatch_decision(), "location")]
+    out = tmp_path / "run.nomatch.md"
+    write_nomatch_report(out, rows)
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert "accused" in next(line for line in lines if "हेम राज" in line)
+    assert "location" in next(line for line in lines if "निर्देशनालय" in line)
+
+
+def test_nomatch_report_lists_every_section_a_grouped_name_appeared_under(tmp_path):
+    # The report groups by normalised name across cases, so one group can hold
+    # rows extracted under different sections. Showing only the first would tell
+    # a caseworker the name is a location when another case called it accused.
+    rows = [("सुर्खेत जिल्ला", "case-a", _nomatch_decision(), "location"),
+            ("सुर्खेत जिल्ला", "case-b", _nomatch_decision(), "related")]
+    out = tmp_path / "run.nomatch.md"
+    write_nomatch_report(out, rows)
+
+    row = next(line for line in out.read_text(encoding="utf-8").splitlines()
+               if "सुर्खेत" in line)
+    assert "location" in row and "related" in row
+
+
+def test_report_paths_includes_the_new_sidecars():
+    paths = {"log": "/tmp/20260805T121433Z-entities-645b1483.log"}
+    out = report_paths(paths)
+    stem = "20260805T121433Z-entities-645b1483"
+    assert out["extracted"].endswith(f"{stem}.extracted.jsonl")
+    assert out["accused_notes"].endswith(f"{stem}.accused_notes.jsonl")
+    assert out["created"].endswith(f"{stem}.created.jsonl")
+
+
+NOTHING_RESOLVES_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+         "notes": "तत्कालीन प्रमुख"},
+        {"entity_name": "मानस नर्सरी, धनगढी", "relationship_type": "related",
+         "notes": "ठेक्का पाएको फर्म"},
+    ],
+    "accused_notes": [
+        {"name": "हेम राज बिष्ट", "notes": "वन अधिकृत, वन निर्देशनालय धनगढी"},
+    ],
+})
+
+
+def test_extraction_sidecar_records_every_name_when_nothing_resolves(
+    monkeypatch, patched_fetch_markdown
+):
+    # The run that motivated this: every extracted name failed to resolve, so
+    # binds.jsonl and review.jsonl were both empty and the $0.34 the extraction
+    # cost bought a report of counts. The sidecar is the only place the model's
+    # own answer survives a zero-bind run.
+    case = dict(PRESS_ONLY_CASE, slug="case-nothing-resolves", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "मानस नर्सरी, धनगढी": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: NOTHING_RESOLVES_RESPONSE,
+              argv=["--dry-run"])
+
+    rows = [json.loads(line) for line in Path(_report_files()["extracted"])
+            .read_text(encoding="utf-8").splitlines()]
+
+    assert [(r["extracted"], r["relationship_type"]) for r in rows] == [
+        ("हेम राज बिष्ट", "accused"),
+        ("मानस नर्सरी, धनगढी", "related"),
+    ]
+    assert rows[0]["notes"] == "तत्कालीन प्रमुख"
+    assert rows[0]["slug"] == "case-nothing-resolves"
+
+
+def test_extraction_sidecar_records_accused_notes(
+    monkeypatch, patched_fetch_markdown
+):
+    # accused_notes is a whole second section of the extraction that reached no
+    # output file at all -- the run log counted them and nothing else.
+    case = dict(PRESS_ONLY_CASE, slug="case-accused-notes", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "मानस नर्सरी, धनगढी": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: NOTHING_RESOLVES_RESPONSE,
+              argv=["--dry-run"])
+
+    notes = [json.loads(line) for line in Path(_report_files()["accused_notes"])
+             .read_text(encoding="utf-8").splitlines()]
+    assert notes == [{"slug": "case-accused-notes",
+                      "name": "हेम राज बिष्ट",
+                      "notes": "वन अधिकृत, वन निर्देशनालय धनगढी"}]

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -2979,6 +2979,53 @@ def test_one_office_named_twice_creates_one_entity(
     assert items[0]["relationship_type"] == "related"
 
 
+# The other half of the dedup: two names that are the same STRING but not the
+# same THING. A person and a school can carry one name -- the run cache is
+# keyed on the prefix as well for exactly this reason, because the two live at
+# different IRIs (`person/...` and `organization/...`) and the server would
+# never 409 one against the other. Keyed on the name alone, the second case
+# binds a PERSON entity as the organisation in a corruption case.
+HOMONYM_PERSON_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "श्रीकृष्ण श्रेष्ठ", "relationship_type": "related",
+         "entity_prefix": "person", "entity_type": "Person",
+         "is_named_entity": True, "name_en": "", "notes": "क"},
+    ],
+    "accused_notes": [],
+})
+
+HOMONYM_ORG_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "श्रीकृष्ण श्रेष्ठ", "relationship_type": "related",
+         "entity_prefix": "organization", "entity_type": "Organization",
+         "is_named_entity": True, "name_en": "", "notes": "ख"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_the_same_name_under_a_different_prefix_is_not_reused(
+    monkeypatch, patched_fetch_markdown
+):
+    person_case = dict(PRESS_ONLY_CASE, slug="case-homonym-person", entities=[])
+    org_case = dict(PRESS_ONLY_CASE, slug="case-homonym-org", entities=[])
+    api = _SearchStubApi([person_case, org_case], {"श्रीकृष्ण श्रेष्ठ": []})
+    replies = iter([HOMONYM_PERSON_RESPONSE, HOMONYM_ORG_RESPONSE])
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: next(replies),
+              argv=["--apply", "--create-entities"])
+
+    assert [p["prefix"] for p in api.create_entity_calls] == ["person", "organization"]
+    bound = [items[0]["nes_id"] for _s, _p, items, _e in api.replace_list_calls]
+    assert bound == [
+        "https://jawafdehi.org/entity/person/shrikrishna-shreshtha",
+        "https://jawafdehi.org/entity/organization/shrikrishna-shreshtha",
+    ]
+    # And the report agrees with itself: a row's prefix and its IRI can no
+    # longer disagree, which is what a name-keyed reuse used to write.
+    for row in _created_rows():
+        assert f"/entity/{row['prefix']}/" in row["nes_id"]
+
+
 BAD_PREFIX_RESPONSE = json.dumps({
     "entities": [
         {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -3269,7 +3269,7 @@ def test_a_500_propagates_untouched():
 # different ground: the section it came from, the shape of the string, the
 # model's own verdict on whether the string names a thing, and identity.
 # A refused name still BINDS whatever it matched -- these gate creation only.
-# See docs/entity-extraction-hardening-design.md.
+# The order is fixed in `_cannot_create`, which carries the reasoning for each.
 # --------------------------------------------------------------------------
 
 

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -1262,9 +1262,10 @@ def test_strict_buckets_review_and_nomatch_separately():
 
 def test_permissive_binds_the_ambiguity_and_still_cannot_bind_a_nomatch():
     # The default mode's whole point, and its limit. An ambiguity between two
-    # same-name entities resolves to the first by the `(-score, nes_id)` sort and
-    # binds; a name with NO candidate stays in nomatch, because there is nothing
-    # to promote and this module may never create an NES entity.
+    # same-name entities binds BOTH of them (2026-08-05: no review queue, the
+    # later filtering pass decides which is real); a name with NO candidate stays
+    # in nomatch, because there is nothing to bind. Creating one is the create
+    # step's job and requires `--create-entities`.
     anish_a = {"id": "https://jawafdehi.org/entity/person/anish-shrestha-219986",
                "title": {"ne": "अनिष श्रेष्‍ठ"}, "score": 182.17}
     anish_b = {"id": "https://jawafdehi.org/entity/person/anish-shrestha-285096",
@@ -1279,11 +1280,14 @@ def test_permissive_binds_the_ambiguity_and_still_cannot_bind_a_nomatch():
         {"entity_name": "खगेन्द्र पराजुली", "relationship_type": "related", "notes": "ख"}])
 
     assert plan.action == "WOULD_PATCH"
-    assert len(plan.bound) == 1
+    assert len(plan.bound) == 2
     assert plan.review == []
     assert len(plan.nomatch) == 1
+    # Both namesakes bound, in the deterministic `(-score, nes_id)` order so a
+    # re-run produces the same list rather than a reshuffled one.
+    assert [d.nes_id for _n, d, _notes, _s in plan.bound] == [
+        anish_a["id"], anish_b["id"]]
     _name, decision, _notes, _section = plan.bound[0]
-    assert decision.nes_id == anish_a["id"]      # first by the deterministic sort
     assert is_promoted(decision)
     assert "ambiguous" in decision.reason
 
@@ -1317,41 +1321,31 @@ KAMALA_IRI = "https://jawafdehi.org/entity/person/kamala-thapa-4f21ac"
 KAMALA_LATIN_ONLY = {"id": KAMALA_IRI, "title": {"en": "Kamala Thapa"}, "score": 190.0}
 
 
-def test_permissive_mode_refuses_to_promote_a_cross_script_only_match():
-    # THE ONE VETO PERMISSIVE MODE LEAVES STANDING. Every other promotion binds a
-    # name that matched, on grounds outside the name; this one would bind a name
-    # that did not match at all -- कमला थापा is a woman, कमल थापा is a man, and
-    # only romanisation makes them equal. The extracted name must stay in review
-    # even though its top candidate scores 0.96, well over MIN_BIND_SCORE.
+def test_permissive_mode_now_binds_a_cross_script_only_match():
+    # WAS THE ONE VETO PERMISSIVE MODE LEFT STANDING, and it is gone by decision
+    # (2026-08-05): this stage produces no review queue.
+    #
+    # Keeping the original reasoning on the record, because the test no longer
+    # states it: every other promotion binds a name that matched on grounds
+    # outside the name, while this one binds a name that did not match at all.
+    # कमला थापा is a woman, कमल थापा is a man, and only romanisation makes them
+    # equal -- 0.96 across scripts, 0.00 within Devanagari. So this bind can name
+    # a different person than the case charges, and the later filtering pass is
+    # what catches it.
     case = {"slug": "case-kamal", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"कमल थापा": [KAMALA_LATIN_ONLY]})
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
 
-    assert plan.action == "NOOP"
-    assert plan.patch_items == []
-    assert plan.bound == []
-    assert len(plan.review) == 1
-    _name, decision, section = plan.review[0]
-    assert decision.nes_id is None
-    assert section == "accused"
-    assert "across scripts" in decision.reason
-    assert "not promoted" in decision.reason
-    # The candidate is preserved so a caseworker can confirm or reject it by hand;
-    # only the automatic bind is refused.
-    assert decision.candidates[0][1] == KAMALA_IRI
-    # And the document was never fetched: a name this module will not bind must
-    # not cost an HTTP round trip either.
-    assert api.get_entity_calls == []
+    assert plan.action == "WOULD_PATCH"
+    assert plan.review == []
+    assert [item["nes_id"] for item in plan.patch_items] == [KAMALA_IRI]
 
 
-def test_a_cross_script_match_is_refused_even_when_another_veto_reports_first():
-    # The reason `_promote_top_candidate` checks the CANDIDATE and not
-    # `decision.reason`. `resolve` reports only the first veto that fires, and
-    # ambiguity is checked before the cross-script guard -- so a name that is both
-    # comes back reading "ambiguous", and a reason-text check would promote it,
-    # restoring the exact wrong bind. Two Latin-only namesakes, both above
-    # threshold: the reason says ambiguous, the refusal must still happen.
+def test_a_cross_script_match_is_bound_even_when_another_veto_reports_first():
+    # Two Latin-only namesakes, both above threshold. `resolve` reports only the
+    # first veto that fires and ambiguity is checked before the cross-script
+    # guard, so the reason reads "ambiguous". Both now bind.
     second = {"id": "https://jawafdehi.org/entity/person/kamala-thapa-9b7e10",
               "title": {"en": "Kamala Thapa"}, "score": 188.0}
     case = {"slug": "case-kamal-2", "state": "DRAFT", "entities": []}
@@ -1359,11 +1353,9 @@ def test_a_cross_script_match_is_refused_even_when_another_veto_reports_first():
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
 
-    assert plan.bound == []
-    _name, decision, _section = plan.review[0]
-    assert "ambiguous" in decision.reason      # the veto that reported
-    assert "not promoted" in decision.reason   # the refusal that still applies
-    assert decision.nes_id is None
+    assert plan.review == []
+    assert sorted(item["nes_id"] for item in plan.patch_items) == sorted(
+        [KAMALA_IRI, second["id"]])
 
 
 def test_a_same_script_candidate_is_still_promoted_over_its_veto():
@@ -1498,19 +1490,22 @@ def test_each_review_row_reports_its_own_section():
     assert [section for _n, _d, section in plan.review] == ["alleged", "witness"]
 
 
-def test_an_unrecognised_section_is_reported_verbatim_on_its_review_row():
-    # The row exists to tell a caseworker what the model actually said, so the raw
-    # value is what goes on it -- not "" and not a guessed section.
+def test_an_unrecognised_section_is_recorded_verbatim_when_it_is_coerced():
+    # WAS a review row carrying the raw value. The row is gone, but the raw value
+    # still has to be recoverable: a relabelled section is a claim nobody made,
+    # so `plan.coerced` keeps what the model actually said, lowercased.
+    #
+    # The name is now searched, where before the bad section short-circuited it.
+    # That is a real added cost -- one search request per coerced name -- and it
+    # is the price of not failing the whole case's PATCH on one bad label.
     case = {"slug": "case-bad-section", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {})
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "अनिष श्रेष्ठ", "relationship_type": "Suspect", "notes": "क"}])
 
-    _name, decision, section = plan.review[0]
-    assert section == "suspect"
-    assert "is not one of the" in decision.reason
-    # Refused before a search request was spent.
-    assert api.search_calls == []
+    assert plan.review == []
+    assert plan.coerced == [("अनिष श्रेष्ठ", "suspect", "related")]
+    assert api.search_calls != []
 
 
 # --- Correction 1: the document veto (Task 5's `apply_document_veto`) -----
@@ -1731,42 +1726,35 @@ def test_a_valid_section_binds_however_the_llm_cased_it(relationship_type, expec
 
 
 @pytest.mark.parametrize("relationship_type", ["", "organization", "Related party", None])
-def test_a_section_the_api_does_not_accept_reviews_without_searching(relationship_type):
-    # There is no section to bind these into, and guessing one would file the
-    # entity under a relationship nobody asserted. Refused BEFORE any search, so
-    # a malformed extraction costs no request.
+def test_a_section_the_api_does_not_accept_is_coerced_and_still_binds(relationship_type):
+    # WAS refused before any search, so a malformed extraction cost no request.
+    # Now coerced to `related` and bound: one unaccepted section fails the whole
+    # case's PATCH, so the name that would have been held is the cheap loss and
+    # every other bind on the case is the expensive one.
     case = {"slug": "case-scope", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "अंकुर खत्री", "relationship_type": relationship_type,
          "notes": "क"}])
 
-    assert plan.action == "NOOP"
-    assert plan.patch_items == []
-    assert plan.bound == []
-    assert len(plan.review) == 1
-    name, decision, _section = plan.review[0]
-    assert name == "अंकुर खत्री"
-    assert decision.nes_id is None
-    assert api.search_calls == []
-    assert api.get_entity_calls == []
+    assert plan.action == "WOULD_PATCH"
+    assert plan.review == []
+    assert [item["relationship_type"] for item in plan.patch_items] == ["related"]
+    assert [c[1] for c in plan.coerced] == [(relationship_type or "").strip().lower()]
 
 
-
-
-def test_plan_treats_a_missing_relationship_type_as_out_of_scope():
-    # The allow-list's other half: a missing key must fail the same way as an
-    # explicit "location" -- previously this was "safe" only because a filter
-    # in the unrelated `main()` function happened to drop such items first, a
-    # coupling this planner should not have to rely on.
+def test_plan_coerces_a_missing_relationship_type_rather_than_holding_it():
+    # The allow-list's other half: a missing key coerces the same way an
+    # unrecognised string does, so the planner never depends on `main()` having
+    # filtered such items out first.
     case = {"slug": "case-missing-type", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "अंकुर खत्री", "notes": "क"}])  # no relationship_type at all
 
-    assert plan.action == "NOOP"
-    assert len(plan.review) == 1
-    assert api.search_calls == []
+    assert plan.action == "WOULD_PATCH"
+    assert plan.review == []
+    assert plan.coerced == [("अंकुर खत्री", "", "related")]
 
 
 # --- Item 2 (important): a case payload with no "entities" key -----------
@@ -2201,8 +2189,12 @@ def test_plan_summary_reconciles_when_permissive_mode_promotes_the_ambiguity():
     ]
     plan = plan_case_entities(api, case, 'W/"e"', extracted_items)
 
+    # bound=3 from 3 names: अंकुर once, अनिष TWICE (both namesakes qualify). The
+    # buckets deliberately no longer sum to `extracted` -- `bound` counts rows,
+    # and `already_bound` is derived from names that produced no row at all, so
+    # the old subtraction's -1 cannot come back.
     assert plan_summary(plan, extracted_items) == {
-        "extracted": 3, "bound": 2, "review": 0, "nomatch": 1, "already_bound": 0,
+        "extracted": 3, "bound": 3, "review": 0, "nomatch": 1, "already_bound": 0,
     }
 
 
@@ -2349,12 +2341,13 @@ def test_dry_run_bind_rows_are_marked_unwritten(
 
     binds = [json.loads(line) for line
              in Path(_report_files()["binds"]).read_text(encoding="utf-8").splitlines()]
-    # Two rows in the default mode: the clean match, plus the promoted ambiguity.
-    # Both must be marked unwritten -- a promoted bind is still only a prediction
-    # in a dry run.
-    assert [b["written"] for b in binds] == [False, False]
+    # THREE rows in the default mode: the clean match, plus BOTH namesakes of the
+    # ambiguity. Every one marked unwritten -- a promoted bind is still only a
+    # prediction in a dry run.
+    assert [b["written"] for b in binds] == [False, False, False]
     assert api.replace_list_calls == []
-    assert [b["reason"].startswith(PROMOTED_PREFIX) for b in binds] == [False, True]
+    assert [b["reason"].startswith(PROMOTED_PREFIX) for b in binds] == [
+        False, True, True]
 
 
 TWO_SECTION_RESPONSE = json.dumps({
@@ -2630,3 +2623,158 @@ def test_extraction_sidecar_records_accused_notes(
     assert notes == [{"slug": "case-accused-notes",
                       "name": "हेम राज बिष्ट",
                       "notes": "वन अधिकृत, वन निर्देशनालय धनगढी"}]
+
+
+# --------------------------------------------------------------------------
+# Draft-case enrichment binds or creates -- it never reviews.
+#
+# Gaurav set this on 2026-08-05: deciding which entities deserve to exist is a
+# later pass, so this stage stops producing a review queue. Three behaviours
+# change, each pinned below.
+# --------------------------------------------------------------------------
+
+
+TWO_NAMESAKES_ABOVE_THRESHOLD = {
+    "अनिष श्रेष्ठ": [
+        {"id": "https://jawafdehi.org/entity/person/anish-shrestha-219986",
+         "title": {"ne": "अनिष श्रेष्‍ठ"}, "score": 182.17},
+        {"id": "https://jawafdehi.org/entity/person/anish-shrestha-285096",
+         "title": {"ne": "अनिष श्रेष्ठ"}, "score": 182.17},
+    ],
+}
+
+
+def test_ambiguity_binds_every_qualifying_candidate():
+    # Was: promote the top candidate, drop the runners-up. Now: bind all of them
+    # and let the later filtering pass decide. Two NES rows scoring identically
+    # are usually one person entered twice; when they are two different people
+    # sharing a name, both get bound and a human unpicks it later.
+    case = {"slug": "case-both-namesakes", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], TWO_NAMESAKES_ABOVE_THRESHOLD)
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अनिष श्रेष्ठ", "relationship_type": "related",
+         "notes": "क"}])
+
+    assert plan.action == "WOULD_PATCH"
+    assert plan.review == []
+    bound_ids = sorted(item["nes_id"] for item in plan.patch_items)
+    assert bound_ids == [
+        "https://jawafdehi.org/entity/person/anish-shrestha-219986",
+        "https://jawafdehi.org/entity/person/anish-shrestha-285096",
+    ]
+    # One extracted name, two bind rows -- both must be reported, or binds.jsonl
+    # under-reports what reached the case.
+    assert len(plan.bound) == 2
+
+
+def test_ambiguity_still_reviews_nothing_under_strict():
+    # `--strict` is untouched: it remains the conservative pipeline for anyone
+    # who wants an ambiguity held rather than bound.
+    case = {"slug": "case-strict-ambiguity", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], TWO_NAMESAKES_ABOVE_THRESHOLD)
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अनिष श्रेष्ठ", "relationship_type": "related",
+         "notes": "क"}], strict=True)
+
+    assert plan.bound == []
+    assert len(plan.review) == 1
+
+
+def test_a_candidate_below_the_threshold_is_not_bound_alongside_a_qualifying_one():
+    # "Bind every qualifying candidate" means every one at or above
+    # MIN_BIND_SCORE, not every one the search returned. A weak near-miss riding
+    # along on a strong match would bind an unrelated entity.
+    case = {"slug": "case-one-strong-one-weak", "state": "DRAFT", "entities": []}
+    strong = {"id": "https://jawafdehi.org/entity/person/anish-shrestha-219986",
+              "title": {"ne": "अनिष श्रेष्ठ"}, "score": 182.17}
+    weak = {"id": "https://jawafdehi.org/entity/person/anisha-shah-111111",
+            "title": {"ne": "अनिशा शाह"}, "score": 12.0}
+    api = _SearchStubApi([case], {"अनिष श्रेष्ठ": [strong, weak]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अनिष श्रेष्ठ", "relationship_type": "related",
+         "notes": "क"}])
+
+    assert [item["nes_id"] for item in plan.patch_items] == [
+        "https://jawafdehi.org/entity/person/anish-shrestha-219986"]
+
+
+def test_cross_script_only_match_is_bound_not_held():
+    # REVERSES `test_permissive_mode_refuses_to_promote_a_cross_script_only_match`.
+    # That veto was the one permissive mode left standing, because कमल (a man)
+    # and कमला (a woman) score 0.96 across scripts and 0.00 within Devanagari --
+    # so this bind names a different person than the case charges. Bound anyway
+    # per the 2026-08-05 decision: no review queue in this stage.
+    case = {"slug": "case-kamal-bound", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], {"कमल थापा": [KAMALA_LATIN_ONLY]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
+
+    assert plan.action == "WOULD_PATCH"
+    assert plan.review == []
+    assert [item["nes_id"] for item in plan.patch_items] == [KAMALA_IRI]
+
+
+def test_an_unaccepted_relationship_type_is_coerced_to_related():
+    # Was: review, because there was no section to bind into. Now: coerced to
+    # `related`, the prompt's own default. This is not cosmetic -- PATCH
+    # /entities validates the whole list, so one unaccepted section fails every
+    # bind on the case, not just its own row.
+    case = {"slug": "case-bad-section", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अंकुर खत्री", "relationship_type": "supervisor",
+         "notes": "क"}])
+
+    assert plan.review == []
+    assert [item["relationship_type"] for item in plan.patch_items] == ["related"]
+
+
+def test_a_missing_relationship_type_is_coerced_to_related():
+    case = {"slug": "case-no-section", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अंकुर खत्री", "notes": "क"}])
+
+    assert plan.review == []
+    assert [item["relationship_type"] for item in plan.patch_items] == ["related"]
+
+
+def test_the_coercion_is_recorded_so_a_reader_can_see_it_happened():
+    # A silently relabelled section is a section nobody asserted. The original
+    # value rides on the plan so the run log and the reports can name it.
+    case = {"slug": "case-coercion-recorded", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अंकुर खत्री", "relationship_type": "supervisor",
+         "notes": "क"}])
+
+    assert plan.coerced == [("अंकुर खत्री", "supervisor", "related")]
+
+
+def test_coercion_does_not_fire_for_an_accepted_section():
+    case = {"slug": "case-good-section", "state": "DRAFT", "entities": []}
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अंकुर खत्री", "relationship_type": "witness",
+         "notes": "क"}])
+
+    assert plan.coerced == []
+    assert [item["relationship_type"] for item in plan.patch_items] == ["witness"]
+
+
+def test_accused_escalation_still_needs_a_human():
+    # The one review this stage KEEPS. Escalating an already-characterised entity
+    # to `accused` sets outcome=charged and asserts the person is the subject of
+    # the case. Removing the review queue did not remove this guard, because the
+    # alternative is not "bind it later", it is "publish a charge on an LLM's
+    # say-so".
+    case = {"slug": "case-escalation", "state": "DRAFT",
+            "entities": [{"nes_id": ANKUR_IRI, "type": "related",
+                          "notes": "पहिले नै जोडिएको"}]}
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    plan = plan_case_entities(api, case, 'W/"e"', [
+        {"entity_name": "अंकुर खत्री", "relationship_type": "accused",
+         "notes": "क"}])
+
+    assert len(plan.review) == 1
+    assert "escalate to 'accused'" in plan.review[0][1].reason

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -877,7 +877,7 @@ def test_summary_reports_the_three_counts_separately(
               argv=["--dry-run"])
     out = capsys.readouterr().out
     assert "TOTAL entities extracted across all cases: 2" in out
-    assert "TOTAL entities that WOULD bind to cases (dry run, nothing written): 0" in out
+    assert "TOTAL that WOULD bind to an EXISTING NES entity (dry run, nothing written): 0" in out
     assert "TOTAL reported for human review:" in out
     assert "TOTAL with no NES match:" in out
     assert "bound zero" in out.lower()
@@ -940,7 +940,7 @@ def test_summary_uses_plan_summary_so_already_bound_names_do_not_vanish(
 
     out = capsys.readouterr().out
     assert "TOTAL entities extracted across all cases: 2" in out
-    assert "TOTAL entities bound to cases: 1" in out
+    assert "TOTAL bound to an EXISTING NES entity: 1" in out
     assert "TOTAL already bound (nothing to write): 1" in out
     assert "TOTAL reported for human review: 0" in out
     assert "TOTAL with no NES match: 0" in out
@@ -2199,7 +2199,7 @@ def test_plan_summary_reconciles_on_the_ordinary_bind_review_nomatch_split():
     # `already_bound` subtraction and drive it negative, which is what the three
     # court-record keys that used to sit here existed to avoid.
     assert summary == {
-        "extracted": 3, "bound": 1, "review": 1, "nomatch": 1, "already_bound": 0,
+        "extracted": 3, "bound": 1, "review": 1, "nomatch": 1, "created": 0, "already_bound": 0,
     }
 
 
@@ -2230,7 +2230,7 @@ def test_plan_summary_reconciles_when_permissive_mode_promotes_the_ambiguity():
     # and `already_bound` is derived from names that produced no row at all, so
     # the old subtraction's -1 cannot come back.
     assert plan_summary(plan, extracted_items) == {
-        "extracted": 3, "bound": 3, "review": 0, "nomatch": 1, "already_bound": 0,
+        "extracted": 3, "bound": 3, "review": 0, "nomatch": 1, "created": 0, "already_bound": 0,
     }
 
 
@@ -2326,7 +2326,7 @@ def test_a_failed_write_leaves_no_bound_row_and_no_bound_claim(
     out = capsys.readouterr().out
 
     assert "  BOUND " not in out
-    assert "TOTAL entities bound to cases: 0" in out
+    assert "TOTAL bound to an EXISTING NES entity: 0" in out
     assert api.replace_list_calls == []
     assert Path(_report_files()["binds"]).read_text(encoding="utf-8") == ""
     statuses = [r["status"] for r in report.rows if r["slug"] == "case-write-fails"]
@@ -2443,7 +2443,7 @@ def test_dry_run_refuses_what_apply_refuses_instead_of_promising_a_bind(
     assert "WOULD BIND" not in out
     assert "WOULD REFUSE" in out
     assert "no ETag" in out
-    assert "TOTAL entities that WOULD bind to cases (dry run, nothing written): 0" in out
+    assert "TOTAL that WOULD bind to an EXISTING NES entity (dry run, nothing written): 0" in out
     statuses = [r["status"] for r in report.rows if r["slug"] == "case-dry-no-etag"]
     assert statuses == ["would-refuse"]
     assert Path(_report_files()["binds"]).read_text(encoding="utf-8") == ""
@@ -3133,3 +3133,102 @@ def test_the_category_list_ships_with_the_flag(
               argv=["--dry-run", "--create-entities"])
     assert "ENTITY CATEGORY" in seen["system"]
     assert "organization/government/district/dfo" in seen["system"]
+
+
+def test_a_created_name_is_not_counted_as_already_bound():
+    # Found on the first production dry run (226fb34b, case 078-CR-0038): 13
+    # extracted, 1 bound, 12 would-create, 0 no-match -- reported as "already
+    # bound (nothing to write): 12". The create step removes a name from
+    # `plan.nomatch`, so it produced no row in bound/review/nomatch and the
+    # accounted-for check counted it as dropped-because-already-bound. Every
+    # created entity was reported as work that did not need doing.
+    plan = ere.EntityBindPlan(slug="case-count", action="NOOP", examined=True)
+    plan.bound = [("नागरिक लगानी कोष", None, "क", "related")]
+    plan.created = ["हेम राज विष्ट", "सविना आले"]
+    items = [{"entity_name": "नागरिक लगानी कोष"},
+             {"entity_name": "हेम राज विष्ट"},
+             {"entity_name": "सविना आले"}]
+
+    summary = ere.plan_summary(plan, items)
+    assert summary["created"] == 2
+    assert summary["already_bound"] == 0
+
+
+def test_a_genuinely_already_bound_name_is_still_counted():
+    # The counter must keep working: a name that resolved to an entity already on
+    # the case in that section produces no row anywhere, and that IS
+    # already-bound.
+    plan = ere.EntityBindPlan(slug="case-count-2", action="NOOP", examined=True)
+    plan.bound = [("नागरिक लगानी कोष", None, "क", "related")]
+    items = [{"entity_name": "नागरिक लगानी कोष"},
+             {"entity_name": "पहिले नै जोडिएको नाम"}]
+
+    summary = ere.plan_summary(plan, items)
+    assert summary["already_bound"] == 1
+    assert summary["created"] == 0
+
+
+# --------------------------------------------------------------------------
+# CaseworkApi.create_entity's error mapping.
+#
+# Found by the local harness run, not by a unit test: the first version keyed
+# already-exists off 422, which is what the view returns for a VALIDATION
+# failure. A duplicate IRI goes through `_map_service_value_error` instead and
+# comes back 409 ENTITY_EXISTS (`entities/views.py:420`), so every re-run
+# recorded `error` and rebound nothing.
+# --------------------------------------------------------------------------
+
+
+def _http_error(code, body):
+    import io
+    import urllib.error
+
+    return urllib.error.HTTPError(
+        "http://127.0.0.1:48010/api/entities", code, "err", {},
+        io.BytesIO(body.encode("utf-8")))
+
+
+def _api_raising(exc):
+    from casework.common.api import CaseworkApi
+
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+
+    def boom(*a, **kw):
+        raise exc
+
+    api._request = boom
+    return api
+
+
+def test_a_409_conflict_becomes_entity_already_exists():
+    from casework.common.api import EntityAlreadyExists
+
+    api = _api_raising(_http_error(409, json.dumps({"error": {
+        "code": "ENTITY_EXISTS",
+        "message": "Entity https://jawafdehi.org/entity/person/hema-raja-vishta "
+                   "already exists"}})))
+    with pytest.raises(EntityAlreadyExists):
+        api.create_entity({"prefix": "person", "slug": "hema-raja-vishta",
+                           "type": "Person", "name": {"ne": "हेम राज विष्ट"}})
+
+
+def test_a_422_validation_failure_is_not_mistaken_for_a_conflict():
+    # 422 is the view's VALIDATION status. Treating it as already-exists would
+    # bind a nonexistent IRI on every malformed payload.
+    from casework.common.api import EntityAlreadyExists
+
+    api = _api_raising(_http_error(422, json.dumps({"error": {
+        "code": "VALIDATION_ERROR",
+        "message": "@type must be a known schema.org/jawafdehi type"}})))
+    with pytest.raises(ValueError) as caught:
+        api.create_entity({"prefix": "person", "slug": "x", "type": "Nonsense",
+                           "name": {"ne": "क"}})
+    assert not isinstance(caught.value, EntityAlreadyExists)
+
+
+def test_a_500_propagates_untouched():
+    api = _api_raising(_http_error(500, "boom"))
+    with pytest.raises(Exception) as caught:
+        api.create_entity({"prefix": "person", "slug": "x", "type": "Person",
+                           "name": {"ne": "क"}})
+    assert "500" in str(caught.value)

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -31,6 +31,7 @@ import logging
 import subprocess
 import sys
 import types
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -3627,3 +3628,48 @@ def test_the_new_bind_validator_still_applies_the_generic_rules():
     with pytest.raises(ValueError, match="canonical NES entity IRI"):
         ere.validate_new_bind({"nes_id": "not-an-iri",
                                "relationship_type": "related", "notes": ""})
+
+
+def test_a_failed_prefix_read_costs_one_case_not_the_whole_run(
+    monkeypatch, patched_fetch_markdown
+):
+    # Every other API call in the per-case loop is wrapped so one case's failure
+    # does not cost the run. `entity_prefixes` was not, so a single 502 aborted
+    # a 3,000-case batch -- and at the second call site, after entities had
+    # already been created and cases already PATCHed.
+    case = dict(PRESS_ONLY_CASE, slug="case-prefix-502", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "वन निर्देशनालय, धनगढी": []})
+
+    def boom(timeout=60):
+        raise urllib.error.HTTPError("u", 502, "Bad Gateway", {}, None)
+    api.entity_prefixes = boom
+
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    # The run survived and created nothing, rather than raising out of main().
+    assert api.create_entity_calls == []
+
+
+def test_an_uncanonical_created_iri_costs_one_name_not_the_run(
+    monkeypatch, patched_fetch_markdown
+):
+    # `_created_bind` validates, and validation RAISES. The per-name handler
+    # only wrapped the POST, so a server answering with an off-authority `@id`
+    # escaped both it and the call site, killing the run after entities had
+    # already been created.
+    case = dict(PRESS_ONLY_CASE, slug="case-bad-iri", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "वन निर्देशनालय, धनगढी": []})
+    real_create = api.create_entity
+
+    def odd_iri(payload, timeout=60):
+        real_create(payload, timeout)
+        return {"@id": "https://elsewhere.example/entity/person/x"}
+    api.create_entity = odd_iri
+
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    rows = _created_rows()
+    assert [r["outcome"] for r in rows] == ["error", "error"]
+    assert all("canonical NES entity IRI" in r["reason"] for r in rows)

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -144,12 +144,26 @@ class TestDonorFidelity:
         # silent edit to them is the failure this class exists to catch.
         for anchor in ("PART 1 — LOCATION ENTITIES",
                        "DO NOT extract accused home addresses",
-                       'The entity_name should include context in the format: '
-                       '"Organisation/Activity - Location"',
                        "PART 3 — ACCUSED NOTES",
                        "Only include primary accused persons. Keep notes under 80 chars."):
             assert anchor in donor["SYSTEM_PROMPT"], "anchor is not donor text"
             assert anchor in ere.SYSTEM_PROMPT
+
+    def test_the_composite_location_name_is_a_deliberate_divergence(self, donor):
+        # THE ONE DONOR RULE WE REFUSE. The donor tells the model to name a
+        # location "Organisation/Activity - Location", which is why the
+        # 2026-08-05 production run extracted `घरजग्गा सम्पत्ति - काठमाडौं` -- a
+        # description of seized property -- and was about to mint it as an NES
+        # entity. The composite also scores 0.00 against the canonical district
+        # it was meant to name, so it bound nothing either.
+        #
+        # Asserted against the donor as well as against us: if the donor text
+        # ever changes, this stops being a divergence and the test should be
+        # revisited rather than silently passing.
+        composite_rule = ('The entity_name should include context in the format: '
+                          '"Organisation/Activity - Location"')
+        assert composite_rule in donor["SYSTEM_PROMPT"]
+        assert composite_rule not in ere.SYSTEM_PROMPT
 
     def test_system_prompt_offers_every_section_the_binder_can_write(self):
         # Without this, widening `plan_case_entities` to all nine sections is dead
@@ -2831,10 +2845,12 @@ CREATE_RESPONSE = json.dumps({
     "entities": [
         {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
          "entity_prefix": "person", "entity_type": "Person",
+         "is_named_entity": True, "name_en": "",
          "notes": "तत्कालीन प्रमुख"},
         {"entity_name": "वन निर्देशनालय, धनगढी", "relationship_type": "related",
          "entity_prefix": "organization/government/district/dfo",
          "entity_type": "GovernmentOrganization",
+         "is_named_entity": True, "name_en": "",
          "notes": "आरोपी कार्यरत रहेको निकाय"},
     ],
     "accused_notes": [],
@@ -2921,14 +2937,16 @@ def test_the_created_entity_cites_the_material_it_came_from(
 
 TWO_SPELLINGS_RESPONSE = json.dumps({
     "entities": [
-        {"entity_name": "वन निदेशनालय, धनगढी - कैलाली जिल्ला",
+        {"entity_name": "वन निदेशनालय, धनगढी",
          "relationship_type": "related",
          "entity_prefix": "organization/government/district/dfo",
-         "entity_type": "GovernmentOrganization", "notes": "क"},
-        {"entity_name": "वन निदेशनालय, धनगढी - कैलाली जिल्ला ",
-         "relationship_type": "location",
+         "entity_type": "GovernmentOrganization",
+         "is_named_entity": True, "name_en": "", "notes": "क"},
+        {"entity_name": "वन निदेशनालय, धनगढी ",
+         "relationship_type": "related",
          "entity_prefix": "organization/government/district/dfo",
-         "entity_type": "GovernmentOrganization", "notes": "ख"},
+         "entity_type": "GovernmentOrganization",
+         "is_named_entity": True, "name_en": "", "notes": "ख"},
     ],
     "accused_notes": [],
 })
@@ -2945,17 +2963,19 @@ def test_one_office_named_twice_creates_one_entity(
               argv=["--apply", "--create-entities"])
 
     assert len(api.create_entity_calls) == 1
-    # Both binds point at the single created entity, in their own sections.
+    # Two spellings, one entity, and one bind row -- the case cannot carry the
+    # same entity twice in the same section, so the second bind merges away.
     _slug, _path, items, _etag = api.replace_list_calls[0]
-    assert len({item["nes_id"] for item in items}) == 1
-    assert sorted(item["relationship_type"] for item in items) == [
-        "location", "related"]
+    assert len(items) == 1
+    assert items[0]["nes_id"].endswith("/vana-nideshanalaya-dhanagadhi")
+    assert items[0]["relationship_type"] == "related"
 
 
 BAD_PREFIX_RESPONSE = json.dumps({
     "entities": [
         {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
-         "entity_prefix": "persen", "entity_type": "Person", "notes": "क"},
+         "entity_prefix": "persen", "entity_type": "Person",
+         "is_named_entity": True, "name_en": "", "notes": "क"},
     ],
     "accused_notes": [],
 })
@@ -3232,3 +3252,240 @@ def test_a_500_propagates_untouched():
         api.create_entity({"prefix": "person", "slug": "x", "type": "Person",
                            "name": {"ne": "क"}})
     assert "500" in str(caught.value)
+
+
+# --------------------------------------------------------------------------
+# Four gates in front of the POST.
+#
+# Creating an entity is permanent and public, so each gate refuses on a
+# different ground: the section it came from, the shape of the string, the
+# model's own verdict on whether the string names a thing, and identity.
+# A refused name still BINDS whatever it matched -- these gate creation only.
+# See docs/entity-extraction-hardening-design.md.
+# --------------------------------------------------------------------------
+
+
+LOCATION_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "काठमाडौं", "relationship_type": "location",
+         "entity_prefix": "location/district", "entity_type": "Place",
+         "is_named_entity": True, "name_en": "Kathmandu",
+         "notes": "जग्गा तथा शेयर लगानी रहेको जिल्ला"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_a_location_is_never_created_even_when_everything_else_is_valid(
+    monkeypatch, patched_fetch_markdown
+):
+    # NES already holds all 77 districts under official codes
+    # (location/district/kailali-np0771). A location this pipeline creates is
+    # therefore always a duplicate of a canonical district or junk -- there is
+    # no third case.
+    case = dict(PRESS_ONLY_CASE, slug="case-location-nocreate", entities=[])
+    api = _SearchStubApi([case], {"काठमाडौं": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: LOCATION_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    row, = _created_rows()
+    assert row["outcome"] == "skipped"
+    assert "location" in row["reason"]
+
+
+COMPOSITE_RELATED_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "घरजग्गा सम्पत्ति - काठमाडौं", "relationship_type": "related",
+         "entity_prefix": "organization", "entity_type": "Organization",
+         "is_named_entity": True, "name_en": "Real estate property - Kathmandu",
+         "notes": "जफत गरिएको सम्पत्ति"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_a_composite_name_in_the_related_section_is_never_created(
+    monkeypatch, patched_fetch_markdown
+):
+    # The backstop. `_name_vetoes` catches nothing in the current production
+    # sample that the location gate does not already catch, but a composite
+    # reaching the RELATED section would otherwise create junk for free -- and
+    # the model claiming is_named_entity=True does not make it a thing.
+    case = dict(PRESS_ONLY_CASE, slug="case-composite-related", entities=[])
+    api = _SearchStubApi([case], {"घरजग्गा सम्पत्ति - काठमाडौं": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: COMPOSITE_RELATED_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    row, = _created_rows()
+    assert row["outcome"] == "skipped"
+    assert "composite" in row["reason"]
+
+
+def _named_entity_response(flag):
+    """One related company, with `is_named_entity` set to whatever `flag` is.
+
+    `flag is None` omits the key entirely -- the prompt-regression shape.
+    """
+    entity = {"entity_name": "सामुदायिक वन उपभोक्ता समूह",
+              "relationship_type": "related",
+              "entity_prefix": "organization", "entity_type": "Organization",
+              "name_en": "Community Forest User Group",
+              "notes": "रुख कटान गरिएको भनिएको समूह"}
+    if flag is not None:
+        entity["is_named_entity"] = flag
+    return json.dumps({"entities": [entity], "accused_notes": []})
+
+
+def test_is_named_entity_false_blocks_creation(monkeypatch, patched_fetch_markdown):
+    # "Community Forest User Group" is a category of body, not a named one.
+    # `_name_vetoes` misses it: the generic rule needs EVERY word in its
+    # 53-word list, and सामुदायिक and समूह are not in it. Only the model,
+    # which read the passage, can tell.
+    case = dict(PRESS_ONLY_CASE, slug="case-not-named", entities=[])
+    api = _SearchStubApi([case], {"सामुदायिक वन उपभोक्ता समूह": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: _named_entity_response(False),
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    row, = _created_rows()
+    assert row["outcome"] == "skipped"
+    assert "named entity" in row["reason"]
+
+
+def test_a_missing_is_named_entity_blocks_creation(
+    monkeypatch, patched_fetch_markdown
+):
+    # FAIL CLOSED. A prompt regression that drops the field shows up as
+    # `0 created` in the summary, which is visible and fixable. Defaulting the
+    # other way fills NES with junk that cannot be deleted.
+    case = dict(PRESS_ONLY_CASE, slug="case-flag-absent", entities=[])
+    api = _SearchStubApi([case], {"सामुदायिक वन उपभोक्ता समूह": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: _named_entity_response(None),
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    row, = _created_rows()
+    assert row["outcome"] == "skipped"
+
+
+def test_is_named_entity_true_still_creates(monkeypatch, patched_fetch_markdown):
+    case = dict(PRESS_ONLY_CASE, slug="case-named-true", entities=[])
+    api = _SearchStubApi([case], {"सामुदायिक वन उपभोक्ता समूह": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: _named_entity_response(True),
+              argv=["--apply", "--create-entities"])
+
+    payload, = api.create_entity_calls
+    assert payload["slug"] == "community-forest-user-group"
+
+
+def test_a_gated_name_still_binds_when_the_resolver_matched_it(
+    monkeypatch, patched_fetch_markdown
+):
+    # The gates stop CREATION, never binding. A location that matches its
+    # canonical district must still reach the case.
+    case = dict(PRESS_ONLY_CASE, slug="case-gate-still-binds", entities=[])
+    api = _SearchStubApi([case], {"काठमाडौं": [
+        {"id": "https://jawafdehi.org/entity/location/district/kathmandu-np0261",
+         "title": {"ne": "काठमाडौं", "en": "Kathmandu"}, "score": 112.6},
+    ]})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: LOCATION_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    assert [i["nes_id"] for i in items] == [
+        "https://jawafdehi.org/entity/location/district/kathmandu-np0261"]
+
+
+# --------------------------------------------------------------------------
+# The English name reaches the payload, not just the slug.
+# --------------------------------------------------------------------------
+
+
+def test_the_payload_carries_both_names_when_english_is_supplied(
+    monkeypatch, patched_fetch_markdown
+):
+    # Canonical NES entities carry both ({"ne": "काठमाडौं", "en": "Kathmandu"}).
+    # Ours carried `ne` only, so every entity we created was missing its
+    # English name for the English UI and for search.
+    case = dict(PRESS_ONLY_CASE, slug="case-payload-en", entities=[])
+    api = _SearchStubApi([case], {"सामुदायिक वन उपभोक्ता समूह": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: _named_entity_response(True),
+              argv=["--apply", "--create-entities"])
+
+    payload, = api.create_entity_calls
+    assert payload["name"] == {"ne": "सामुदायिक वन उपभोक्ता समूह",
+                               "en": "Community Forest User Group"}
+
+
+NO_ENGLISH_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+         "entity_prefix": "person", "entity_type": "Person",
+         "is_named_entity": True, "name_en": "",
+         "notes": "तत्कालीन प्रमुख"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_the_payload_omits_the_english_name_rather_than_sending_it_blank(
+    monkeypatch, patched_fetch_markdown
+):
+    case = dict(PRESS_ONLY_CASE, slug="case-payload-no-en", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: NO_ENGLISH_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    payload, = api.create_entity_calls
+    assert payload["name"] == {"ne": "हेम राज बिष्ट"}
+    assert payload["slug"] == "hema-raja-bishta"
+
+
+# --------------------------------------------------------------------------
+# The prompt itself.
+# --------------------------------------------------------------------------
+
+
+def test_the_prompt_asks_for_both_new_fields():
+    assert "is_named_entity" in ere.SYSTEM_PROMPT
+    assert "name_en" in ere.SYSTEM_PROMPT
+
+
+def test_the_prompt_no_longer_teaches_the_composite_location_name():
+    # Line 204 used to mandate "Organisation/Activity - Location", which is why
+    # `घरजग्गा सम्पत्ति - काठमाडौं` was extracted at all. Both dry-run cases
+    # produced one, and the composite also scores 0.00 against the canonical
+    # district it was supposed to name.
+    assert "Activity - Location" not in ere.SYSTEM_PROMPT
+    # The composite survives only as a labelled counter-example. Showing the
+    # model the exact string it used to emit, marked WRONG, beats deleting it.
+    correct, _sep, wrong = ere.SYSTEM_PROMPT.partition(
+        "Examples of WRONG location names:")
+    assert "स्वास्थ्य उपकरण खरिद - जनकपुरधाम" not in correct
+    assert "स्वास्थ्य उपकरण खरिद - जनकपुरधाम" in wrong
+
+
+def test_the_prompt_no_longer_demands_blank_location_notes():
+    # The activity context moves out of the name and into notes, so the old
+    # "leave notes BLANK" rule would now throw it away.
+    assert 'Leave notes BLANK ("") for all location entities' not in ere.SYSTEM_PROMPT
+
+
+def test_the_prompt_rules_out_media_that_only_reported_the_case():
+    # `नयाँ पत्रिका` was extracted as `related` for publishing the story. A
+    # newspaper that reported a case is a source, not a participant.
+    assert "नयाँ पत्रिका" in ere.SYSTEM_PROMPT
+
+
+def test_the_creation_block_explains_both_new_fields():
+    section = ere.prefix_prompt_section(["person", "organization"])
+    assert "is_named_entity" in section
+    assert "name_en" in section

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -37,6 +37,7 @@ import pytest
 
 from casework import enrich_related_entities as ere
 from casework.common.api import CandidateList, ENTITY_SEARCH_MAX_PAGES, ENTITY_SEARCH_PAGE_SIZE
+from casework.common.api import EntityAlreadyExists
 from casework.court_record import CHARGED
 from casework.enrich_related_entities import (
     PROMOTED_PREFIX,
@@ -217,11 +218,19 @@ class TestDonorFidelity:
         source = _donor_source()
         assert 'api.create_entity(display_name=name, nes_id="")' in source
 
-    def test_donor_has_no_create_entity_method_on_current_api(self):
-        # CaseworkApi (this branch) genuinely has no create_entity method --
-        # confirms the donor's write path is not just discouraged but
-        # structurally impossible to call as written.
-        assert not hasattr(ere.CaseworkApi, "create_entity")
+    def test_the_donor_create_entity_call_is_still_impossible_to_make(self):
+        # `CaseworkApi` DOES have `create_entity` now -- the --create-entities
+        # step needs it. The donor's CALL remains impossible, which is what this
+        # guard was always about: it minted an entity from a `display_name` and a
+        # blank `nes_id`, with no prefix, no type and therefore no IRI. Ours takes
+        # the API's authoring payload and the IRI comes from prefix+slug, so the
+        # donor's signature raises instead of quietly creating a nameless entity.
+        import inspect
+
+        params = inspect.signature(ere.CaseworkApi.create_entity).parameters
+        assert "display_name" not in params
+        assert "nes_id" not in params
+        assert "payload" in params
 
 
 # --------------------------------------------------------------------------
@@ -1171,6 +1180,33 @@ class _SearchStubApi(_StubApi):
         self.etag = 'W/"abc123"'
         self.search_calls = []
         self.get_entity_calls = []
+        # Entity creation. `create_entity_calls` records the payload as sent;
+        # `create_conflicts` holds `<prefix>/<slug>` values that answer as though
+        # the entity already exists, and `create_errors` maps one to the
+        # exception the POST should raise instead.
+        self.create_entity_calls = []
+        self.create_conflicts = set()
+        self.create_errors = {}
+        self.live_prefixes = [
+            "person",
+            "location", "location/district",
+            "organization", "organization/contractor",
+            "organization/government", "organization/government/department",
+            "organization/government/district/dfo",
+        ]
+
+    def entity_prefixes(self, timeout=60):
+        return list(self.live_prefixes)
+
+    def create_entity(self, payload, timeout=60):
+        self.create_entity_calls.append(dict(payload))
+        ref = f"{payload['prefix']}/{payload['slug']}"
+        if ref in self.create_errors:
+            raise self.create_errors[ref]
+        if ref in self.create_conflicts:
+            raise EntityAlreadyExists(f"Entity {ref} already exists")
+        return {"@id": f"https://jawafdehi.org/entity/{ref}",
+                "@type": payload.get("type"), "name": payload.get("name")}
 
     def search_entities(self, query, **kw):
         self.search_calls.append(query)
@@ -2778,3 +2814,322 @@ def test_accused_escalation_still_needs_a_human():
 
     assert len(plan.review) == 1
     assert "escalate to 'accused'" in plan.review[0][1].reason
+
+
+# --------------------------------------------------------------------------
+# Creating the NES entity a name has no match for, then binding it.
+#
+# `--create-entities`, default OFF, on top of `--apply`. POST /api/entities has
+# no sourcing gate (`entities/validation.py:150` checks @id, @type and name and
+# nothing else) and the 2-distinct-publisher rule lives only in
+# `manage.py bulk_ingest`, so entities created here publish unsourced. Accepted
+# on 2026-08-05.
+# --------------------------------------------------------------------------
+
+
+CREATE_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+         "entity_prefix": "person", "entity_type": "Person",
+         "notes": "तत्कालीन प्रमुख"},
+        {"entity_name": "वन निर्देशनालय, धनगढी", "relationship_type": "related",
+         "entity_prefix": "organization/government/district/dfo",
+         "entity_type": "GovernmentOrganization",
+         "notes": "आरोपी कार्यरत रहेको निकाय"},
+    ],
+    "accused_notes": [],
+})
+
+
+def _created_rows():
+    return [json.loads(line) for line in Path(_report_files()["created"])
+            .read_text(encoding="utf-8").splitlines()]
+
+
+def test_no_entity_is_created_without_the_flag_even_under_apply(
+    monkeypatch, patched_fetch_markdown
+):
+    # THE SAFETY PROPERTY THAT MATTERS MOST. Creation opts in on TOP of --apply,
+    # never with it, so upgrading this enricher cannot make an existing --apply
+    # run start writing to NES.
+    case = dict(PRESS_ONLY_CASE, slug="case-no-flag", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply"])
+
+    assert api.create_entity_calls == []
+    # Both names stay unmatched and reach the no-match report, exactly as before.
+    assert Path(_report_files()["created"]).read_text(encoding="utf-8") == ""
+
+
+def test_creates_an_entity_for_an_unmatched_name_and_binds_it(
+    monkeypatch, patched_fetch_markdown
+):
+    case = dict(PRESS_ONLY_CASE, slug="case-create-bind", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    # Both names were POSTed, under the prefix the extraction named.
+    posted = sorted((p["prefix"], p["slug"]) for p in api.create_entity_calls)
+    assert posted == [
+        ("organization/government/district/dfo", "vana-nirdeshanalaya-dhanagadhi"),
+        ("person", "hema-raja-bishta"),
+    ]
+    # ...and both reached the case, in the section the extraction gave them.
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    sections = {item["nes_id"].rsplit("/", 2)[-2]: item["relationship_type"]
+                for item in items}
+    assert sections["person"] == "accused"
+    assert sections["dfo"] == "related"
+
+
+def test_a_dry_run_creates_nothing_but_reports_what_it_would_create(
+    monkeypatch, patched_fetch_markdown
+):
+    case = dict(PRESS_ONLY_CASE, slug="case-create-dry", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--dry-run", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    assert api.replace_list_calls == []
+    rows = _created_rows()
+    assert [r["outcome"] for r in rows] == ["would-create", "would-create"]
+    assert {r["extracted"] for r in rows} == {"हेम राज बिष्ट",
+                                             "वन निर्देशनालय, धनगढी"}
+
+
+def test_the_created_entity_cites_the_material_it_came_from(
+    monkeypatch, patched_fetch_markdown
+):
+    # An entity created here has no sources, which the 2-publisher rule would
+    # otherwise hold as staged. The citation is what keeps it traceable to the
+    # document that justified it.
+    case = dict(PRESS_ONLY_CASE, slug="case-create-citation", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    citations = {p["citation"] for p in api.create_entity_calls}
+    assert citations == {"https://jawafdehi.org/material/ciaa/press_releases/1"}
+
+
+TWO_SPELLINGS_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "वन निदेशनालय, धनगढी - कैलाली जिल्ला",
+         "relationship_type": "related",
+         "entity_prefix": "organization/government/district/dfo",
+         "entity_type": "GovernmentOrganization", "notes": "क"},
+        {"entity_name": "वन निदेशनालय, धनगढी - कैलाली जिल्ला ",
+         "relationship_type": "location",
+         "entity_prefix": "organization/government/district/dfo",
+         "entity_type": "GovernmentOrganization", "notes": "ख"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_one_office_named_twice_creates_one_entity(
+    monkeypatch, patched_fetch_markdown
+):
+    # Case 078-CR-0038 named the Dhangadhi forest directorate twice. Without the
+    # within-run dedup that case creates two entities on its first run.
+    case = dict(PRESS_ONLY_CASE, slug="case-two-spellings", entities=[])
+    api = _SearchStubApi([case], {})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: TWO_SPELLINGS_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert len(api.create_entity_calls) == 1
+    # Both binds point at the single created entity, in their own sections.
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    assert len({item["nes_id"] for item in items}) == 1
+    assert sorted(item["relationship_type"] for item in items) == [
+        "location", "related"]
+
+
+BAD_PREFIX_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+         "entity_prefix": "persen", "entity_type": "Person", "notes": "क"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_a_prefix_with_no_existing_parent_is_skipped_not_posted(
+    monkeypatch, patched_fetch_markdown
+):
+    # `persen` is a typo'd root: not in use and with no parent to vouch for it.
+    # Creating it would strand the entity where no search filter reaches, and the
+    # bad prefix would then report as live via /api/entity_prefixes.
+    case = dict(PRESS_ONLY_CASE, slug="case-bad-prefix", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: BAD_PREFIX_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    rows = _created_rows()
+    assert [r["outcome"] for r in rows] == ["skipped"]
+    assert "persen" in rows[0]["reason"]
+
+
+def test_an_already_exists_response_binds_the_existing_entity(
+    monkeypatch, patched_fetch_markdown
+):
+    # Someone got there first, which is the good case. `create_entity` raises on a
+    # duplicate @id (`publication/service.py:68`); the run must bind that IRI
+    # rather than record an error.
+    case = dict(PRESS_ONLY_CASE, slug="case-already-exists", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    api.create_conflicts = {"person/hema-raja-bishta"}
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    assert "https://jawafdehi.org/entity/person/hema-raja-bishta" in {
+        item["nes_id"] for item in items}
+    outcomes = {r["extracted"]: r["outcome"] for r in _created_rows()}
+    assert outcomes["हेम राज बिष्ट"] == "already-exists"
+
+
+def test_a_failed_post_skips_that_name_and_keeps_the_rest_of_the_case(
+    monkeypatch, patched_fetch_markdown
+):
+    # One name's POST failing must not cost the case its other binds.
+    case = dict(PRESS_ONLY_CASE, slug="case-post-fails", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    api.create_errors = {"person/hema-raja-bishta": RuntimeError("500 boom")}
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    bound_ids = {item["nes_id"] for item in items}
+    assert "https://jawafdehi.org/entity/person/hema-raja-bishta" not in bound_ids
+    assert any("dfo" in nes_id for nes_id in bound_ids)
+    outcomes = {r["extracted"]: r["outcome"] for r in _created_rows()}
+    assert outcomes["हेम राज बिष्ट"] == "error"
+
+
+def test_creation_preserves_binds_already_on_the_case(
+    monkeypatch, patched_fetch_markdown
+):
+    # PATCH /entities replaces the WHOLE list. A create step that sent only its
+    # new entities would delete the press release and court order binds someone
+    # attached last month.
+    # The existing bind is `accused`, NOT `related`, on purpose: the idempotency
+    # gate counts `related` binds only, so a case carrying one is skipped whole
+    # and never reaches the create step at all (see the test below).
+    existing = {"nes_id": ANKUR_IRI, "type": "accused", "outcome": "charged",
+                "notes": "पहिलेको टिप्पणी"}
+    case = dict(PRESS_ONLY_CASE, slug="case-preserve", entities=[existing])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    kept = [item for item in items if item["nes_id"] == ANKUR_IRI]
+    assert len(kept) == 1
+    assert kept[0]["notes"] == "पहिलेको टिप्पणी"
+    assert len(items) == 3       # the existing one plus the two created
+
+
+def test_a_case_with_a_related_bind_never_reaches_the_create_step(
+    monkeypatch, patched_fetch_markdown
+):
+    # A LIMITATION, PINNED RATHER THAN FIXED. The idempotency gate skips a case
+    # that already holds any `related` bind, and it runs before anything else --
+    # so on an already-enriched case, --create-entities creates nothing, however
+    # many unmatched names that case has. `--force` is the way past it.
+    #
+    # Left alone deliberately: widening the gate changes which cases every run of
+    # this enricher touches, which deserves its own measurement rather than
+    # riding along with entity creation.
+    existing = {"nes_id": ANKUR_IRI, "type": "related", "notes": "पहिलेको"}
+    case = dict(PRESS_ONLY_CASE, slug="case-gated", entities=[existing])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert api.create_entity_calls == []
+    assert api.replace_list_calls == []
+
+
+def test_force_gets_past_the_gate_and_creates(
+    monkeypatch, patched_fetch_markdown
+):
+    existing = {"nes_id": ANKUR_IRI, "type": "related", "notes": "पहिलेको"}
+    case = dict(PRESS_ONLY_CASE, slug="case-forced", entities=[existing])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
+                                  "वन निर्देशनालय, धनगढी": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities", "--force"])
+
+    assert len(api.create_entity_calls) == 2
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    assert ANKUR_IRI in {item["nes_id"] for item in items}
+
+
+def test_the_prefix_section_lists_every_live_category():
+    section = ere.prefix_prompt_section(
+        ["person", "organization/government/district/dfo", "location/district"])
+    assert "person" in section
+    assert "organization/government/district/dfo" in section
+    # Sorted, so two runs over the same prefix list build a byte-identical
+    # prompt. A reshuffled list is a different prompt for no reason.
+    assert section.index("location/district") < section.index("person")
+
+
+def test_the_prefix_section_is_empty_without_prefixes():
+    # An instruction to choose from an empty list makes the model invent values,
+    # and every invented value is then discarded -- an expensive way to create
+    # nothing.
+    assert ere.prefix_prompt_section([]) == ""
+    assert ere.prefix_prompt_section(None) == ""
+
+
+def test_the_system_prompt_asks_for_the_two_new_fields():
+    assert "entity_prefix" in ere.SYSTEM_PROMPT
+    assert "entity_type" in ere.SYSTEM_PROMPT
+
+
+def test_the_category_list_is_absent_from_the_prompt_without_the_flag(
+    monkeypatch, patched_fetch_markdown
+):
+    # Two fields nobody reads cost prompt budget on a stage where the budget is
+    # already the binding constraint, so the list only ships when it can be used.
+    case = dict(PRESS_ONLY_CASE, slug="case-no-prefix-prompt", entities=[])
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"entities": [], "accused_notes": []})
+
+    _run_main(monkeypatch, api, invoke_text_stub=stub, argv=["--dry-run"])
+    assert "ENTITY CATEGORY" not in seen["system"]
+
+
+def test_the_category_list_ships_with_the_flag(
+    monkeypatch, patched_fetch_markdown
+):
+    case = dict(PRESS_ONLY_CASE, slug="case-prefix-prompt", entities=[])
+    api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"entities": [], "accused_notes": []})
+
+    _run_main(monkeypatch, api, invoke_text_stub=stub,
+              argv=["--dry-run", "--create-entities"])
+    assert "ENTITY CATEGORY" in seen["system"]
+    assert "organization/government/district/dfo" in seen["system"]

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -38,7 +38,6 @@ import pytest
 from casework import enrich_related_entities as ere
 from casework.common.api import CandidateList, ENTITY_SEARCH_MAX_PAGES, ENTITY_SEARCH_PAGE_SIZE
 from casework.common.api import EntityAlreadyExists
-from casework.court_record import CHARGED
 from casework.enrich_related_entities import (
     PROMOTED_PREFIX,
     RELATIONSHIP_TYPES,
@@ -170,7 +169,10 @@ class TestDonorFidelity:
         # code: the LLM never emits anything but the two the donor asked for.
         # Asserted against the prompt's own output-format line so the two cannot
         # drift apart.
-        offered = {"location", "related", "accused", "alleged", "witness"}
+        # `accused` is deliberately absent: this module no longer writes it
+        # (2026-08-06). Defendants come from the NGM court record, which states
+        # them instead of guessing -- see `validate_new_bind`.
+        offered = {"location", "related", "alleged", "witness"}
         format_line = next(
             line for line in ere.SYSTEM_PROMPT.splitlines()
             if line.strip().startswith('"relationship_type"'))
@@ -1385,7 +1387,7 @@ def test_permissive_mode_now_binds_a_cross_script_only_match():
     case = {"slug": "case-kamal", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"कमल थापा": [KAMALA_LATIN_ONLY]})
     plan = plan_case_entities(api, case, 'W/"e"', [
-        {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
+        {"entity_name": "कमल थापा", "relationship_type": "related", "notes": "क"}])
 
     assert plan.action == "WOULD_PATCH"
     assert plan.review == []
@@ -1401,7 +1403,7 @@ def test_a_cross_script_match_is_bound_even_when_another_veto_reports_first():
     case = {"slug": "case-kamal-2", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"कमल थापा": [KAMALA_LATIN_ONLY, second]})
     plan = plan_case_entities(api, case, 'W/"e"', [
-        {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
+        {"entity_name": "कमल थापा", "relationship_type": "related", "notes": "क"}])
 
     assert plan.review == []
     assert sorted(item["nes_id"] for item in plan.patch_items) == sorted(
@@ -1419,7 +1421,7 @@ def test_a_same_script_candidate_is_still_promoted_over_its_veto():
     case = {"slug": "case-kamal-3", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"कमल थापा": [thapa_a, thapa_b]})
     plan = plan_case_entities(api, case, 'W/"e"', [
-        {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
+        {"entity_name": "कमल थापा", "relationship_type": "related", "notes": "क"}])
 
     assert plan.review == []
     _name, decision, _notes, _section = plan.bound[0]
@@ -1435,7 +1437,7 @@ def test_strict_mode_also_refuses_a_cross_script_only_match():
     case = {"slug": "case-kamal-strict", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"कमल थापा": [KAMALA_LATIN_ONLY]})
     plan = plan_case_entities(api, case, 'W/"e"', [
-        {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}],
+        {"entity_name": "कमल थापा", "relationship_type": "related", "notes": "क"}],
         strict=True)
 
     assert plan.bound == []
@@ -1476,11 +1478,12 @@ def test_the_same_entity_and_section_twice_is_planned_once():
     assert len(plan.bound) == 1
 
 
-def test_an_accused_bind_never_escalates_an_already_characterised_entity():
-    # The most consequential bind this module can write, and the one it will not
-    # write on its own: the case already binds this person as `related`, and an
-    # `accused` bind would assert they are the subject of the case AND set
-    # outcome=charged. A human decides that, so it goes to review.
+def test_an_accused_extraction_never_touches_an_existing_bind():
+    # This used to be the escalation guard: an `accused` bind on an entity the
+    # case already binds as `related` would assert they are the subject of the
+    # case AND set outcome=charged, so it went to review. The guard is now moot
+    # -- accused never reaches the binder at all (2026-08-06, confirmed with
+    # Gaurav's supervisor: defendants come from the NGM court record).
     case = {"slug": "case-escalate", "state": "DRAFT", "entities": [
         {"nes_id": ANKUR_IRI, "type": "related", "notes": "मानव-लिखित टिप्पणी"}]}
     api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
@@ -1489,10 +1492,8 @@ def test_an_accused_bind_never_escalates_an_already_characterised_entity():
 
     assert plan.action == "NOOP"
     assert plan.bound == []
-    _name, decision, section = plan.review[0]
-    assert section == "accused"
-    assert "would escalate to 'accused'" in decision.reason
-    assert "'related'" in decision.reason          # names what the case already says
+    assert plan.review == []          # no review either -- there is nothing to decide
+    assert plan.court_record_only == [("अंकुर खत्री", "accused")]
     # The existing bind and its human note are untouched.
     assert plan.patch_items == []
 
@@ -1511,17 +1512,18 @@ def test_a_non_accused_section_does_join_an_already_characterised_entity():
         (SURKHET_IRI, "related"), (SURKHET_IRI, "location")]
 
 
-def test_an_accused_bind_is_written_when_the_entity_is_new_to_the_case():
-    # The guard keys on an EXISTING characterisation, so a first-time accused
-    # bind is unaffected -- this is the ordinary path and must stay open.
+def test_a_first_time_accused_is_not_written_either():
+    # Not a narrowing of the old escalation guard -- a removal of the path. Even
+    # with a clean case, an unambiguous name and a perfect match, nothing is
+    # written, because the court record already states who the defendants are.
     case = {"slug": "case-first-accused", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"अंकुर खत्री": [ANKUR_CANDIDATE]})
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "अंकुर खत्री", "relationship_type": "accused", "notes": "क"}])
 
-    assert plan.action == "WOULD_PATCH"
-    assert plan.patch_items == [{"nes_id": ANKUR_IRI, "relationship_type": "accused",
-                                 "notes": "क", "outcome": "charged"}]
+    assert plan.action == "NOOP"
+    assert plan.patch_items == []
+    assert plan.court_record_only == [("अंकुर खत्री", "accused")]
 
 
 def test_each_review_row_reports_its_own_section():
@@ -1726,7 +1728,7 @@ def test_a_location_and_a_related_item_each_bind_into_their_own_section():
     assert len(plan.bound) == 2
 
 
-def test_an_accused_extraction_binds_as_accused_and_carries_the_charged_outcome():
+def test_an_accused_extraction_writes_nothing():
     # `accused` is the one section with an extra requirement: the DB's
     # `outcome_only_on_accused` CHECK makes `outcome` legal here and nowhere
     # else, and every case in this corpus is a Special Court `-CR-` case, so
@@ -1737,9 +1739,11 @@ def test_an_accused_extraction_binds_as_accused_and_carries_the_charged_outcome(
     plan = plan_case_entities(api, case, 'W/"e"', [
         {"entity_name": "अंकुर खत्री", "relationship_type": "accused", "notes": "क"}])
 
-    assert plan.action == "WOULD_PATCH"
-    assert plan.patch_items == [{"nes_id": ANKUR_IRI, "relationship_type": "accused",
-                                 "outcome": CHARGED, "notes": "क"}]
+    # No bind, and therefore no `outcome` -- which is the point. `outcome` is
+    # legal only on an accused bind, so with the section gone this module can
+    # never send one.
+    assert plan.action == "NOOP"
+    assert plan.patch_items == []
 
 
 # --------------------------------------------------------------------------
@@ -2572,13 +2576,13 @@ def test_nomatch_rows_carry_the_section_they_were_extracted_under():
     api = _SearchStubApi([case], {"हेम राज बिष्ट": [],
                                   "वन निर्देशनालय, धनगढी": []})
     plan = plan_case_entities(api, case, 'W/"e"', [
-        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",
          "notes": "क"},
         {"entity_name": "वन निर्देशनालय, धनगढी", "relationship_type": "location",
          "notes": "ख"}], strict=True)
 
     assert [(name, section) for name, _decision, section in plan.nomatch] == [
-        ("हेम राज बिष्ट", "accused"),
+        ("हेम राज बिष्ट", "related"),
         ("वन निर्देशनालय, धनगढी", "location"),
     ]
 
@@ -2587,13 +2591,13 @@ def test_nomatch_report_shows_the_section_for_each_unmatched_name(tmp_path):
     # The report IS the caseworker's queue for creating NES entities. Creating a
     # person and creating a district office are different jobs, and the queue
     # could not tell them apart.
-    rows = [("हेम राज बिष्ट", "case-a", _nomatch_decision(), "accused"),
+    rows = [("हेम राज बिष्ट", "case-a", _nomatch_decision(), "related"),
             ("वन निर्देशनालय, धनगढी", "case-b", _nomatch_decision(), "location")]
     out = tmp_path / "run.nomatch.md"
     write_nomatch_report(out, rows)
 
     lines = out.read_text(encoding="utf-8").splitlines()
-    assert "accused" in next(line for line in lines if "हेम राज" in line)
+    assert "related" in next(line for line in lines if "हेम राज" in line)
     assert "location" in next(line for line in lines if "निर्देशनालय" in line)
 
 
@@ -2622,7 +2626,7 @@ def test_report_paths_includes_the_new_sidecars():
 
 NOTHING_RESOLVES_RESPONSE = json.dumps({
     "entities": [
-        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",
          "notes": "तत्कालीन प्रमुख"},
         {"entity_name": "मानस नर्सरी, धनगढी", "relationship_type": "related",
          "notes": "ठेक्का पाएको फर्म"},
@@ -2650,7 +2654,7 @@ def test_extraction_sidecar_records_every_name_when_nothing_resolves(
             .read_text(encoding="utf-8").splitlines()]
 
     assert [(r["extracted"], r["relationship_type"]) for r in rows] == [
-        ("हेम राज बिष्ट", "accused"),
+        ("हेम राज बिष्ट", "related"),
         ("मानस नर्सरी, धनगढी", "related"),
     ]
     assert rows[0]["notes"] == "तत्कालीन प्रमुख"
@@ -2757,7 +2761,7 @@ def test_cross_script_only_match_is_bound_not_held():
     case = {"slug": "case-kamal-bound", "state": "DRAFT", "entities": []}
     api = _SearchStubApi([case], {"कमल थापा": [KAMALA_LATIN_ONLY]})
     plan = plan_case_entities(api, case, 'W/"e"', [
-        {"entity_name": "कमल थापा", "relationship_type": "accused", "notes": "क"}])
+        {"entity_name": "कमल थापा", "relationship_type": "related", "notes": "क"}])
 
     assert plan.action == "WOULD_PATCH"
     assert plan.review == []
@@ -2812,7 +2816,7 @@ def test_coercion_does_not_fire_for_an_accepted_section():
     assert [item["relationship_type"] for item in plan.patch_items] == ["witness"]
 
 
-def test_accused_escalation_still_needs_a_human():
+def test_an_accused_name_never_reaches_the_case_at_all():
     # The one review this stage KEEPS. Escalating an already-characterised entity
     # to `accused` sets outcome=charged and asserts the person is the subject of
     # the case. Removing the review queue did not remove this guard, because the
@@ -2826,8 +2830,11 @@ def test_accused_escalation_still_needs_a_human():
         {"entity_name": "अंकुर खत्री", "relationship_type": "accused",
          "notes": "क"}])
 
-    assert len(plan.review) == 1
-    assert "escalate to 'accused'" in plan.review[0][1].reason
+    # Nothing to escalate and nothing to review: the section is refused before
+    # resolution runs, so the case keeps exactly what it had.
+    assert plan.review == []
+    assert plan.patch_items == []
+    assert plan.court_record_only == [("अंकुर खत्री", "accused")]
 
 
 # --------------------------------------------------------------------------
@@ -2843,7 +2850,7 @@ def test_accused_escalation_still_needs_a_human():
 
 CREATE_RESPONSE = json.dumps({
     "entities": [
-        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",
          "entity_prefix": "person", "entity_type": "Person",
          "is_named_entity": True, "name_en": "",
          "notes": "तत्कालीन प्रमुख"},
@@ -2898,7 +2905,7 @@ def test_creates_an_entity_for_an_unmatched_name_and_binds_it(
     _slug, _path, items, _etag = api.replace_list_calls[0]
     sections = {item["nes_id"].rsplit("/", 2)[-2]: item["relationship_type"]
                 for item in items}
-    assert sections["person"] == "accused"
+    assert sections["person"] == "related"
     assert sections["dfo"] == "related"
 
 
@@ -2973,7 +2980,7 @@ def test_one_office_named_twice_creates_one_entity(
 
 BAD_PREFIX_RESPONSE = json.dumps({
     "entities": [
-        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",
          "entity_prefix": "persen", "entity_type": "Person",
          "is_named_entity": True, "name_en": "", "notes": "क"},
     ],
@@ -3427,7 +3434,7 @@ def test_the_payload_carries_both_names_when_english_is_supplied(
 
 NO_ENGLISH_RESPONSE = json.dumps({
     "entities": [
-        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",
          "entity_prefix": "person", "entity_type": "Person",
          "is_named_entity": True, "name_en": "",
          "notes": "तत्कालीन प्रमुख"},
@@ -3489,3 +3496,134 @@ def test_the_creation_block_explains_both_new_fields():
     section = ere.prefix_prompt_section(["person", "organization"])
     assert "is_named_entity" in section
     assert "name_en" in section
+
+
+# --------------------------------------------------------------------------
+# The LLM does not supply accused. The court record does.
+#
+# `GET /courtcases/<court>/<number>/entities` returns the defendants CIAA
+# actually charged -- for 078-CR-0038, हेम राज विष्ट and रुबी जि.सी. विष्ट, the
+# same two the extraction guessed at. `casework/court_record.py` already reads
+# it and is deliberately unwired here (see the import comment at line 127).
+#
+# THE HARM THIS REMOVES: an accused bind carries `outcome = CHARGED`, and since
+# 2026-08-05 one extracted name binds EVERY candidate above the threshold. An
+# ambiguous accused name therefore recorded every namesake as charged in a
+# corruption case -- `resolve`'s own docstring names 13 same-name entities for
+# `संजय प्रसाद यादव`. Dropping the section removes the path entirely rather than
+# narrowing it.
+# --------------------------------------------------------------------------
+
+
+ACCUSED_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "हेम राज बिष्ट", "relationship_type": "accused",
+         "entity_prefix": "person", "entity_type": "Person",
+         "is_named_entity": True, "name_en": "Hem Raj Bista",
+         "notes": "प्रतिवादी"},
+        {"entity_name": "नानी काजी थापा", "relationship_type": "alleged",
+         "entity_prefix": "person", "entity_type": "Person",
+         "is_named_entity": True, "name_en": "Nani Kaji Thapa",
+         "notes": "घुस लेनदेनमा संलग्न भनी उल्लेख"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_an_extracted_accused_is_never_bound(monkeypatch, patched_fetch_markdown):
+    case = dict(PRESS_ONLY_CASE, slug="case-accused-dropped", entities=[])
+    api = _SearchStubApi([case], {
+        "हेम राज बिष्ट": [{"id": "https://jawafdehi.org/entity/person/hem-raj-bista",
+                            "title": {"ne": "हेम राज बिष्ट"}, "score": 180.0}],
+        "नानी काजी थापा": [{"id": "https://jawafdehi.org/entity/person/nani-kaji-thapa",
+                             "title": {"ne": "नानी काजी थापा"}, "score": 180.0}],
+    })
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: ACCUSED_RESPONSE,
+              argv=["--apply"])
+
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    sections = {item["relationship_type"] for item in items}
+    assert "accused" not in sections
+    # The alleged name is untouched -- it is not in the court record, so the
+    # extraction is the only source for it.
+    assert sections == {"alleged"}
+
+
+def test_an_extracted_accused_is_never_created(monkeypatch, patched_fetch_markdown):
+    # Creation must not sneak an accused in through the other door.
+    case = dict(PRESS_ONLY_CASE, slug="case-accused-nocreate", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "नानी काजी थापा": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: ACCUSED_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    posted = [p["slug"] for p in api.create_entity_calls]
+    assert "hem-raj-bista" not in posted
+    assert posted == ["nani-kaji-thapa"]
+
+
+def test_a_dropped_accused_is_reported_not_silently_discarded(
+    monkeypatch, patched_fetch_markdown
+):
+    case = dict(PRESS_ONLY_CASE, slug="case-accused-reported", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "नानी काजी थापा": []})
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: ACCUSED_RESPONSE,
+              argv=["--dry-run"])
+
+    rows = [json.loads(line) for line in
+            Path(_report_files()["extracted"]).read_text(encoding="utf-8").splitlines()]
+    dropped = [r for r in rows if r["extracted"] == "हेम राज बिष्ट"]
+    assert dropped, "the accused name must still reach extracted.jsonl"
+    assert dropped[0]["relationship_type"] == "accused"
+
+
+def test_no_bind_this_module_writes_can_carry_a_charged_outcome(
+    monkeypatch, patched_fetch_markdown
+):
+    # `outcome` is legal only on an accused bind (the `outcome_only_on_accused`
+    # CHECK constraint). With accused gone, this module can never send one.
+    case = dict(PRESS_ONLY_CASE, slug="case-no-outcome", entities=[])
+    api = _SearchStubApi([case], {
+        "हेम राज बिष्ट": [{"id": "https://jawafdehi.org/entity/person/hem-raj-bista",
+                            "title": {"ne": "हेम राज बिष्ट"}, "score": 180.0}],
+        "नानी काजी थापा": [{"id": "https://jawafdehi.org/entity/person/nani-kaji-thapa",
+                             "title": {"ne": "नानी काजी थापा"}, "score": 180.0}],
+    })
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: ACCUSED_RESPONSE,
+              argv=["--apply"])
+
+    _slug, _path, items, _etag = api.replace_list_calls[0]
+    assert all(not item.get("outcome") for item in items)
+
+
+def test_the_prompt_no_longer_offers_accused_as_a_relationship_type():
+    assert '"accused"' not in ere.SYSTEM_PROMPT
+    assert "relationship_type" in ere.SYSTEM_PROMPT      # the others survive
+    assert '"alleged"' in ere.SYSTEM_PROMPT
+    assert '"witness"' in ere.SYSTEM_PROMPT
+
+
+def test_the_prompt_says_where_defendants_actually_come_from():
+    assert "court record" in ere.SYSTEM_PROMPT
+
+
+def test_the_carry_through_validator_still_accepts_an_existing_accused_bind():
+    # THE TRAP THE SPLIT AVOIDS. `apply_entity_plan` validates every row of the
+    # whole-list PATCH, including binds the case already had. A human's accused
+    # bind -- or one the court-record path wrote -- must survive that, or the
+    # case becomes unpatchable and we destroy the authoritative record.
+    existing = {"nes_id": ANKUR_IRI, "relationship_type": "accused",
+                "outcome": "charged", "notes": "मानव-लिखित"}
+    assert ere.validate_bind_item(existing) == existing
+
+
+def test_this_module_may_not_propose_an_accused_bind_of_its_own():
+    proposed = {"nes_id": ANKUR_IRI, "relationship_type": "accused",
+                "notes": "क"}
+    with pytest.raises(ValueError, match="court record"):
+        ere.validate_new_bind(proposed)
+
+
+def test_the_new_bind_validator_still_applies_the_generic_rules():
+    with pytest.raises(ValueError, match="canonical NES entity IRI"):
+        ere.validate_new_bind({"nes_id": "not-an-iri",
+                               "relationship_type": "related", "notes": ""})

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -3766,6 +3766,32 @@ def test_a_failed_prefix_read_costs_one_case_not_the_whole_run(
     assert api.create_entity_calls == []
 
 
+def test_an_unreadable_prefix_list_does_not_blame_the_prefix(
+    monkeypatch, patched_fetch_markdown
+):
+    # `read_live_prefixes` returns None rather than [] so a failed read cannot
+    # be mistaken for "no prefix is in use" -- but `prefix_is_creatable` folds
+    # both to an empty set, so every name came back refused for a reason that
+    # was never checked. `person` is in use in production; telling a caseworker
+    # its parent branch does not exist sends them to fix nothing.
+    case = dict(PRESS_ONLY_CASE, slug="case-prefix-502-reason", entities=[])
+    api = _SearchStubApi([case], {"हेम राज बिष्ट": [], "वन निर्देशनालय, धनगढी": []})
+
+    def boom(timeout=60):
+        raise urllib.error.HTTPError("u", 502, "Bad Gateway", {}, None)
+    api.entity_prefixes = boom
+
+    _run_main(monkeypatch, api, invoke_text_stub=lambda **kw: CREATE_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    rows = _created_rows()
+    assert rows, "the refused names must still reach created.jsonl"
+    for row in rows:
+        assert row["outcome"] == "skipped"
+        assert "could not be read" in row["reason"]
+        assert "parent branch does not exist" not in row["reason"]
+
+
 def test_an_uncanonical_created_iri_costs_one_name_not_the_run(
     monkeypatch, patched_fetch_markdown
 ):

--- a/tests/casework/test_enrich_related_entities.py
+++ b/tests/casework/test_enrich_related_entities.py
@@ -3026,6 +3026,74 @@ def test_the_same_name_under_a_different_prefix_is_not_reused(
         assert f"/entity/{row['prefix']}/" in row["nes_id"]
 
 
+# One name, two sections, contradictory metadata. `items_by_name` used to key on
+# the name alone, so BOTH `plan.nomatch` entries read whichever item the model
+# happened to emit last -- here the `person`/`is_named_entity: False` one, which
+# fails the creation gate and takes the legitimate contractor down with it.
+CROSSED_SECTIONS_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "गोरखा निर्माण सेवा", "relationship_type": "related",
+         "entity_prefix": "organization/contractor",
+         "entity_type": "Organization", "is_named_entity": True,
+         "name_en": "Gorkha Construction Services", "notes": "ठेक्का पाएको फर्म"},
+        {"entity_name": "गोरखा निर्माण सेवा", "relationship_type": "witness",
+         "entity_prefix": "person", "entity_type": "Person",
+         "is_named_entity": False, "name_en": "", "notes": "साक्षी"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_each_section_reads_its_own_extracted_item(
+    monkeypatch, patched_fetch_markdown
+):
+    case = dict(PRESS_ONLY_CASE, slug="case-crossed-sections", entities=[])
+    api = _SearchStubApi([case], {"गोरखा निर्माण सेवा": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: CROSSED_SECTIONS_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    # The contractor is created from its OWN item -- its prefix, its English
+    # name, its `is_named_entity`. The witness row is refused by its own.
+    assert [p["prefix"] for p in api.create_entity_calls] == ["organization/contractor"]
+    assert api.create_entity_calls[0]["slug"] == "gorkha-construction-services"
+
+    by_role = {row["role"]: row for row in _created_rows()}
+    assert by_role["related"]["outcome"] == "created"
+    assert by_role["witness"]["outcome"] == "skipped"
+    assert "is_named_entity" in by_role["witness"]["reason"]
+
+
+COERCED_SECTION_RESPONSE = json.dumps({
+    "entities": [
+        {"entity_name": "साझा भण्डार सहकारी", "relationship_type": "employer",
+         "entity_prefix": "organization", "entity_type": "Organization",
+         "is_named_entity": True, "name_en": "Sajha Bhandar Cooperative",
+         "notes": "क"},
+    ],
+    "accused_notes": [],
+})
+
+
+def test_a_coerced_section_still_finds_its_own_item(
+    monkeypatch, patched_fetch_markdown
+):
+    # The other half of keying on the section: `employer` is not a section the
+    # API accepts, so the planner coerces it to `related` and files the name
+    # under THAT. A lookup keyed on the raw `relationship_type` misses, the item
+    # comes back empty, and a perfectly good name is refused for having no
+    # prefix -- a silent loss, since "no prefix" reads like a model failure.
+    case = dict(PRESS_ONLY_CASE, slug="case-coerced-section", entities=[])
+    api = _SearchStubApi([case], {"साझा भण्डार सहकारी": []})
+    _run_main(monkeypatch, api,
+              invoke_text_stub=lambda **kw: COERCED_SECTION_RESPONSE,
+              argv=["--apply", "--create-entities"])
+
+    assert [p["prefix"] for p in api.create_entity_calls] == ["organization"]
+    row = _created_rows()[0]
+    assert (row["role"], row["outcome"]) == ("related", "created")
+
+
 BAD_PREFIX_RESPONSE = json.dumps({
     "entities": [
         {"entity_name": "हेम राज बिष्ट", "relationship_type": "related",

--- a/tests/casework/test_entity_identity.py
+++ b/tests/casework/test_entity_identity.py
@@ -6,7 +6,11 @@ they live apart from `enrich_related_entities` and are tested without a harness.
 
 import pytest
 
-from casework.entity_identity import entity_slug, prefix_is_creatable
+from casework.entity_identity import (
+    MAX_SLUG_LENGTH,
+    entity_slug,
+    prefix_is_creatable,
+)
 
 # The live prefix list is `SELECT DISTINCT prefix` over existing entities
 # (`entities/persistence.py:313`), so it is whatever is in use -- not a
@@ -123,3 +127,64 @@ def test_a_deeper_leaf_needs_its_immediate_parent_not_just_a_grandparent():
     # any ancestor rather than the immediate parent would let a typo'd middle
     # segment through.
     assert prefix_is_creatable("organization/government/revenue/customs", LIVE) is False
+
+
+# --------------------------------------------------------------------------
+# The English name decides the slug.
+#
+# These firms are English names WRITTEN IN DEVANAGARI, so sounding them back
+# out gives `phareshta-debhalapamenta-enda-indashtrija` for "Forest Development
+# and Industries". The IRI is permanent, so that is not merely ugly: a
+# caseworker adding the same firm by hand authors
+# `forest-development-and-industries`, and NES ends up holding the company
+# twice with nothing linking the two.
+# --------------------------------------------------------------------------
+
+
+def test_slug_prefers_the_english_name_when_the_extraction_supplies_one():
+    slug = entity_slug("फरेष्ट डेभलपमेन्ट एण्ड इण्डष्ट्रिज",
+                       name_en="Forest Development and Industries")
+    assert slug == "forest-development-and-industries"
+
+
+def test_slug_transliterates_when_no_english_name_is_supplied():
+    # Unchanged behaviour: a genuinely Nepali name has no English form to
+    # prefer, and transliteration is right for it.
+    assert entity_slug("हेम राज विष्ट") == "hema-raja-vishta"
+
+
+def test_slug_falls_back_to_transliteration_when_english_yields_nothing():
+    # The model returned punctuation, or a string of nothing sluggable. Falling
+    # back beats returning "" -- "" makes the caller skip a real entity.
+    assert entity_slug("हेम राज विष्ट", name_en="!!!") == "hema-raja-vishta"
+
+
+def test_slug_falls_back_when_the_english_name_is_blank():
+    assert entity_slug("हेम राज विष्ट", name_en="") == "hema-raja-vishta"
+
+
+def test_slug_falls_back_when_the_english_name_is_not_a_string():
+    assert entity_slug("हेम राज विष्ट", name_en=123) == "hema-raja-vishta"
+
+
+def test_an_english_slug_is_length_capped_like_any_other():
+    long_en = "Global Wild Farming and Agroforestry and Timber and Nursery " \
+              "and Plantation Private Limited Company"
+    slug = entity_slug("ग्लोवल वाइल्ड फार्मिङ", name_en=long_en)
+    assert len(slug) <= MAX_SLUG_LENGTH
+    # Cut on a hyphen, so the slug never ends mid-word.
+    assert not slug.endswith("-")
+    assert long_en.lower().startswith(slug.split("-")[0])
+
+
+def test_an_english_slug_is_stable_across_calls():
+    # A re-run must find the entity it created, not mint a second one.
+    args = ("ग्लोवल वाइल्ड फार्मिङ एण्ड एग्रोफरेष्ट्री प्रा.लि.",)
+    kwargs = {"name_en": "Global Wild Farming and Agroforestry Pvt. Ltd."}
+    assert entity_slug(*args, **kwargs) == entity_slug(*args, **kwargs)
+
+
+def test_the_english_slug_drops_punctuation_the_iri_grammar_forbids():
+    slug = entity_slug("विध मानेजमेन्ट प्रा.लि.",
+                       name_en="Vidh Management Pvt. Ltd.")
+    assert slug == "vidh-management-pvt-ltd"

--- a/tests/casework/test_entity_identity.py
+++ b/tests/casework/test_entity_identity.py
@@ -1,0 +1,125 @@
+"""Identity helpers for entities this package creates: slug + prefix rules.
+
+Both are pure functions over strings. No API, no Django, no LLM -- which is why
+they live apart from `enrich_related_entities` and are tested without a harness.
+"""
+
+import pytest
+
+from casework.entity_identity import entity_slug, prefix_is_creatable
+
+# The live prefix list is `SELECT DISTINCT prefix` over existing entities
+# (`entities/persistence.py:313`), so it is whatever is in use -- not a
+# whitelist. A trimmed sample of the real 66.
+LIVE = frozenset({
+    "person",
+    "location", "location/district", "location/province",
+    "organization", "organization/contractor",
+    "organization/government", "organization/government/department",
+    "organization/government/district/dfo",
+    "organization/government/provincial/sudurpashchim",
+})
+
+
+# --- entity_slug ----------------------------------------------------------
+
+
+def test_slug_transliterates_a_devanagari_person_name():
+    assert entity_slug("हेम राज बिष्ट") == "hema-raja-bishta"
+
+
+def test_slug_does_not_double_the_name():
+    # `to_roman_colloquial` returns TWO spellings joined by a space -- a strict
+    # transliteration and a schwa-dropped one ("hema raja bishta hem raj bisht")
+    # -- because it feeds a search index that wants to match either. Slugging
+    # that output yields `hema-raja-bishta-hem-raj-bisht`.
+    slug = entity_slug("हेम राज बिष्ट")
+    assert slug.count("bisht") == 1
+    assert "hem-raj" not in slug
+
+
+def test_slug_drops_punctuation_and_parentheses():
+    # Real extracted name from case 078-CR-0038: a maiden name in parentheses.
+    assert entity_slug("रुबी जि.सी. (बिष्ट)") == "rubi-ji-si-bishta"
+
+
+def test_slug_passes_latin_text_through_lowercased():
+    assert entity_slug("UOB Singapore") == "uob-singapore"
+
+
+def test_slug_never_starts_or_ends_with_a_hyphen():
+    # The IRI grammar is `[a-z0-9][a-z0-9-]*` -- a leading hyphen is invalid and
+    # a trailing one is silently ugly.
+    slug = entity_slug("  ,वन निर्देशनालय,  ")
+    assert not slug.startswith("-")
+    assert not slug.endswith("-")
+    assert "--" not in slug
+
+
+def test_slug_is_capped_so_the_iri_stays_under_the_limit():
+    # MAX_IRI_LENGTH is 300 and the prefix eats into it, so the slug is bounded
+    # well below that rather than at it.
+    long_name = "वैज्ञानिक वन ब्यवस्थापन अध्ययन उपसमिति " * 12
+    assert len(entity_slug(long_name)) <= 80
+
+
+def test_slug_returns_empty_when_nothing_survives():
+    # A name of pure punctuation cannot become a valid slug. Returning "" lets
+    # the caller skip and record it, rather than building an invalid IRI.
+    assert entity_slug("!!! ??? ---") == ""
+    assert entity_slug("") == ""
+
+
+def test_slug_is_stable_across_calls():
+    # Two runs over the same case must produce the same IRI, or a re-run creates
+    # a duplicate entity instead of hitting the already-exists path.
+    assert entity_slug("मानस नर्सरी, धनगढी") == entity_slug("मानस नर्सरी, धनगढी")
+
+
+# --- prefix_is_creatable --------------------------------------------------
+
+
+def test_prefix_already_in_use_is_creatable():
+    assert prefix_is_creatable("organization/government/district/dfo", LIVE) is True
+
+
+def test_new_leaf_on_an_existing_branch_is_creatable():
+    # `organization/government` exists, so a forest-office category under it is
+    # the hierarchy growing where it already has a trunk.
+    assert prefix_is_creatable("organization/government/forest", LIVE) is True
+
+
+def test_a_typo_in_the_trunk_is_not_creatable():
+    # `organizaton/government` is in no live prefix, so this has no parent. This
+    # is the case the rule exists for: an unchecked prefix is self-ratifying,
+    # because /api/entity_prefixes reports whatever exists.
+    assert prefix_is_creatable("organizaton/government/police", LIVE) is False
+
+
+def test_a_brand_new_root_is_not_creatable():
+    assert prefix_is_creatable("ministry/forest", LIVE) is False
+    assert prefix_is_creatable("ministry", LIVE) is False
+
+
+def test_an_existing_single_segment_prefix_is_creatable():
+    assert prefix_is_creatable("person", LIVE) is True
+
+
+@pytest.mark.parametrize("bad", [
+    "",
+    "Organization/Government",        # uppercase breaks the IRI grammar
+    "organization//government",       # empty segment
+    "organization/government/a/b/c",  # 5 segments; the grammar allows 4
+    "organization/government/pol ice",
+    None,
+])
+def test_a_malformed_prefix_is_never_creatable(bad):
+    assert prefix_is_creatable(bad, LIVE) is False
+
+
+def test_a_deeper_leaf_needs_its_immediate_parent_not_just_a_grandparent():
+    # `organization/government` exists but `organization/government/revenue`
+    # does not, so a child of the latter has no parent to hang from. Checking
+    # any ancestor rather than the immediate parent would let a typo'd middle
+    # segment through.
+    assert prefix_is_creatable("organization/government/revenue/customs", LIVE) is False

--- a/tests/casework/test_entity_resolver.py
+++ b/tests/casework/test_entity_resolver.py
@@ -1085,8 +1085,8 @@ def test_the_devanagari_title_is_preferred_when_both_are_present():
 # opposite: a closed gazetteer of 77, ingested with official codes
 # (location/district/jhapa-np0104), where the whole name IS one token. Vetoing
 # them means the location section can never bind anything, which is what the
-# 2026-08-06 extraction hardening found. See
-# docs/entity-extraction-hardening-design.md.
+# 2026-08-06 extraction hardening found once the prompt stopped gluing an
+# activity onto the front of every place name.
 # --------------------------------------------------------------------------
 
 

--- a/tests/casework/test_entity_resolver.py
+++ b/tests/casework/test_entity_resolver.py
@@ -689,7 +689,15 @@ def test_resolve_still_binds_on_names_alone_and_takes_no_document():
     # is "nothing that implies I/O", asserted directly below rather than by an
     # exact list that any harmless addition breaks.
     params = list(inspect.signature(resolve).parameters)
-    assert params == ["extracted_name", "candidates", "candidates_complete"]
+    assert params[:2] == ["extracted_name", "candidates"]
+    # Everything after the first two must be a plain flag the caller already
+    # knows -- no api, no document, no fetcher, nothing that implies a read.
+    for extra in params[2:]:
+        # Annotations are strings in this module (postponed evaluation).
+        assert inspect.signature(resolve).parameters[extra].annotation in (
+            bool, "bool"), (
+            f"{extra!r} is not a plain bool -- I/O must stay out of resolve()")
+    assert not {"api", "document", "fetch", "session", "client"} & set(params)
     forbidden = ("document", "api", "client", "session", "fetch", "get", "url")
     assert not [p for p in params if any(word in p for word in forbidden)]
 
@@ -1136,3 +1144,90 @@ def test_name_vetoes_without_a_candidate_still_refuses_a_single_token():
     # so every veto stays on.
     assert "single token" in _name_vetoes("काठमाडौं")
     assert _name_vetoes("काठमाडौं", None) == _name_vetoes("काठमाडौं")
+
+
+# --------------------------------------------------------------------------
+# Preferring the coded gazetteer entry when NES holds a place twice.
+#
+# Production run c92ad032 bound `झापा` to BOTH `location/district/jhapa-np0104`
+# and `location/jhapa`, each scoring 146.20, so one district reached the case as
+# two rows. Only the location section asks for this: elsewhere two entities
+# scoring alike is a real ambiguity, not a duplicate.
+#
+# The preference is score-aware. It picks among candidates that ALREADY qualify,
+# so a coded entry scoring below the threshold can never displace an un-coded
+# one that scored above it.
+# --------------------------------------------------------------------------
+
+
+_JHAPA_CODED = "https://jawafdehi.org/entity/location/district/jhapa-np0104"
+_JHAPA_BARE = "https://jawafdehi.org/entity/location/jhapa"
+
+
+def test_the_coded_district_wins_when_nes_holds_the_place_twice():
+    coded = _candidate(_JHAPA_CODED, ne="झापा")
+    bare = _candidate(_JHAPA_BARE, ne="झापा")
+    decision = resolve("झापा", [coded, bare], prefer_gazetteer=True)
+    assert decision.verdict == BIND
+    assert decision.nes_id == _JHAPA_CODED
+
+
+def test_without_the_preference_the_duplicate_is_still_an_ambiguity():
+    # The default is unchanged, so `related` and every other section keeps
+    # treating two qualifying entities as the ambiguity it usually is.
+    coded = _candidate(_JHAPA_CODED, ne="झापा")
+    bare = _candidate(_JHAPA_BARE, ne="झापा")
+    decision = resolve("झापा", [coded, bare])
+    assert decision.verdict == REVIEW
+    assert "ambiguous" in decision.reason
+
+
+def test_the_preference_leaves_an_uncoded_only_place_alone():
+    # NES has no `location/district/kathmandu-*`. Kathmandu exists only as
+    # `location/kathamadaum-98646f`, so there is nothing to prefer and the
+    # single-token veto still applies exactly as before.
+    bare = _candidate("https://jawafdehi.org/entity/location/kathamadaum-98646f",
+                      ne="काठमाडौं")
+    decision = resolve("काठमाडौं", [bare], prefer_gazetteer=True)
+    assert decision.verdict == REVIEW
+    assert "single token" in decision.reason
+
+
+def test_two_coded_districts_are_still_a_real_ambiguity():
+    # The preference narrows the field; it never invents a winner.
+    a = _candidate("https://jawafdehi.org/entity/location/district/jhapa-np0104",
+                   ne="झापा")
+    b = _candidate("https://jawafdehi.org/entity/location/district/jhapa-np0105",
+                   ne="झापा")
+    decision = resolve("झापा", [a, b], prefer_gazetteer=True)
+    assert decision.verdict == REVIEW
+    assert "ambiguous" in decision.reason
+
+
+def test_a_low_scoring_coded_entry_never_displaces_a_qualifying_one():
+    # THE TRAP THIS AVOIDS. Filtering candidates before scoring would hand the
+    # bind to a coded entry that matched badly, or drop to NO_MATCH entirely.
+    # The preference runs AFTER scoring, over the qualifying set only.
+    # Two tokens, so the single-token rule stays out of the way and this test
+    # pins the preference alone. Both IRIs are real: NES returns them for
+    # `कैलाली`.
+    coded_wrong = _candidate(
+        "https://jawafdehi.org/entity/location/district/sarlahi-np0219",
+        ne="सर्लाही")
+    bare_right = _candidate(
+        "https://jawafdehi.org/entity/location/dhanagadhi-kailali-f174bf",
+        ne="धनगढी, कैलाली")
+    decision = resolve("धनगढी, कैलाली", [coded_wrong, bare_right],
+                       prefer_gazetteer=True)
+    assert decision.verdict == BIND
+    assert decision.nes_id == (
+        "https://jawafdehi.org/entity/location/dhanagadhi-kailali-f174bf")
+
+
+def test_the_preference_reports_every_candidate_it_considered():
+    # The dropped duplicate still reaches the report, so a caseworker can see
+    # that NES holds the place twice.
+    coded = _candidate(_JHAPA_CODED, ne="झापा")
+    bare = _candidate(_JHAPA_BARE, ne="झापा")
+    decision = resolve("झापा", [coded, bare], prefer_gazetteer=True)
+    assert {row[1] for row in decision.candidates} == {_JHAPA_CODED, _JHAPA_BARE}

--- a/tests/casework/test_entity_resolver.py
+++ b/tests/casework/test_entity_resolver.py
@@ -14,6 +14,7 @@ from casework.entity_resolver import (
     ELECTION_RECORD_MARKERS,
     MIN_BIND_SCORE,
     NO_MATCH,
+    _name_vetoes,
     PROVINCE_NAME_FORMS,
     REVIEW,
     apply_document_veto,
@@ -1066,3 +1067,72 @@ def test_the_devanagari_title_is_preferred_when_both_are_present():
         "अनिष श्रेष्ठ", "Anish Shrestha")
     # And it still binds that way -- this fix must not break Latin extractions.
     assert resolve("Anish Shrestha", [candidate]).verdict == BIND
+
+
+# --------------------------------------------------------------------------
+# A district name is one token, and that is not a weakness.
+#
+# The single-token veto exists because a lone token is a weak anchor in an open
+# name space -- one surname, one word of a firm's name. Districts are the
+# opposite: a closed gazetteer of 77, ingested with official codes
+# (location/district/jhapa-np0104), where the whole name IS one token. Vetoing
+# them means the location section can never bind anything, which is what the
+# 2026-08-06 extraction hardening found. See
+# docs/entity-extraction-hardening-design.md.
+# --------------------------------------------------------------------------
+
+
+def test_a_single_token_district_name_binds_its_gazetteer_entry():
+    district = _candidate(
+        "https://jawafdehi.org/entity/location/district/kathmandu-np0261",
+        ne="काठमाडौं", en="Kathmandu")
+    decision = resolve("काठमाडौं", [district])
+    assert decision.verdict == BIND
+    assert decision.nes_id.endswith("/location/district/kathmandu-np0261")
+
+
+def test_a_single_token_province_name_binds_too():
+    province = _candidate(
+        "https://jawafdehi.org/entity/location/province/koshi-np01",
+        ne="कोशी", en="Koshi")
+    assert resolve("कोशी", [province]).verdict == BIND
+
+
+def test_the_exemption_does_not_reach_the_bare_location_prefix():
+    # `location/` holds countries and hand-added places with no gazetteer code.
+    # A lone token there is the weak anchor the veto was written for -- and
+    # `test_single_token_name_goes_to_review` pins the country case.
+    place = _candidate("https://jawafdehi.org/entity/location/kathamadaum-98646f",
+                       ne="काठमाडौं")
+    decision = resolve("काठमाडौं", [place])
+    assert decision.verdict == REVIEW
+    assert "single token" in decision.reason
+
+
+def test_the_exemption_does_not_reach_organisations():
+    org = _candidate("https://jawafdehi.org/entity/organization/kathamadaum",
+                     ne="काठमाडौं")
+    assert resolve("काठमाडौं", [org]).verdict == REVIEW
+
+
+def test_a_composite_name_is_still_vetoed_against_a_district():
+    # The exemption is for the single-token rule only. `घरजग्गा सम्पत्ति -
+    # काठमाडौं` describes seized property; matching it to Kathmandu district
+    # would assert the description IS the district.
+    district = _candidate(
+        "https://jawafdehi.org/entity/location/district/kathmandu-np0261",
+        ne="काठमाडौं", en="Kathmandu")
+    decision = resolve("घरजग्गा सम्पत्ति - काठमाडौं", [district])
+    assert decision.verdict != BIND
+    # Refused on score here, before the veto is consulted -- but the veto is
+    # still armed behind it, and it is the one the CREATE gate relies on.
+    assert "composite" in _name_vetoes("घरजग्गा सम्पत्ति - काठमाडौं",
+                                       district["id"])
+
+
+def test_name_vetoes_without_a_candidate_still_refuses_a_single_token():
+    # The create gate calls it with no candidate at all
+    # (`enrich_related_entities._cannot_create`). Nothing to exempt against,
+    # so every veto stays on.
+    assert "single token" in _name_vetoes("काठमाडौं")
+    assert _name_vetoes("काठमाडौं", None) == _name_vetoes("काठमाडौं")


### PR DESCRIPTION
Creates the NES entities a case needs instead of listing them for a caseworker, and gates what is allowed to become one.

Production run `645b1483` (case 078-CR-0038) extracted 13 names and matched **none** — NES holds almost no institution a CIAA court order names. The output was a to-do list that cost $0.34.

## What changed

**Entity creation.** `--create-entities`, off by default and independent of `--apply`, POSTs the entity an unmatched name needs and binds it in the same pass. Slug and prefix rules live in the new `casework/entity_identity.py`; a new prefix is allowed only on an existing parent branch, so a typo in the trunk cannot mint a permanent category.

**Logging.** The old run reported counts and nothing else. Every extracted name now reaches a file with its section and classification, whatever the outcome — `extracted.jsonl`, `accused_notes.jsonl`, `created.jsonl`, plus a Role column on the no-match report.

**Four gates in front of every POST.** A refused name still binds whatever it matched; these gate creation only.

| Gate | Refuses |
|------|---------|
| Section | Anything from `location`. NES already holds all 77 districts under official codes (`location/district/jhapa-np0104`), so a location created here is always a duplicate or junk |
| Name shape | `_name_vetoes`: composites, lone tokens, all-generic institution names |
| `is_named_entity` | Anything the extraction did not confirm names one specific thing. **Missing counts as no** |
| Identity | No prefix, no existing parent branch, no slug |

`is_named_entity` fails closed deliberately. A prompt regression then shows as `0 created`, which is visible and fixable; defaulting the other way fills NES with entries nobody can delete.

**The junk was prompt-mandated.** `SYSTEM_PROMPT` line 204 told the model to name a location `"Organisation/Activity - Location"`, which is why `घरजग्गा सम्पत्ति - काठमाडौं` — a description of seized property — was extracted at all. That format also scores 0.00 against the district it was meant to name, so locations bound nothing either. Now the section asks for the bare place name and the activity moves into notes.

**`accused` is gone from this enricher.** `GET /courtcases/special/078-cr-0038/entities` returns हेम राज विष्ट and रुबी जि.सी. विष्ट as defendants — exactly the two the LLM was guessing at. Confirmed with the supervisor on 2026-08-06. This also closes the worst hole on the branch: an accused bind carries `outcome = CHARGED`, and since `b1d2d01` one name binds *every* candidate above threshold, so an ambiguous accused name recorded every namesake as charged. `resolve`'s own docstring names 13 same-name entities for `संजय प्रसाद यादव`. Removing the section removes the path rather than narrowing it.

**English names.** Entities carried `{"ne": ...}` only, while canonical NES entities carry both. `name_en` fills that and gives the slug a caseworker would recognise:

```
before  organization/phareshta-debhalapamenta-enda-indashtrija
after   organization/forest-development-and-industries
```

It also absorbs Devanagari spelling variance — two runs of 078-CR-0111 spelled one firm `विध अटोमोबाइल` and `विध अटोमोवाइल`; transliteration gives two entities, the English name gives one.

## Measured on production, read-only

Two cases, same ones before and after. No writes at any point.

| | 078-CR-0038 before | after | 078-CR-0111 before | after |
|---|---|---|---|---|
| Extracted | 13 | 14 | 16 | 17 |
| Bound to existing NES | 0 | **3** | 0 | **4** |
| Would create | 13 | 10 | 16 | 14 |
| Composite junk names | 2 | **0** | 2 | **0** |

Roughly $0.43 per case.

Also verified by loopback apply against a real Django server (`work/2026-08-06-entity-creation/gated_apply_probe.py`): all five refusals fired with the right reason, entities created with English-derived slugs, the stored record read back carrying both languages, material binds untouched, and a second run added nothing.

**Tests:** 1285 casework, 4408 repo-wide (`pytest --ignore=integration-tests`, CI's own scope), on top of current `main`. `ruff check .` clean.

## Fixed from review

**Reporting a check that never ran.** `read_live_prefixes` returns `None` rather than `[]` so a failed read cannot read as "no prefix is in use" — but `prefix_is_creatable` folds both to the same empty set. A transient 502 refused every name with *"prefix `person` is not in use and its parent branch does not exist"*, which is false for a prefix as ordinary as `person` and points a caseworker at nothing. `_cannot_create` now checks for `None` first and says what actually happened. (CodeRabbit)

**Three docs corrections.** `--create-entities` claimed to be "independent of `--apply`" when `--apply` *is* `--dry-run` (`dest="dry_run", action="store_false"`) — it is not implied by `--apply` and does not override the dry run. `--strict` still promised to refuse a cross-script-only match, which this branch removed on 2026-08-05. The README's production example passed `--allow-remote-writes` with no `--api-base-url` or `--api-token`, and its outcome table called `would-create` "bound to the case" when a dry run binds nothing. (CodeRabbit)

**Two dead guards removed**, both of which read like protection that does not exist: `already_characterised`, unused since the accused section was refused outright, and the `MAX_IRI_LENGTH` cap in `_slugify`, which can never fire because 80 is already far under 300. (CodeRabbit)

Two real bugs in the creation stage, both found by pr-agent, both reproduced as a failing test before the fix:

- **The run cache collapsed two categories.** Entities created in a run were cached by normalised name alone, but `person/ram-bahadur-thapa` and `organization/ram-bahadur-thapa` are different IRIs the server will never 409 against each other. The second case reused the first's IRI and bound a **person** as the organisation. The prefix is now part of the key; the name still carries within a prefix, so two spellings of one office still collapse to one entity.
- **One name extracted twice let output order decide a safety gate.** `items_by_name` kept only the last item per name, so a contractor extracted as `related` with `is_named_entity: true` was refused — along with its prefix, type and English name — because a same-named `witness` row said false. The test creates zero entities before the fix. Now keyed on `(name, section)`.

The section in that key must be the **coerced** one. `plan_case_entities` files an unrecognised `relationship_type` under `related`, so a key built from the raw value misses every coerced item and refuses it for having no prefix — the regression pr-agent's suggested patch would have introduced. A new `bind_section` helper gives both sides one source of truth, with a test that fails if they diverge.

## Known issues, not fixed here

Raised by a review of this branch and left deliberately, so they are visible rather than lost:

- **Ambiguous `related` names bind every namesake without their entity documents being read.** `_resolve_with_vetoes` fetches the document for the top candidate only, so the election-record veto never sees candidates 2..N. Lower harm than the accused case — no `outcome` — but the same shape.
- **`--create-entities` can resurrect a soft-deleted entity.** The server's duplicate check only looks at live rows (`_live()`), and `put_entity` hardcodes `is_deleted: False`, so a POST silently reverses a moderator's delete and replaces the curated document.
- **A 409 binds whoever owns that slug**, without checking it is the same real-world thing. Two different people named राम बहादुर थापा collide.
- **Entities are POSTed before the PATCH is gated.** If `apply_entity_plan` then refuses (no ETag captured), the created entities are live in NES bound to nothing.
- **Reporting understates a creation run.** `total_bound` counts existing-entity binds only, so a run that created and bound 13 entities can still print "This run bound zero entities."
- **`source_citation_iri` re-downloads both document sets per case** to read a material IRI that needs no I/O.
- **`plan.coerced` is written and never read**, so a section relabelling reaches no run artefact.
- **The output schema requests `entity_prefix` on every run**, but the category list is appended only under `--create-entities`, so a default run asks the model to choose "from the list below" when there is no list.

## Not covered

**Nothing binds `accused` any more.** Removing the section closed the harm, but `casework/court_record.py::defendant_names` is written, tested and unwired — no CLI. Every case sampled from the 1cr batch has a usable court record (2, 1, 3, 4, 3 and 19 defendants), so the data is there. A separate deterministic stage should read it: no LLM, no documents, seconds per batch. Suggested behaviour — bind on an unambiguous match, create when there is no match, hold when ambiguous, because the alternative is naming the wrong person as charged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
