### PR TITLE
refactor(casework): one evidence normaliser, not two copies

### DIFF
--- a/casework/README.md
+++ b/casework/README.md
@@ -197,17 +197,18 @@ against a bound case and left its `evidence` rows and their notes untouched.
 ### Writing `evidence` or `entities` — read, merge, send the whole list
 
 `PATCH /evidence` **replaces the entire list.** The server deletes every existing
-row and recreates from exactly what you send (`_write_material_references`,
-`cases/api_views.py:647`). Send only your new document and you delete the press
-release and court order someone bound last month.
+row and recreates from exactly what you send (`cases.api_views._write_material_references`).
+Send only your new document and you delete the press release and court order
+someone bound last month.
 
 Never send a delta. Read the case, merge into what is already there, send it all:
 
 ```python
-from casework.bind_materials import current_evidence, merge_evidence
+from casework.common.evidence import current_evidence, merge_evidence
 
 case, etag = api.get_case_with_etag(slug)
-merged = merge_evidence(current_evidence(case), [new_iri])   # append, keep order
+# (material_iri, note) pairs. Pass "" when the stage has no note to bind yet.
+merged = merge_evidence(current_evidence(case), [(new_iri, "")])
 api.replace_list(slug, "evidence", merged, if_match=etag)
 ```
 

--- a/casework/bind_materials.py
+++ b/casework/bind_materials.py
@@ -36,6 +36,7 @@ import time
 from dataclasses import dataclass, field
 
 from casework.common.api import CaseworkApi
