### PR TITLE
cases: add a ?courtcase= reverse filter to GET /api/cases/

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -298,7 +298,10 @@ def _if_match_matches(request, case) -> bool:
                     "https://jawafdehi.org/courtcase/kathmandudc/081-fn-12327). "
                     "Reverse-chronological. Unlike the other filters this one "
                     "is PUBLISHED-only for EVERY caller, including casework "
-                    "roles — it powers a public court-record page."
+                    "roles — it powers a public court-record page. Fails "
+                    "closed: a malformed or empty value returns an empty page, "
+                    "never an unfiltered one. Composes with `entity` (both "
+                    "narrow, and PUBLISHED-only still wins)."
                 ),
                 required=False,
             ),
@@ -497,6 +500,55 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
             "material_references",
         )
 
+        # Reverse lookup: cases citing a specific NGM court case by its canonical
+        # ``@id`` IRI (``CaseCourtCaseReference.courtcase_iri``), powering the
+        # "Related Jawafdehi cases" section on a court case's own page. Flat and
+        # reverse-chronological — ``CaseCourtCaseReference`` has no
+        # ``relationship_type``, so there is no accused/alleged tier to float
+        # here the way the ``entity`` branch below does.
+        #
+        # PUBLISHED-only for EVERY caller, deliberately NOT inheriting the
+        # role-scoped queryset the ``entity`` branch uses: a court-case page is a
+        # public archive record, not a casework surface. Caseworkers work on the
+        # Jawafdehi case itself, so there is no reason for a DRAFT/IN_REVIEW case
+        # to ever be named on one.
+        #
+        # This NARROWS ``queryset`` rather than returning, so it composes with
+        # the ``entity`` branch below instead of being silently dropped when both
+        # params are present. Applying it first also means its PUBLISHED-only
+        # rule — the stricter of the two — survives the combination: a request
+        # carrying ``courtcase`` can never widen past PUBLISHED via ``entity``.
+        #
+        # Presence, not truthiness: ``?courtcase=`` is malformed input, not an
+        # absent filter, and must fail CLOSED to an empty page. A falsey check
+        # would skip this branch and hand back the whole unfiltered case list —
+        # exactly the failure mode this filter exists to prevent.
+        courtcase_param = self.request.query_params.get("courtcase")
+        if self.action == "list" and courtcase_param is not None:
+            # Stored IRIs are canonical (``build_courtcase_iri`` lowercases court
+            # + case number), so normalize the param first — otherwise a caller
+            # echoing the court's own casing ("/KathmanduDC/081-FN-12327")
+            # silently matches nothing. ``canonicalize_courtcase_iri`` alone is
+            # not enough: its regex is lowercase-only, so it REJECTS mixed case
+            # rather than folding it. Lowercasing the whole IRI first is safe
+            # here — canonicalization discards the host and re-emits on the
+            # canonical authority regardless.
+            try:
+                courtcase_iri = canonicalize_courtcase_iri(courtcase_param.lower())
+            except ValueError:
+                # Not a court-case IRI at all (including "") — nothing cites it.
+                return queryset.none()
+            # No ``.distinct()``: the ``unique_case_courtcase_reference``
+            # constraint is on (case, courtcase_iri), so this join matches at
+            # most one reference row per case and cannot duplicate a ``Case``.
+            # The ``entity`` branch below DOES need it — its constraint includes
+            # ``relationship_type``, so one case can hold several rows for the
+            # same ``nes_id``.
+            queryset = queryset.filter(
+                state=CaseState.PUBLISHED,
+                courtcase_references__courtcase_iri=courtcase_iri,
+            )
+
         # Reverse lookup: cases citing a specific NES entity by its canonical
         # ``@id`` IRI (``CaseEntityRelationship.nes_id``), powering the "Related
         # cases" section on an entity's record page. List action only — retrieve
@@ -522,38 +574,6 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 .annotate(_accused_first=accused_first)
                 .order_by("-_accused_first", "-created_at")
             )
