### PR TITLE
fix(feedback): give the submission throttle its own bucket, not the shared anon one

### DIFF
--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -1624,8 +1624,27 @@ class StatisticsView(APIView):
 
 
 class FeedbackRateThrottle(AnonRateThrottle):
-    """Rate throttle for feedback submissions: 5 per hour."""
+    """Rate throttle for feedback submissions: 5 per hour, in its OWN bucket.
 
+    ``scope`` is set explicitly. Without it this inherits ``AnonRateThrottle``'s
+    ``scope = "anon"``, and DRF derives the cache key from the scope alone
+    (``throttle_anon_<ident>``) — so this 5/hour throttle would share one history
+    list with the GLOBAL ``SyncedAnonRateThrottle``, which also has scope
+    ``anon`` and runs on every other public endpoint at 1000/hour. A visitor who
+    had merely browsed the site (5+ anonymous API calls in the past hour) would
+    then be refused on their FIRST feedback or corruption-report submission,
+    because those unrelated reads had already filled this bucket.
+
+    ``NewsletterRateThrottle`` sets ``scope = "newsletter"`` for exactly this
+    reason; the omission here was an oversight rather than a decision.
+
+    Not caught by the existing tests because the global throttle classes are
+    emptied under ``TESTING`` (config/settings.py), so the two never collide
+    there — see ``test_feedback_throttle_scope.py``, which asserts on the cache
+    key instead of trying to reproduce the collision.
+    """
+
+    scope = "feedback"
     rate = "5/hour"
 
 

--- a/tests/api/test_feedback_throttle_scope.py
+++ b/tests/api/test_feedback_throttle_scope.py
@@ -1,0 +1,81 @@
+"""The feedback throttle must count in its own bucket, not the global anon one.
+
+DRF's ``SimpleRateThrottle`` derives its cache key from ``scope`` alone
+(``throttle_<scope>_<ident>``). ``FeedbackRateThrottle`` and the platform-wide
+``SyncedAnonRateThrottle`` are both ``AnonRateThrottle`` subclasses, so if the
+feedback one doesn't override ``scope`` they share the key — and the global
+throttle, which runs on every other public endpoint at 1000/hour, spends the
+feedback throttle's 5/hour allowance on ordinary browsing.
+
+These tests assert on the cache key rather than trying to reproduce the
+collision end-to-end, because the global throttle classes are emptied under
+``TESTING`` (config/settings.py) and the two can never actually collide in the
+suite. That is precisely why the bug survived: the only place it appears is
+production.
+"""
+
+import pytest
+from django.core.cache import cache
+from rest_framework.test import APIRequestFactory
+
+from cases.api_views import FeedbackRateThrottle
+from jawafdehi_shared.drf.throttling import SyncedAnonRateThrottle
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+IP = "203.0.113.7"
+
+
+def _request():
+    request = APIRequestFactory().post("/api/feedback/", REMOTE_ADDR=IP)
+    # DRF's View wrapper normally supplies request.user; AnonRateThrottle only
+    # reads `.user` to decide whether the caller is anonymous.
+    request.user = None
+    return request
+
+
+def test_feedback_throttle_has_its_own_scope():
+    assert FeedbackRateThrottle.scope == "feedback"
+
+
+def test_feedback_throttle_scope_differs_from_the_global_anon_bucket():
+    """The regression, asserted on the class attributes.
+
+    Compared as class attributes rather than by instantiating the global
+    throttle: ``SyncedAnonRateThrottle`` has no hardcoded ``rate``, so under
+    ``TESTING`` (where ``DEFAULT_THROTTLE_RATES`` is ``{}``) constructing one
+    raises ImproperlyConfigured. The scope is what determines the cache key, so
+    comparing scopes is the honest assertion anyway.
+    """
+    assert FeedbackRateThrottle.scope != SyncedAnonRateThrottle.scope
+    assert SyncedAnonRateThrottle.scope == "anon"
+
+
+def test_feedback_cache_key_is_not_the_shared_anon_key():
+    """The concrete consequence: a different bucket for the same client."""
+    key = FeedbackRateThrottle().get_cache_key(_request(), view=None)
+
+    assert key == f"throttle_feedback_{IP}"
+    assert key != f"throttle_anon_{IP}", (
+        "feedback submissions would be counted in the global anonymous bucket, "
+        "so ordinary browsing consumes the reporter's 5/hour allowance"
+    )
+
+
+def test_feedback_throttle_keeps_its_rate():
+    """The scope must not send DRF looking up THROTTLE_RATES['feedback'].
+
+    ``SimpleRateThrottle.__init__`` only calls ``get_rate()`` when ``rate`` is
+    unset; the explicit class attribute keeps 5/hour without needing a settings
+    entry (same arrangement as NewsletterRateThrottle).
+    """
+    throttle = FeedbackRateThrottle()
+    assert throttle.rate == "5/hour"
+    assert throttle.num_requests == 5
+    assert throttle.duration == 3600


