### PR TITLE
Statistics: bucket court cases by Bikram Sambat year, not Gregorian

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -1449,7 +1449,10 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
     - `ngm`: NGM (judicial) coverage — court-case / court totals, by-court-type
       breakdown, court-cases-per-year (`by_year`) and per-court-level-per-year
       (`by_court_type_year`), and completeness percentages (NES-resolved /
-      registration date / document sources)
+      registration date / document sources). Both per-year breakdowns are keyed
+      by `bs_year` — the **Bikram Sambat** registration year taken from the court
+      register, not a Gregorian one (BS 2081 runs mid-April 2024 to mid-April
+      2025), covering the most recent 25 years on record
     - `materials`: NGM materials (development-project / document dataset) coverage —
       total, by-type / by-source breakdowns, and completeness percentages
       (description / url / date)

--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -23,7 +23,7 @@ import json
 
 from django.db import connections
 from django.db.models import Count, Q, Sum
-from django.db.models.functions import ExtractYear
+from django.db.models.functions import Substr
 from django.utils import timezone
 
 # NES + NGM models live in sibling apps; the DB router (config.db_router) sends
@@ -48,6 +48,18 @@ STATISTICS_SNAPSHOT_KEY = "statistics"
 def _pct(part: int, whole: int) -> float:
     """Percentage of ``part`` over ``whole``, 1 dp; 0.0 when ``whole`` is 0."""
     return round((part / whole) * 100, 1) if whole else 0.0
+
+
+def _bs_year(value: str | None) -> int | None:
+    """Bikram Sambat year from a stored ``registration_date_bs``, or None.
+
+    The column is free text written by the scrapers, so the year is the leading
+    four characters of ``YYYY-MM-DD`` (``YYYY/MM/DD`` works out the same). Values
+    that are not four decimal digits — empty strings, truncated dates — return
+    None so one bad row is dropped instead of failing the whole aggregation.
+    """
+    digits = (value or "").strip()
+    return int(digits) if len(digits) == 4 and digits.isdecimal() else None
 
 
 def compute_statistics() -> dict:
@@ -353,26 +365,45 @@ def _ngm_metrics():
     )
 
     # Court cases filed per year, and per court level per year (the matrix). Both
-    # key off the indexed registration_date_ad; cases with no registration date
-    # are excluded so a null year never appears as a column. Capped to the most
-    # recent N years so an outlier/dirty registration year cannot make the matrix
-    # grow unbounded (the heatmap has one column per kept year).
+    # bucket on the Bikram Sambat registration year, which is the calendar the
+    # court registers themselves are written in: the scrapers read
+    # registration_date_bs off the register and DERIVE registration_date_ad from
+    # it. Bucketing on the AD column instead would be doubly wrong for a BS axis —
+    # the BS year turns in mid-April, so every AD year straddles two BS years and
+    # no relabelling can unmix them. Nor is it a coverage trade-off: every case
+    # missing a BS date is also missing the AD one (prod, 2026-08: 1,694,773 rows
+    # carry BS vs 1,694,688 AD), so this buckets marginally MORE cases.
+    #
+    # Grouping happens in SQL on the leading four characters; the cast to int
+    # happens in Python via _bs_year so an unparseable value drops its row rather
+    # than erroring the aggregation. Capped to the most recent N years so an
+    # outlier/dirty registration year cannot make the matrix grow unbounded (the
+    # heatmap paints one column per kept year) — the cap is also what excludes the
+    # stray implausible years the register carries (BS 2007, 2029: one case each).
     _MATRIX_YEARS = 25
