### PR TITLE
chore(typing): scope unresolved-import per-file, fix a confidence OverflowError, retract three doc claims

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,17 +46,31 @@ repos:
   # cross-module view, and the per-path scoping in [tool.ty.overrides] is keyed on
   # paths it discovers itself.
   #
-  # `files` covers pyproject.toml as well as sources, and that is not incidental.
-  # The obvious `types: [python]` looks right and is subtly wrong: pyproject.toml
-  # HOLDS the [tool.ty] config, so under a python-only trigger a commit that
-  # loosens a rule, widens an override, or drops a whole block skips the very
-  # check it just weakened. Verified by staging pyproject.toml alone — the hook
-  # reported "no files to check" and passed.
+  # `files` covers pyproject.toml and uv.lock as well as sources, and neither is
+  # incidental. The obvious `types: [python]` looks right and is subtly wrong on
+  # both counts:
+  #
+  #   pyproject.toml HOLDS the [tool.ty] config, so under a python-only trigger a
+  #   commit that loosens a rule, widens an override, or drops a whole block skips
+  #   the very check it just weakened.
+  #
+  #   uv.lock pins ty ITSELF, plus django-stubs, drf-stubs and every dep whose
+  #   types ty reads. A dependency bump therefore changes what the checker is and
+  #   what it knows while touching no `.py` file at all — upstream #436
+  #   (`chore(deps): bump likhit`) is exactly that shape. #436 also moved a
+  #   `pyproject.toml` line, so the pyproject entry alone would have caught it;
+  #   what the uv.lock entry adds is the bump that DOESN'T, i.e. a plain
+  #   `uv lock --upgrade` refresh, which moves pinned versions and nothing else.
+  #
+  # Both entries were verified the same way, and it is worth repeating if you
+  # change this regex: run `pre-commit run ty --files <the file>` against the
+  # config WITHOUT the entry and it reports "no files to check" and passes, which
+  # is the failure — then add the entry and the same command actually runs ty.
   - repo: local
     hooks:
       - id: ty
         name: ty check
         entry: uv run ty check
         language: system
-        files: '(\.pyi?$|^pyproject\.toml$)'
+        files: '(\.pyi?$|^pyproject\.toml$|^uv\.lock$)'
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,14 +29,24 @@ suite that *errors* rather than skips when the stack is down.
 **Baseline the suite on your untouched branch and compare against that**, rather
 than against a number written down here — the totals move whenever upstream lands
 tests, and a stale figure here would just make a green run look wrong. What is
-stable is the shape: green, a handful of skips, exactly one warning.
+stable is the shape: green, and a handful of skips.
 
 The skips are `materials/tests/test_patch_concurrency_postgres.py`, which needs a
 real Postgres `ngm` alias AND `DJANGO_SETTINGS_MODULE=config.settings` — see that
 module's docstring; `settings_test` hardcodes sqlite, so they can never run on the
-default gate. The one warning is upstream's own un-awaited `_drain_tasks`
-coroutine in `case_events`, not something this tree introduced. **A second
-warning is a real signal** — see the note under Conventions.
+default gate.
+
+**The warning count depends on whether `staticfiles/` exists, so baseline it in
+the same tree you will compare in.** With the directory present the suite settles
+at one warning — upstream's own un-awaited `_drain_tasks` coroutine in
+`case_events`, not something this tree introduced. Without it, whitenoise emits
+`UserWarning: No directory at: .../staticfiles/` from nearly every test that
+builds a Django handler, which is worth hundreds. `staticfiles/` is a
+`collectstatic` artifact and is gitignored, so a FRESH clone or worktree does not
+have one and shows the large number. Re-derive it in one step if you doubt this:
+run `uv run pytest -q newsletter/tests/test_api.py` either side of
+`mkdir staticfiles` and watch the warnings go to zero. Do not go looking for what
+you broke; make the directory, or just compare like for like.
 
 Run one test: `uv run pytest tests/api/test_public_api.py -k name`. Security suite
 only: `uv run pytest -m security`.
@@ -65,25 +75,39 @@ now, beyond ty's defaults: `invalid-argument-type`, `not-subscriptable`,
 plus `possibly-unresolved-reference` and `possibly-missing-import`, which ty
 ships OFF and which found real bugs.
 