+from casework.common.evidence import current_evidence, merge_evidence
 from casework.common.cli import (
     _utc_iso_now, add_common_args, basic_auth_from_env, configure_run_logging,
     log_run_footer, log_run_header, print_summary,
@@ -121,44 +122,6 @@ class BindPlan:
         return len(self.patch_items) if self.action == "WOULD_PATCH" else self.n_current
 
 
-def current_evidence(case):
-    """Normalize the case's evidence into the {material_iri, additional_details}
-    shape the PATCH expects, preserving order.
-
-    DELIBERATELY DUPLICATED in `casework/enrich_news_articles.py`. Both stages
-    write the same destructive whole-list `PATCH /evidence`, so both must
-    normalise it identically; the copy is kept rather than shared because these
-    are standalone scripts with no shared sequencing. Change one, change the
-    other -- a divergence here silently drops evidence rows.
-    """
-    return [
-        {"material_iri": e.get("material_iri"),
-         "additional_details": e.get("additional_details") or ""}
-        for e in (case.get("evidence") or [])
-        if e.get("material_iri")
-    ]
-
-
-def merge_evidence(current, add_iris):
-    """Append each new IRI not already present, preserving existing order and
-    de-duplicating. Never reorders or drops an existing entry -- the whole-list
-    replace makes any omission destructive.
-
-    DELIBERATELY DUPLICATED as `merge_news_evidence` in
-    `casework/enrich_news_articles.py`, which differs in ONE respect: it binds
-    the Nepali evidence note at the same time instead of `additional_details:
-    ""` (its deviation 2). The append-only contract is identical and must stay
-    that way in both.
-    """
-    have = {e["material_iri"] for e in current}
-    merged = list(current)
-    for iri in add_iris:
-        if iri not in have:
-            merged.append({"material_iri": iri, "additional_details": ""})
-            have.add(iri)
-    return merged
-
-
 def missing_candidates(case, candidates):
     """Return the ``(source, ident)`` candidates NOT already bound to ``case``.
 
@@ -213,7 +176,8 @@ def plan_case(api, case, etag, candidates, required_state=REQUIRED_STATE):
                         dropped=dropped, uncertain=uncertain, probes=probes,
                         reason=f"{len(uncertain)} material(s) uncertain")
 
-    merged = merge_evidence(current, add)
+    # This stage binds no note; the news stage passes a real one.
+    merged = merge_evidence(current, [(iri, "") for iri in add])
     if merged == current:
         return BindPlan(slug=slug, action="NOOP", state=state, if_match=etag,
                         n_current=len(current), dropped=dropped, probes=probes)

--- a/casework/common/evidence.py
+++ b/casework/common/evidence.py
@@ -1,0 +1,28 @@
+"""Read and merge a case's `/evidence` list. Shared by every stage that writes it."""
+
+
+def current_evidence(case):
+    """The case's evidence in the `{material_iri, additional_details}` shape PATCH wants."""
+    return [
+        {"material_iri": e.get("material_iri"),
+         "additional_details": e.get("additional_details") or ""}
+        for e in (case.get("evidence") or [])
+        if e.get("material_iri")
+    ]
+
+
+def merge_evidence(current, additions):
+    """Append `(material_iri, note)` pairs not already present, preserving order.
+
+    Never reorders, rewrites or drops an existing entry: `PATCH /evidence` replaces
+    the whole list, so anything left out is deleted. An IRI already present is
+    skipped rather than allowed to overwrite a note a human may have edited.
+    """
+    have = {e["material_iri"] for e in current}
+    merged = list(current)
+    for iri, note in additions:
+        if iri in have:
+            continue
+        merged.append({"material_iri": iri, "additional_details": note})
+        have.add(iri)
+    return merged

--- a/casework/common/evidence.py
+++ b/casework/common/evidence.py
@@ -20,7 +20,14 @@ def merge_evidence(current, additions):
     """
     have = {e["material_iri"] for e in current}
     merged = list(current)
-    for iri, note in additions:
+    for addition in additions:
+        # A bare IRI is the natural mistake here, and a 2-character string would
+        # unpack into iri="a", note="b" and bind silently. Say so instead.
+        if isinstance(addition, str):
+            raise TypeError(
+                f"merge_evidence takes (material_iri, note) pairs, got the bare "
+                f"string {addition!r}. Pass [(iri, '')] if there is no note.")
+        iri, note = addition
         if iri in have:
             continue
         merged.append({"material_iri": iri, "additional_details": note})

--- a/casework/enrich_news_articles.py
+++ b/casework/enrich_news_articles.py
@@ -40,9 +40,9 @@ shaper, `materials.jsonld.documentsource_to_jsonld`, so what this writes is
 byte-compatible with the 48 `/material/news/*` rows already in production; the
 IRI form is not invented here (see `news_search.news_material_ident`).
 
-DEVIATION 2 -- THE NOTE IS WRITTEN AT BIND TIME, NEVER BLANK. `bind_materials.py
-:143` appends new evidence with `additional_details: ""` and leaves a later stage
-to backfill. This stage has the article in hand and the verifier has already
+DEVIATION 2 -- THE NOTE IS WRITTEN AT BIND TIME, NEVER BLANK. `bind_materials`
+appends new evidence with `additional_details: ""` and leaves a later stage to
+backfill. This stage has the article in hand and the verifier has already
 produced the Nepali note, so binding blank would cost a second document fetch of
 a document already read and strand the entry meanwhile. The register and length
 come from the 33 news notes on the 15 IN_REVIEW cases, read from production
@@ -103,6 +103,7 @@ import urllib.parse
 from dataclasses import dataclass, field
 
 from casework.common.api import CaseworkApi
+from casework.common.evidence import current_evidence, merge_evidence
 from casework.common.cli import (
     add_common_args,
     basic_auth_from_env,
@@ -190,24 +191,6 @@ def _require_loopback(api):
 # ---------------------------------------------------------------------------
 
 
-def current_evidence(case):
-    """The case's evidence normalised to the `{material_iri, additional_details}`
-    shape the PATCH expects, order preserved.
-
-    Byte-identical to `bind_materials.current_evidence` and imported-by-copy on
-    purpose: this is the contract for what a whole-list replace must send back,
-    and the two writers of `/evidence` must not be able to disagree about it.
-    Consolidating them into `casework/common/` is a separate change that would
-    edit a module this port has no other reason to touch.
-    """
-    return [
-        {"material_iri": e.get("material_iri"),
-         "additional_details": e.get("additional_details") or ""}
-        for e in (case.get("evidence") or [])
-        if e.get("material_iri")
-    ]
-
-
 def bound_news_urls(case):
     """Every article URL already bound to this case, normalised for comparison.
 
@@ -226,27 +209,6 @@ def bound_news_urls(case):
 
 def count_news_evidence(case):
     return len(materials_of_type(case, (NEWS_MATERIAL_TYPE,)))
-
-
-def merge_news_evidence(current, additions):
-    """Union-merge `additions` into `current`, preserving existing order.
-
-    `bind_materials.merge_evidence` with one difference: an appended entry
-    carries its note instead of `""` (deviation 2). Everything else is that
-    function's contract, and it is the load-bearing half -- an existing entry is
-    never reordered, rewritten or dropped, because the server deletes every row
-    and recreates from exactly what is sent, so any omission destroys data. An
-    addition whose IRI is already present is skipped rather than allowed to
-    overwrite the note a human may have edited.
-    """
-    have = {e["material_iri"] for e in current}
-    merged = list(current)
-    for iri, note in additions:
-        if iri in have:
-            continue
-        merged.append({"material_iri": iri, "additional_details": note})
-        have.add(iri)
-    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +493,7 @@ def plan_case(case, etag, outcome, *, client=None, save_permalinks=True):
         materials.append((iri, doc, verdict.summary, article))
         additions.append((iri, verdict.summary))
 
-    merged = merge_news_evidence(current, additions)
+    merged = merge_evidence(current, additions)
     if merged == current:
         return NewsPlan(slug=slug, action="NOOP", state=state, if_match=etag,
                         n_current=len(current), outcome=outcome,

--- a/casework/news_search.py
+++ b/casework/news_search.py
@@ -282,9 +282,9 @@ class Verdict:
         All four conditions are load-bearing. `high` is the bar (see the module
         docstring). `event_type` must be a real lifecycle value because the
         per-event cap and the bind ordering both key on it. `summary` must be
-        SUBSTANTIAL because it IS the evidence note -- binding without one is the
-        blank-note behaviour in `bind_materials.merge_evidence` that this port
-        exists to avoid, and a one-line note is that behaviour with extra steps.
+        SUBSTANTIAL because it IS the evidence note -- an entry bound blank is
+        what this stage exists to avoid, and a one-line note is that with extra
+        steps.
 
         The length floor is not cosmetic. `salvage_json` repairs a reply truncated
         at `max_tokens` by closing the open string, so an overflowing verify call

--- a/tests/casework/test_bind_materials.py
+++ b/tests/casework/test_bind_materials.py
@@ -7,9 +7,10 @@ import urllib.error
 
 import pytest
 
+from casework.common.evidence import merge_evidence
 from casework.bind_materials import (
     BindPlan, _build_api, _ledger_status, apply_plan, candidates_from_row,
-    merge_evidence, missing_candidates, parse_source_ident, plan_case, run,
+    missing_candidates, parse_source_ident, plan_case, run,
 )
 
 HOST = "https://jawafdehi.org/material"
@@ -87,13 +88,13 @@ def test_candidates_from_row_strips_status_dedupes_and_orders():
 
 def test_merge_evidence_appends_new_preserving_order():
     current = [{"material_iri": PR, "additional_details": ""}]
-    merged = merge_evidence(current, [CO])
+    merged = merge_evidence(current, [(CO, "")])
     assert [e["material_iri"] for e in merged] == [PR, CO]
 
 
 def test_merge_evidence_is_idempotent_on_existing():
     current = [{"material_iri": PR, "additional_details": "note"}]
-    assert merge_evidence(current, [PR]) == current
+    assert merge_evidence(current, [(PR, "")]) == current
 
 
 # ---------------------------------------------------------------------------

--- a/tests/casework/test_bind_materials.py
+++ b/tests/casework/test_bind_materials.py
@@ -97,6 +97,15 @@ def test_merge_evidence_is_idempotent_on_existing():
     assert merge_evidence(current, [(PR, "")]) == current
 
 
+def test_merge_evidence_refuses_bare_iris():
+    """A bare IRI is the natural mistake, and a 2-char one would unpack into
+    iri="a", note="b" and bind garbage without complaint."""
+    with pytest.raises(TypeError, match="material_iri"):
+        merge_evidence([], [PR])
+    with pytest.raises(TypeError, match="material_iri"):
+        merge_evidence([], ["ab"])
+
+
 # ---------------------------------------------------------------------------
 # missing_candidates -- the shared "still needs binding" predicate the ledger
 # and binder both use, so they cannot drift on what "bound" means.

--- a/tests/casework/test_enrich_news_articles.py
+++ b/tests/casework/test_enrich_news_articles.py
@@ -34,6 +34,7 @@ from datetime import date
 
 import pytest
 
+from casework import bind_materials
 from casework import enrich_news_articles as en
 from casework import news_search as ns
 from tests.casework.fakes import FakeUsage
@@ -725,7 +726,7 @@ def test_the_merge_appends_and_never_disturbs_an_existing_entry():
                 "additional_details": "a human wrote this"},
                {"material_iri": "https://jawafdehi.org/material/court_order/2",
                 "additional_details": ""}]