-    dated = CourtCase.objects.exclude(registration_date_ad__isnull=True).annotate(
-        year=ExtractYear("registration_date_ad")
+    dated = CourtCase.objects.exclude(registration_date_bs__isnull=True).annotate(
+        bs=Substr("registration_date_bs", 1, 4)
     )
-    year_rows = list(
-        dated.values("year").annotate(count=Count("case_number")).order_by("year")
-    )
-    # Keep the most-recent N years, but return them ascending (frontend order).
-    kept_years = {row["year"] for row in year_rows[-_MATRIX_YEARS:]}
-    by_year = [row for row in year_rows if row["year"] in kept_years]
-    by_court_type_year = [
-        row
-        for row in dated.values("court__court_type", "year")
+    year_rows = [
+        {"bs_year": year, "count": row["count"]}
+        for row in dated.values("bs")
         .annotate(count=Count("case_number"))
-        .order_by("court__court_type", "year")
-        if row["year"] in kept_years
+        .order_by("bs")
+        if (year := _bs_year(row["bs"])) is not None
+    ]
+    # Keep the most-recent N years, but return them ascending (frontend order).
+    kept_years = {row["bs_year"] for row in year_rows[-_MATRIX_YEARS:]}
+    by_year = [row for row in year_rows if row["bs_year"] in kept_years]
+    by_court_type_year = [
+        {
+            "court__court_type": row["court__court_type"],
+            "bs_year": year,
+            "count": row["count"],
+        }
+        for row in dated.values("court__court_type", "bs")
+        .annotate(count=Count("case_number"))
+        .order_by("court__court_type", "bs")
+        if (year := _bs_year(row["bs"])) is not None and year in kept_years
     ]
 
     nes_resolved = (

--- a/cases/services/statistics.py
+++ b/cases/services/statistics.py
@@ -20,6 +20,7 @@ request-blocking recompute or an error.
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 
 from django.db import connections
 from django.db.models import Count, Q, Sum
@@ -54,9 +55,14 @@ def _bs_year(value: str | None) -> int | None:
     """Bikram Sambat year from a stored ``registration_date_bs``, or None.
 
     The column is free text written by the scrapers, so the year is the leading
-    four characters of ``YYYY-MM-DD`` (``YYYY/MM/DD`` works out the same). Values
-    that are not four decimal digits — empty strings, truncated dates — return
-    None so one bad row is dropped instead of failing the whole aggregation.
+    four characters of ``YYYY-MM-DD`` (``YYYY/MM/DD`` works out the same).
+    Deliberately reads the YEAR rather than validating the whole date: a value
+    whose month or day is missing or nonsense still tells us which year the case
+    was registered, and dropping it would lose a case we can place. Only a
+    leading four characters that are not decimal digits — an empty string, a
+    two-digit stub — gives None, so one bad row is dropped instead of erroring
+    the whole aggregation. Devanagari digits count as decimal and convert, which
+    is why callers must merge on the returned int, not the raw prefix.
     """
     digits = (value or "").strip()
     return int(digits) if len(digits) == 4 and digits.isdecimal() else None
@@ -376,7 +382,12 @@ def _ngm_metrics():
     #
     # Grouping happens in SQL on the leading four characters; the cast to int
     # happens in Python via _bs_year so an unparseable value drops its row rather
-    # than erroring the aggregation. Capped to the most recent N years so an
+    # than erroring the aggregation. The SQL groups are STRINGS, and several can
+    # normalise to the same year — "2082-01-15" and a bare "2082" are two groups,
+    # and so is a Devanagari "२०८२", which _bs_year reads as 2082 too. So sum into
+    # a dict keyed by the normalised int; leaving them separate would plot one
+    # year as two points and make the string ordering (Devanagari sorts after
+    # ASCII) pick the wrong 25. Capped to the most recent N years so an
     # outlier/dirty registration year cannot make the matrix grow unbounded (the
     # heatmap paints one column per kept year) — the cap is also what excludes the
     # stray implausible years the register carries (BS 2007, 2029: one case each).
@@ -384,26 +395,27 @@ def _ngm_metrics():
     dated = CourtCase.objects.exclude(registration_date_bs__isnull=True).annotate(
         bs=Substr("registration_date_bs", 1, 4)
     )
-    year_rows = [
-        {"bs_year": year, "count": row["count"]}
-        for row in dated.values("bs")
-        .annotate(count=Count("case_number"))
-        .order_by("bs")
-        if (year := _bs_year(row["bs"])) is not None
-    ]
-    # Keep the most-recent N years, but return them ascending (frontend order).
-    kept_years = {row["bs_year"] for row in year_rows[-_MATRIX_YEARS:]}
-    by_year = [row for row in year_rows if row["bs_year"] in kept_years]
+    totals: dict[int, int] = defaultdict(int)
+    for row in dated.values("bs").annotate(count=Count("case_number")):
+        year = _bs_year(row["bs"])
+        if year is not None:
+            totals[year] += row["count"]
+    # Keep the most-recent N years, and return them ascending (frontend order).
+    kept_years = set(sorted(totals)[-_MATRIX_YEARS:])
+    by_year = [{"bs_year": year, "count": totals[year]} for year in sorted(kept_years)]
+
+    matrix: dict[tuple[str, int], int] = defaultdict(int)
+    for row in dated.values("court__court_type", "bs").annotate(
+        count=Count("case_number")
+    ):
+        year = _bs_year(row["bs"])
+        if year in kept_years:
+            matrix[(row["court__court_type"], year)] += row["count"]
     by_court_type_year = [
-        {
-            "court__court_type": row["court__court_type"],
-            "bs_year": year,
-            "count": row["count"],
-        }
-        for row in dated.values("court__court_type", "bs")
-        .annotate(count=Count("case_number"))
-        .order_by("court__court_type", "bs")
-        if (year := _bs_year(row["bs"])) is not None and year in kept_years
+        {"court__court_type": court_type, "bs_year": year, "count": count}
+        for (court_type, year), count in sorted(
+            matrix.items(), key=lambda item: (item[0][0] or "", item[0][1])
+        )
     ]
 
     nes_resolved = (

--- a/tests/api/test_statistics_api.py
+++ b/tests/api/test_statistics_api.py
@@ -795,6 +795,7 @@ class TestNgmMetrics:
         CourtCase.objects.create(
             case_number="082-OA-0001",
             court=district,
+            registration_date_bs="2082-09-27",
             registration_date_ad=date(2026, 1, 11),
             nes_id="https://jawafdehi.org/entity/person/ram",
             document_sources=[{"document_id": "ngm:doc:1"}],
@@ -805,6 +806,7 @@ class TestNgmMetrics:
         CourtCase.objects.create(
             case_number="082-CR-0003",
             court=supreme,
+            registration_date_bs="2082-10-18",
             registration_date_ad=date(2026, 2, 1),
         )
 
@@ -830,15 +832,16 @@ class TestNgmMetrics:
         }
         assert by_court_type == {"district": 2, "supreme": 1}
 
-        # Court-cases-per-year and per-court-level-per-year (the bare case with
-        # no registration date is excluded, so only the 2 dated cases count).
-        by_year = {row["year"]: row["count"] for row in ngm["by_year"]}
-        assert by_year == {2026: 2}
+        # Court-cases-per-year and per-court-level-per-year, bucketed on the BS
+        # registration year (the bare case with no registration date is excluded,
+        # so only the 2 dated cases count).
+        by_year = {row["bs_year"]: row["count"] for row in ngm["by_year"]}
+        assert by_year == {2082: 2}
         by_type_year = {
-            (row["court__court_type"], row["year"]): row["count"]
+            (row["court__court_type"], row["bs_year"]): row["count"]
             for row in ngm["by_court_type_year"]
         }
-        assert by_type_year == {("district", 2026): 1, ("supreme", 2026): 1}
+        assert by_type_year == {("district", 2082): 1, ("supreme", 2082): 1}
 
         # Materials now live in their own top-level block, not under ngm.
         mats = payload["materials"]
@@ -863,6 +866,48 @@ class TestNgmMetrics:
         assert ngm["completeness"]["nes_resolved"] == pytest.approx(33.3)
         assert ngm["completeness"]["with_registration_date"] == pytest.approx(66.7)
         assert ngm["completeness"]["with_document_sources"] == pytest.approx(33.3)
+
+    def test_per_year_buckets_follow_the_bs_year_not_the_ad_one(self, api_client):
+        # The BS year turns in mid-April, so a single AD year spans two of them.
+        # These two cases share AD 2026 but sit in different BS years — proof the
+        # buckets key off registration_date_bs and not the derived AD column.
+        from datetime import date
+
+        court = Court.objects.create(
+            identifier="lalitpurdc",
+            court_type="district",
+            full_name_nepali="जिल्ला अदालत ललितपुर",
+            full_name_english="District Court Lalitpur",
+        )
+        CourtCase.objects.create(
+            case_number="082-OA-1001",
+            court=court,
+            registration_date_bs="2082-12-06",
+            registration_date_ad=date(2026, 3, 20),
+        )
+        CourtCase.objects.create(
+            case_number="083-OA-1002",
+            court=court,
+            registration_date_bs="2083-02-06",
+            registration_date_ad=date(2026, 5, 20),
+        )
+        # Unparseable BS date: dropped from the breakdown, never bucketed as 0.
+        CourtCase.objects.create(
+            case_number="083-OA-1003",
+            court=court,
+            registration_date_bs="",
+            registration_date_ad=date(2026, 5, 21),
+        )
+
+        ngm = api_client.get("/api/statistics/").json()["ngm"]
+        assert {row["bs_year"]: row["count"] for row in ngm["by_year"]} == {
+            2082: 1,
+            2083: 1,
+        }
+        assert {
+            (row["court__court_type"], row["bs_year"]): row["count"]
+            for row in ngm["by_court_type_year"]
+        } == {("district", 2082): 1, ("district", 2083): 1}
 
     def test_materials_exclude_soft_deleted(self, api_client):
         # Soft-deleted materials are off every read plane (retrieve/search/sitemap

--- a/tests/api/test_statistics_api.py
+++ b/tests/api/test_statistics_api.py
@@ -898,6 +898,13 @@ class TestNgmMetrics:
             registration_date_bs="",
             registration_date_ad=date(2026, 5, 21),
         )
+        # A two-digit stub carries no year either, so it goes the same way.
+        CourtCase.objects.create(
+            case_number="083-OA-1004",
+            court=court,
+            registration_date_bs="20",
+            registration_date_ad=None,
+        )
 
         ngm = api_client.get("/api/statistics/").json()["ngm"]
         assert {row["bs_year"]: row["count"] for row in ngm["by_year"]} == {
@@ -908,6 +915,32 @@ class TestNgmMetrics:
             (row["court__court_type"], row["bs_year"]): row["count"]
             for row in ngm["by_court_type_year"]
         } == {("district", 2082): 1, ("district", 2083): 1}
+
+    def test_year_buckets_merge_every_spelling_of_the_same_bs_year(self, api_client):
+        # The SQL groups on the raw four-character prefix, so one BS year can
+        # arrive as several groups: the canonical date, the slash form, a bare
+        # year, and Devanagari digits (which _bs_year reads as the same number).
+        # Left unmerged these would plot one year as four points, and the string
+        # ordering — Devanagari sorts after ASCII — would pick the wrong 25.
+        court = Court.objects.create(
+            identifier="bhaktapurdc",
+            court_type="district",
+            full_name_nepali="जिल्ला अदालत भक्तपुर",
+            full_name_english="District Court Bhaktapur",
+        )
+        for i, stored in enumerate(["2082-01-15", "2082/02/20", "2082", "२०८२-०३-०१"]):
+            CourtCase.objects.create(
+                case_number=f"082-OA-200{i}",
+                court=court,
+                registration_date_bs=stored,
+            )
+
+        ngm = api_client.get("/api/statistics/").json()["ngm"]
+        assert [row["bs_year"] for row in ngm["by_year"]] == [2082]
+        assert ngm["by_year"] == [{"bs_year": 2082, "count": 4}]
+        assert ngm["by_court_type_year"] == [
+            {"court__court_type": "district", "bs_year": 2082, "count": 4}
+        ]
 
     def test_materials_exclude_soft_deleted(self, api_client):
         # Soft-deleted materials are off every read plane (retrieve/search/sitemap


### PR DESCRIPTION
### **User description**
## Why

`/data-quality` labels Nepal's court record with bare Gregorian years — `2003 … 2027` — in Nepali as much as in English. The two per-year breakdowns behind that page were computed as `EXTRACT(YEAR FROM registration_date_ad)`.

## What

Bucket on `registration_date_bs` instead: the calendar the court registers are written in, and the value the scrapers read *first* (`registration_date_ad` is derived from it via `bs_to_ad`).

This is not a relabelling of the same buckets. The BS year turns in mid-Baishakh, so every AD year straddles two BS years — no formatting on the frontend could have unmixed them.

**Coverage does not suffer.** Checked against prod: every case missing a BS date is also missing the AD one.

| | rows |
|---|---|
| `court_cases` total | 1,749,442 |
| with `registration_date_ad` | 1,694,688 |
| with `registration_date_bs` | **1,694,773** |
| BS present, AD missing | 85 |
| AD present, BS missing | 0 |

So this buckets marginally *more* cases. The 25-year cap now also excludes the stray implausible registrations the register carries (BS 2007 and 2029, one case each), and the dirty `2027` bucket that currently leaks into the chart is gone.

## Breaking: the row key is now `bs_year`

`by_year` and `by_court_type_year` rows change from `{year, count}` to `{bs_year, count}`. Deliberate and loud: a field named `year` that silently shifts calendar would read as a 57-year jump in the data. The only consumer is our own data-quality page — companion PR on the frontend.

## Notes for review

- Grouping runs in SQL on the leading four characters; the cast to int happens in Python (`_bs_year`), so one malformed value drops its row instead of failing the whole aggregation. `""` (10 rows on prod) is handled that way.
- The payload is computed out-of-band by `refresh_statistics` into `StatisticsSnapshot`, so the extra scan is off the request path. `registration_date_bs` is not indexed, but neither aggregation could use an index anyway.
- `counts.with_registration_date` still measures the AD column — it's a separate completeness metric, left alone.

## Verification

- `pytest tests/api/test_statistics_api.py` — 36 passed, including a new test that pins the buckets to BS: two cases sharing AD 2026 but sitting in BS 2082 and 2083 land in different buckets, and an unparseable BS value is dropped rather than bucketed as 0.
- Ran the whole thing locally against a seeded sqlite (15.5k cases across BS 2059–2083 plus the two junk rows): snapshot returns 25 BS-year buckets, junk excluded.
- Drove `/data-quality` in a headless browser against this API — see the frontend PR for screenshots.

## Deploy order

Merge and deploy **this first**, then the frontend. Either order is safe — the frontend PR drops rows it can't read rather than drawing them — but this order keeps the charts visible throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- NGM year buckets use BS

- API rows expose `bs_year`

- Malformed BS dates skipped

- Tests cover BS/AD split


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CourtCase registration_date_bs"] -- "SQL Substr first four chars" --> B["Python _bs_year validation"]
  B -- "valid recent years" --> C["ngm.by_year bs_year"]
  B -- "valid recent years" --> D["ngm.by_court_type_year bs_year"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_views.py</strong><dd><code>Document BS year statistics contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cases/api_views.py

<ul><li>Documents NGM per-year keys as <code>bs_year</code><br> <li> Clarifies BS calendar range<br> <li> Notes 25-year recent-record cap</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/434/files#diff-926cb1b9dfa09c768f390c34cfd718fa4c7c17e97f530b19cac222c2a9a55138">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statistics.py</strong><dd><code>Aggregate NGM statistics by BS year</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cases/services/statistics.py

<ul><li>Replaces <code>ExtractYear</code> with <code>Substr</code><br> <li> Adds <code>_bs_year</code> validator/parser<br> <li> Buckets <code>by_year</code> by <code>registration_date_bs</code><br> <li> Emits <code>bs_year</code> in yearly rows</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/434/files#diff-6aea93af7e7c4ec4da34e89ee5232f4c8b70d96e5052583b1cbf7947cb4c55f2">+47/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_statistics_api.py</strong><dd><code>Cover BS year statistics buckets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api/test_statistics_api.py

<ul><li>Seeds BS registration dates<br> <li> Updates yearly assertions to <code>bs_year</code><br> <li> Adds AD-shared, BS-split coverage test<br> <li> Verifies malformed BS dates drop</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/434/files#diff-38a8b1bb4f634239e81fa3b669f8bbafda51c6e57643871a619b6adc03662d10">+51/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Court-case statistics now group yearly results by Bikram Sambat registration year.
  - Results cover the most recent 25 Bikram Sambat years.
  - Invalid registration dates are excluded from yearly statistics.
  - Statistics responses now label yearly values as `bs_year`.
- **Documentation**
  - Updated API documentation to clarify the Bikram Sambat year-based breakdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->