-Two families remain exempt: `unresolved-attribute` (the one genuine plugin gap —
-implicit FK `_id`, reverse accessors, `get_user_model()`) and `unresolved-import`
-(optional lazily-imported deps; permanent). Tests and a list of named source
-files are scoped out of the four new families via `[[tool.ty.overrides]]` —
-**deleting an entry from that list is how a file opts in**, and only once
-`ty check <file>` is already 0.
+One family remains exempt tree-wide: `unresolved-attribute` (the one genuine
+plugin gap — implicit FK `_id`, reverse accessors, `get_user_model()`).
+`unresolved-import` used to be the second, and is now ON with four named files
+scoped out instead — two genuinely-optional deps absent from the venv, two
+django-stubs re-export gaps. A tree-wide ignore there bought silence about typos
+and nothing else: a misspelled module resolves to nothing and blows up at import
+time in whatever environment first runs that path.
 
-**The measured cost of every exemption lives in `pyproject.toml`, next to the
-config it justifies — not here.** That is deliberate: a number is only useful
-where you can act on it, and a count in this file rots silently while a count
-beside the `include =` list is read by whoever is about to delete an entry. Each
-block records how it was measured, so re-derive rather than trust.
+Tests and a list of named source files are scoped out of the four new families via
+`[[tool.ty.overrides]]` — **deleting an entry from that list is how a file opts
+in**, and only once `ty check <file>` is already 0.
+
+**Costs and the recipe for re-deriving them live in `pyproject.toml`, next to the
+config they justify — not here.** A number is only useful where you can act on it,
+and a count in this file rots silently while a count beside the `include =` list is
+read by whoever is about to delete an entry.
+
+Which counts survived is itself the durable lesson, and it is a three-way split.
+A figure scoped to an explicit file list moves when someone edits the list it sits
+beside, so it stays honest — the two debt blocks keep theirs. A count in the past
+tense about a finished change ("these six annotations removed 91 diagnostics")
+describes an event, not a state, so it cannot go stale either. A whole-tree total
+of the CURRENT state has neither anchor: three of those were written down, and all
+three were wrong within two rebases. Those are gone, replaced by the command that
+reproduces them.
 
 **The gate's diagnostic set is a function of the resolved DEPENDENCY set.** This
-is the trap most likely to waste your afternoon. Families like
-`unresolved-import` are exempt, so before a package resolves, everything
-downstream of it infers as `Unknown` and no rule can fire on it. Promote that
-package into the main dependency set and its consumers become checked code
-overnight — so `ty check` can go red in files nobody edited. It happened here:
+is the trap most likely to waste your afternoon. Until a package resolves,
+everything downstream of it infers as `Unknown` and no rule can fire on it —
+which is still true for the four files whose imports are exempted per-file, so
+enabling `unresolved-import` did not close this. Promote that package into the
+main dependency set and its consumers become checked code overnight — so
+`ty check` can go red in files nobody edited. It happened here:
 PR #427 moved `markitdown`, `httpcore` and `likhit` out of extras, which
 surfaced findings in `review/converter.py` and `materials/sourcing/ppmo/ocr.py`,
 both untouched for weeks. **Re-measure after a dependency change; do not assume
@@ -180,10 +204,14 @@ fallback path to add.
   set `FORMS_URLFIELD_ASSUME_HTTPS`; that transitional setting is itself deprecated
   and warns on assignment (verified: `django/conf/__init__.py:239`). Swapping the
   field class needs a state-only `AlterField` migration (see `cases/migrations/0055`).
-- **The suite must stay at one warning.** It was 916 before 2026-08-04 (98% one
-  repeated whitenoise `UserWarning`); the 1 that remains is upstream's un-awaited
-  `_drain_tasks` coroutine in `case_events`. A *second* new warning is a real
-  signal; keep it that way rather than letting volume rebuild.
+- **The suite stays at one warning — in a tree that has `staticfiles/`.** The
+  repeated whitenoise `UserWarning` that used to dominate (98% of ~916) is
+  suppressed by the directory existing, not by a code fix, and the directory is a
+  gitignored `collectstatic` artifact. So the invariant holds for a working clone
+  and NOT for a fresh worktree, where the count is back in the hundreds. See the
+  note under Tests. What remains in a `staticfiles/`-bearing tree is upstream's
+  un-awaited `_drain_tasks` coroutine in `case_events`. A *second* new warning
+  there is a real signal; keep it that way rather than letting volume rebuild.
 
 ## Working model
 
@@ -222,14 +250,31 @@ do not push to it.
   `cases/api_views.py` is still a 1989-line module even after the split.
 - **`ty` is clean and gated** — the debt this bullet used to list is gone. The
   `__str__`-returning-`CharField` family evaporated with django-stubs; the rest
