### PR TITLE
feat(courts): expose verdict fields on the court-case API, whitelisted

### DIFF
--- a/courts/case_status.py
+++ b/courts/case_status.py
@@ -56,6 +56,25 @@ AFFIRMED = "AFFIRMED"
 REVERSED = "REVERSED"
 PARTIALLY_REVERSED = "PARTIALLY_REVERSED"
 
+# The closed set of values ``CourtCase.verdict_type`` is *supposed* to hold. The
+# column is a plain CharField with no DB constraint, and historic enrichment
+# wrote raw portal text straight into it — measured 2026-08-06 on prod, 1,323
+# Supreme rows (1.27% of the populated ones, 37 distinct values) hold Nepali
+# strings rather than a member here, including bench referrals
+# (``पूर्ण इजलासमा पेस हुने``), interlocutory orders (``कैफियत प्रतिवेदन माग्ने``)
+# and pure punctuation (``।।।।।।।``). Every such row has a NULL verdict date, so
+# they are enrichment noise rather than asserted verdicts — but a referral
+# rendered as an outcome would tell a reader a live case was decided. Anything
+# crossing a public boundary must therefore be filtered through this set; see
+# ``courts.serializers.CourtCaseSerializer.get_verdict_type``.
+VERDICT_TYPES = frozenset({
+    CONVICTED, ACQUITTED, PARTIALLY_CONVICTED,
+    CLAIM_UPHELD, CLAIM_DENIED, PARTIALLY_UPHELD,
+    SETTLED, WITHDRAWN, DISMISSED, QUASHED,
+    PROCEDURAL, ABEYANCE, STRUCK_OFF, AMENDED, OTHER,
+    AFFIRMED, REVERSED, PARTIALLY_REVERSED,
+})
+
 
 # --- vocabulary --------------------------------------------------------------
 

--- a/courts/serializers.py
+++ b/courts/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from materials.jsonld import court_case_material_iri
 
+from . import case_status as cs
 from .models import (
     BlacklistedFirm,
     CaseEntity,
@@ -27,6 +28,8 @@ class CourtCaseSerializer(serializers.ModelSerializer):
     # The court-case row's synthesized @id IRI (/courtcase/<court>/<case_number>),
     # distinct from the material IRI above. Derived from the composite key.
     courtcase_iri = serializers.CharField(source="iri", read_only=True)
+    # Whitelisted against cs.VERDICT_TYPES — see get_verdict_type below.
+    verdict_type = serializers.SerializerMethodField()
 
     class Meta:
         model = CourtCase
@@ -35,10 +38,28 @@ class CourtCaseSerializer(serializers.ModelSerializer):
             "registration_date_ad", "case_type", "case_status",
             "plaintiff", "defendant", "nes_id", "document_sources",
             "material_id", "courtcase_iri",
+            "verdict_type", "verdict_date_bs", "verdict_date_ad",
         ]
 
     def get_material_id(self, obj: CourtCase) -> str:
         return court_case_material_iri(obj.court_id, obj.case_number)
+
+    def get_verdict_type(self, obj: CourtCase) -> str | None:
+        """Expose ``verdict_type`` only when it is a real enum member.
+
+        The column carries no DB constraint and historic Supreme enrichment
+        wrote raw portal text into it (see ``cs.VERDICT_TYPES``). Publishing
+        that verbatim would state an outcome the court never reached — a bench
+        referral such as ``पूर्ण इजलासमा पेस हुने`` ("to be presented to the full
+        bench") reads like a disposition but means the case is still live.
+
+        Unrecognised values become ``None`` rather than leaking: the honest
+        public claim is "we hold no classified verdict for this docket", which
+        is what a null says. The raw value stays in the database for the DQ
+        backfill to repair.
+        """
+        value = (obj.verdict_type or "").strip()
+        return value if value in cs.VERDICT_TYPES else None
 
 
 class CourtCaseHearingSerializer(serializers.ModelSerializer):