-
-        # Reverse lookup: cases citing a specific NGM court case by its canonical
-        # ``@id`` IRI (``CaseCourtCaseReference.courtcase_iri``), powering the
-        # "Related Jawafdehi cases" section on a court case's own page. Flat and
-        # reverse-chronological — ``CaseCourtCaseReference`` has no
-        # ``relationship_type``, so there is no accused/alleged tier to float
-        # here the way the ``entity`` branch above does.
-        #
-        # PUBLISHED-only for EVERY caller, deliberately NOT inheriting the
-        # role-scoped queryset the ``entity`` branch uses: a court-case page is a
-        # public archive record, not a casework surface. Caseworkers work on the
-        # Jawafdehi case itself, so there is no reason for a DRAFT/IN_REVIEW case
-        # to ever be named on one.
-        courtcase_param = self.request.query_params.get("courtcase")
-        if self.action == "list" and courtcase_param:
-            # Stored IRIs are canonical (``build_courtcase_iri`` lowercases court
-            # + case number), so normalize the param first — otherwise a caller
-            # echoing the court's own casing ("/KathmanduDC/081-FN-12327")
-            # silently matches nothing. ``canonicalize_courtcase_iri`` alone is
-            # not enough: its regex is lowercase-only, so it REJECTS mixed case
-            # rather than folding it. Lowercasing the whole IRI first is safe
-            # here — canonicalization discards the host and re-emits on the
-            # canonical authority regardless.
-            try:
-                courtcase_iri = canonicalize_courtcase_iri(courtcase_param.lower())
-            except ValueError:
-                # Not a court-case IRI at all — no case can cite it.
-                return queryset.none()
-            return queryset.filter(
-                state=CaseState.PUBLISHED,
-                courtcase_references__courtcase_iri=courtcase_iri,
-            ).order_by("-created_at")
 
         return queryset.order_by("-created_at")
 

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -38,6 +38,7 @@ from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 
 from jawafdehi_shared.drf.auditlog import AuditlogActorMixin
+from jawafdehi_shared.entities.ids import canonicalize_courtcase_iri
 from jawafdehi_shared.identity import (
     JAWAFDEHI_USER_ID_HEADER,
     resolve_or_create_identity,
@@ -288,6 +289,20 @@ def _if_match_matches(request, case) -> bool:
                 required=False,
             ),
             OpenApiParameter(
+                name="courtcase",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Reverse lookup: PUBLISHED cases citing this court case by "
+                    "its canonical @id IRI (e.g. "
+                    "https://jawafdehi.org/courtcase/kathmandudc/081-fn-12327). "
+                    "Reverse-chronological. Unlike the other filters this one "
+                    "is PUBLISHED-only for EVERY caller, including casework "
+                    "roles — it powers a public court-record page."
+                ),
+                required=False,
+            ),
+            OpenApiParameter(
                 name="search",
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
@@ -507,6 +522,38 @@ class CaseViewSet(AuditlogActorMixin, viewsets.ReadOnlyModelViewSet):
                 .annotate(_accused_first=accused_first)
                 .order_by("-_accused_first", "-created_at")
             )
+
+        # Reverse lookup: cases citing a specific NGM court case by its canonical
+        # ``@id`` IRI (``CaseCourtCaseReference.courtcase_iri``), powering the
+        # "Related Jawafdehi cases" section on a court case's own page. Flat and
+        # reverse-chronological — ``CaseCourtCaseReference`` has no
+        # ``relationship_type``, so there is no accused/alleged tier to float
+        # here the way the ``entity`` branch above does.
+        #
+        # PUBLISHED-only for EVERY caller, deliberately NOT inheriting the
+        # role-scoped queryset the ``entity`` branch uses: a court-case page is a
+        # public archive record, not a casework surface. Caseworkers work on the
+        # Jawafdehi case itself, so there is no reason for a DRAFT/IN_REVIEW case
+        # to ever be named on one.
+        courtcase_param = self.request.query_params.get("courtcase")
+        if self.action == "list" and courtcase_param:
+            # Stored IRIs are canonical (``build_courtcase_iri`` lowercases court
+            # + case number), so normalize the param first — otherwise a caller
+            # echoing the court's own casing ("/KathmanduDC/081-FN-12327")
+            # silently matches nothing. ``canonicalize_courtcase_iri`` alone is
+            # not enough: its regex is lowercase-only, so it REJECTS mixed case
+            # rather than folding it. Lowercasing the whole IRI first is safe
+            # here — canonicalization discards the host and re-emits on the
+            # canonical authority regardless.
+            try:
+                courtcase_iri = canonicalize_courtcase_iri(courtcase_param.lower())
+            except ValueError:
+                # Not a court-case IRI at all — no case can cite it.
+                return queryset.none()
+            return queryset.filter(
+                state=CaseState.PUBLISHED,
+                courtcase_references__courtcase_iri=courtcase_iri,
+            ).order_by("-created_at")
 
         return queryset.order_by("-created_at")
 