### PR DESCRIPTION
### **User description**
## The bug

`FeedbackRateThrottle` subclasses `AnonRateThrottle` without overriding `scope`, so it inherits scope `anon`. DRF derives the throttle cache key from the scope alone (`throttle_<scope>_<ident>`), which means this **5/hour** throttle has been sharing one history list with the global `SyncedAnonRateThrottle` — also scope `anon`, running on every other public endpoint at **1000/hour**.

The cost falls on the worst possible user: someone who browsed the site before reporting. Five anonymous API reads in the past hour fill the bucket, and their **first** corruption report or feedback submission is refused with a 429.

`NewsletterRateThrottle` sets `scope = "newsletter"` for exactly this reason (`newsletter/views.py`), and its docstring predates this one — the omission looks like an oversight rather than a decision.

## Why no test caught it

The global throttle classes are emptied under `TESTING` (`config/settings.py`), so the two can never collide in the suite. The only place the bug exists is production. The new test therefore asserts on the **scope and cache key** rather than trying to reproduce a collision the test settings make impossible.

## Verification

```
$ pytest tests/api/test_feedback_throttle_scope.py tests/api/test_feedback_api.py
24 passed
```

Before: `throttle_anon_203.0.113.7` (shared). After: `throttle_feedback_203.0.113.7`.

The explicit `rate` attribute stays, so DRF never looks up `DEFAULT_THROTTLE_RATES["feedback"]` and no settings entry is needed — same arrangement as the newsletter throttle.

## Note

Found while reviewing #447; split out deliberately because it is an independent production bug with its own blast radius, and is branched from `main` rather than that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Isolate feedback throttle bucket

- Preserve `5/hour` feedback limit

- Add regression cache-key tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  feedback["FeedbackRateThrottle"] -- "sets scope" --> bucket["throttle_feedback_<ident>"]
  anon["SyncedAnonRateThrottle"] -- "keeps scope" --> anonBucket["throttle_anon_<ident>"]
  tests["Regression tests"] -- "assert" --> bucket
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_views.py</strong><dd><code>Feedback throttle gets dedicated scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cases/api_views.py

<ul><li>Sets <code>FeedbackRateThrottle.scope = "feedback"</code><br> <li> Documents prior shared <code>anon</code> bucket bug<br> <li> Keeps explicit <code>rate = "5/hour"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/446/files#diff-926cb1b9dfa09c768f390c34cfd718fa4c7c17e97f530b19cac222c2a9a55138">+20/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_feedback_throttle_scope.py</strong><dd><code>Regression tests for feedback throttle scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/api/test_feedback_throttle_scope.py

<ul><li>Adds cache-clearing throttle tests<br> <li> Verifies dedicated <code>feedback</code> scope<br> <li> Asserts cache key avoids <code>throttle_anon</code><br> <li> Confirms <code>5/hour</code> parsing remains</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/446/files#diff-54052a955acb7f310442bb6f8b1572a6ea02d0c4a8816af4116fad8a6bb70864">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback submissions now use a dedicated rate-limit scope, preventing them from sharing limits with other anonymous activity.
  * The existing limit of five feedback submissions per hour remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->