### PR TITLE
fix(casework): let an operator raise the description output-token cap

### DIFF
--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -136,6 +136,9 @@ def _max_tokens_from_env() -> int:
     chars needs more and the CLI hard-errors rather than truncating (078-CR-0038,
     078-CR-0073). Validated rather than trusted because a bad value is expensive:
     one extra zero and every request fails after ~10 minutes of model time.
+
+    Called from `main`, never at import -- doing it at module scope turned a typo
+    into a pytest INTERNALERROR and made `--help` fail.
     """
     raw = (os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS") or "").strip()
     if not raw:
@@ -154,7 +157,7 @@ def _max_tokens_from_env() -> int:
     return value
 
 
-DESCRIPTION_MAX_TOKENS = _max_tokens_from_env()
+DESCRIPTION_MAX_TOKENS = DONOR_MAX_TOKENS
 
 EXTRACTION_SYSTEM_PROMPT = """\
 You are a Nepali legal analyst writing the public case summary (description) for \
@@ -411,7 +414,8 @@ def _assemble_source_text(chunks, invoke_text, usage):
     return "\n\n---\n\n".join(parts), fed
 
 
-def _generate_description(detail, court_number, source_text, invoke_text, usage):
+def _generate_description(detail, court_number, source_text, invoke_text, usage,
+                          max_tokens=DESCRIPTION_MAX_TOKENS):
     """One premium-tier call. Returns `(description, documents)`.
 
     `documents` is raw model output, unvalidated on purpose --
@@ -438,7 +442,7 @@ def _generate_description(detail, court_number, source_text, invoke_text, usage)
     response_text = invoke_text(
         system=EXTRACTION_SYSTEM_PROMPT,
         content=prompt,
-        max_tokens=DESCRIPTION_MAX_TOKENS,
+        max_tokens=max_tokens,
         tier=tier_for("description"),
         usage=usage,
     )
@@ -537,6 +541,9 @@ def main(argv=None):
     )
     add_common_args(ap)
     args = ap.parse_args(argv)
+    # After parse_args so `--help` still works, before any API or LLM call so a
+    # typo costs nothing.
+    max_tokens = _max_tokens_from_env()
 
     setup_logging(args.verbose)
     logger, run_id, paths = configure_run_logging("description", verbose=args.verbose)
@@ -713,6 +720,7 @@ def main(argv=None):
                 source_text=source_block,
                 invoke_text=invoke_text,
                 usage=usage,
+                max_tokens=max_tokens,
             )
         except Exception as exc:  # noqa: BLE001 - an LLM failure is recorded per-case and the run continues
             report.record(slug, "description", "error", f"LLM generation failed: {exc}")

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -58,6 +58,7 @@ Usage:
 import argparse
 import json
 import logging
+import os
 import sys
 import time
 
@@ -123,7 +124,10 @@ DESCRIPTION_SOURCE_ORDER = ("charge_sheet", "ciaa_press_release", "press_release
 # enricher (see `enrich_allegations.py`'s identical note). Fixed at the
 # donor's own default.
 SOURCE_TEXT_BUDGET = 60000
-DESCRIPTION_MAX_TOKENS = 8000
+# Default holds the donor's 8000, but a case whose verdict summarises to ~16k chars
+# needs more and the CLI hard-errors rather than truncating (078-CR-0038,
+# 078-CR-0073). Raise per run; the model's own per-call ceiling is 64000.
+DESCRIPTION_MAX_TOKENS = int(os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS", "8000"))
 
 EXTRACTION_SYSTEM_PROMPT = """\
 You are a Nepali legal analyst writing the public case summary (description) for \