-    merged = en.merge_news_evidence(
+    merged = en.merge_evidence(
         current, [("https://jawafdehi.org/material/news/20240101.aaaaaaaa", "नयाँ नोट")])
     assert merged[:2] == current
     assert merged[2] == {
@@ -736,12 +737,12 @@ def test_the_merge_appends_and_never_disturbs_an_existing_entry():
 def test_the_merge_never_overwrites_a_note_on_an_iri_already_present():
     iri = "https://jawafdehi.org/material/news/20240101.aaaaaaaa"
     current = [{"material_iri": iri, "additional_details": "a human edited this"}]
-    merged = en.merge_news_evidence(current, [(iri, "the model would say this")])
+    merged = en.merge_evidence(current, [(iri, "the model would say this")])
     assert merged == current
 
 
 def test_a_bound_entry_carries_its_note_rather_than_binding_blank():
-    """Deviation 2 -- `bind_materials.merge_evidence` appends `""`; not here."""
+    """The news stage passes a real note where the binder passes `""`."""
     pair = MATCHES[0]
     plan = _plan_for_pair(pair, dict(SLOPPY_MEDIUM, confidence="high"))
     appended = plan.patch_items[-1]
@@ -810,7 +811,7 @@ def test_the_write_sends_the_whole_merged_list_not_a_delta():
                                    "https://jawafdehi.org/material/news/20230101.aaaa")
     api = FakeApi(case_payload(evidence=[existing]))
     plan = _bindable_plan()
-    plan.patch_items = en.merge_news_evidence(
+    plan.patch_items = en.merge_evidence(
         en.current_evidence(api.case), [(plan.bound_iris[0], "नोट")])
     en.apply_plan(api, plan)
     items = api.replaced[0]["items"]
@@ -1747,12 +1748,15 @@ def test_an_aborted_run_exits_non_zero_but_still_ships_what_it_had(monkeypatch,
     assert "ABORTED at case 1/1" in out.err
 
 
-def test_bind_materials_records_the_reciprocal_duplicate_contract():
-    """Both stages PATCH the same destructive whole-list /evidence, so both
-    normalisers must stay identical. Only one side said so."""
-    src = pathlib.Path(en.__file__).parent.joinpath("bind_materials.py").read_text(encoding="utf-8")
-    assert src.count("DELIBERATELY DUPLICATED") == 2
-    assert "enrich_news_articles" in src
+def test_both_evidence_writers_share_one_normaliser():
+    """Two copies of a whole-list-replace normaliser can diverge and silently drop
+    evidence rows. Identity, not similarity, is what makes that impossible."""
+    from casework.common import evidence as shared
+
+    assert en.current_evidence is shared.current_evidence
+    assert en.merge_evidence is shared.merge_evidence
+    assert bind_materials.current_evidence is shared.current_evidence
+    assert bind_materials.merge_evidence is shared.merge_evidence
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### **User description**
Follow-up to @damo-da's review comment on #429:

> I don't like this. The script can import django modules but not the other way around.

`current_evidence` and `merge_evidence` existed twice — once in `bind_materials.py`,
once in `enrich_news_articles.py` — with a docstring justifying the copy because
"these are standalone scripts with no shared sequencing".

That reason does not hold, and the files disprove it themselves. A casework script
may import from shared and app modules; only the reverse is forbidden.
`enrich_news_articles` already imports `materials.jsonld`, a Django app module, and
both scripts already import half of `casework/common/`.

## What changed

Both helpers now live in `casework/common/evidence.py` and both writers import them.
Net −24 lines.

The copies were not identical: the binder appended `additional_details: ""`, the news
stage appended a real Nepali note. The shared `merge_evidence` takes
`(material_iri, note)` pairs, so the binder passes `""` at its own call site. The
difference is now one visible argument instead of a second function.

## Why it is worth doing

`PATCH /evidence` is a destructive whole-list replace — the body **is** the new list,
so a normaliser that drops a field drops evidence rows from a published case. The old
arrangement guarded that with a comment asking the next person to keep two copies in
sync.

The test that checked the comment existed is replaced by one that checks the thing
that matters:

```python
assert en.current_evidence is shared.current_evidence
assert bind_materials.merge_evidence is shared.merge_evidence
```

Identity, not similarity. Two copies can drift; the same function object cannot.

## Second commit: what code review caught

`casework/README.md` teaches the canonical `/evidence` write, and its snippet still
passed bare IRI strings — `ValueError: too many values to unpack` against the new
signature. The page whose job is to stop people destroying an evidence list handed
them code that does not run. Its import also still named `casework.bind_materials`,
which kept working as a re-export and would have gone on pointing readers at the old
home.

The quieter half is the worse one. A 2-character string unpacked into
`iri="a", note="b"` and bound silently. Real IRIs are long so it never fires by
accident, but a function guarding a destructive write should not have a shape of input
it accepts and corrupts. `merge_evidence` now rejects a bare string with a message
naming the fix.

## Verification

```bash
uv run pytest -q --ignore=integration-tests   # 4,619 passed, 5 skipped
uv run ruff check .                           # clean
uv run ty check                               # clean
```

## One thing to confirm

The shared code went into `casework/common/`, next to its only two callers and beside
the other shared casework helpers. Your comment mentions django modules, so if you
meant `jawafdehi_shared/` instead, that is a one-file move — say so and I will redo it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Share `/evidence` merge helpers

- Preserve note differences via arguments

- Reject bare IRI additions

- Update tests, README recipe


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bind_materials"] -- "imports" --> B["common.evidence"]
  C["enrich_news_articles"] -- "imports" --> B
  B -- "normalizes" --> D["PATCH /evidence payload"]
  E["tests"] -- "assert identity" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>bind_materials.py</strong><dd><code>Import shared evidence helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-b1f31c7ffcaa826affeaf82726dd7b71879345983cbf16f1aba9941410a98f44">+3/-39</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>evidence.py</strong><dd><code>Add shared evidence utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-bc471398c1a670971260f41976b3c84f105290799a8aa044e03462bd222cd951">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich_news_articles.py</strong><dd><code>Reuse shared evidence merging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-8eceb19cb4dcccf0c6e5d367d1206c28358d771b897ef16c8a39a97d5da85dfa">+5/-43</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>news_search.py</strong><dd><code>Clarify blank note rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-1e287824bef9ebf2a7a3bacc9640360ea14fb1ba5616c1d49a7c83ace77203d0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update evidence merge recipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-0772aa74e880257e4e1fdb43ef6fc2e83edb8cb8e019d875fc568166524214a9">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_bind_materials.py</strong><dd><code>Cover pair-based evidence merge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-3b8c104b9aaa426245fcb1376cdf2a2b07d2d77e703e3f7bdd9bde8559cc9841">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_enrich_news_articles.py</strong><dd><code>Assert shared helper identity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/440/files#diff-21ee199888384089354b1522f05813dc9d2bc9785c03e7e2a0c214d9b7ab8708">+14/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Evidence records now preserve existing notes and ordering when new materials are added.
  - Duplicate materials are skipped automatically.
  - Missing evidence notes are handled consistently with an empty note.
  - Invalid evidence entries now produce clearer validation errors.

- **Documentation**
  - Updated evidence-writing guidance and evidence summary requirements for greater clarity.

- **Tests**
  - Expanded coverage for evidence merging, duplicate handling, note preservation, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->