### PR TITLE
feat(consumer): publish the jobs-consumer for arm64 as well as amd64

### DIFF
--- a/.github/workflows/docker-publish-platform.yml
+++ b/.github/workflows/docker-publish-platform.yml
@@ -29,6 +29,9 @@ jobs:
   build-and-push:
     needs: [unit-and-security-gate, live-integration-gate]
     runs-on: ubuntu-latest
+    outputs:
+      # The consumer jobs layer on this exact commit's platform image.
+      short_sha: ${{ steps.shortsha.outputs.value }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - uses: docker/setup-qemu-action@eaefd20f597840d8870070b5b0e1bd33d2fff867
@@ -62,16 +65,85 @@ jobs:
           cache-from: type=gha,scope=platform
           cache-to: type=gha,mode=max,scope=platform
 
-      # Jobs-consumer image (platform + Node + claude CLI, Dockerfile.consumer).
-      # Layers on the platform image pushed above, referenced by its immutable
-      # short-sha tag so the pair is always built from the same commit. Skipped on
-      # PRs (the base tag is only pushed on branch builds). amd64-only — see
-      # Dockerfile.consumer.
       - name: Short SHA for the consumer base tag
-        if: github.event_name != 'pull_request'
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+        id: shortsha
+        run: echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+  # Jobs-consumer image (platform + Node + claude CLI + LibreOffice,
+  # Dockerfile.consumer). Layers on the platform image built above, referenced by
+  # its immutable short-sha tag so the pair always comes from the same commit.
+  #
+  # Built on native runners per architecture rather than one job with QEMU: the
+  # image npm-installs the claude CLI, which is unreliable under emulation. Each
+  # job pushes an untagged manifest by digest; consumer-manifest then assembles
+  # the two digests into the tag list, so no per-arch tags litter the registry.
+  # GitHub's arm64 runners are free for public repositories.
+  consumer-amd64:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - name: Log into DockerHub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        id: build
+        with:
+          context: .
+          file: Dockerfile.consumer
+          platforms: linux/amd64
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.short_sha }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-consumer,push-by-digest=true,name-canonical=true,push=true
+          # Scope per architecture: the two arch jobs would otherwise share one
+          # gha scope and each overwrite the other's export every run.
+          cache-from: type=gha,scope=consumer-amd64
+          cache-to: type=gha,mode=max,scope=consumer-amd64
+
+  consumer-arm64:
+    needs: build-and-push
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - name: Log into DockerHub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        id: build
+        with:
+          context: .
+          file: Dockerfile.consumer
+          platforms: linux/arm64
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.short_sha }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-consumer,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=consumer-arm64
+          cache-to: type=gha,mode=max,scope=consumer-arm64
+
+  # Assemble the two per-arch digests into the real tags (:main, :<short-sha>,
+  # semver). Until this job runs the digests are unreferenced, so a failure here
+  # leaves the previous manifest list serving rather than a half-published tag.
+  consumer-manifest:
+    needs: [consumer-amd64, consumer-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+      - name: Log into DockerHub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
-        if: github.event_name != 'pull_request'
         id: meta-consumer
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-consumer
@@ -80,16 +152,29 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=,format=short
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        if: github.event_name != 'pull_request'
-        with:
-          context: .
-          file: Dockerfile.consumer
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SHORT_SHA }}
-          tags: ${{ steps.meta-consumer.outputs.tags }}
-          labels: ${{ steps.meta-consumer.outputs.labels }}
-          cache-from: type=gha,scope=consumer
-          cache-to: type=gha,mode=max,scope=consumer
+      - name: Create the multi-arch manifest list
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-consumer
+          AMD64_DIGEST: ${{ needs.consumer-amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.consumer-arm64.outputs.digest }}
+          META_JSON: ${{ steps.meta-consumer.outputs.json }}
+        run: |
+          set -euo pipefail
+          mapfile -t TAG_ARGS < <(jq -r '.tags[] | "-t\n" + .' <<<"$META_JSON")
+          docker buildx imagetools create "${TAG_ARGS[@]}" \
+            "${IMAGE}@${AMD64_DIGEST}" \
+            "${IMAGE}@${ARM64_DIGEST}"
+      - name: Verify both architectures are present
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-consumer
+        run: |
+          set -euo pipefail
+          # A manifest list that silently lost an arch is the failure this whole
+          # change exists to prevent, so assert on it rather than trusting it.
+          # buildx attaches provenance as extra manifests with platform
+          # unknown/unknown; those must be filtered or this never matches.
+          ARCHES=$(docker buildx imagetools inspect --raw "${IMAGE}:${GITHUB_SHA::7}" \
+            | jq -r '[.manifests[].platform.architecture]
+                     | map(select(. != "unknown")) | unique | sort | join(",")')
+          echo "architectures: $ARCHES"
+          test "$ARCHES" = "amd64,arm64"

--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -5,10 +5,16 @@
 # judge shells out to the `claude` binary authenticated by the operator's
 # subscription (CLAUDE_CODE_OAUTH_TOKEN) — so the CLI must ship in the image.
 #
-# Built amd64-only: likhit's legacy-.doc fallback (antiword) bundles an
-# x86_64-only binary (on arm64 those sources convert to 0 chars and reviews
-# grade on partial material), and npm-installing the CLI under arm64 QEMU
-# emulation is unreliable. Schedule on an amd64 node.
+# Built for amd64 AND arm64. This image used to be amd64-only because likhit's
+# legacy-.doc path relies on pyantiword, which bundles an x86-64 binary that
+# cannot execute anywhere else. LibreOffice (installed below) is packaged for
+# every architecture we deploy to and now anchors likhit's fallback chain, so
+# that constraint is gone. Verified on arm64 against a real CIAA press release:
+# LibreOffice's extraction is identical to amd64 antiword's, 0 replacement chars.
+#
+# The other former blocker was npm-installing the claude CLI under arm64 QEMU.
+# The workflow now builds each architecture on its own native runner and merges
+# the two into one manifest list, so nothing is emulated.
 ARG BASE_IMAGE=jawafdehi/jawafdehi-platform:main
 FROM ${BASE_IMAGE}
 
@@ -18,12 +24,27 @@ USER root
 
 # Node.js 22 LTS via NodeSource (claude-code needs a recent Node). The slim base
 # lacks curl/gnupg needed to add the apt repo.
+#
+# libreoffice-writer converts legacy .doc for the material_convert handler. In
+# this RUN to share the apt lists; --no-install-recommends keeps Java and the
+# rest of the suite out (~214 MB installed). `command -v soffice` is a build-time
+# guard: likhit locates it with shutil.which(), so the build must fail loudly if
+# the binary ever stops landing on PATH.
+#
+# ⚠️ Deliberately NOT installing `antiword`, even though it is 1 MB, is built for
+# arm64, and likhit would try it before LibreOffice. antiword selects its output
+# charmap from the locale, and this image inherits python:3.12-slim's unset LANG,
+# so a bare `antiword` call renders every Devanagari character as `?` — exit 0,
+# empty stderr, valid UTF-8, silently wrong. Measured on the CIAA fixture:
+# 1853 Devanagari codepoints via LibreOffice, 0 via locale-less antiword. It is
+# safe to add here only once likhit passes `-m UTF-8.txt` in a released version.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get install -y --no-install-recommends nodejs libreoffice-writer \
+    && command -v soffice \
     && rm -rf /var/lib/apt/lists/*
 
 # The claude_cli judge provider invokes this binary (settings.CLAUDE_CLI_BIN).


### PR DESCRIPTION
### **User description**
The consumer image is amd64-only, which makes the three Monal nodes the cluster's **only legal home** for the four cronjobs that run it — including `platform-jobs-processor` on a `*/5` schedule. Every OCI node is arm64. So the LLM review queue is pinned inside a 16 GiB single fault domain that also holds both CNPG instances, Zitadel and two of three OpenBao peers, and that has been dropping out of etcd raft roughly weekly.

`Dockerfile.consumer` documented two reasons for the pin. Both are addressed.

## Legacy `.doc` conversion

likhit's primary path is `pyantiword`, whose bundled **x86-64-only** binary cannot execute on arm64. `libreoffice-writer` is packaged for every architecture we deploy to and now anchors likhit's fallback chain. `--no-install-recommends` keeps Java and the rest of the suite out: ~214 MB installed. `command -v soffice` is a build-time guard, since likhit locates the binary with `shutil.which()` and would otherwise fail only at runtime.

Verified on a real arm64 node against a real CIAA press release — extraction is identical to correct amd64 antiword (2265 chars, 1853 Devanagari codepoints, 0 replacement characters, 100% token overlap).

### `antiword` is deliberately NOT installed

It is 1 MB, Debian builds it for arm64, and likhit tries it *before* LibreOffice — so it looks like the obvious cheap fix. I added it, then testing rejected it.

`antiword` selects its output charmap from the locale, and this image inherits `python:3.12-slim`'s unset `LANG`. A bare call renders **every** Devanagari character as an ASCII `?` while exiting 0 with an empty stderr — valid UTF-8, zero replacement characters, undetectable downstream. Measured on the CIAA fixture: **1853** Devanagari codepoints via LibreOffice, **0** via locale-less antiword. Because likhit tries antiword first, installing it here would have actively poisoned the working path.

The rationale is recorded in the Dockerfile so this isn't rediscovered. It becomes safe to add once likhit passes `-m UTF-8.txt` in a released rev (Jawafdehi/likhit#28 does).

## npm under emulation

Rather than adding `linux/arm64` to the existing QEMU build, each architecture builds on **its own native runner** and a merge job assembles the two digests into the tag list. GitHub's arm64 runners are free for public repositories, and this repo is public.

- The per-arch jobs push **untagged manifests by digest**, so a merge failure leaves the previous manifest list serving rather than a half-published tag, and no per-arch tags accumulate in the registry.
- **Cache scopes are per architecture.** Sharing one scope would have each run overwrite the other's export — the same trap the existing platform/consumer split already documents.
- The merge job **asserts both architectures are present**, filtering the `unknown/unknown` provenance manifests buildx attaches. (Without that filter the assertion never matches; confirmed against the live `jawafdehi-platform:main` index, which carries two of them.)

The platform image's own multi-arch QEMU build is untouched — it works today and changing it adds risk for no gain.

## ⚠️ Do not drop the `arch=amd64` pins on the strength of this PR alone

likhit is pinned here by git rev (`e98eb44…` in `pyproject.toml`), and the soffice fallback is in a later rev. Required order:

1. Merge Jawafdehi/likhit#28
2. Bump the likhit rev here + `uv lock`
3. Let this workflow publish the consumer for both architectures
4. Assert the manifest carries amd64 **and** arm64
5. *Then* remove the `arch=amd64` nodeAffinity in the infra repo — **keeping** the `hostname NotIn [monal-instance1]` term that was added separately

Removing the pins earlier yields `ImagePullBackOff`, or `ExtractionError` on `.doc` once the image exists but likhit is stale.

## Verification

The Dockerfile's apt line and the exact `soffice` invocation were exercised on an aarch64 node before this was written: `libreoffice-writer 4:7.4.7-1+deb12u14 arm64` installs cleanly with `--no-install-recommends`, and the conversion succeeds with `HOME` unset. The workflow YAML parses and the job graph resolves; the `mapfile`/`jq` tag-args construction and the arch-filter jq were both run against sample input.

I could not build the image end-to-end locally — no usable Docker daemon on this host — so the first real multi-arch build happens in CI on merge. Step 4 above exists for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Publish consumer for amd64, arm64

- Build each arch natively

- Merge digests into manifest list

- Add LibreOffice `.doc` fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Platform image"] -- "short SHA base" --> B["amd64 consumer build"]
  A["Platform image"] -- "short SHA base" --> C["arm64 consumer build"]
  B["digest"] --> D["consumer manifest list"]
  C["digest"] --> D["consumer manifest list"]
  D["verify"] --> E["amd64, arm64 tags"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish-platform.yml</strong><dd><code>Multi-arch consumer CI publishing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish-platform.yml

<ul><li>Exposes platform <code>short_sha</code> output.<br> <li> Adds native amd64 consumer build.<br> <li> Adds native arm64 consumer build.<br> <li> Merges digests, verifies architectures.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/435/files#diff-6fe97b10300d8a58a533a31ed6f5a00409b97f8c0ccf3a4d8d83a64606b6656b">+106/-21</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.consumer</strong><dd><code>LibreOffice-backed multi-arch consumer image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.consumer

<ul><li>Documents amd64 and arm64 support.<br> <li> Installs <code>libreoffice-writer</code> for <code>.doc</code>.<br> <li> Verifies <code>soffice</code> during build.<br> <li> Explains deliberate <code>antiword</code> exclusion.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/435/files#diff-8873e849979e504d3fe654525e4380f652ad5923d619e7f2264b6abbd24a3fd5">+26/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
