### PR TITLE
fix(search): add Timing-Allow-Origin so RUM can see search latency

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -16,6 +16,7 @@ import time
 import uuid
 
 import sentry_sdk
+from django.conf import settings
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, status
@@ -252,7 +253,13 @@ class UnifiedSearchView(APIView):
             response=response,
             took_ms=took_ms,
         )
-        return Response(response)
+        api_response = Response(response)
+        # Without this header, browser RUM sees every search request as
+        # transferSize: 0 with no timing breakdown (cross-origin timing is
+        # opaque by default) — the site's most important request is invisible
+        # to real-user monitoring.
+        api_response["Timing-Allow-Origin"] = settings.FRONTEND_BASE_URL
+        return api_response
 
 
 class SearchClickSerializer(serializers.Serializer):


### PR DESCRIPTION
`api.jawafdehi.org` sends no `Timing-Allow-Origin`, so cross-origin timing is opaque to the browser: every search request from jawafdehi.org reads back as `transferSize: 0` with no timing breakdown. The most important request on the site — someone's multi-second Nepali search — is invisible in RUM.

Adds the header to the search response, sourced from the existing `FRONTEND_BASE_URL` setting rather than hardcoding the origin. Audit finding #9 (MINOR).

Three gaps I've flagged rather than fixed, since none of them affect prod RUM. Happy to fold any in if you'd rather they land together:

- Only the prod origin gets timing. `CORS_ALLOWED_ORIGINS` also allows `beta.jawafdehi.org`, `localhost:8080`, and `*.newnepal.workers.dev`.
- The header is set only on the success return, so the 400 (bad cursor) and 503 (search unavailable) paths stay opaque — arguably the responses RUM most wants to see.
- No test asserts the header is present.

## Test plan

- [x] `pytest search/` — 82 passed. (The 16 `ModuleNotFoundError: sqlglot` errors are my stale local venv, not the repo — it's pinned in `uv.lock` and CI is green.)
- [ ] Confirm `Timing-Allow-Origin: https://jawafdehi.org` on a `GET /api/search/` response
