### PR TITLE
feat(casework): bulk-submit a batch into the review queue

### DIFF
--- a/casework/README.md
+++ b/casework/README.md
@@ -135,6 +135,7 @@ flowchart LR
 | entities | `enrich_related_entities` | `entities` (+ NES entities with `--create-entities`) | `patch_field`, `POST /api/entities` | yes ¹ | premium |
 | court_record | `enrich_court_record` | `case_start_date`, `case_end_date`, `entities` (accused) (+ NES person entities) | `patch_case`, `POST /api/entities` | yes ¹ | — (no LLM) |
 | ledger | `ledger` | ledger JSON (local file) | none (reads run logs) | local file | — |
+| submit reviews | `submit_reviews` | review queue (no case field) | `POST /api/casework/reviews/submit/` | yes ¹ | — |
 
 ¹ Remote write requires **`--apply` + `--allow-remote-writes` + `--api-token`** together.
 
@@ -477,6 +478,36 @@ uv run python -m casework.ledger
 uv run python -m casework.ledger --stage bigo --stage tags --status ok
 uv run python -m casework.ledger --no-write        # print only, don't write ledger file
 ```
+
+### 5. Submit a batch for review — `submit_reviews`
+
+Enqueues one LLM grading run per case. A case that already carries a review of any
+status is skipped, so a re-run after a crash resumes rather than re-grading.
+
+```bash
+# DRY-RUN: prints the exact POST body per case
+uv run python -m casework.submit_reviews --batch-csv batch.csv --dry-run
+
+# APPLY (remote / production)
+uv run python -m casework.submit_reviews --batch-csv batch.csv \
+    --api-base-url https://api.jawafdehi.org --api-token "$JAWAFDEHI_API_TOKEN" \
+    --apply --allow-remote-writes
+
+# Read the grades back, any time after. Read-only.
+uv run python -m casework.submit_reviews --batch-csv batch.csv --report
+```
+
+Submitting is instant and tells you nothing — every case comes back `pending`. Grading
+happens out of process on the jobs queue and takes hours, so `--report` is a separate
+run you make later. It writes `work/reviews/<ts>-submit_reviews-<run>.md`.
+
+`--batch-csv` or `--slug` is required. A bare run is refused rather than submitting
+every case in the corpus for grading. There is no state gate and no enrichment gate:
+the batch is the authority, and a PUBLISHED case is a legitimate review target.
+
+Two failures abort the run instead of being counted per case — an HTTP 403 (the token
+lacks the Caseworker role) and the write-guard refusal (a remote host without
+`--allow-remote-writes`). Both fail identically on every remaining case.
 
 ---
 

--- a/casework/README.md
+++ b/casework/README.md
@@ -505,9 +505,16 @@ run you make later. It writes `work/reviews/<ts>-submit_reviews-<run>.md`.
 every case in the corpus for grading. There is no state gate and no enrichment gate:
 the batch is the authority, and a PUBLISHED case is a legitimate review target.
 
-Two failures abort the run instead of being counted per case — an HTTP 403 (the token
-lacks the Caseworker role) and the write-guard refusal (a remote host without
-`--allow-remote-writes`). Both fail identically on every remaining case.
+Two failures abort the run instead of being counted per case: a credential rejection
+(**401** an expired or invalid token, **403** a valid token without the Caseworker
+role) and the write-guard refusal (a remote host without `--allow-remote-writes`). All
+three fail identically on every remaining case, so counting them would bury one
+configuration mistake under several hundred warnings and still exit 0.
+
+Everything else is per-case. A read or POST that fails on one slug costs that slug and
+the batch continues; in `--report` it becomes an `unreadable` row rather than losing the
+whole file. Recover a failed subset with `--slug <a> --slug <b> --force` — re-running
+the whole batch with `--force` re-grades every passing case too.
 
 ---
 

--- a/casework/README.md
+++ b/casework/README.md
@@ -507,14 +507,20 @@ the batch is the authority, and a PUBLISHED case is a legitimate review target.
 
 Two failures abort the run instead of being counted per case: a credential rejection
 (**401** an expired or invalid token, **403** a valid token without the Caseworker
-role) and the write-guard refusal (a remote host without `--allow-remote-writes`). All
-three fail identically on every remaining case, so counting them would bury one
-configuration mistake under several hundred warnings and still exit 0.
+role) and the write-guard refusal (a remote host without `--allow-remote-writes`). Both
+fail identically on every remaining case, so counting them would bury one configuration
+mistake under several hundred warnings.
 
 Everything else is per-case. A read or POST that fails on one slug costs that slug and
 the batch continues; in `--report` it becomes an `unreadable` row rather than losing the
 whole file. Recover a failed subset with `--slug <a> --slug <b> --force` — re-running
 the whole batch with `--force` re-grades every passing case too.
+
+**Exit code, and how it differs from the other stages.** `submit_reviews` returns **1**
+when any case failed, 0 otherwise. Every other stage in this package always returns 0.
+The divergence is deliberate: this one is meant to be chained after the enrichers in a
+script, and a batch where every POST 500'd is otherwise indistinguishable from a clean
+run. Skips and dry-run `would_submit` counts are not errors.
 
 ---
 

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -323,9 +323,8 @@ class CaseworkApi:
         """
         url = self.base_url + "/casework/reviews/submit/"
         body = json.dumps({"slug": slug}).encode("utf-8")
-        headers = dict(self._headers())
-        headers["Content-Type"] = "application/json"
-        with self._request("POST", url, data=body, headers=headers,
+        with self._request("POST", url, data=body,
+                           headers=self._headers("application/json"),
                            timeout=timeout) as r:
             return json.loads(r.read().decode())
 

--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -297,6 +297,38 @@ class CaseworkApi:
                     f"{exc.read().decode(errors='replace')}") from exc
             raise
 
+    def reviews_for_slug(self, slug, timeout=60):
+        """Every review run for `slug`, newest first; `[]` when never reviewed.
+
+        Page one answers "has this case been reviewed": the list view orders by
+        `-created_at` (`CaseReview.Meta.ordering`), so the newest run is row zero.
+        Both the paginated envelope and a bare list are handled -- pagination is a
+        project-wide DRF setting, not a promise this view makes.
+        """
+        payload = self.get("/casework/reviews/", params={"slug": slug}, timeout=timeout)
+        if isinstance(payload, dict):
+            return list(payload.get("results") or ())
+        return list(payload or ())
+
+    def review_detail(self, review_id, timeout=60):
+        """One review, including `error` -- which the list serializer omits."""
+        return self.get(f"/casework/reviews/{int(review_id)}/", timeout=timeout)
+
+    def submit_review(self, slug, timeout=60):
+        """POST one case into the review queue. Returns the created review row.
+
+        Goes through `_request` rather than a bespoke opener, which is what puts it
+        under the host write-guard: a non-loopback POST is refused unless
+        `allow_remote_writes` is set.
+        """
+        url = self.base_url + "/casework/reviews/submit/"
+        body = json.dumps({"slug": slug}).encode("utf-8")
+        headers = dict(self._headers())
+        headers["Content-Type"] = "application/json"
+        with self._request("POST", url, data=body, headers=headers,
+                           timeout=timeout) as r:
+            return json.loads(r.read().decode())
+
     # The list endpoint's server-side default is 20 per page, so walking all
     # 3,003 cases costs 151 round trips -- ~2m45s against production, paid by
     # every enricher run before it processes a single case. The API caps

--- a/casework/submit_reviews.py
+++ b/casework/submit_reviews.py
@@ -72,9 +72,12 @@ def _describe(review):
 def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
     """POST each slug that has no review yet. Returns a status->count mapping.
 
-    A 403 aborts the run: the role check fails identically on every remaining case,
-    so one clear error beats several hundred. Any other HTTP failure is recorded and
-    the batch continues -- a re-run skips whatever already landed.
+    Two failures abort the whole run instead of being counted: a 403 (the role check
+    fails identically on every remaining case) and the write-guard's `RuntimeError`
+    (so does a non-loopback base URL without `--allow-remote-writes`). Counting either
+    per-case would turn one configuration mistake into several hundred logged errors
+    and a zero exit code. Any other HTTP failure is recorded and the batch continues --
+    a re-run skips whatever already landed.
     """
     stats = {"selected": len(slugs), "submitted": 0, "would_submit": 0,
              "already_reviewed": 0, "error": 0}
@@ -108,6 +111,10 @@ def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
             stats["error"] += 1
             event(slug, "error", f"HTTP {exc.code}", level=logging.WARNING)
             continue
+        except RuntimeError:
+            # The write-guard, raised before any socket opens. Not a per-case
+            # failure: every remaining slug would raise it too.
+            raise
         except Exception as exc:  # noqa: BLE001 - network, decode, anything else
             stats["error"] += 1
             event(slug, "error", f"{type(exc).__name__}: {exc}", level=logging.WARNING)

--- a/casework/submit_reviews.py
+++ b/casework/submit_reviews.py
@@ -13,6 +13,7 @@ either.
 import argparse
 import json
 import logging
+import os
 import sys
 import time
 import urllib.error
@@ -27,6 +28,7 @@ from casework.common.cli import (
     log_run_footer,
     log_run_header,
 )
+from casework.common.review import review_path
 from casework.common.select import slugs_from_batch_csv
 
 STAGE = "submit_reviews"
@@ -118,6 +120,113 @@ def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
     return stats
 
 
+def report_rows(api, slugs):
+    """One row per batch slug: what the review queue did with it.
+
+    Everything but `error` comes off the list row. `error` lives only on the detail
+    serializer, so it is fetched for failed rows and nothing else.
+    """
+    rows = []
+    for slug in slugs:
+        review = existing_review(api, slug)
+        if review is None:
+            rows.append({"slug": slug, "review_id": None, "status": "never-submitted",
+                         "score": None, "disposition": None, "duration": None,
+                         "title": "", "error": ""})
+            continue
+        error = ""
+        if review.get("status") == "failed":
+            detail = api.review_detail(review["id"]) or {}
+            first_line = (detail.get("error") or "").strip().splitlines()
+            error = first_line[0] if first_line else ""
+        rows.append({
+            "slug": slug,
+            "review_id": review.get("id"),
+            "status": review.get("status") or "?",
+            "score": review.get("overall_score"),
+            "disposition": review.get("disposition"),
+            "duration": review.get("duration_seconds"),
+            "title": review.get("case_title") or "",
+            "error": error,
+        })
+    return rows
+
+
+def summarize(rows):
+    """Status counts, disposition counts, score spread, and the never-submitted."""
+    statuses, dispositions, scores, never = {}, {}, [], []
+    for row in rows:
+        statuses[row["status"]] = statuses.get(row["status"], 0) + 1
+        if row["status"] == "never-submitted":
+            never.append(row["slug"])
+        if row.get("disposition"):
+            dispositions[row["disposition"]] = dispositions.get(row["disposition"], 0) + 1
+        if isinstance(row.get("score"), (int, float)):
+            scores.append(row["score"])
+    return {
+        "statuses": statuses,
+        "dispositions": dispositions,
+        "scored": len(scores),
+        "avg": round(sum(scores) / len(scores), 1) if scores else None,
+        "min": min(scores) if scores else None,
+        "max": max(scores) if scores else None,
+        "never_submitted": never,
+    }
+
+
+def _counts_table(title, counts):
+    lines = [f"| {title} | Cases |", "|---|---|"]
+    lines += [f"| {k} | {v} |" for k, v in sorted(counts.items())]
+    return lines + [""]
+
+
+def render_report(rows, summary, *, base_url, run_id, batch):
+    """The markdown the report run writes. Read top-down: totals, then cases."""
+    lines = [
+        f"# Review batch report — `{batch}`",
+        "",
+        f"- Target: `{base_url}`",
+        f"- Run id: `{run_id}`",
+        f"- Cases in batch: {len(rows)}",
+        "",
+        "## Summary",
+        "",
+    ]
+    lines += _counts_table("Status", summary["statuses"])
+    lines += _counts_table("Disposition", summary["dispositions"])
+    if summary["avg"] is not None:
+        lines += [f"Score: avg **{summary['avg']}**, min {summary['min']}, "
+                  f"max {summary['max']} (over {summary['scored']} graded).", ""]
+
+    lines += ["## Cases", "",
+              "| # | Slug | Review | Status | Score | Disposition | Seconds |",
+              "|---|---|---|---|---|---|---|"]
+    for i, row in enumerate(rows, 1):
+        duration = (f"{row['duration']:.0f}"
+                    if isinstance(row.get("duration"), (int, float)) else "—")
+        lines.append(
+            f"| {i} | `{row['slug']}` | {row['review_id'] or '—'} | {row['status']} "
+            f"| {row['score'] if row['score'] is not None else '—'} "
+            f"| {row['disposition'] or '—'} | {duration} |")
+    lines.append("")
+
+    failed = [r for r in rows if r["status"] == "failed"]
+    if failed:
+        lines += ["## Failed", ""]
+        lines += [f"- `{r['slug']}` — review {r['review_id']} — "
+                  f"{r['error'] or '(no error recorded)'}" for r in failed]
+        lines.append("")
+
+    if summary["never_submitted"]:
+        lines += ["## Never submitted", "",
+                  "These batch slugs carry no review at all. Re-run without "
+                  "`--report` to submit them.", ""]
+        lines += [f"- `{slug}`" for slug in summary["never_submitted"]]
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def build_parser():
     p = argparse.ArgumentParser(
         description="Submit a batch of cases to the casework review queue, or report "
@@ -156,6 +265,26 @@ def main(argv=None):
                    run_id=run_id, paths=paths)
 
     started = time.monotonic()
+    if args.report:
+        rows = report_rows(api, slugs)
+        summary = summarize(rows)
+        path = review_path(STAGE, run_id, args.review_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            render_report(rows, summary, base_url=api.base_url, run_id=run_id,
+                          batch=os.path.basename(args.batch_csv or "(--slug)")),
+            encoding="utf-8")
+        log_run_footer(logger, stage=STAGE, stats=summary["statuses"],
+                       duration_s=time.monotonic() - started)
+        print("\n=== review batch report (READ-ONLY) ===")
+        print(f"  {len(rows)} cases — {format_counts(summary['statuses'])}")
+        if summary["dispositions"]:
+            print(f"  {format_counts(summary['dispositions'])}   "
+                  f"score avg {summary['avg']} "
+                  f"(min {summary['min']}, max {summary['max']})")
+        print(f"  Wrote {path}")
+        return 0
+
     stats = submit_batch(api, slugs, dry_run=args.dry_run, force=args.force,
                          logger=logger, events_path=paths["events"], run_id=run_id)
     log_run_footer(logger, stage=STAGE, stats=stats,

--- a/casework/submit_reviews.py
+++ b/casework/submit_reviews.py
@@ -1,0 +1,169 @@
+"""Submit a batch of cases into the casework review queue, and read the grades back.
+
+Two modes. The default POSTs each slug to `/api/casework/reviews/submit/`; `--report`
+reads back what the grading produced and writes nothing. They are one module because
+they share the batch selection and the review-row shape.
+
+The script reads no case. A slug is all the POST needs, and the review list row already
+carries the title, state, score and disposition the report shows -- so a 238-case batch
+costs 2 requests per case to submit and 1 to report, with no corpus listing in front of
+either.
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+import urllib.error
+
+from casework.common.api import CaseworkApi
+from casework.common.cli import (
+    add_common_args,
+    basic_auth_from_env,
+    configure_run_logging,
+    format_counts,
+    log_event,
+    log_run_footer,
+    log_run_header,
+)
+from casework.common.select import slugs_from_batch_csv
+
+STAGE = "submit_reviews"
+
+
+def slugs_for_run(args):
+    """The slugs to work on, in batch order, capped by `--limit`.
+
+    A run with neither `--batch-csv` nor `--slug` is refused rather than falling
+    through to the whole corpus: that fallback would enqueue ~3,000 LLM grading runs
+    off a forgotten flag. There is no state gate -- a PUBLISHED case is a legitimate
+    review target, unlike an enrichment target.
+    """
+    slugs = []
+    if args.batch_csv:
+        slugs.extend(slugs_from_batch_csv(args.batch_csv))
+    slugs.extend(s for s in args.slug if s not in slugs)
+    if not slugs:
+        raise SystemExit(
+            "nothing selected: pass --batch-csv or --slug. A bare run is refused "
+            "rather than submitting every case in the corpus for LLM grading.")
+    return slugs[: args.limit] if args.limit else slugs
+
+
+def existing_review(api, slug):
+    """The newest review for `slug`, or None when the case has never been reviewed."""
+    rows = api.reviews_for_slug(slug)
+    return rows[0] if rows else None
+
+
+def _describe(review):
+    """`"review 1841 done PASS 84"` -- what a skip line says about the run it found."""
+    bits = [f"review {review.get('id')}", str(review.get("status") or "?")]
+    if review.get("disposition"):
+        bits.append(str(review["disposition"]))
+    if review.get("overall_score") is not None:
+        bits.append(str(review["overall_score"]))
+    return " ".join(bits)
+
+
+def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
+    """POST each slug that has no review yet. Returns a status->count mapping.
+
+    A 403 aborts the run: the role check fails identically on every remaining case,
+    so one clear error beats several hundred. Any other HTTP failure is recorded and
+    the batch continues -- a re-run skips whatever already landed.
+    """
+    stats = {"selected": len(slugs), "submitted": 0, "would_submit": 0,
+             "already_reviewed": 0, "error": 0}
+
+    def event(slug, status, detail="", level=logging.INFO):
+        log_event(logger, events_path, run_id=run_id, stage=STAGE, slug=slug,
+                  step="submit", status=status, detail=detail, level=level)
+
+    for slug in slugs:
+        if not force:
+            found = existing_review(api, slug)
+            if found is not None:
+                stats["already_reviewed"] += 1
+                event(slug, "already-reviewed", _describe(found))
+                continue
+
+        if dry_run:
+            stats["would_submit"] += 1
+            event(slug, "would-submit", json.dumps({"slug": slug}, ensure_ascii=False))
+            continue
+
+        started = time.monotonic()
+        try:
+            review = api.submit_review(slug)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 403:
+                raise SystemExit(
+                    f"HTTP 403 submitting {slug}: this token lacks the Caseworker "
+                    "role, which every remaining case would fail on too. Nothing "
+                    f"further was submitted ({stats['submitted']} landed).") from exc
+            stats["error"] += 1
+            event(slug, "error", f"HTTP {exc.code}", level=logging.WARNING)
+            continue
+        except Exception as exc:  # noqa: BLE001 - network, decode, anything else
+            stats["error"] += 1
+            event(slug, "error", f"{type(exc).__name__}: {exc}", level=logging.WARNING)
+            continue
+
+        stats["submitted"] += 1
+        event(slug, "submitted", f"review {review.get('id')}")
+        logger.debug("submitted %s in %dms", slug,
+                     int((time.monotonic() - started) * 1000))
+    return stats
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        description="Submit a batch of cases to the casework review queue, or report "
+                    "the grades a submitted batch came back with.")
+    add_common_args(p)
+    p.add_argument(
+        "--report", action="store_true",
+        help="Read-only: print and write the grades for the batch instead of "
+             "submitting it. Ignores --apply.")
+    return p
+
+
+def build_api(args):
+    """Construct the client. Basic (local DEV_AUTH) unless a token is given."""
+    if args.api_token:
+        return CaseworkApi(
+            args.api_base_url, token=args.api_token,
+            allow_remote_writes=args.allow_remote_writes,
+        )
+    return CaseworkApi(
+        args.api_base_url,
+        basic=basic_auth_from_env(),
+        allow_remote_writes=args.allow_remote_writes,
+    )
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    slugs = slugs_for_run(args)
+    logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
+    api = build_api(args)
+
+    log_run_header(logger, stage=STAGE, base_url=api.base_url,
+                   dry_run=args.dry_run and not args.report,
+                   provider="(none)", model="", n_selected=len(slugs),
+                   run_id=run_id, paths=paths)
+
+    started = time.monotonic()
+    stats = submit_batch(api, slugs, dry_run=args.dry_run, force=args.force,
+                         logger=logger, events_path=paths["events"], run_id=run_id)
+    log_run_footer(logger, stage=STAGE, stats=stats,
+                   duration_s=time.monotonic() - started)
+    print(f"\n=== submit reviews ({'DRY RUN' if args.dry_run else 'APPLIED'}) ===")
+    print(f"  {format_counts(stats)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/casework/submit_reviews.py
+++ b/casework/submit_reviews.py
@@ -376,7 +376,11 @@ def main(argv=None):
                    duration_s=time.monotonic() - started)
     print(f"\n=== submit reviews ({'DRY RUN' if args.dry_run else 'APPLIED'}) ===")
     print(f"  {format_counts(stats)}")
-    return 0
+    # Exit non-zero when any case failed. This DIVERGES from the sibling enrichers,
+    # which always return 0: a wrapper cannot otherwise tell a clean batch from one
+    # where every POST 500'd, and the abort paths above exist precisely to stop a
+    # configuration mistake exiting 0. Skipped and would-submit cases are not errors.
+    return 1 if stats["error"] else 0
 
 
 if __name__ == "__main__":

--- a/casework/submit_reviews.py
+++ b/casework/submit_reviews.py
@@ -5,9 +5,9 @@ reads back what the grading produced and writes nothing. They are one module bec
 they share the batch selection and the review-row shape.
 
 The script reads no case. A slug is all the POST needs, and the review list row already
-carries the title, state, score and disposition the report shows -- so a 238-case batch
-costs 2 requests per case to submit and 1 to report, with no corpus listing in front of
-either.
+carries the status, score and disposition the report shows -- so a 238-case batch costs
+2 requests per case to submit and 1 to report, with no corpus listing in front of
+either. Only a failed row costs a third request, for the `error` the list row omits.
 """
 
 import argparse
@@ -59,6 +59,42 @@ def existing_review(api, slug):
     return rows[0] if rows else None
 
 
+#: Statuses that mean the credential itself is wrong, not this one case. 401 is an
+#: expired, malformed or wrong-audience token -- `OIDCAuthentication` raises
+#: `AuthenticationFailed` and supplies `authenticate_header`, so DRF answers 401, not
+#: 403. 403 is a valid token without the Caseworker role. Counting either per-case
+#: turns one stale token into several hundred logged errors and a zero exit code.
+CREDENTIAL_STATUSES = (401, 403)
+
+
+def _raise_if_credential_failure(exc, slug, note=""):
+    """Turn a 401/403 into a run-ending SystemExit. Any other status returns."""
+    if exc.code not in CREDENTIAL_STATUSES:
+        return
+    raise SystemExit(
+        f"HTTP {exc.code} on {slug}: the API rejected this credential (401 = expired "
+        "or invalid token, 403 = valid token without the Caseworker role). Every "
+        f"remaining case would fail the same way, so the run stopped here.{note}"
+    ) from exc
+
+
+def _warn_on_slug_drift(logger, requested, review):
+    """Warn when the review came back filed under a different slug than we asked for.
+
+    The two sides resolve slugs differently: `SubmitSerializer` falls back to
+    `CaseSlugHistory` for a retired slug, while the list endpoint filters on
+    `case__slug` and sees live slugs only. So a stale batch row submits fine but is
+    invisible to the next run's skip check, and the case is re-graded at full LLM
+    cost on every run. One warning naming both slugs is what makes that visible.
+    """
+    landed = (review.get("slug") or "").strip()
+    if landed and landed != requested:
+        logger.warning(
+            "%s is a retired slug -- the review was filed under %s. The skip check "
+            "reads live slugs only, so this case will be re-submitted on every run "
+            "until the batch CSV is updated.", requested, landed)
+
+
 def _describe(review):
     """`"review 1841 done PASS 84"` -- what a skip line says about the run it found."""
     bits = [f"review {review.get('id')}", str(review.get("status") or "?")]
@@ -72,12 +108,12 @@ def _describe(review):
 def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
     """POST each slug that has no review yet. Returns a status->count mapping.
 
-    Two failures abort the whole run instead of being counted: a 403 (the role check
-    fails identically on every remaining case) and the write-guard's `RuntimeError`
-    (so does a non-loopback base URL without `--allow-remote-writes`). Counting either
-    per-case would turn one configuration mistake into several hundred logged errors
-    and a zero exit code. Any other HTTP failure is recorded and the batch continues --
-    a re-run skips whatever already landed.
+    Two classes of failure abort the whole run instead of being counted: a credential
+    rejection (`CREDENTIAL_STATUSES`) and the write-guard's `RuntimeError`. Both fail
+    identically on every remaining case, so counting them per-case would turn one
+    configuration mistake into several hundred logged errors and a zero exit code.
+    Every other failure -- on the pre-check read as much as on the POST -- is recorded
+    and the batch continues; a re-run skips whatever already landed.
     """
     stats = {"selected": len(slugs), "submitted": 0, "would_submit": 0,
              "already_reviewed": 0, "error": 0}
@@ -88,7 +124,23 @@ def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
 
     for slug in slugs:
         if not force:
-            found = existing_review(api, slug)
+            # The pre-check read is half of this run's requests. A blip on one of
+            # them must cost that case, not the batch -- the same rule the POST
+            # below follows, and the one `bind_materials` follows on its case read.
+            try:
+                found = existing_review(api, slug)
+            except urllib.error.HTTPError as exc:
+                _raise_if_credential_failure(
+                    exc, slug, f" {stats['submitted']} case(s) were submitted first.")
+                stats["error"] += 1
+                event(slug, "error", f"HTTP {exc.code} reading reviews",
+                      level=logging.WARNING)
+                continue
+            except Exception as exc:  # noqa: BLE001 - network, decode, anything else
+                stats["error"] += 1
+                event(slug, "error", f"{type(exc).__name__} reading reviews: {exc}",
+                      level=logging.WARNING)
+                continue
             if found is not None:
                 stats["already_reviewed"] += 1
                 event(slug, "already-reviewed", _describe(found))
@@ -103,11 +155,8 @@ def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
         try:
             review = api.submit_review(slug)
         except urllib.error.HTTPError as exc:
-            if exc.code == 403:
-                raise SystemExit(
-                    f"HTTP 403 submitting {slug}: this token lacks the Caseworker "
-                    "role, which every remaining case would fail on too. Nothing "
-                    f"further was submitted ({stats['submitted']} landed).") from exc
+            _raise_if_credential_failure(
+                exc, slug, f" {stats['submitted']} case(s) were submitted first.")
             stats["error"] += 1
             event(slug, "error", f"HTTP {exc.code}", level=logging.WARNING)
             continue
@@ -122,9 +171,16 @@ def submit_batch(api, slugs, *, dry_run, force, logger, events_path, run_id):
 
         stats["submitted"] += 1
         event(slug, "submitted", f"review {review.get('id')}")
+        _warn_on_slug_drift(logger, slug, review)
         logger.debug("submitted %s in %dms", slug,
                      int((time.monotonic() - started) * 1000))
     return stats
+
+
+def _row(slug, status, **kw):
+    """A report row with every column present, so the renderer never key-errors."""
+    return {"slug": slug, "review_id": None, "status": status, "score": None,
+            "disposition": None, "duration": None, "error": "", **kw}
 
 
 def report_rows(api, slugs):
@@ -132,30 +188,45 @@ def report_rows(api, slugs):
 
     Everything but `error` comes off the list row. `error` lives only on the detail
     serializer, so it is fetched for failed rows and nothing else.
+
+    A read that fails becomes an `unreadable` row rather than ending the report. This
+    pass runs over a batch that took hours to grade, so losing the whole file to one
+    blip on case 200 of 238 is the expensive outcome. A credential rejection still
+    aborts -- every remaining read would fail the same way.
     """
     rows = []
     for slug in slugs:
-        review = existing_review(api, slug)
-        if review is None:
-            rows.append({"slug": slug, "review_id": None, "status": "never-submitted",
-                         "score": None, "disposition": None, "duration": None,
-                         "title": "", "error": ""})
+        try:
+            review = existing_review(api, slug)
+        except urllib.error.HTTPError as exc:
+            _raise_if_credential_failure(exc, slug)
+            rows.append(_row(slug, "unreadable", error=f"HTTP {exc.code}"))
             continue
+        except Exception as exc:  # noqa: BLE001 - network, decode, anything else
+            rows.append(_row(slug, "unreadable", error=f"{type(exc).__name__}: {exc}"))
+            continue
+
+        if review is None:
+            rows.append(_row(slug, "never-submitted"))
+            continue
+
         error = ""
         if review.get("status") == "failed":
-            detail = api.review_detail(review["id"]) or {}
+            try:
+                detail = api.review_detail(review["id"]) or {}
+            except Exception as exc:  # noqa: BLE001 - the error line is a nicety
+                detail = {"error": f"({type(exc).__name__} reading the detail)"}
             first_line = (detail.get("error") or "").strip().splitlines()
             error = first_line[0] if first_line else ""
-        rows.append({
-            "slug": slug,
-            "review_id": review.get("id"),
-            "status": review.get("status") or "?",
-            "score": review.get("overall_score"),
-            "disposition": review.get("disposition"),
-            "duration": review.get("duration_seconds"),
-            "title": review.get("case_title") or "",
-            "error": error,
-        })
+        rows.append(_row(
+            slug,
+            review.get("status") or "?",
+            review_id=review.get("id"),
+            score=review.get("overall_score"),
+            disposition=review.get("disposition"),
+            duration=review.get("duration_seconds"),
+            error=error,
+        ))
     return rows
 
 
@@ -217,11 +288,16 @@ def render_report(rows, summary, *, base_url, run_id, batch):
             f"| {row['disposition'] or '—'} | {duration} |")
     lines.append("")
 
-    failed = [r for r in rows if r["status"] == "failed"]
-    if failed:
-        lines += ["## Failed", ""]
-        lines += [f"- `{r['slug']}` — review {r['review_id']} — "
-                  f"{r['error'] or '(no error recorded)'}" for r in failed]
+    problems = [r for r in rows if r["status"] in ("failed", "unreadable")]
+    if problems:
+        lines += ["## Failed and unreadable", "",
+                  "Re-submit these on their own — `--slug <a> --slug <b> --force` — "
+                  "rather than re-running the batch with `--force`, which re-grades "
+                  "every passing case too.", ""]
+        for r in problems:
+            named = f"review {r['review_id']}" if r["review_id"] else "no review read"
+            lines.append(f"- `{r['slug']}` — {named} — "
+                         f"{r['error'] or '(no error recorded)'}")
         lines.append("")
 
     if summary["never_submitted"]:
@@ -266,8 +342,10 @@ def main(argv=None):
     logger, run_id, paths = configure_run_logging(STAGE, verbose=args.verbose)
     api = build_api(args)
 
+    # `--report` writes nothing, so the header must never say APPLY on one -- the
+    # `.log` file is the record of what a run was allowed to do.
     log_run_header(logger, stage=STAGE, base_url=api.base_url,
-                   dry_run=args.dry_run and not args.report,
+                   dry_run=args.dry_run or args.report,
                    provider="(none)", model="", n_selected=len(slugs),
                    run_id=run_id, paths=paths)
 

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -1201,6 +1201,15 @@ def test_reviews_for_slug_unwraps_the_paginated_envelope(monkeypatch):
     assert rows == [{"id": 1841, "status": "done"}]
 
 
+def test_reviews_for_slug_accepts_an_unpaginated_list(monkeypatch):
+    """Pagination is a project-wide DRF setting, not this view's promise -- turning
+    it off must not make the skip check see zero reviews and re-grade the corpus."""
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    monkeypatch.setattr(api, "get", lambda *a, **kw: [{"id": 1841, "status": "done"}])
+    rows = api.reviews_for_slug("case-078-cr-0038-ciaa-special-court-case-078-cr-9a")
+    assert rows == [{"id": 1841, "status": "done"}]
+
+
 def test_reviews_for_slug_on_a_never_reviewed_case_is_empty(monkeypatch):
     api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
     monkeypatch.setattr(api, "get", lambda *a, **kw: {"count": 0, "results": []})

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -1164,3 +1164,82 @@ def test_patch_case_makes_no_request_when_nothing_changed(monkeypatch):
     api = CaseworkApi("http://127.0.0.1:48010", token="t")
     monkeypatch.setattr(api, "_patch", lambda *a, **k: pytest.fail("should not PATCH"))
     assert api.patch_case("case-079-cr-0151") == {}
+
+
+class _FakeResponse:
+    """Minimal stand-in for what `_request` returns: a context manager with `.read()`."""
+
+    def __init__(self, body=b"{}"):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_reviews_for_slug_unwraps_the_paginated_envelope(monkeypatch):
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    seen = {}
+
+    def fake_get(path, params=None, timeout=60):
+        seen["path"] = path
+        seen["params"] = params
+        return {"count": 1, "results": [{"id": 1841, "status": "done"}]}
+
+    monkeypatch.setattr(api, "get", fake_get)
+    rows = api.reviews_for_slug("case-078-cr-0038-ciaa-special-court-case-078-cr-9a")
+
+    assert seen["path"] == "/casework/reviews/"
+    assert seen["params"] == {
+        "slug": "case-078-cr-0038-ciaa-special-court-case-078-cr-9a"
+    }
+    assert rows == [{"id": 1841, "status": "done"}]
+
+
+def test_reviews_for_slug_on_a_never_reviewed_case_is_empty(monkeypatch):
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    monkeypatch.setattr(api, "get", lambda *a, **kw: {"count": 0, "results": []})
+    assert api.reviews_for_slug("case-078-cr-0044-ciaa-special-court-case-078-cr-12") == []
+
+
+def test_review_detail_reads_one_review_by_id(monkeypatch):
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    seen = {}
+
+    def fake_get(path, params=None, timeout=60):
+        seen["path"] = path
+        return {"id": 1842, "error": "convert failed"}
+
+    monkeypatch.setattr(api, "get", fake_get)
+    assert api.review_detail(1842)["error"] == "convert failed"
+    assert seen["path"] == "/casework/reviews/1842/"
+
+
+def test_submit_review_posts_only_the_slug(monkeypatch):
+    api = CaseworkApi("http://127.0.0.1:48010", basic=("u", "p"))
+    sent = {}
+
+    def fake_request(method, url, data=None, headers=None, timeout=60):
+        sent.update(method=method, url=url, body=json.loads(data.decode()),
+                    content_type=headers.get("Content-Type"))
+        return _FakeResponse(b'{"id": 1901, "status": "pending"}')
+
+    monkeypatch.setattr(api, "_request", fake_request)
+    review = api.submit_review("case-078-cr-0038-ciaa-special-court-case-078-cr-9a")
+
+    assert sent["method"] == "POST"
+    assert sent["url"] == "http://127.0.0.1:48010/api/casework/reviews/submit/"
+    assert sent["body"] == {"slug": "case-078-cr-0038-ciaa-special-court-case-078-cr-9a"}
+    assert sent["content_type"] == "application/json"
+    assert review["id"] == 1901
+
+
+def test_submit_review_to_a_remote_host_is_refused_without_the_flag():
+    api = CaseworkApi("https://example.invalid", token="t")
+    with pytest.raises(RuntimeError, match="refusing to write to non-loopback"):
+        api.submit_review("case-078-cr-0038-ciaa-special-court-case-078-cr-9a")

--- a/tests/casework/test_guard_wiring.py
+++ b/tests/casework/test_guard_wiring.py
@@ -180,3 +180,22 @@ def test_apply_with_allow_remote_writes_lets_the_patch_reach_urlopen(monkeypatch
 
     assert any(method == "PATCH" for method, _ in calls)
     assert any(r["status"] == "enriched" for r in report.rows)
+
+
+def test_submit_reviews_remote_post_is_stopped_by_the_real_guard(monkeypatch, tmp_path):
+    """`main()` -> real `build_api` -> real `CaseworkApi` -> the guard. No stub stands
+    in for the client, so this is what proves the wiring, not the flag."""
+    from casework import submit_reviews as sr
+
+    def no_sockets(*a, **kw):
+        raise AssertionError("the guard must refuse before any request is opened")
+
+    monkeypatch.setattr(urllib.request, "urlopen", no_sockets)
+    monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
+    batch = tmp_path / "batch.csv"
+    batch.write_text(
+        "slug\ncase-078-cr-0038-ciaa-special-court-case-078-cr-9a\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="refusing to write to non-loopback"):
+        sr.main(["--batch-csv", str(batch), "--api-base-url", NON_LOOPBACK_BASE_URL,
+                 "--api-token", "t", "--apply", "--force"])

--- a/tests/casework/test_guard_wiring.py
+++ b/tests/casework/test_guard_wiring.py
@@ -196,6 +196,9 @@ def test_submit_reviews_remote_post_is_stopped_by_the_real_guard(monkeypatch, tm
     batch.write_text(
         "slug\ncase-078-cr-0038-ciaa-special-court-case-078-cr-9a\n", encoding="utf-8")
 
+    # `--force` is load-bearing: it skips the pre-check GET. Reads are not
+    # write-guarded, so an unforced run would reach `no_sockets` first and fail with
+    # AssertionError before the POST guard ever fires.
     with pytest.raises(RuntimeError, match="refusing to write to non-loopback"):
         sr.main(["--batch-csv", str(batch), "--api-base-url", NON_LOOPBACK_BASE_URL,
                  "--api-token", "t", "--apply", "--force"])

--- a/tests/casework/test_submit_reviews.py
+++ b/tests/casework/test_submit_reviews.py
@@ -14,6 +14,8 @@ SLUG_B = "case-078-cr-0044-ciaa-special-court-case-078-cr-12"
 class _StubApi:
     """Stands in for `CaseworkApi` at the two methods submit mode calls."""
 
+    base_url = "http://127.0.0.1:48010/api"
+
     def __init__(self, reviews=None, errors=None):
         self.reviews = {k: list(v) for k, v in (reviews or {}).items()}
         self.errors = errors or {}
@@ -186,3 +188,118 @@ def test_the_rendered_report_names_every_case_and_the_totals():
     assert SLUG_A in text
     assert "PASS" in text
     assert "1841" in text
+
+
+# --- what aborts a run vs what it counts -----------------------------------
+
+
+class _ReadFailApi(_StubApi):
+    """Fails the pre-check READ for named slugs; the POST itself is fine."""
+
+    def __init__(self, read_errors, **kw):
+        super().__init__(**kw)
+        self.read_errors = read_errors
+
+    def reviews_for_slug(self, slug):
+        if slug in self.read_errors:
+            raise self.read_errors[slug]
+        return super().reviews_for_slug(slug)
+
+
+@pytest.mark.parametrize("code", [401, 403])
+def test_a_credential_rejection_on_the_post_aborts_the_run(code, tmp_path):
+    """401 is the one that used to slip through: OIDCAuthentication supplies
+    `authenticate_header`, so an expired token is a 401, not a 403."""
+    api = _StubApi(errors={SLUG_A: _http_error(code)})
+    with pytest.raises(SystemExit, match=f"HTTP {code}"):
+        _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == []
+
+
+@pytest.mark.parametrize("code", [401, 403])
+def test_a_credential_rejection_on_the_precheck_read_aborts_the_run(code, tmp_path):
+    api = _ReadFailApi({SLUG_A: _http_error(code)})
+    with pytest.raises(SystemExit, match=f"HTTP {code}"):
+        _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == []
+
+
+def test_a_transient_read_failure_costs_one_case_not_the_batch(tmp_path):
+    """The pre-check read is half of a run's requests; a 502 on one of them must
+    not discard the stats and the footer for the other 237."""
+    api = _ReadFailApi({SLUG_A: _http_error(502)})
+    stats = _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == [SLUG_B]
+    assert stats["error"] == 1
+
+
+def test_a_non_http_read_failure_also_costs_only_one_case(tmp_path):
+    api = _ReadFailApi({SLUG_A: TimeoutError("read timed out")})
+    stats = _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == [SLUG_B]
+    assert stats["error"] == 1
+
+
+def test_a_retired_slug_warns_that_it_will_be_resubmitted_forever(tmp_path, caplog):
+    """The submit path resolves retired slugs through CaseSlugHistory; the skip
+    check reads live slugs only. The mismatch is silent without this warning."""
+    class _ReslugApi(_StubApi):
+        def submit_review(self, slug):
+            row = super().submit_review(slug)
+            row["slug"] = "case-078-cr-0038-renamed"
+            return row
+
+    with caplog.at_level(logging.WARNING):
+        _submit(_ReslugApi(), [SLUG_A], tmp_path)
+    assert "retired slug" in caplog.text
+    assert "case-078-cr-0038-renamed" in caplog.text
+
+
+# --- report resilience ------------------------------------------------------
+
+
+def test_an_unreadable_case_becomes_a_row_not_a_dead_report():
+    class _Boom(_ReportApi):
+        def reviews_for_slug(self, slug):
+            if slug == SLUG_A:
+                raise _http_error(502)
+            return super().reviews_for_slug(slug)
+
+    api = _Boom(reviews={SLUG_B: [{"id": 1842, "status": "done"}]})
+    rows = sr.report_rows(api, [SLUG_A, SLUG_B])
+    assert rows[0]["status"] == "unreadable"
+    assert rows[0]["error"] == "HTTP 502"
+    assert rows[1]["status"] == "done"
+
+
+def test_a_credential_rejection_aborts_the_report():
+    class _Boom(_ReportApi):
+        def reviews_for_slug(self, slug):
+            raise _http_error(401)
+
+    with pytest.raises(SystemExit, match="HTTP 401"):
+        sr.report_rows(_Boom(), [SLUG_A])
+
+
+def test_unreadable_rows_are_listed_with_the_failures():
+    rows = [{"slug": SLUG_A, "review_id": None, "status": "unreadable", "score": None,
+             "disposition": None, "duration": None, "error": "HTTP 502"}]
+    text = sr.render_report(rows, sr.summarize(rows), base_url="x", run_id="r",
+                            batch="b.csv")
+    assert "## Failed and unreadable" in text
+    assert "HTTP 502" in text
+
+
+def test_the_report_header_never_claims_apply_on_a_read_only_run(tmp_path, monkeypatch):
+    """`--report` writes nothing, so the persisted .log must not say APPLY."""
+    monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("CASEWORK_REVIEW_DIR", str(tmp_path))
+    monkeypatch.setattr(sr, "build_api", lambda args: _ReportApi())
+    batch = tmp_path / "batch.csv"
+    batch.write_text(f"slug\n{SLUG_A}\n", encoding="utf-8")
+
+    sr.main(["--batch-csv", str(batch), "--report",
+             "--api-base-url", "http://127.0.0.1:48010", "--api-token", "t"])
+
+    log = next(p for p in tmp_path.iterdir() if p.suffix == ".log")
+    assert "mode        : DRY-RUN" in log.read_text(encoding="utf-8")

--- a/tests/casework/test_submit_reviews.py
+++ b/tests/casework/test_submit_reviews.py
@@ -180,8 +180,8 @@ def test_summary_counts_dispositions_and_scores():
 
 
 def test_the_rendered_report_names_every_case_and_the_totals():
-    rows = [{"slug": SLUG_A, "review_id": 1841, "status": "done", "score": 84,
-             "disposition": "PASS", "duration": 92.4, "title": "", "error": ""}]
+    rows = [sr._row(SLUG_A, "done", review_id=1841, score=84,
+                    disposition="PASS", duration=92.4)]
     text = sr.render_report(rows, sr.summarize(rows),
                             base_url="http://127.0.0.1:48010/api",
                             run_id="testrun", batch="batch.csv")
@@ -303,3 +303,30 @@ def test_the_report_header_never_claims_apply_on_a_read_only_run(tmp_path, monke
 
     log = next(p for p in tmp_path.iterdir() if p.suffix == ".log")
     assert "mode        : DRY-RUN" in log.read_text(encoding="utf-8")
+
+
+# --- exit code --------------------------------------------------------------
+
+
+def _main_exit(api, batch_rows, tmp_path, monkeypatch, *args):
+    monkeypatch.setenv("CASEWORK_RUN_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(sr, "build_api", lambda a: api)
+    batch = tmp_path / "batch.csv"
+    batch.write_text("slug\n" + "".join(f"{s}\n" for s in batch_rows), encoding="utf-8")
+    return sr.main(["--batch-csv", str(batch), "--api-base-url",
+                    "http://127.0.0.1:48010", "--api-token", "t", *args])
+
+
+def test_a_clean_run_exits_zero(tmp_path, monkeypatch):
+    assert _main_exit(_StubApi(), [SLUG_A], tmp_path, monkeypatch, "--apply") == 0
+
+
+def test_a_run_with_any_failed_case_exits_non_zero(tmp_path, monkeypatch):
+    """A wrapper cannot otherwise tell a clean batch from one where every POST 500'd."""
+    api = _StubApi(errors={SLUG_A: _http_error(500)})
+    assert _main_exit(api, [SLUG_A, SLUG_B], tmp_path, monkeypatch, "--apply") == 1
+
+
+def test_skipped_cases_are_not_errors(tmp_path, monkeypatch):
+    api = _StubApi(reviews={SLUG_A: [{"id": 1841, "status": "done"}]})
+    assert _main_exit(api, [SLUG_A], tmp_path, monkeypatch, "--apply") == 0

--- a/tests/casework/test_submit_reviews.py
+++ b/tests/casework/test_submit_reviews.py
@@ -95,6 +95,17 @@ def test_a_403_aborts_the_whole_run(tmp_path):
     assert api.submitted == []
 
 
+def test_the_write_guard_aborts_the_run_rather_than_counting_it(tmp_path):
+    """A non-loopback base URL without --allow-remote-writes raises before any
+    socket opens. Counting it per-case would turn one configuration mistake into
+    several hundred logged errors and a zero exit code."""
+    api = _StubApi(errors={SLUG_A: RuntimeError(
+        "refusing to write to non-loopback base_url")})
+    with pytest.raises(RuntimeError, match="non-loopback"):
+        _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == []
+
+
 def test_a_run_with_no_batch_and_no_slug_is_refused():
     args = sr.build_parser().parse_args([])
     with pytest.raises(SystemExit, match="--batch-csv or --slug"):

--- a/tests/casework/test_submit_reviews.py
+++ b/tests/casework/test_submit_reviews.py
@@ -1,0 +1,108 @@
+"""Submit mode: what gets POSTed, what gets skipped, and what stops a run."""
+
+import logging
+import urllib.error
+
+import pytest
+
+from casework import submit_reviews as sr
+
+SLUG_A = "case-078-cr-0038-ciaa-special-court-case-078-cr-9a"
+SLUG_B = "case-078-cr-0044-ciaa-special-court-case-078-cr-12"
+
+
+class _StubApi:
+    """Stands in for `CaseworkApi` at the two methods submit mode calls."""
+
+    def __init__(self, reviews=None, errors=None):
+        self.reviews = {k: list(v) for k, v in (reviews or {}).items()}
+        self.errors = errors or {}
+        self.submitted = []
+        self._next_id = 1900
+
+    def reviews_for_slug(self, slug):
+        return list(self.reviews.get(slug, ()))
+
+    def submit_review(self, slug):
+        if slug in self.errors:
+            raise self.errors[slug]
+        self._next_id += 1
+        row = {"id": self._next_id, "slug": slug, "status": "pending"}
+        self.submitted.append(slug)
+        self.reviews.setdefault(slug, []).insert(0, row)
+        return row
+
+
+def _http_error(code):
+    return urllib.error.HTTPError(
+        "http://127.0.0.1:48010/api/casework/reviews/submit/", code, "err", {}, None)
+
+
+def _submit(api, slugs, tmp_path, **kw):
+    """Call `submit_batch` with the run-logging arguments the CLI supplies."""
+    events = tmp_path / "events.jsonl"
+    events.touch()
+    options = {"dry_run": False, "force": False}
+    options.update(kw)
+    return sr.submit_batch(api, slugs, logger=logging.getLogger("test"),
+                           events_path=str(events), run_id="testrun", **options)
+
+
+def test_a_never_reviewed_case_is_submitted(tmp_path):
+    api = _StubApi()
+    stats = _submit(api, [SLUG_A], tmp_path)
+    assert api.submitted == [SLUG_A]
+    assert stats["submitted"] == 1
+
+
+def test_a_case_with_any_existing_review_is_skipped(tmp_path):
+    api = _StubApi(reviews={SLUG_A: [{"id": 1841, "status": "done",
+                                      "overall_score": 84, "disposition": "PASS"}]})
+    stats = _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == [SLUG_B]
+    assert stats["already_reviewed"] == 1
+    assert stats["submitted"] == 1
+
+
+def test_force_submits_a_case_that_already_has_a_review(tmp_path):
+    api = _StubApi(reviews={SLUG_A: [{"id": 1841, "status": "done"}]})
+    stats = _submit(api, [SLUG_A], tmp_path, force=True)
+    assert api.submitted == [SLUG_A]
+    assert stats["submitted"] == 1
+
+
+def test_a_dry_run_posts_nothing(tmp_path):
+    api = _StubApi()
+    stats = _submit(api, [SLUG_A, SLUG_B], tmp_path, dry_run=True)
+    assert api.submitted == []
+    assert stats["would_submit"] == 2
+
+
+def test_a_400_is_recorded_and_the_batch_continues(tmp_path):
+    api = _StubApi(errors={SLUG_A: _http_error(400)})
+    stats = _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == [SLUG_B]
+    assert stats["error"] == 1
+    assert stats["submitted"] == 1
+
+
+def test_a_403_aborts_the_whole_run(tmp_path):
+    """It will fail identically on every remaining case, so one clear error beats
+    several hundred."""
+    api = _StubApi(errors={SLUG_A: _http_error(403)})
+    with pytest.raises(SystemExit, match="Caseworker role"):
+        _submit(api, [SLUG_A, SLUG_B], tmp_path)
+    assert api.submitted == []
+
+
+def test_a_run_with_no_batch_and_no_slug_is_refused():
+    args = sr.build_parser().parse_args([])
+    with pytest.raises(SystemExit, match="--batch-csv or --slug"):
+        sr.slugs_for_run(args)
+
+
+def test_limit_takes_the_batch_in_file_order(tmp_path):
+    batch = tmp_path / "batch.csv"
+    batch.write_text(f"slug\n{SLUG_A}\n{SLUG_B}\n", encoding="utf-8")
+    args = sr.build_parser().parse_args(["--batch-csv", str(batch), "--limit", "1"])
+    assert sr.slugs_for_run(args) == [SLUG_A]

--- a/tests/casework/test_submit_reviews.py
+++ b/tests/casework/test_submit_reviews.py
@@ -106,3 +106,72 @@ def test_limit_takes_the_batch_in_file_order(tmp_path):
     batch.write_text(f"slug\n{SLUG_A}\n{SLUG_B}\n", encoding="utf-8")
     args = sr.build_parser().parse_args(["--batch-csv", str(batch), "--limit", "1"])
     assert sr.slugs_for_run(args) == [SLUG_A]
+
+
+class _ReportApi(_StubApi):
+    """Adds the detail read the report makes for failed rows only."""
+
+    def __init__(self, reviews=None, details=None):
+        super().__init__(reviews=reviews)
+        self.details = details or {}
+        self.detail_calls = []
+
+    def review_detail(self, review_id):
+        self.detail_calls.append(review_id)
+        return self.details.get(review_id, {})
+
+
+def test_report_reads_score_and_disposition_off_the_list_row():
+    api = _ReportApi(reviews={SLUG_A: [{"id": 1841, "status": "done",
+                                        "overall_score": 84, "disposition": "PASS",
+                                        "case_title": "ओक्सिजन प्लान्ट",
+                                        "duration_seconds": 92.4}]})
+    rows = sr.report_rows(api, [SLUG_A])
+    assert rows[0]["review_id"] == 1841
+    assert rows[0]["disposition"] == "PASS"
+    assert rows[0]["score"] == 84
+    assert api.detail_calls == []          # a done row needs no detail fetch
+
+
+def test_report_fetches_the_error_only_for_failed_rows():
+    api = _ReportApi(
+        reviews={SLUG_A: [{"id": 1841, "status": "done"}],
+                 SLUG_B: [{"id": 1842, "status": "failed"}]},
+        details={1842: {"error": "convert failed: no MARKDOWN role\ntraceback…"}},
+    )
+    rows = sr.report_rows(api, [SLUG_A, SLUG_B])
+    assert api.detail_calls == [1842]
+    failed = [r for r in rows if r["status"] == "failed"][0]
+    assert failed["error"] == "convert failed: no MARKDOWN role"
+
+
+def test_a_batch_slug_with_no_review_is_reported_as_never_submitted():
+    api = _ReportApi()
+    rows = sr.report_rows(api, [SLUG_A])
+    assert rows[0]["status"] == "never-submitted"
+    assert sr.summarize(rows)["never_submitted"] == [SLUG_A]
+
+
+def test_summary_counts_dispositions_and_scores():
+    rows = [
+        {"slug": SLUG_A, "status": "done", "score": 84, "disposition": "PASS"},
+        {"slug": SLUG_B, "status": "done", "score": 58, "disposition": "REVISE"},
+        {"slug": "case-c", "status": "pending", "score": None, "disposition": None},
+    ]
+    summary = sr.summarize(rows)
+    assert summary["statuses"]["done"] == 2
+    assert summary["dispositions"]["PASS"] == 1
+    assert summary["scored"] == 2
+    assert summary["avg"] == 71.0
+    assert (summary["min"], summary["max"]) == (58, 84)
+
+
+def test_the_rendered_report_names_every_case_and_the_totals():
+    rows = [{"slug": SLUG_A, "review_id": 1841, "status": "done", "score": 84,
+             "disposition": "PASS", "duration": 92.4, "title": "", "error": ""}]
+    text = sr.render_report(rows, sr.summarize(rows),
+                            base_url="http://127.0.0.1:48010/api",
+                            run_id="testrun", batch="batch.csv")
+    assert SLUG_A in text
+    assert "PASS" in text
+    assert "1841" in text


### PR DESCRIPTION
### **User description**
Bulk-submits a batch of enriched cases into the casework review queue, and reads the
grades back in a separate read-only pass.

Today the only ways to submit a case for review are one click in the SPA, one MCP call,
or `regrade-all` — which only re-queues cases that already carry a review, so it can
never introduce a fresh batch. A 238-case batch means 238 clicks.

## What it does

```bash
# submit (writes; remote needs all three, as every casework write does)
uv run python -m casework.submit_reviews --batch-csv batch.csv \
    --api-base-url https://api.jawafdehi.org --api-token "$JAWAFDEHI_API_TOKEN" \
    --apply --allow-remote-writes