-  were fixed. Keep reading its output rather than dismissing it, because that pass
-  found more real bugs: a SECOND Optional-`response.text` in `case_scraper.py` (the
-  phase-2 structuring call, one function below the phase-1 one already fixed);
-  `build_convert_payload` annotated `Optional[dict]` while all three of its failure
-  paths `raise`; `_die()` missing `-> NoReturn`, which made six reads genuinely
-  possibly-unbound; a `get_form` override silently dropping Django's `change`; and
-  `case_events.bus` passing a possibly-None loop *after* building the coroutine,
-  orphaning it.
+  were fixed. Keep reading its output rather than dismissing it. What that pass
+  actually turned up, sorted by whether runtime behaviour changed — the distinction
+  matters, because an earlier version of this bullet ran all of it together and
+  claimed more than was true:
+  - **Behaviour changed.** `case_events.bus` built the publish coroutine as an
+    argument to `run_coroutine_threadsafe` and only then passed a possibly-None
+    loop, so a publish before the bus started raised, left the coroutine unawaited,
+    and lost the message. Now the loop is checked first and the coroutine is closed
+    by hand if the handoff throws.
+  - **Unhandled `None` on a live path.** A SECOND Optional-`response.text` in
+    `case_scraper.py` (the phase-2 structuring call, one function below the phase-1
+    one already fixed). The scrape failed either way; what changed is that a blocked
+    candidate now says so instead of raising a pydantic error about the schema.
+  - **Annotation-only — runtime identical before and after.** `_die()` missing
+    `-> NoReturn` (it always raised; the six reads were only *statically*
+    possibly-unbound), and `build_convert_payload` annotated `Optional[dict]` while
+    all three of its failure paths `raise`.
+  - **Not a bug at all**, recorded because the claim outlived its correction: this
+    bullet used to say a `get_form` override silently dropped Django's `change`. It
+    did not. `_changeform_view` passes `change` as a keyword, so a `**kwargs`-only
+    override forwards it untouched — verified with a spy on `ModelAdmin.get_form`,
+    which reports `change=True` for both the old and the new signature. Spelling the
+    parameter out is a readability and typing change only. The same overstatement is
+    baked into the merged commit message for the gate and into PR #428's body, and
+    cannot be edited out of the former.
 - **Two real defects sit behind the MCP type debt** (found 2026-08-05 while
   gating ty over PR #427; each wants its own PR, neither is a typing fix):
   `jawafdehi_mcp/tools/ngm_extract.py` `_validate_environment` is annotated
@@ -243,10 +288,14 @@ do not push to it.
   also why ty reports most of that file — `all()` does not narrow.
 - **The remaining type debt is enumerated, not vague** — read the
   `[[tool.ty.overrides]]` blocks in `pyproject.toml`, which name every file and
-  carry the per-block measurement and reasoning. The THIRD block is source files
-  predating the gate (the first is `urls.py`, the second tests); the FOURTH is
-  everything PR #427 brought in. Nearly all of it is two shapes: bs4 attribute
-  values (`str | AttributeValueList | None`) used as plain `str`, and unnarrowed
+  carry the per-block reasoning. Find a block by its opening comment, not by
+  position — this list used to identify them by ordinal, and the ordinals went
+  stale the moment a block was inserted above them. The two that hold actual debt
+  are the SOURCE-files one (files predating the gate) and the PR #427 one (the MCP
+  server, which merged while ty was still advisory); the rest are permanent
+  exemptions — `urls.py`, tests, and two `unresolved-import` blocks.
+  Nearly all the debt is two shapes: bs4 attribute values
+  (`str | AttributeValueList | None`) used as plain `str`, and unnarrowed
   Optionals. The `dict(...)`-splat lever — annotating a heterogeneous carrier dict
   `dict[str, Any]` so a typed constructor stops unioning every field — is the
   biggest single win available and is mostly spent.

--- a/case_events/bus.py
+++ b/case_events/bus.py
@@ -229,9 +229,13 @@ class _Bus:
         # Both of the next two blocks exist to keep a failed publish from ALSO
         # orphaning a coroutine. `self._js.publish(...)` builds one eagerly, and a
         # coroutine that is created and never awaited emits a "coroutine was never
-        # awaited" RuntimeWarning when it is collected. The suite is held at exactly
-        # one warning (see AGENTS.md), so a second one is a real signal and must not
-        # come from here.
+        # awaited" RuntimeWarning when it is collected — and, more to the point,
+        # means the publish silently did not happen on a path that returns a plain
+        # False. (An earlier version of this comment justified the care by "the
+        # suite is held at exactly one warning". Don't rely on that: the count is
+        # only low in a tree that has a `staticfiles/` directory, so it is not the
+        # tripwire it was described as. The orphaned-work argument stands on its
+        # own.)
         #
         # `_loop` is None until the bus starts, so check it BEFORE constructing the
         # coroutine — there is nothing to clean up if we never build it.