--- a/tests/api/test_cases_courtcase_filter.py
+++ b/tests/api/test_cases_courtcase_filter.py
@@ -1,0 +1,122 @@
+"""
+Tests for the ``?courtcase=<iri>`` reverse-lookup filter on GET /api/cases/.
+
+Powers the "Related Jawafdehi cases" section on a court case's own page: the
+PUBLISHED cases that cite a given NGM court case, flat and reverse-chronological.
+
+Unlike the sibling ``?entity=`` filter, this one is PUBLISHED-only for EVERY
+caller including casework roles — a court-case page is a public archive record,
+not a casework surface, so a DRAFT/IN_REVIEW case must never be named on one.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from cases.models import Case, CaseState, CaseType
+from tests.conftest import create_user_with_role
+
+CC = "https://jawafdehi.org/courtcase/kathmandudc/081-fn-12327"
+OTHER_CC = "https://jawafdehi.org/courtcase/special/081-cr-0079"
+
+
+def _make(slug, title, state, court_cases):
+    return Case.objects.create(
+        slug=slug,
+        title=title,
+        state=state,
+        case_type=CaseType.CORRUPTION,
+        court_cases=court_cases,
+    )
+
+
+def _get(courtcase, client=None):
+    resp = (client or APIClient()).get("/api/cases/", {"courtcase": courtcase})
+    assert resp.status_code == 200
+    return resp.data
+
+
+@pytest.mark.django_db
+class TestCaseCourtCaseFilter:
+    def test_returns_only_citing_published_cases(self):
+        _make("cf-a", "Cites it", CaseState.PUBLISHED, [CC])
+        _make("cf-b", "Also cites it", CaseState.PUBLISHED, [OTHER_CC, CC])
+        # Published but cites a different court case -> excluded.
+        _make("cf-other", "Other court case", CaseState.PUBLISHED, [OTHER_CC])
+        # Cites it but IN_REVIEW -> hidden.
+        _make("cf-inreview", "In review", CaseState.IN_REVIEW, [CC])
+        # Cites it but DRAFT -> hidden.
+        _make("cf-draft", "Draft", CaseState.DRAFT, [CC])
+
+        data = _get(CC)
+
+        assert data["count"] == 2
+        assert {c["slug"] for c in data["results"]} == {"cf-a", "cf-b"}
+
+    def test_unknown_courtcase_returns_empty(self):
+        _make("cf-lonely", "Lonely", CaseState.PUBLISHED, [CC])
+
+        data = _get("https://jawafdehi.org/courtcase/supreme/099-cr-9999")
+
+        assert data["count"] == 0
+        assert data["results"] == []
+
+    def test_mixed_case_iri_is_canonicalized_before_lookup(self):
+        # Stored IRIs are canonical (build_courtcase_iri lowercases court +
+        # case number). A caller echoing the court's own casing must still match.
+        _make("cf-canon", "Canonical", CaseState.PUBLISHED, [CC])
+
+        data = _get("https://jawafdehi.org/courtcase/KathmanduDC/081-FN-12327")
+
+        assert [c["slug"] for c in data["results"]] == ["cf-canon"]
+
+    def test_non_iri_param_returns_empty_not_500(self):
+        _make("cf-safe", "Safe", CaseState.PUBLISHED, [CC])
+
+        # A bare case number, a stray URL, junk — none can be cited by a case.
+        for junk in ("081-FN-12327", "https://example.com/nope", "../../etc/passwd"):
+            data = _get(junk)
+            assert data["count"] == 0, junk
+
+    def test_reverse_chronological(self):
+        now = timezone.now()
+        old = _make("cf-old", "Oldest", CaseState.PUBLISHED, [CC])
+        mid = _make("cf-mid", "Middle", CaseState.PUBLISHED, [CC])
+        new = _make("cf-new", "Newest", CaseState.PUBLISHED, [CC])
+
+        # auto_now_add ignores create-time created_at; set it explicitly.
+        Case.objects.filter(pk=new.pk).update(created_at=now)
+        Case.objects.filter(pk=mid.pk).update(created_at=now - timedelta(days=1))
+        Case.objects.filter(pk=old.pk).update(created_at=now - timedelta(days=2))
+
+        assert [c["slug"] for c in _get(CC)["results"]] == [
+            "cf-new",
+            "cf-mid",
+            "cf-old",
+        ]
+
+    def test_caseworker_also_sees_published_only(self):
+        # THE deviation from ?entity=: a signed-in caseworker gets the same
+        # PUBLISHED-only list as the public, because this powers a public
+        # court-record page. Caseworkers work on the Jawafdehi case itself.
+        _make("cf-pub", "Published", CaseState.PUBLISHED, [CC])
+        _make("cf-hidden", "In review", CaseState.IN_REVIEW, [CC])
+
+        client = APIClient()
+        client.force_authenticate(
+            user=create_user_with_role("cw", "cw@example.com", "Caseworker")
+        )
+
+        data = _get(CC, client)
+
+        assert [c["slug"] for c in data["results"]] == ["cf-pub"]
+
+    def test_state_param_cannot_widen_past_published(self):
+        _make("cf-scoped", "In review", CaseState.IN_REVIEW, [CC])
+
+        resp = APIClient().get("/api/cases/", {"courtcase": CC, "state": "IN_REVIEW"})
+
+        assert resp.status_code == 200
+        assert resp.data["count"] == 0

--- a/tests/api/test_cases_courtcase_filter.py
+++ b/tests/api/test_cases_courtcase_filter.py
@@ -16,7 +16,7 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from cases.models import Case, CaseState, CaseType
-from tests.conftest import create_user_with_role
+from tests.conftest import create_case_with_entities, create_user_with_role
 
 CC = "https://jawafdehi.org/courtcase/kathmandudc/081-fn-12327"
 OTHER_CC = "https://jawafdehi.org/courtcase/special/081-cr-0079"
@@ -76,9 +76,27 @@ class TestCaseCourtCaseFilter:
         _make("cf-safe", "Safe", CaseState.PUBLISHED, [CC])
 
         # A bare case number, a stray URL, junk — none can be cited by a case.
-        for junk in ("081-FN-12327", "https://example.com/nope", "../../etc/passwd"):
+        # "" is malformed input too, NOT an absent filter: ``?courtcase=`` must
+        # fail closed to an empty page rather than fall through to the full
+        # unfiltered case list (a falsey presence check used to do exactly that).
+        for junk in (
+            "081-FN-12327",
+            "https://example.com/nope",
+            "../../etc/passwd",
+            "",
+        ):
             data = _get(junk)
-            assert data["count"] == 0, junk
+            assert data["count"] == 0, repr(junk)
+
+    def test_empty_param_does_not_fall_through_to_unfiltered_list(self):
+        # Pins the regression directly: the empty-value response must not be the
+        # unfiltered list. Cases here cite NO court case, so a fall-through would
+        # return them while a correctly-failing-closed filter returns nothing.
+        _make("cf-unrelated-1", "Unrelated", CaseState.PUBLISHED, [])
+        _make("cf-unrelated-2", "Also unrelated", CaseState.PUBLISHED, [])
+
+        assert APIClient().get("/api/cases/").data["count"] == 2
+        assert _get("")["count"] == 0
 
     def test_reverse_chronological(self):
         now = timezone.now()
@@ -120,3 +138,95 @@ class TestCaseCourtCaseFilter:
 
         assert resp.status_code == 200
         assert resp.data["count"] == 0
+
+
+ENTITY = "https://jawafdehi.org/entity/person/cf-test-person"
+
+
+@pytest.mark.django_db
+class TestCourtCaseFilterComposesWithEntity:
+    """``?courtcase=`` must NARROW alongside ``?entity=``, not be dropped by it.
+
+    Both are reverse lookups and the ``entity`` branch returns early, so before
+    this was fixed ``?entity=X&courtcase=Y`` silently ignored ``courtcase`` and
+    answered as though only ``entity`` had been passed — a filter failing OPEN.
+    """
+
+    def test_both_params_intersect(self):
+        # Cites the entity AND the court case -> the only match.
+        create_case_with_entities(
+            slug="cf-both",
+            title="Both",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[ENTITY],
+            court_cases=[CC],
+        )
+        # Cites the entity but a DIFFERENT court case -> must be excluded.
+        create_case_with_entities(
+            slug="cf-entity-only",
+            title="Entity only",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[ENTITY],
+            court_cases=[OTHER_CC],
+        )
+
+        resp = APIClient().get("/api/cases/", {"entity": ENTITY, "courtcase": CC})
+
+        assert resp.status_code == 200
+        assert [c["slug"] for c in resp.data["results"]] == ["cf-both"]
+
+    def test_entity_param_cannot_widen_courtcase_past_published(self):
+        # The PUBLISHED-only rule is the stricter of the two and must survive the
+        # combination: a caseworker sees DRAFT/IN_REVIEW through ``?entity=``
+        # alone, but adding ``courtcase`` scopes the answer to a public
+        # court-record page, where an unpublished case must never be named.
+        create_case_with_entities(
+            slug="cf-combo-pub",
+            title="Published",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[ENTITY],
+            court_cases=[CC],
+        )
+        create_case_with_entities(
+            slug="cf-combo-inreview",
+            title="In review",
+            state=CaseState.IN_REVIEW,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[ENTITY],
+            court_cases=[CC],
+        )
+
+        client = APIClient()
+        client.force_authenticate(
+            user=create_user_with_role("cw2", "cw2@example.com", "Caseworker")
+        )
+
+        # Sanity: ?entity= alone DOES show the caseworker the in-review case.
+        entity_only = client.get("/api/cases/", {"entity": ENTITY})
+        assert {c["slug"] for c in entity_only.data["results"]} == {
+            "cf-combo-pub",
+            "cf-combo-inreview",
+        }
+
+        # Adding ?courtcase= narrows it back to PUBLISHED-only.
+        combined = client.get("/api/cases/", {"entity": ENTITY, "courtcase": CC})
+        assert combined.status_code == 200
+        assert [c["slug"] for c in combined.data["results"]] == ["cf-combo-pub"]
+
+    def test_malformed_courtcase_still_fails_closed_alongside_entity(self):
+        create_case_with_entities(
+            slug="cf-junk-combo",
+            title="Cites entity",
+            state=CaseState.PUBLISHED,
+            case_type=CaseType.CORRUPTION,
+            alleged_entities=[ENTITY],
+            court_cases=[CC],
+        )
+
+        for junk in ("not-an-iri", ""):
+            resp = APIClient().get("/api/cases/", {"entity": ENTITY, "courtcase": junk})
+            assert resp.status_code == 200
+            assert resp.data["count"] == 0, repr(junk)


### PR DESCRIPTION
### **User description**
Backend half of [Planka 1835595896759256731](https://tasks.jawafdehi.org/cards/1835595896759256731) — "Court case page: show related published Jawafdehi cases". Frontend counterpart: Jawafdehi#`feat/courtcase-related-jawafdehi-cases`. **Merge this one first** — see *Ordering* below.

## The gap

A Jawafdehi case can cite a court case (`CaseCourtCaseReference`: case FK, `courtcase_iri`, `ordinal`), but nothing reads that link in reverse. Opening a court case's own page gives no indication that a published case references it.

This adds the server-side filter the court-case page needs, mirroring the `?entity=` reverse lookup that already powers the "Related cases" section on an entity record page (`cases/api_views.py`).

## Two deliberate differences from `?entity=`

**PUBLISHED-only for every caller**, not the role-scoped queryset. `?entity=` inherits the visibility scoping, so a signed-in caseworker sees DRAFT/IN_REVIEW cases there. A court-case page is a public archive record, not a casework surface — caseworkers work on the Jawafdehi case itself — so an unpublished case must never be named on one, whoever is looking. Pinned by `test_caseworker_also_sees_published_only`.

**Flat and reverse-chronological**, with no accused/alleged tier to float. `CaseCourtCaseReference` carries no `relationship_type` (unlike `CaseEntityRelationship`); adding one is out of scope per the card.

## Ordering — this filter fails CLOSED, and that matters

Before this change `?courtcase=` was an unknown query param, and **DRF silently ignores unknown params**. The endpoint returned the complete published case list, byte-identical to an unfiltered request. Verified against production:

```
GET /api/cases/?courtcase=<iri>   ->  count: 62
GET /api/cases/                   ->  count: 62   # identical
```

Had the frontend shipped first, every court-case page would have listed **every published case on the platform** under "Related Jawafdehi Cases". Hence: merge and deploy this before the frontend PR. For the same reason a malformed IRI returns an empty page rather than an unfiltered one.

## IRI normalization

Stored IRIs are canonical (`build_courtcase_iri` lowercases court + case number), so a caller echoing the court's own casing — `/KathmanduDC/081-FN-12327` — would otherwise match nothing.

`canonicalize_courtcase_iri` alone is **not** sufficient: `COURTCASE_IRI_RE` is lowercase-only, so it *rejects* mixed case rather than folding it. The param is lowercased first, which is safe because canonicalization discards the host and re-emits on the canonical authority regardless.

No `.distinct()` is needed — the `unique_case_courtcase_reference` constraint already rules out a case citing the same court case twice.

## Testing

`tests/api/test_cases_courtcase_filter.py` — 7 tests modeled on `test_cases_entity_filter.py`: PUBLISHED-only filtering (DRAFT and IN_REVIEW excluded), unknown IRI, mixed-case canonicalization, junk-param safety, reverse-chron ordering, caseworker-sees-published-only, and `?state=IN_REVIEW` not widening.

- `pytest tests/api tests/casework` → **1652 passed**
- `ruff check` clean. `ruff format` flags two spots in `api_views.py`, both pre-existing on `main` (confirmed by stashing); left untouched.

Also verified by running `main` and this branch against the same local database, swapping only `api_views.py`:

| Request | main | this branch |
|---|---|---|
| `?courtcase=<iri>` | count 2 (both published cases) | count 1 (only the citing one) |
| no param | count 2 | count 2 |

## Out of scope / follow-up

`seed_dev` creates a `Court` with identifier `supreme-court`, which `validate_courtcase_iri` rejects — its allowlist has `supreme`, not `supreme-court`. That court case therefore cannot be referenced by IRI at all. Unrelated to this change; worth its own card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `?courtcase=` case reverse filter

- Enforce published-only courtcase results

- Normalize mixed-case courtcase IRIs

- Cover filter behavior with API tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GET /api/cases/?courtcase="]
  B["canonicalize courtcase IRI"]
  C["filter published citing cases"]
  D["reverse chronological results"]
  A -- "query" --> B
  B -- "valid IRI" --> C
  C -- "order" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_views.py</strong><dd><code>Add courtcase reverse case filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cases/api_views.py

<ul><li>Import <code>canonicalize_courtcase_iri</code><br> <li> Document new OpenAPI <code>courtcase</code> query parameter<br> <li> Add list-only courtcase reverse lookup<br> <li> Return <code>queryset.none()</code> for invalid IRIs</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/437/files#diff-926cb1b9dfa09c768f390c34cfd718fa4c7c17e97f530b19cac222c2a9a55138">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cases_courtcase_filter.py</strong><dd><code>Cover courtcase filter API behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api/test_cases_courtcase_filter.py

<ul><li>Add API coverage for citing published cases<br> <li> Verify mixed-case IRI canonicalization<br> <li> Assert invalid params return empty pages<br> <li> Pin published-only behavior for caseworkers</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/437/files#diff-0f609d26c30409056d8cbf25179446701c3b13c4441ddff3e860fb23b12b875a">+122/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `courtcase` filter to case listings for finding cases that cite a specified court case.
  * Search input is normalized for consistent matching, including mixed-case IRIs.
  * Results are limited to published cases and sorted newest first.

* **Bug Fixes**
  * Invalid or unknown court-case IRIs now return no results.
  * Published-only filtering remains consistent regardless of additional state parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->