# read the grades back, any time after. Read-only.
uv run python -m casework.submit_reviews --batch-csv batch.csv --report
```

Submitting is instant and tells you nothing — every case comes back `pending`. Grading
runs out of process on the jobs queue and takes hours, so the read-back is a separate
run. It writes `work/reviews/<ts>-submit_reviews-<run>.md`: status and disposition
counts, score spread, a per-case table, the failures with their error line, and the
batch slugs that carry no review at all.

## Design notes for the reviewer

**No case reads.** A slug is all the POST needs, and `CaseReviewListSerializer` already
carries the status, score, disposition and duration the report shows. So submit mode is
2 requests per case and report mode is 1, with no 16-request corpus listing in front of
either. Only a `failed` row costs a third request, for the `error` the list row omits.

**Skip on any existing review.** The endpoint has no idempotency — every POST creates a
new row, and the job dedup key is the review id, which is new each time. Skipping makes
a run resumable: one that dies at case 120 picks up at 121 instead of re-grading the
first 120 at full LLM cost. `--force` overrides.

**An explicit target is required.** `--batch-csv` or `--slug`. A bare run is refused
rather than falling through to bulk selection, which would enqueue ~3,000 LLM grading
runs off a forgotten flag. The script deliberately does not call `select_for_run`: that
path hardcodes the DRAFT/IN_REVIEW gate, which is right for an enricher and wrong here,
because a PUBLISHED case is a legitimate review target.

**No case state change.** Cases stay DRAFT. Promotion to IN_REVIEW is a human decision
and the grade is its input, which is the wrong order to automate before anyone has read
a grade.

**Which failures are fatal.** A credential rejection (401 expired/invalid token, 403 no
Caseworker role) and the write-guard's refusal abort the run — all three fail identically
on every remaining case. Everything else costs one case and the batch continues. 401
matters specifically: `OIDCAuthentication` supplies `authenticate_header`, so an expired
token is a 401, and a 403-only guard would count the commonest credential failure 238
times and still exit 0.

**One known hole, mitigated not closed.** `SubmitSerializer` resolves retired slugs
through `CaseSlugHistory`; the list endpoint filters `case__slug` and sees live slugs
only. A stale batch row therefore submits fine but stays invisible to the skip check and
is re-graded every run. Closing it properly costs a case read per slug — the exact cost
this design avoids — so instead the submit compares the requested slug against the one in
the 201 body (no extra request) and warns, naming both.

## Verification

`1612 passed, 1 skipped` in `tests/casework/`, ruff clean.

Smoke-tested end to end against a local DEV_AUTH harness on `127.0.0.1:48010` with three
sqlite DBs and two seeded cases — dry run wrote nothing, apply created two reviews and two
queued jobs, the re-run skipped both, the report rendered graded/failed/never-submitted,
an unknown slug logged HTTP 400 and the batch continued, `--force` created a new review
and dead-lettered the old job as `superseded`, and both refusal paths (no selector, remote
without `--allow-remote-writes`) refused before opening a connection.

**No production writes were made at any point.**

Design and plan: `docs/superpowers/specs/2026-08-10-bulk-review-submit-design.md` and
`docs/superpowers/plans/2026-08-10-bulk-review-submit.md` in the meta-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Batch review submission CLI

- Review report generation

- API review helpers

- Guard/error tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Batch CSV or slugs"] --> B["submit_reviews CLI"]
  B -- "skip existing" --> C["review list API"]
  B -- "enqueue" --> D["review submit API"]
  B -- "read-only report" --> E["Markdown report"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.py</strong><dd><code>Add casework review API helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/common/api.py

<ul><li>Added <code>reviews_for_slug</code><br> <li> Added <code>review_detail</code><br> <li> Added guarded <code>submit_review</code> POST</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/444/files#diff-543d520a75c6ab7cb169dc2e1d945691ed725d6ba3e177c282f2c9cbcd83b341">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>submit_reviews.py</strong><dd><code>Add batch review submit CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/submit_reviews.py

<ul><li>Added batch submit/report CLI<br> <li> Skips existing reviews unless <code>--force</code><br> <li> Aborts on 401/403, write guard<br> <li> Renders markdown grade reports</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/444/files#diff-aa5203be075dfd79fa2bea419894c3cb2bc2e204fd23ba17c25d3f52a952ce44">+387/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Cover review API client helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/casework/test_api.py

<ul><li>Tests review list unwrapping<br> <li> Tests detail endpoint path<br> <li> Tests submit POST body<br> <li> Tests remote write guard</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/444/files#diff-691498b1b6a7fd15b306238041c444e55a340b29288c4e271e5605cc5570e935">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_guard_wiring.py</strong><dd><code>Verify submit_reviews write guard wiring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/casework/test_guard_wiring.py

<ul><li>Tests real guard wiring<br> <li> Verifies no socket opens<br> <li> Covers <code>submit_reviews</code> remote POST refusal</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/444/files#diff-e9238535e1a2c0b2ad2f1bee34e1c92f6c450d56658b0fbd98882c4d688d9b12">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_submit_reviews.py</strong><dd><code>Cover submit_reviews CLI behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/casework/test_submit_reviews.py

<ul><li>Tests submit skip/force/dry-run<br> <li> Tests credential abort behavior<br> <li> Tests report rows and summaries<br> <li> Tests exit codes</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/444/files#diff-8a384bc8109cbecc5e6f92bafc20576a916ad765273521ab213c10396f33b7fd">+332/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document batch review submission workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

casework/README.md

<ul><li>Documents <code>submit_reviews</code><br> <li> Adds command examples<br> <li> Explains failures and exit codes</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/444/files#diff-0772aa74e880257e4e1fdb43ef6fc2e83edb8cb8e019d875fc568166524214a9">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