--- a/case_proposals/job_kind.py
+++ b/case_proposals/job_kind.py
@@ -249,11 +249,21 @@ def on_result(job, result: dict) -> None:
 
     try:
         # Passing a missing key's None into float() is the INTENT here: the
-        # `except (TypeError, ValueError)` immediately below is what handles both
-        # "absent" and "not a number", in one place. Narrowing first would just
+        # `except` immediately below is what handles "absent", "not a number" and
+        # "too big to be a float", in one place. Narrowing first would just
         # duplicate that branch.
+        #
+        # OverflowError is in the tuple because a JSON number is not bounded by
+        # what a float can hold. `json.loads` parses a few-hundred-digit integer
+        # into an unbounded Python int, and `float()` on that raises OverflowError — an
+        # ArithmeticError, so NOT covered by TypeError/ValueError. Without it a
+        # runaway integer escapes this handler, and because `jobs.queue.finalize`
+        # swallows whatever `on_result` raises, the result is a DONE job with no
+        # proposal and no recorded reason: the one outcome this module's docstring
+        # promises cannot happen. (A JSON `1e400` is different — it parses to
+        # float `inf`, converts fine, and is then caught by the range check below.)
         confidence = float(result.get("confidence"))  # ty: ignore[invalid-argument-type]
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return _validation_failure(job, "confidence is missing or not a number")
     if not 0.0 <= confidence <= 1.0:
         return _validation_failure(job, "confidence out of range", confidence=confidence)

--- a/case_proposals/tests/test_intent_job.py
+++ b/case_proposals/tests/test_intent_job.py
@@ -302,7 +302,26 @@ class TestWhatAModelIsNotAllowedToDraft:
         on_result(job, good_result(confidence=0.8))
         assert not CaseUpdateProposal.objects.exists()
 
-    @pytest.mark.parametrize("confidence", [None, "high", float("nan"), 1.5, -0.1])
+    @pytest.mark.parametrize(
+        "confidence",
+        [
+            None,
+            "high",
+            float("nan"),
+            1.5,
+            -0.1,
+            # A JSON number has no size limit, so `json.loads` hands us a Python
+            # int this large and `float()` on it raises OverflowError — which is
+            # an ArithmeticError, not a TypeError or ValueError. Given an explicit
+            # id because the default one would be 401 digits wide.
+            pytest.param(10**400, id="too-big-for-a-float"),
+            # The float spelling is NOT the same case: JSON `1e400` parses to
+            # float("inf"), converts without complaint, and is stopped by the
+            # range check instead. Here so a fix aimed at one cannot regress the
+            # other.
+            pytest.param(float("inf"), id="inf"),
+        ],
+    )
     def test_a_confidence_that_is_not_a_number_in_range_stages_nothing(self, confidence):
         job = make_job(make_case())
         on_result(job, good_result(confidence=confidence))
@@ -368,6 +387,18 @@ class TestNoRejectionIsSilent:
             {"intent": {"type": "append_timeline_entry", "entry": {}}, "confidence": 0.9},
             {"intent": {"type": "append_timeline_entry", "entry": {"date": "2026-03-14", "title": "t"}}},
             ["nope"],