--- a/casework/enrich_description.py
+++ b/casework/enrich_description.py
@@ -124,10 +124,37 @@ DESCRIPTION_SOURCE_ORDER = ("charge_sheet", "ciaa_press_release", "press_release
 # enricher (see `enrich_allegations.py`'s identical note). Fixed at the
 # donor's own default.
 SOURCE_TEXT_BUDGET = 60000
-# Default holds the donor's 8000, but a case whose verdict summarises to ~16k chars
-# needs more and the CLI hard-errors rather than truncating (078-CR-0038,
-# 078-CR-0073). Raise per run; the model's own per-call ceiling is 64000.
-DESCRIPTION_MAX_TOKENS = int(os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS", "8000"))
+DONOR_MAX_TOKENS = 8000
+# `maxOutputTokens` for this model, as the CLI reports it in its result JSON.
+MODEL_MAX_OUTPUT_TOKENS = 64000
+
+
+def _max_tokens_from_env() -> int:
+    """Description output cap, from `CASEWORK_DESCRIPTION_MAX_TOKENS`.
+
+    The donor's 8000 is the default, but a case whose verdict summarises to ~16k
+    chars needs more and the CLI hard-errors rather than truncating (078-CR-0038,
+    078-CR-0073). Validated rather than trusted because a bad value is expensive:
+    one extra zero and every request fails after ~10 minutes of model time.
+    """
+    raw = (os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS") or "").strip()
+    if not raw:
+        return DONOR_MAX_TOKENS
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(
+            f"CASEWORK_DESCRIPTION_MAX_TOKENS must be a whole number, got {raw!r}"
+        ) from None
+    if not 1 <= value <= MODEL_MAX_OUTPUT_TOKENS:
+        raise SystemExit(
+            "CASEWORK_DESCRIPTION_MAX_TOKENS must be between 1 and "
+            f"{MODEL_MAX_OUTPUT_TOKENS:,}, got {value:,}"
+        )
+    return value
+
+
+DESCRIPTION_MAX_TOKENS = _max_tokens_from_env()
 
 EXTRACTION_SYSTEM_PROMPT = """\
 You are a Nepali legal analyst writing the public case summary (description) for \

--- a/tests/casework/conftest.py
+++ b/tests/casework/conftest.py
@@ -20,6 +20,17 @@ def _isolate_casework_run_logs(monkeypatch, tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_description_max_tokens(monkeypatch):
+    """Keep a stale `CASEWORK_DESCRIPTION_MAX_TOKENS` export out of the suite.
+
+    `enrich_description.main()` validates it and exits, so a shell holding a bad
+    value for a real run would fail every test that drives `main()`.
+    `TestMaxTokensConfig` sets it per test and still wins -- fixtures run first.
+    """
+    monkeypatch.delenv("CASEWORK_DESCRIPTION_MAX_TOKENS", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_review_files(monkeypatch, tmp_path):
     """Enricher `main()`s write a human review file on EVERY run, dry runs
     included (`casework/common/review.py`), defaulting to

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -247,14 +247,60 @@ class TestDonorDeviations:
         assert ">= 600" in donor_source
         assert ed.SUBSTANTIAL_DESCRIPTION_CHARS == 600
 
-    def test_max_tokens_defaults_to_the_donor_but_is_raisable(self, donor_source):
-        # The default must stay at donor parity. The env escape exists because the
-        # CLI hard-errors rather than truncating when a description wants more --
-        # 078-CR-0038 and 078-CR-0073 both died there on a ~16k-char verdict summary.
+    def test_max_tokens_defaults_to_the_donor(self, donor_source):
+        # The shipped default must stay at parity so the 23 descriptions already
+        # written from it keep reproducing. The env escape is covered by
+        # TestMaxTokensConfig.
         assert "max_tokens=8000" in donor_source
         assert ed.DESCRIPTION_MAX_TOKENS == 8000
-        assert ('os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS", "8000")'
-                in _shipped_source())
+        assert ed.DONOR_MAX_TOKENS == 8000
+
+
+class TestMaxTokensConfig:
+    """`CASEWORK_DESCRIPTION_MAX_TOKENS` is an operator knob, so it validates.
+
+    The typo that matters is one extra zero: `160000` would reach the model and
+    fail every description request after ~10 minutes of work per case.
+    """
+
+    VAR = "CASEWORK_DESCRIPTION_MAX_TOKENS"
+
+    def test_an_unset_variable_gives_the_donor_default(self, monkeypatch):
+        monkeypatch.delenv(self.VAR, raising=False)
+        assert ed._max_tokens_from_env() == ed.DONOR_MAX_TOKENS
+
+    @pytest.mark.parametrize("raw", ["", "   "])
+    def test_a_blank_variable_is_treated_as_unset(self, monkeypatch, raw):
+        monkeypatch.setenv(self.VAR, raw)
+        assert ed._max_tokens_from_env() == ed.DONOR_MAX_TOKENS
+
+    @pytest.mark.parametrize("raw,expected",
+                             [("12000", 12000), ("1", 1), ("64000", 64000),
+                              (" 16000 ", 16000)])
+    def test_a_usable_value_is_taken_including_both_boundaries(
+            self, monkeypatch, raw, expected):
+        monkeypatch.setenv(self.VAR, raw)
+        assert ed._max_tokens_from_env() == expected
+
+    @pytest.mark.parametrize("raw", ["0", "-1", "64001", "160000"])
+    def test_a_value_the_model_would_refuse_is_rejected(self, monkeypatch, raw):
+        monkeypatch.setenv(self.VAR, raw)
+        with pytest.raises(SystemExit) as exc:
+            ed._max_tokens_from_env()
+        assert self.VAR in str(exc.value)
+
+    @pytest.mark.parametrize("raw", ["16k", "16.5", "abc", "1e4"])
+    def test_a_non_integer_exits_cleanly_instead_of_raising_valueerror(
+            self, monkeypatch, raw):
+        # SystemExit, not ValueError: an operator typo should print a message, not a
+        # traceback. Matches `casework.common.select`'s handling of bad --batch-csv.
+        monkeypatch.setenv(self.VAR, raw)
+        with pytest.raises(SystemExit) as exc:
+            ed._max_tokens_from_env()
+        assert self.VAR in str(exc.value) and raw in str(exc.value)
+
+    def test_the_ceiling_is_the_one_the_cli_reports(self):
+        assert ed.MODEL_MAX_OUTPUT_TOKENS == 64000
 
 
 def _imported_modules(source):

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -302,6 +302,23 @@ class TestMaxTokensConfig:
     def test_the_ceiling_is_the_one_the_cli_reports(self):
         assert ed.MODEL_MAX_OUTPUT_TOKENS == 64000
 
+    def test_the_env_is_never_read_at_import_time(self):
+        # Regression: resolving this at module scope made a typo take out anything
+        # that merely IMPORTS the module -- pytest reported INTERNALERROR and
+        # `--help` printed the config error instead of help. `main` resolves it.
+        # Only top-level statements that are not defs -- walking a FunctionDef
+        # descends into it and would flag the legitimate call inside `main`.
+        module_scope = [
+            call for node in ast.parse(_shipped_source()).body
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef,
+                                     ast.ClassDef))
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and getattr(call.func, "id", "") == "_max_tokens_from_env"
+        ]
+        assert not module_scope, (
+            "_max_tokens_from_env() must not be called at module scope")
+
 
 def _imported_modules(source):
     """Every module name imported by `source`, for the "must not import" pin."""
@@ -697,6 +714,23 @@ def test_generate_uses_premium_tier_and_8000_max_tokens():
     assert seen["system"] == ed.EXTRACTION_SYSTEM_PROMPT
     # No tool loop -- deviation 2. `tools=` would make the call uncacheable.
     assert "tools" not in seen
+
+
+def test_generate_honours_a_raised_max_tokens():
+    """`main` resolves the env override and threads it through, so the cap has to
+    actually reach `invoke_text` -- not just sit in a module constant."""
+    seen = {}
+
+    def stub(**kw):
+        seen.update(kw)
+        return json.dumps({"description": "विवरण।"})
+
+    _generate_description(
+        detail=DETAIL_FOR_PROMPT, court_number="081-cr-0091",
+        source_text="स्रोत पाठ", invoke_text=stub, usage=None,
+        max_tokens=16000,
+    )
+    assert seen["max_tokens"] == 16000
 
 
 def test_generate_prompt_carries_every_context_block():

--- a/tests/casework/test_enrich_description.py
+++ b/tests/casework/test_enrich_description.py
@@ -247,9 +247,14 @@ class TestDonorDeviations:
         assert ">= 600" in donor_source
         assert ed.SUBSTANTIAL_DESCRIPTION_CHARS == 600
 
-    def test_max_tokens_matches_the_donor(self, donor_source):
+    def test_max_tokens_defaults_to_the_donor_but_is_raisable(self, donor_source):
+        # The default must stay at donor parity. The env escape exists because the
+        # CLI hard-errors rather than truncating when a description wants more --
+        # 078-CR-0038 and 078-CR-0073 both died there on a ~16k-char verdict summary.
         assert "max_tokens=8000" in donor_source
         assert ed.DESCRIPTION_MAX_TOKENS == 8000
+        assert ('os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS", "8000")'
+                in _shipped_source())
 
 
 def _imported_modules(source):


### PR DESCRIPTION
### **User description**
## Why

Two cases in the `bigo-1cr-25` batch could not be enriched at all. `DESCRIPTION_MAX_TOKENS`
was pinned at the donor's `8000`, and both cases need more:

| Case | court_order | Verdict summary | Result |
|---|---|---|---|
| `078-CR-0038` | 409,503 chars | 16,605 chars (3 passes) | failed |
| `078-CR-0073` | 356,775 chars, 27 co-defendants | ~16k chars | failed |

A verdict longer than `VERDICT_SUMMARY_CHUNK_CHARS` (150,000) is summarised one pass per
chunk and the summaries concatenated — deliberately, so the ठहर at the end of a फैसला
survives. A 400k-char judgment therefore yields ~16k chars of summary where a single-pass
one yields ~8k. The description the model writes from that scales with it and goes past
8000 output tokens.

The CLI **hard-errors** rather than truncating:

```
API Error: Claude's response exceeded the 8000 output token maximum.
To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.
```

That string is not in `cli.py`'s retryable set, so the case fails outright. A 300s timeout
had been masking this; raising `REVIEW_CLI_TIMEOUT` to 900 let the call run its full 590s
and only then hit the real wall.

Exporting `CLAUDE_CODE_MAX_OUTPUT_TOKENS` does **not** help — `cli.py::_claude_env`
overwrites it with whatever `max_tokens` the caller passed.

## What changed

```python
DESCRIPTION_MAX_TOKENS = int(os.getenv("CASEWORK_DESCRIPTION_MAX_TOKENS", "8000"))
```

The default stays at donor parity on purpose: the 23 descriptions already written in this
batch keep reproducing unchanged. An operator raises it per run for the outliers.

`maxOutputTokens` in the CLI's own result JSON is `64000` for this model, so a run at 16000
sits comfortably inside the ceiling. Input was never the constraint — 19,600 chars of source
against a 1M-token context window.

## Testing

- `tests/casework/` — 176 pass across `test_enrich_description.py` + `test_missing_details.py`
- `ruff check` clean; pre-commit (`ruff`, `ty`) passed
- Override verified live: unset → `8000`, `CASEWORK_DESCRIPTION_MAX_TOKENS=16000` → `16000`

`test_max_tokens_matches_the_donor` becomes
`test_max_tokens_defaults_to_the_donor_but_is_raisable` — it still pins the default to the
donor's value and now also pins the env escape, so a future edit can't quietly remove it.

## Not fixed here

The prompt carries **no output-length instruction at all**. The 23 successful descriptions
landed in a 5,609–9,694 char band because of input size, not because we asked for a length.
Giving the model an explicit target would change output for every case, so it does not
belong in a patch whose point is to keep the written 23 reproducible. Worth its own change
before the next batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Description token cap configurable

- Donor default preserved

- Regression test updated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["CASEWORK_DESCRIPTION_MAX_TOKENS"] -- "overrides" --> cap["DESCRIPTION_MAX_TOKENS"]
  cap -- "passed to" --> cli["description enrichment CLI"]
  test["regression test"] -- "pins" --> cap
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enrich_description.py</strong><dd><code>Configurable description output token limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/enrich_description.py

<ul><li>Imports <code>os</code><br> <li> Reads <code>CASEWORK_DESCRIPTION_MAX_TOKENS</code><br> <li> Keeps default <code>8000</code><br> <li> Documents hard-error outliers</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/443/files#diff-5ae987953d8c0a7283b3d17be907f84a93dc39867ed0658f68300fb2d721f2e4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_enrich_description.py</strong><dd><code>Token cap override regression coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/casework/test_enrich_description.py

<ul><li>Renames token-limit parity test<br> <li> Verifies donor default remains <code>8000</code><br> <li> Asserts env override source exists</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/443/files#diff-6f603901804e5d04baea2759d4569cbd4ed32ef6fc630b70b8bfac080631c839">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for adjusting the maximum description length through an environment variable.
  * Retains the default maximum of 8,000 tokens when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->