### PR TITLE
chore(deps): bump likhit to the rev with the LibreOffice .doc fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ bigo-enrichment = [
 
 [tool.uv.sources]
 # Shared by material enrichment and the embedded MCP document converter.
-likhit = { git = "https://github.com/Jawafdehi/likhit.git", rev = "e98eb446437f8a086e1e8da409d413ca81106532" }
+likhit = { git = "https://github.com/Jawafdehi/likhit.git", rev = "5ae527711c8542e04b919b930cb2b19fdfaffc65" }
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -1259,8 +1259,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "indic-transliteration", specifier = ">=2.3.82" },
     { name = "jsonpatch", specifier = ">=1.33" },
-    { name = "likhit", git = "https://github.com/Jawafdehi/likhit.git?rev=e98eb446437f8a086e1e8da409d413ca81106532" },
-    { name = "likhit", marker = "extra == 'bigo-enrichment'", git = "https://github.com/Jawafdehi/likhit.git?rev=e98eb446437f8a086e1e8da409d413ca81106532" },
+    { name = "likhit", git = "https://github.com/Jawafdehi/likhit.git?rev=5ae527711c8542e04b919b930cb2b19fdfaffc65" },
+    { name = "likhit", marker = "extra == 'bigo-enrichment'", git = "https://github.com/Jawafdehi/likhit.git?rev=5ae527711c8542e04b919b930cb2b19fdfaffc65" },
     { name = "lxml", specifier = ">=5.0" },
     { name = "markdown", specifier = ">=3.5" },
     { name = "markitdown", extras = ["docx", "pdf", "pptx", "xlsx"], specifier = ">=0.1.5" },
@@ -1448,8 +1448,8 @@ wheels = [
 
 [[package]]
 name = "likhit"
-version = "0.1.7"
-source = { git = "https://github.com/Jawafdehi/likhit.git?rev=e98eb446437f8a086e1e8da409d413ca81106532#e98eb446437f8a086e1e8da409d413ca81106532" }
+version = "0.1.8"
+source = { git = "https://github.com/Jawafdehi/likhit.git?rev=5ae527711c8542e04b919b930cb2b19fdfaffc65#5ae527711c8542e04b919b930cb2b19fdfaffc65" }
 dependencies = [
     { name = "fonttools" },
     { name = "markitdown", extra = ["docx", "pdf"] },


### PR DESCRIPTION
Closes the gap #435 left open.

## Why this is needed now

#435 built the consumer for arm64 and installed `libreoffice-writer` — confirmed working, `jawafdehi-platform-consumer:main` now publishes `['amd64', 'arm64']`. But the likhit pin stayed at `e98eb44`, whose only legacy-`.doc` path is pyantiword's bundled **x86-64** binary.

So the published arm64 image currently has the converter installed and **no code that calls it**. `.doc` conversion raises `ExtractionError` there.

This is not causing live breakage: all four cronjobs still carry `arch=amd64`, so nothing schedules on arm64 yet. Verified on the cluster before opening this.

## The change

Pin moves to `5ae5277` (likhit 0.1.8, Jawafdehi/likhit#28), which adds `_extract_doc_with_soffice` and pins a system antiword to `-m UTF-8.txt`.

Relocked with `uv lock --upgrade-package likhit` so nothing unrelated moves. The entire lockfile delta:

```
- version = "0.1.7"  source = ...?rev=e98eb446...
+ version = "0.1.8"  source = ...?rev=5ae52771...
```

plus the two matching dependency-edge lines. No other package changes.

## Verification

After `uv sync`, the resolved `likhit/extractors/docx_based.py` in the venv carries all of:

- `_extract_doc_with_soffice`
- `Text (encoded):UTF8` (the filter that preserves Devanagari)
- `"-m", "UTF-8.txt"` (the antiword charmap pin)
- `utf-8-sig` (BOM handling)
- `SOFFICE_TIMEOUT_SECONDS`

## After this merges

This is the **last gate** before the `arch=amd64` nodeAffinity can come off the four consumer cronjobs (`platform-jobs-processor`, `ngm-ciaa-press-releases`, `ngm-kanun-patrika`, `ngm-ppmo-blacklist`) in the infra repo — keeping the `hostname NotIn [monal-instance1]` term that was added separately.

That is what actually relieves the Monal concentration: those jobs are currently confined to a 16 GiB fault domain that also holds both CNPG instances, Zitadel and two of three OpenBao peers.

## Note on ordering

Jawafdehi/likhit#29 is open with a small follow-up (percent-encode the LibreOffice profile path). If that merges before this PR, say the word and I'll re-point the rev so one bump picks up both rather than needing a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned revision of an internal dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->