+            # A confidence too large to be a float. This is the case this class
+            # exists for: `float()` raises OverflowError, which is neither a
+            # TypeError nor a ValueError, so before the fix it escaped on_result
+            # entirely — and `finalize` would then have swallowed it, leaving a
+            # DONE job with no proposal and nothing recorded.
+            pytest.param(
+                {
+                    "intent": {"type": "append_timeline_entry", "entry": {"date": "2026-03-14", "title": "t"}},
+                    "confidence": 10**400,
+                },
+                id="confidence-too-big-for-a-float",
+            ),
         ],
     )
     def test_every_path_that_stages_nothing_leaves_a_reason_on_the_job(self, result):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,40 +193,58 @@ dev = [
 # the metaclass blind spot turned out to be closable from STUB DATA, which needs
 # no plugin. django-stubs types field access through `__get__` overloads and
 # declares `objects`, so adding django-stubs + djangorestframework-stubs to the
-# dev group moved this tree, measured:
+# dev group cut the all-families count on this tree by well over half. The bulk
+# of what it removed was `Model.objects` and `force_authenticate` — things the
+# stubs simply declare.
 #
-#     all families on, no stubs .............. 1560   (1174 unresolved-attribute,
-#                                                      of which 809 `objects`
-#                                                      and 110 force_authenticate)
-#     all families on, with stubs ..............676   (pre-fix; the same
-#                                                      measurement on the SHIPPED
-#                                                      tree is 551)
-#     ...after the fixes in this change .........0 against the config below
+# The one figure worth asserting is the invariant CI enforces: ZERO diagnostics
+# against the config below.
 #
-# Provenance, so the next person can re-derive rather than trust. Only the 0 and
-# the 551 are reproducible as-is; 1560 and 676 are historical, read off single
-# `ty check` runs before the fixes landed, so do not expect 676 back. To redo the
-# "all families on" number without editing this file:
+# Every other WHOLE-TREE total that used to be written out here has been removed,
+# because they rot. Three of them were already wrong two rebases after being
+# measured: the tree grows, `main` moves under the branch, and a count in a
+# comment has no way to notice.
+#
+# The per-block counts in the two DEBT blocks (the SOURCE-files one and the PR
+# #427 one) are deliberately kept, and the difference is not arbitrary: those are
+# scoped to an explicit `include` list, so they move only when someone edits the
+# list they sit next to — and they are the numbers that tell you how much work an
+# opt-in costs. Both re-measured correct at the time this was written. A
+# whole-tree total has no such anchor.
+#
+# The past-tense counts further down ("these six annotations removed 91
+# diagnostics") are kept for the same reason: they describe a change that
+# happened, not a state that has to stay true.
+#
+# Re-derive rather than trust. The whole tree, all families on:
 #
 #     uv run ty check --config-file <a ty.toml holding only [environment]+[src]>
 #
-# and for one family, `uv run ty check -c "rules.<name>='error'"` (which is how
-# the 314 below was taken). Note `-c "overrides=[]"` does NOT clear the override
-# blocks — arrays do not replace, so it silently no-ops; use --config-file.
-# 1560 is the sum of the then-baseline (31) plus each silenced family measured on
-# its own via `--error <rule>`; the families are independent.
+# and for one family, `uv run ty check -c "rules.<name>='error'"`.
 #
-# `__str__` returning `CharField` went from 12 to 1 for the same reason. The
-# stubs cost 24 false `path()`/`re_path()` overload reports in URLconfs, handled
-# by the first override block below.
+# Two traps in that recipe, both of which hand you a confidently wrong number:
+#
+#   * `-c "overrides=[]"` does NOT clear the override blocks. TOML arrays do not
+#     replace, so it silently no-ops — you measure the CONFIGURED tree while
+#     believing you measured the raw one. Use --config-file, which does replace
+#     the project config wholesale.
+#
+#   * a run that reports 0 for a forced-on rule is indistinguishable from a path
+#     that was never analysed at all. To show a file really is covered, put a
+#     deliberate error in it and watch the gate report it.
+#
+# `__str__` returning `CharField` all but disappeared for the same reason. The
+# stubs also COST something: they make every `path()`/`re_path()` route in the
+# tree a false overload report, handled by the URLconf override block below.
 #
 # django-stubs targets mypy and says so, so expect occasional friction of exactly
 # that kind rather than none. It is type-only, dev-group, never in the image, and
 # verified inert against the suite.
 #
-# The remaining exemptions are `unresolved-attribute` and `unresolved-import`;
-# both are argued, with their measured cost, in [tool.ty.rules] below. Track
-# astral-sh/ty#255 ("django plugin") — landing it is what closes the first one.
+# One family is exempt tree-wide — `unresolved-attribute` — and it is argued in
+# [tool.ty.rules] below. Track astral-sh/ty#255 ("django plugin"); landing it is
+# what closes it. `unresolved-import` used to be the second tree-wide exemption
+# and is now ON, with four named files scoped out in override blocks of their own.
 # ---------------------------------------------------------------------------
 # ruff — the lint gate (CI runs exactly `uv run ruff check .`).
 #
@@ -314,30 +332,39 @@ exclude = [
 [tool.ty.rules]
 # --- The ONE family still off tree-wide. -----------------------------------
 # `unresolved-attribute` is the django-stubs *plugin* gap, and it is the only
-# thing django-stubs cannot close from stubs alone. What remains after the stubs
-# land (measured on this tree): 109 in source, 205 in tests. The source ones are
-# dominated by things a mypy plugin synthesises and a stub file cannot —
-# implicit FK id columns (`court_id` x17, `case_id` x8), reverse relation
-# accessors (`courtcase_references`, `material_references`), and the custom-User
-# surface (`groups`, `is_superuser`) reached through `get_user_model()`, which is
-# typed `type[AbstractBaseUser]`.
+# thing django-stubs cannot close from stubs alone. Roughly two thirds of what
+# remains is in tests; the source side is dominated by things a mypy plugin
+# synthesises and a stub file cannot — implicit FK id columns (`court_id`,
+# `case_id`), reverse relation accessors (`courtcase_references`,
+# `material_references`), and the custom-User surface (`groups`, `is_superuser`)
+# reached through `get_user_model()`, which is typed `type[AbstractBaseUser]`.
+# For the current figure, run the per-family recipe above.
 #
 # Closing it needs one of: ty gaining a Django plugin (track astral-sh/ty#255 —
 # still absent as of 0.0.67), hand-declaring every FK's `_id` and every
-# `related_name` on the 26 models, or abandoning `get_user_model()` across 38
-# call sites. The first is free and coming; the other two trade a documented
+# `related_name` across the model layer, or abandoning `get_user_model()`
+# tree-wide. The first is free and coming; the other two trade a documented
 # Django practice for type purity. So: off, with the cost written down.
 unresolved-attribute = "ignore"
 
-# `unresolved-import` is off for a different and permanent reason: this tree
-# imports genuinely OPTIONAL dependencies lazily inside function bodies, guarded
-# by try/except ImportError, and they are absent from the base image on purpose.
-# The full set as of this change: markitdown, playwright.sync_api, pymupdf,
-# fitz, likhit.converters, npttf2utf, cloudpathlib, markdownify. Two more are
-# django-stubs re-export gaps rather than optional deps
-# (`django.template.loader.engines`, `django.test.testcases.
-# DatabaseOperationForbidden`) — both resolve fine at runtime.
-unresolved-import = "ignore"
+# `unresolved-import` used to be off here, alongside `unresolved-attribute`. It is
+# now ON, and its exemptions are per-FILE in the two override blocks at the bottom
+# of this file.
+#
+# The reason for the move: a tree-wide `"ignore"` on this rule buys nothing except
+# silence about typos. An optional dep is a handful of known files, whereas the
+# rule's real value is catching `from cases.serialzers import ...` — a misspelling
+# that resolves to nothing, is invisible to both gates under a tree-wide ignore,
+# and blows up at import time in whatever environment first exercises that path.
+# Scoping it to four named files keeps the whole rest of the tree covered.
+#
+# Note the exempt set is a property of the ENVIRONMENT, not just the code: it is
+# the optional deps absent from `uv sync`'s venv. Most of what the old comment
+# here listed as optional (markitdown, pymupdf, fitz, likhit, npttf2utf,
+# markdownify) is in fact installed by the dev group, so ty resolves it and it
+# never needed an exemption. If a future change drops one of those from the dev
+# group, this gate will start reporting it — correctly. Add the file, don't
+# re-disable the rule.
 
 # --- Bug-shaped rules, explicitly ON (ty ships them off by default). ---
 # These two ask "can this name actually be unbound here?", which is a runtime
@@ -380,8 +407,8 @@ possibly-missing-import = "error"
 # django-stubs types `path()`/`re_path()` with overloads whose `view` must be
 # `Callable[..., HttpResponseBase]`. Neither DRF's `@api_view`-decorated
 # functions nor `.as_view()` results match any overload, so EVERY route in the
-# tree gets reported — 24 findings, all confined to URLconfs (review 8,
-# discovery 6, jobs 4, entities 3, materials 3).
+# tree gets reported. The findings are confined to URLconfs and scale with the
+# number of routes, which is why the count that used to sit here is gone.
 #
 # Verified false, not deferred: `path("auth/me/", views.me_view)` in
 # review/urls.py is valid Django that runs in production and is covered by the
@@ -399,29 +426,27 @@ no-matching-overload = "ignore"
 
 # ---------------------------------------------------------------------------
 [[tool.ty.overrides]]
-# TESTS: the four newly-gated families are off here — 168 findings' worth,
-# re-derived on the shipped tree: 93 invalid-argument-type, 47 not-subscriptable,
-# 18 unsupported-operator, 10 invalid-assignment.
+# TESTS: the four newly-gated families are off here.
 #
 # This mirrors the ANN policy above, which exempts tests permanently, and for a
 # related reason: a test double's whole job is to stand in for a shape it does
 # not statically have. Concretely, within THESE four families it is Optional
-# helper returns used without a guard (all 47 not-subscriptable are "cannot
+# helper returns used without a guard (every `not-subscriptable` here is "cannot
 # subscript None") and `None`/double stand-ins passed where the real type is
-# declared — `ModelAdmin(site=None)` 15, `Job | None` into `finalize` 12,
-# `HTTPError.__init__` 9. tests/casework/test_enrich_timeline.py (28) and
-# materials/tests/test_nkp_parse.py (15) are the two biggest files.
+# declared — `ModelAdmin(site=None)`, `Job | None` into `finalize`,
+# `HTTPError.__init__`.
 #
 # NOT this block: the double-attribute noise (`_casework_run_paths`, `calls`) and
 # most of the `APIClient`/`get_user_model()` surface are `unresolved-attribute`,
-# which is off tree-wide above — 205 of its 314 are in tests.
+# which is off tree-wide above.
 #
 # `not-iterable` is here for the same reason and is NOT one of the four: unittest
 # `Mock.await_args`/`call_args` are typed `None` until the mock is called, so the
 # standard `args, kwargs = m.await_args` unpack after an
 # `assert_awaited_once()` reads as "unpacking None". It is the exact same
-# stand-in-shape argument as the 47 "cannot subscript None" above, just a
-# different rule name. 3 findings, all in tests/mcp/test_jawafdehi_write_tools.py.
+# stand-in-shape argument as the "cannot subscript None" findings above, just a
+# different rule name; at time of writing all of them are in
+# tests/mcp/test_jawafdehi_write_tools.py.
 #
 # This is a deliberate trade, not an oversight: it does mean a genuine type
 # mistake in a test body goes unreported. Judged worth it because the same
@@ -441,6 +466,57 @@ not-subscriptable = "ignore"
 unsupported-operator = "ignore"
 invalid-assignment = "ignore"
 not-iterable = "ignore"
+
+# ---------------------------------------------------------------------------
+[[tool.ty.overrides]]
+# OPTIONAL DEPENDENCIES. Two modules this tree imports on purpose without
+# depending on: neither is in `[project]`, `[project.optional-dependencies]` or
+# the dev group, so neither is in the image or in `uv sync`'s venv, and ty is
+# right that it cannot resolve them.
+#
+#   cloudpathlib          — a one-off S3/R2 import command. The import is in a
+#                           try/except that re-raises with the install hint, and
+#                           Django only imports a command module when that command
+#                           is actually invoked.
+#   playwright.sync_api   — the browser fallback in the NKP crawler, imported
+#                           inside `PlaywrightFetcher.__init__` so the requests
+#                           transport works without a browser installed.
+#
+# Per-file rather than tree-wide: see the `unresolved-import` note in
+# [tool.ty.rules]. If either becomes a real dependency, delete its line.
+include = [
+    "cases/management/commands/import_ciaa_cases.py",
+    "materials/sourcing/nkp/crawl.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+
+# ---------------------------------------------------------------------------
+[[tool.ty.overrides]]
+# django-stubs RE-EXPORT GAPS. Unlike the block above, these two are not missing
+# packages — they are names django-stubs declines to re-export from the module the
+# code imports them from. Both resolve at runtime; verified by importing each and
+# checking what comes back (`engines` is an `EngineHandler` instance,
+# `DatabaseOperationForbidden` is a class):
+#
+#   django.template.loader.engines                  -> llm/tests/test_templating.py
+#   django.test.testcases.DatabaseOperationForbidden -> tests/test_router_isolation.py
+#
+# Separate block because the exit condition is different: this one should be
+# re-checked on every django-stubs bump and deleted when the stubs export these,
+# whereas the optional-dependency block above is permanent.
+#
+# Deliberately NOT folded into the tests block above, even though both files are
+# tests it already matches. That block turns rules off for every test in the tree;
+# naming two files keeps a misspelled import in any OTHER test a failure.
+include = [
+    "llm/tests/test_templating.py",
+    "tests/test_router_isolation.py",
+]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
 
 # ---------------------------------------------------------------------------
 [[tool.ty.overrides]]


### PR DESCRIPTION
### **User description**
Follow-up to #428, which had already merged when these came in — hence a new PR
rather than an amend. Five items.

**1. `unresolved-import` is now ON**, with four files scoped out in two override
blocks instead of a tree-wide ignore. A tree-wide ignore bought silence about
typos: `from cases.serialzers import ...` resolves to nothing, is invisible to
both gates, and blows up at import time. Two blocks, not one, because the exit
conditions differ — the optional deps (cloudpathlib, playwright) are permanent;
the django-stubs re-export gaps (`django.template.loader.engines`,
`django.test.testcases.DatabaseOperationForbidden`) should be re-checked on every
stubs bump. Deliberately not folded into the tests block, which would turn the
rule off for every test in the tree. Verified per-file with a deliberate-error
probe: the exempt import stays silent, a fresh bad import in the same file is
still reported.

**2. `OverflowError` on an unfloatable confidence.** `float()` on a large enough
int raises `OverflowError` — an `ArithmeticError`, so not covered by the
`(TypeError, ValueError)` guard in `case_proposals.job_kind.on_result`. JSON
integers are unbounded, and because `jobs.queue.finalize` swallows what
`on_result` raises, the result was a DONE job with no proposal and no recorded
reason: the one outcome that module's docstring promises cannot happen. The float
spelling already worked (`1e400` → `inf`, caught by the range check); both are
parametrized so a fix for one can't regress the other.

**3. The ty pre-commit hook now fires on `uv.lock`**, which pins ty itself plus
every dep whose types it reads — a dependency bump changes what the checker is
while touching no `.py` file.

**4. Whole-tree diagnostic totals in `pyproject.toml` are gone**, replaced by the
command that reproduces them plus the two traps in that recipe: `-c "overrides=[]"`
silently no-ops (TOML arrays don't replace), and a 0 from a forced-on rule is
indistinguishable from a path that was never analysed. Three of those totals were
already wrong. Counts scoped to an `include =` list stay — they move when someone
edits the list beside them.

**5. Three AGENTS.md claims retracted, not deleted**, since the same wording is in
#428's body and merged commit message:
- **The `get_form` override was not a bug.** `_changeform_view` passes `change` as
  a keyword, so a `**kwargs`-only override forwards it untouched — verified with a
  spy on `ModelAdmin.get_form`, `change=True` under both signatures. The "bugs ty
  found" bullet is now sorted by whether runtime behaviour changed.
- **The one-warning invariant is conditional.** Untouched `main` gives 981 in a
  fresh worktree. Whitenoise warns `No directory at: .../staticfiles/` from every
  test that builds a Django handler, and `staticfiles/` is a gitignored
  `collectstatic` artifact. `case_events/bus.py` cited that invariant as a
  tripwire; it now rests on the orphaned-coroutine argument alone.
- **Block ordinals ("THIRD", "FOURTH") went stale** the moment blocks were
  inserted above them; blocks are identified by opening comment now.

**Gates:** `ruff check` clean · `ty check` passes · all 7 pre-commit hooks pass ·
suite 4419 passed / 4 skipped vs 4416 / 4 on untouched main (+3 = the new cases).
Tests verified to bite: reverting only the except-tuple fails exactly the two
`10**400` cases.


___

### **PR Type**
Documentation, Bug fix, Tests


___

### **Description**
- Gate `unresolved-import` per file

- Catch huge confidence `OverflowError`

- Run `ty` on `uv.lock`

- Correct warning/type-debt docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ty config"] -- "enables" --> B["unresolved-import"]
  B -- "exempts" --> C["four files"]
  D["confidence parsing"] -- "catches" --> E["OverflowError"]
  F["docs"] -- "corrects" --> G["warning baseline"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bus.py</strong><dd><code>Clarify publish coroutine failure rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_events/bus.py

<ul><li>Revises coroutine warning comment<br> <li> Emphasizes orphaned publish prevention<br> <li> Removes fragile suite-warning rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/439/files#diff-dc92eb12d22aefaf168f1e7e89c65623028302d58141a03615ce17bc834c82e9">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Update typing and warning guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Corrects warning-count guidance for <code>staticfiles/</code><br> <li> Documents per-file <code>unresolved-import</code> policy<br> <li> Refines type-debt and gate notes<br> <li> Removes stale ordinal/count claims</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/439/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+86/-37</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>job_kind.py</strong><dd><code>Handle unfloatable confidence values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/job_kind.py

<ul><li>Catches <code>OverflowError</code> from <code>float()</code><br> <li> Records validation failure for huge integers<br> <li> Documents JSON integer edge case</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/439/files#diff-3eb9480104e521129e2f2d00d434e81a5c67b23f9fbf8d5c01c35627f8ee711c">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_intent_job.py</strong><dd><code>Cover confidence overflow rejection paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

case_proposals/tests/test_intent_job.py

<ul><li>Adds huge integer confidence case<br> <li> Adds <code>inf</code> confidence regression case<br> <li> Verifies silent rejection reasons remain recorded</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/439/files#diff-ca86befaa75b65be4eca0122214befa67c8faceffb5fcd910f8f45ffec419c55">+32/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Trigger ty on lockfile changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<ul><li>Adds <code>uv.lock</code> to <code>ty</code> trigger<br> <li> Documents dependency-bump type-check risk<br> <li> Keeps whole-project <code>ty</code> execution</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/439/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+21/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Scope unresolved import exemptions precisely</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Removes stale whole-tree diagnostic totals<br> <li> Enables <code>unresolved-import</code> globally<br> <li> Adds optional-dependency import overrides<br> <li> Adds django-stubs re-export gap overrides</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/439/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+129/-53</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid confidence values, including excessively large integers, are now safely rejected and recorded instead of causing processing errors.
  * Expanded validation coverage for non-numeric, NaN, infinite, and out-of-range confidence values.

* **Documentation**
  * Updated contributor guidance and project configuration documentation to reflect current diagnostics, warnings, exemptions, and dependency-sensitive checks.
  * Improved pre-commit coverage for Python, project configuration, and lockfile changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->