--- a/courts/tests/test_api.py
+++ b/courts/tests/test_api.py
@@ -22,6 +22,7 @@ from django.test import SimpleTestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from courts import case_status as cs
 from courts.models import (
     BlacklistedFirm,
     CaseEntity,
@@ -145,6 +146,84 @@ class ReadPlaneTests(_DbAPITestCase):
         resp = self.client.get("/api/courtcase-entities/", {"nes_id": "https://jawafdehi.org/entity/person/ram-bahadur"})
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(len(resp.data["results"]), 1)
+
+
+class VerdictExposureTests(_DbAPITestCase):
+    """``verdict_type`` crosses the public boundary through a whitelist.
+
+    The column has no DB constraint and historic Supreme enrichment wrote raw
+    portal text into it (measured 2026-08-06: 1,323 prod rows, 37 distinct
+    values). The dangerous class is not the punctuation garbage but the bench
+    referrals and interlocutory orders, which read as dispositions while the
+    case is still live — so the serializer must publish only real enum members.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = Court.objects.create(
+            identifier="supreme",
+            court_type="supreme",
+            full_name_nepali="सर्वोच्च अदालत",
+            full_name_english="Supreme Court",
+        )
+        # A promoted appellate outcome — the shape the case stepper reads.
+        CourtCase.objects.create(
+            case_number="081-CR-1038",
+            court=cls.court,
+            verdict_type="AFFIRMED",
+            verdict_date_bs="2082-03-20",
+            verdict_date_ad=date(2025, 7, 4),
+        )
+        # A bench referral stored raw in verdict_type. Reads like a decision
+        # ("to be presented to the full bench"); the case is still live, and
+        # every such prod row carries a NULL verdict date exactly as here.
+        CourtCase.objects.create(
+            case_number="076-RB-0582",
+            court=cls.court,
+            verdict_type="पूर्ण इजलासमा पेस हुने",
+        )
+        # Scrape garbage, likewise seen in prod.
+        CourtCase.objects.create(
+            case_number="067-WO-0527", court=cls.court, verdict_type="।।।।।।।",
+        )
+        # Never enriched at all.
+        CourtCase.objects.create(case_number="081-CR-1318", court=cls.court)
+
+    def _get(self, case_number):
+        resp = self.client.get(f"/api/courtcases/supreme/{case_number}")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        return resp.data
+
+    def test_enum_member_is_published_with_its_dates(self):
+        data = self._get("081-CR-1038")
+        self.assertEqual(data["verdict_type"], "AFFIRMED")
+        self.assertEqual(data["verdict_date_bs"], "2082-03-20")
+        self.assertEqual(str(data["verdict_date_ad"]), "2025-07-04")
+
+    def test_bench_referral_is_not_published_as_a_verdict(self):
+        data = self._get("076-RB-0582")
+        self.assertIsNone(data["verdict_type"])
+        self.assertIsNone(data["verdict_date_bs"])
+
+    def test_scrape_garbage_is_not_published(self):
+        self.assertIsNone(self._get("067-WO-0527")["verdict_type"])
+
+    def test_unenriched_docket_reports_null(self):
+        self.assertIsNone(self._get("081-CR-1318")["verdict_type"])
+
+    def test_whitelist_covers_every_declared_constant(self):
+        """Guards against a new verdict constant being added and silently
+        dropped on the wire because nobody updated ``VERDICT_TYPES``."""
+        declared = {
+            value
+            for name, value in vars(cs).items()
+            if name.isupper()
+            and not name.startswith("_")
+            and isinstance(value, str)
+            and value == name
+            and name not in {"PENDING", "DECIDED", "UNKNOWN"}  # lifecycle, not verdict
+        }
+        self.assertEqual(declared, set(cs.VERDICT_TYPES))
 
 
 class SearchRetiredTests(_DbAPITestCase):


### PR DESCRIPTION
### **User description**
## Why

Groundwork for the case-progress stepper ([design doc](https://github.com/Jawafdehi/jawafdehi-meta/blob/main/docs/2026-08-06-case-progress-stages/DESIGN.md)): the public case page needs to show where a CIAA case sits on the CIAA charge → Special Court → appeal ladder, and that needs the docket's verdict.

`CourtCaseSerializer` exposed 12 fields and stopped there. `verdict_type`, `verdict_date_bs` and `verdict_date_ad` were added to the ORM projection in migration `0003` — the comment at `courts/models.py:84-90` says the point was to make verdict "first-class, queryable, and indexable" — but they never crossed the API boundary. Today the frontend can read `case_status` and hearings, but not the promoted outcome.

## The catch: `verdict_type` is not a clean enum

It's a plain `CharField` with no DB constraint, and historic Supreme enrichment wrote raw portal text into it. Measured on prod 2026-08-06 — of **104,327** populated `supreme` rows, **1,323 (1.27%) across 37 distinct values** are not enum members:

| class | rows | example |
|---|---|---|
| unmapped disposition | 718 | `जारी` (writ issued) |
| unsplit compound | 312 | `बदर, उच्च अदालतमा पठाउने` |
| **bench referral** | **242** | `पूर्ण इजलासमा पेस हुने` |
| **interlocutory** | **46** | `कैफियत प्रतिवेदन माग्ने` |
| garbage | 5 | `।।।।।।।` |

`special`, `patanhc` and `kathmandudc` are 100% clean, so this is Supreme-specific.

**The referrals are the dangerous class, not the garbage.** `पूर्ण इजलासमा पेस हुने` ("to be presented to the full bench") reads like a disposition but means the case is *still live*. Publishing it verbatim would tell a reader that a pending appeal had been decided — on the exact cases where being wrong matters most.

## What this does

`verdict_type` goes out through a new `cs.VERDICT_TYPES` frozenset. Anything else serialises as `null`, which is the honest claim: we hold no classified verdict for that docket. The raw value stays in the database for the DQ backfill to repair.

The dates need no guard. `verdict_date_bs` is shape-clean corpus-wide (95,366 well-formed / 44,382 null / **zero** malformed), and every dirty `verdict_type` row carries a NULL date — so a date can't assert a decision the type guard just suppressed.

**No migration.** The columns are already in Django's state.

## Verification

- `courts/tests` + `cases/tests` — 594 passed
- `tests/api/test_openapi_documentation.py` — 8 passed
- `ruff check` and `ty check` clean
- **Mutation-checked**: replacing the guard with `return value or None` fails exactly `test_bench_referral_is_not_published_as_a_verdict` and `test_scrape_garbage_is_not_published`
- **Replayed against all 53 distinct prod `supreme` values**: 103,004 publish, 1,323 null, no Devanagari leaks, and every enum member seen on other courts is covered

`test_whitelist_covers_every_declared_constant` guards the failure mode where someone adds a verdict constant and it's silently dropped on the wire.

## Reviewer notes

- The 1,323 dirty rows are a pre-existing DQ problem this PR contains rather than fixes. Cleanup is tracked separately with the `backfill_case_status` run.
- Deliberately **not** exposing `verdict_judge` (500-char free-text bench string) or `case_subject` (untruncated TextField) — not needed for the stepper, and both widen the public surface for no gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Expose court-case verdict fields

- Whitelist public verdict types

- Suppress raw Supreme scrape values

- Add API coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CourtCase.verdict_type"] -- "validate" --> B["VERDICT_TYPES"]
  B -- "allowed" --> C["API verdict_type"]
  A -- "unknown" --> D["null"]
  E["Verdict dates"] -- "expose" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case_status.py</strong><dd><code>Add verdict type whitelist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/case_status.py

<ul><li>Adds <code>VERDICT_TYPES</code> whitelist.<br> <li> Documents dirty Supreme raw values.<br> <li> Defines safe public verdict set.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/438/files#diff-8bf1463436bf52616a4c94fcc833984531ee8ca5f1f864322fbdb345eee6a5aa">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Expose filtered verdict fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/serializers.py

<ul><li>Adds <code>verdict_type</code> serializer method.<br> <li> Exposes verdict date fields.<br> <li> Converts unknown verdicts to <code>None</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/438/files#diff-b9e360f87318d41d7a22a517a7d6361b47d276a83c07e88befde90eb130df129">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Cover verdict API exposure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_api.py

<ul><li>Tests enum verdict publication.<br> <li> Tests raw Nepali/garbage suppression.<br> <li> Tests null unenriched dockets.<br> <li> Guards whitelist completeness.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/438/files#diff-bd6ca112fa37369abbd24f3fceb9ad814842274d138643146a86a15f62ee5185">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public case responses now include recognized verdict types and verdict dates.
  * Supported verdict values are validated against a defined set of options.

* **Bug Fixes**
  * Invalid, blank, raw, or unenriched verdict data is excluded from public responses and returned as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->