### PR TITLE
fix(search): set track_total_hits so result counts are exact past 10k

### DIFF
--- a/search/service.py
+++ b/search/service.py
@@ -321,6 +321,9 @@ def build_query(
 
     body: dict[str, Any] = {
         "size": page_size,
+        # Count past OpenSearch's default 10,000-hit cap so ``count`` in the
+        # envelope is exact rather than a "gte" lower bound presented as exact.
+        "track_total_hits": True,
         # Deterministic order (chosen by ``sort``, always iri-tiebroken) so
         # search_after pages are stable + complete.
         "sort": _sort_spec(sort),

--- a/search/tests/test_search_service.py
+++ b/search/tests/test_search_service.py
@@ -48,6 +48,9 @@ def test_build_query_is_bilingual_and_hits_translit():
     assert _recall_multi_match(body)["type"] == "most_fields"
     # Per-type facet aggregation present.
     assert "by_index" in body["aggs"]
+    # Count past OpenSearch's default 10,000-hit cap rather than a "gte" lower
+    # bound presented as an exact count.
+    assert body["track_total_hits"] is True
 
 
 def test_build_query_has_exact_phrase_title_boost():


### PR DESCRIPTION
OpenSearch stops counting matches at 10,000 by default and flags the total as a lower bound (`relation: "gte"`). We read the value and threw the relation away, so `count` went out to clients as if it were exact. It contradicted itself visibly — a browse response could report `count: 10000` while the per-type `counts` in the same payload summed to 338,154, since facet aggregations aren't subject to that cap.

The bad number also fed our analytics. `build_search_event` logs the envelope `count` as `result_count`, so every query matching more than 10k documents was recording `10000` into the dataset we're accumulating for ranking work later.

Fix: `track_total_hits: True` on the query body. Search audit finding #1 (CRITICAL).

Two things it deliberately doesn't do. It doesn't change paging depth — offset paging is still capped at 10,000 (`MAX_OFFSET_RESULT_WINDOW`), which is audit #2's scope. And it doesn't come with latency numbers: exact counting removes OpenSearch's early-exit, so a broad browse now visits every match. I expect that to be cheap because the `aggs` block already forces a full pass on every request, but I haven't measured it.

## Test plan

- [x] `pytest search/` — 82 passed. (The 16 `ModuleNotFoundError: sqlglot` errors are my stale local venv, not the repo — it's declared in `pyproject.toml` and pinned in `uv.lock`. CI is green.)
- [x] Test asserts `track_total_hits` is set on the built query body
- [ ] p50/p95 on a broad query vs `main` before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search result counts are now accurate even when results exceed 10,000 matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
