### PR TITLE
feat(feedback): a staff queue for submissions, so triage leaves Django admin

### DIFF
--- a/cases/admin.py
+++ b/cases/admin.py
@@ -752,7 +752,22 @@ admin.site.index_title = "Welcome to Jawafdehi Contributor Portal"
 
 @admin.register(Feedback)
 class FeedbackAdmin(admin.ModelAdmin):
-    """Admin interface for Feedback model."""
+    """Read-and-delete admin for Feedback. Triage happens in the SPA panel.
+
+    The SPA ``/admin/feedback`` queue (``FeedbackTriageViewSet``) is the sole
+    write surface for ``status`` and ``admin_notes``, following the same rule as
+    ``CaseAdmin`` above: one editor, so two surfaces can't disagree about a
+    submission and so every triage edit is attributed through DRF's
+    authenticated user.
+
+    Reading stays here because this is the only place the reporter's contact
+    details, IP and user agent are visible at all — the API deliberately does
+    not serialize them — and that remains a superuser action.
+
+    Delete is deliberately NOT disabled. Purging spam and honouring an erasure
+    request are destructive and irreversible, so they stay with the superuser
+    who can see the whole record rather than moving to the role-gated queue.
+    """
 
     list_display = [
         "id",
@@ -800,6 +815,14 @@ class FeedbackAdmin(admin.ModelAdmin):
             },
         ),
     )
+
+    def has_add_permission(self, request):
+        """Feedback arrives through the public form; nobody hand-creates it."""
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        """View-only: the SPA panel is the sole feedback write surface."""
+        return False
 
     def has_contact_info(self, obj):
         """Check if feedback has contact information."""

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -27,7 +27,7 @@ from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
 )
-from rest_framework import filters, status, viewsets
+from rest_framework import filters, mixins, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
@@ -57,6 +57,7 @@ from .models import (
     CaseSlugHistory,
     CaseState,
     CaseStateChange,
+    Feedback,
     FeedbackType,
     RelationshipOutcome,
     RelationshipType,
@@ -74,6 +75,7 @@ from .serializers import (
     CaseSerializer,
     CaseStateChangeSerializer,
     FeedbackSerializer,
+    FeedbackTriageSerializer,
 )
 from .services.statistics import (
     STATISTICS_SNAPSHOT_KEY,
@@ -1632,10 +1634,11 @@ class FeedbackRateThrottle(AnonRateThrottle):
 def _notify_case_report(feedback) -> None:
     """Best-effort alert to the casework inbox that a report has landed.
 
-    Feedback has no read API and no notification of any kind, so without this a
-    corruption report is only discovered by someone opening Django admin. Django's
-    mail backend is the dummy one on this platform (it accepts and discards), so
-    SendPulse's transactional endpoint is the only path that actually sends.
+    Reports are now visible in the SPA admin panel's feedback queue
+    (``FeedbackTriageViewSet``), but nothing polls it, so without this mail a
+    corruption report waits until someone happens to look. Django's mail backend
+    is the dummy one on this platform (it accepts and discards), so SendPulse's
+    transactional endpoint is the only path that actually sends.
 
     The mail carries a reference number and an admin link, and nothing else. Not
     the subject, not the description, not whether contact details or an
@@ -1651,12 +1654,18 @@ def _notify_case_report(feedback) -> None:
     recipient = getattr(settings, "CASE_REPORT_NOTIFY_EMAIL", "")
     if not recipient:
         return
-    # A relative link is useless in an email client, so an absolute admin base
-    # is a precondition for sending rather than something to paper over.
-    base = getattr(settings, "WAGTAILADMIN_BASE_URL", "").strip().rstrip("/")
+    # A relative link is useless in an email client, so an absolute base is a
+    # precondition for sending rather than something to paper over.
+    #
+    # This points at the SPA feedback queue, not Django admin. The recipient is
+    # the casework inbox, and a caseworker has no Django admin feedback
+    # permission at all (``create_groups`` grants none) — the old link 403'd for
+    # exactly the people it was sent to. The SPA queue is gated on the Caseworker
+    # role, so it opens for them.
+    base = getattr(settings, "FRONTEND_BASE_URL", "").strip().rstrip("/")
     if not base.startswith(("http://", "https://")):
         logger.warning(
-            "Case report notification skipped for #%s: WAGTAILADMIN_BASE_URL is not an absolute URL (%r)",
+            "Case report notification skipped for #%s: FRONTEND_BASE_URL is not an absolute URL (%r)",
             feedback.pk,
             base,
         )
@@ -1667,7 +1676,7 @@ def _notify_case_report(feedback) -> None:
         client = get_client()
         if client is None or not client.can_send_email:
             return
-        admin_url = f"{base}/django-admin/cases/feedback/{feedback.pk}/change/"
+        admin_url = f"{base}/admin/feedback/{feedback.pk}"
         html = (
             "<p>A corruption case report was submitted through the website.</p>"
             f"<p>Reference: <strong>#{feedback.pk}</strong></p>"
@@ -1786,6 +1795,96 @@ class FeedbackView(APIView):
         else:
             ip = request.META.get("REMOTE_ADDR")
         return ip
+
+
+class IsFeedbackTriager(permissions.BasePermission):
+    """Superuser (admin) or the Caseworker content-staff role.
+
+    Same principal set as ``review.permissions.IsContentStaff`` and built on the
+    same predicate, but declared here so the cases app does not take an import
+    dependency on the review app (review already imports ``cases``). Named for
+    what it gates rather than for the review system, because triaging public
+    feedback is not casework.
+
+    ReadOnly is deliberately excluded even though it is an org-wide *read* role
+    and this class also gates reads. The systemwide-read invariant is about
+    platform records; a feedback submission is a message from a member of the
+    public, sometimes naming an official, and its audience is the people who act
+    on it rather than everyone who can read the platform.
+    """
+
+    message = "Reading or triaging feedback requires the Caseworker role."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        return bool(user.is_superuser or is_admin_or_moderator(user))
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary="List feedback submissions (staff)",
+        description=(
+            "Staff-facing queue of everything submitted through the public feedback "
+            "and case-report forms. Requires the Caseworker role or superuser.\n\n"
+            "The reporter's contact details, IP address and user agent are NOT "
+            "returned by this endpoint — only whether contact details exist. "
+            "Retrieving them remains a superuser action in Django admin."
+        ),
+    ),
+    retrieve=extend_schema(summary="Retrieve one feedback submission (staff)"),
+    partial_update=extend_schema(
+        summary="Triage a feedback submission (staff)",
+        description=(
+            "Update the workflow ``status`` and/or the internal ``adminNotes``. "
+            "Everything the reporter wrote is read-only."
+        ),
+    ),
+)
+class FeedbackTriageViewSet(
+    AuditlogActorMixin,
+    mixins.UpdateModelMixin,
+    viewsets.ReadOnlyModelViewSet,
+):
+    """Staff read + triage surface for feedback, at ``/api/feedback-submissions/``.
+
+    Separate from the public ``FeedbackView`` on purpose, and not simply a GET
+    added to it. That view sets ``authentication_classes = []`` so an anonymous
+    reporter can always POST; with no authenticator running, ``request.user`` is
+    always anonymous there and a staff GET could never be identified. Restoring
+    authentication to serve a read would also mean a stale bearer token in a
+    reporter's browser could 401 the public form — a regression paid by the
+    person least able to work around it. Two routes, two auth postures.
+
+    ``AuditlogActorMixin`` binds the DRF-authenticated user so a triage edit is
+    attributed to whoever made it; the model is auditlog-registered with
+    ``description`` / ``contact_info`` / ``ip_address`` masked, so the trail
+    records who moved a submission through the workflow without copying the
+    reporter's words into a second table.
+    """
+
+    serializer_class = FeedbackTriageSerializer
+    permission_classes = [IsFeedbackTriager]
+    pagination_class = CasePagination
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter,
+    ]
+    filterset_fields = ["status", "feedback_type"]
+    search_fields = ["subject", "description", "related_page"]
+    ordering_fields = ["submitted_at", "updated_at", "status", "feedback_type"]
+    ordering = ["-submitted_at"]
+    # No PUT: only two fields are writable, so a full replace has no meaning
+    # here and would invite a client to send back the read-only reporter fields.
+    http_method_names = ["get", "patch", "head", "options"]
+
+    # ``defer`` rather than relying on the serializer's field list alone. The
+    # two columns this endpoint must never disclose are then not loaded into the
+    # process at all, so a later field added to the serializer by mistake shows
+    # up as an extra query in review rather than as a silent PII leak.
+    queryset = Feedback.objects.defer("ip_address", "user_agent")
 
 
 OEMBED_URL_PATTERN = re.compile(

--- a/cases/api_views.py
+++ b/cases/api_views.py
@@ -27,7 +27,7 @@ from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
 )
-from rest_framework import filters, mixins, permissions, status, viewsets
+from rest_framework import filters, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
@@ -50,6 +50,7 @@ from .caseworker_serializers import (
     CaseCreateSerializer,
     CasePatchSerializer,
 )
+from .permissions import IsFeedbackTriager
 from .models import (
     Case,
     CaseEntityRelationship,
@@ -1654,22 +1655,23 @@ def _notify_case_report(feedback) -> None:
     recipient = getattr(settings, "CASE_REPORT_NOTIFY_EMAIL", "")
     if not recipient:
         return
-    # A relative link is useless in an email client, so an absolute base is a
-    # precondition for sending rather than something to paper over.
-    #
     # This points at the SPA feedback queue, not Django admin. The recipient is
     # the casework inbox, and a caseworker has no Django admin feedback
     # permission at all (``create_groups`` grants none) — the old link 403'd for
     # exactly the people it was sent to. The SPA queue is gated on the Caseworker
     # role, so it opens for them.
-    base = getattr(settings, "FRONTEND_BASE_URL", "").strip().rstrip("/")
+    #
+    # An EMPTY setting falls back to the default rather than suppressing the
+    # mail, matching ``case_events.notify._base_url`` — the other consumer of
+    # this setting, which also builds an /admin/... deep link. os.getenv's
+    # default only applies when the variable is ABSENT, so a ConfigMap key
+    # rendered as "" would otherwise reach us blank; the two consumers must not
+    # disagree about what blank means. Silence is the worst failure mode here:
+    # nothing polls the queue, so a suppressed mail means the report is simply
+    # never read.
+    base = (getattr(settings, "FRONTEND_BASE_URL", "") or "").strip().rstrip("/")
     if not base.startswith(("http://", "https://")):
-        logger.warning(
-            "Case report notification skipped for #%s: FRONTEND_BASE_URL is not an absolute URL (%r)",
-            feedback.pk,
-            base,
-        )
-        return
+        base = "https://jawafdehi.org"
     try:
         from newsletter.sendpulse import get_client
 
@@ -1797,31 +1799,6 @@ class FeedbackView(APIView):
         return ip
 
 
-class IsFeedbackTriager(permissions.BasePermission):
-    """Superuser (admin) or the Caseworker content-staff role.
-
-    Same principal set as ``review.permissions.IsContentStaff`` and built on the
-    same predicate, but declared here so the cases app does not take an import
-    dependency on the review app (review already imports ``cases``). Named for
-    what it gates rather than for the review system, because triaging public
-    feedback is not casework.
-
-    ReadOnly is deliberately excluded even though it is an org-wide *read* role
-    and this class also gates reads. The systemwide-read invariant is about
-    platform records; a feedback submission is a message from a member of the
-    public, sometimes naming an official, and its audience is the people who act
-    on it rather than everyone who can read the platform.
-    """
-
-    message = "Reading or triaging feedback requires the Caseworker role."
-
-    def has_permission(self, request, view):
-        user = request.user
-        if not (user and user.is_authenticated):
-            return False
-        return bool(user.is_superuser or is_admin_or_moderator(user))
-
-
 @extend_schema_view(
     list=extend_schema(
         summary="List feedback submissions (staff)",
@@ -1833,12 +1810,16 @@ class IsFeedbackTriager(permissions.BasePermission):
             "Retrieving them remains a superuser action in Django admin."
         ),
     ),
-    retrieve=extend_schema(summary="Retrieve one feedback submission (staff)"),
+    retrieve=extend_schema(
+        summary="Retrieve one feedback submission (staff)",
+        description="One submission, in the same PII-free shape as the list.",
+    ),
     partial_update=extend_schema(
         summary="Triage a feedback submission (staff)",
         description=(
-            "Update the workflow ``status`` and/or the internal ``adminNotes``. "
-            "Everything the reporter wrote is read-only."
+            "Update the workflow ``status``, the internal ``adminNotes``, and/or "
+            "``feedbackType`` to reclassify a mis-filed submission. Everything "
+            "the reporter wrote is read-only."
         ),
     ),
 )
@@ -1849,21 +1830,26 @@ class FeedbackTriageViewSet(
 ):
     """Staff read + triage surface for feedback, at ``/api/feedback-submissions/``.
 
-    Separate from the public ``FeedbackView`` on purpose, and not simply a GET
-    added to it. That view sets ``authentication_classes = []`` so an anonymous
-    reporter can always POST; with no authenticator running, ``request.user`` is
-    always anonymous there and a staff GET could never be identified. Restoring
-    authentication to serve a read would also mean a stale bearer token in a
-    reporter's browser could 401 the public form — a regression paid by the
-    person least able to work around it. Two routes, two auth postures.
-
-    ``AuditlogActorMixin`` binds the DRF-authenticated user so a triage edit is
-    attributed to whoever made it; the model is auditlog-registered with
-    ``description`` / ``contact_info`` / ``ip_address`` masked, so the trail
-    records who moved a submission through the workflow without copying the
-    reporter's words into a second table.
+    Every operation carries an explicit ``description`` above. That is
+    load-bearing, not decoration: drf-spectacular falls back to THIS docstring
+    for any operation without one, and ``/api/schema/`` is served with
+    drf-spectacular's default ``SERVE_PERMISSIONS`` of ``AllowAny``. Anything
+    written here is world-readable, so the reasoning below stays in comments.
     """
 
+    # Why this is a separate route rather than a GET added to the public
+    # ``FeedbackView``: that view sets ``authentication_classes = []`` so an
+    # anonymous reporter can always POST. With no authenticator running,
+    # ``request.user`` is always anonymous there and a staff GET could never be
+    # identified. Restoring authentication to serve a read would also mean a
+    # stale bearer token in a reporter's browser could 401 the public form — a
+    # regression paid by the person least able to work around it.
+    #
+    # ``AuditlogActorMixin`` binds the DRF-authenticated user so a triage edit is
+    # attributed to whoever made it. Note the trail is NOT a privacy control:
+    # auditlog's ``mask_fields`` (cases/apps.py) replaces only the first half of
+    # a value, so a masked ``contact_info`` still shows the tail of an email
+    # address. The control that matters is the serializer's field list.
     serializer_class = FeedbackTriageSerializer
     permission_classes = [IsFeedbackTriager]
     pagination_class = CasePagination
@@ -1876,14 +1862,21 @@ class FeedbackTriageViewSet(
     search_fields = ["subject", "description", "related_page"]
     ordering_fields = ["submitted_at", "updated_at", "status", "feedback_type"]
     ordering = ["-submitted_at"]
-    # No PUT: only two fields are writable, so a full replace has no meaning
+    # No PUT: only three fields are writable, so a full replace has no meaning
     # here and would invite a client to send back the read-only reporter fields.
     http_method_names = ["get", "patch", "head", "options"]
 
-    # ``defer`` rather than relying on the serializer's field list alone. The
-    # two columns this endpoint must never disclose are then not loaded into the
-    # process at all, so a later field added to the serializer by mistake shows
-    # up as an extra query in review rather than as a silent PII leak.
+    # Defence in depth on the READ path only, and it is worth being precise
+    # about how little that is worth: ``defer`` is a laziness hint, NOT an access
+    # boundary. Django loads a deferred column transparently on first attribute
+    # access, so a PII field added to the serializer by mistake would still be
+    # served — just with an extra query per row. The control that actually holds
+    # is ``FeedbackTriageSerializer``'s field list, guarded by the PII_KEYS
+    # assertions in tests/api/test_feedback_triage.py.
+    #
+    # It does hold on this path because nothing here touches the two columns.
+    # It does NOT survive ``Model.save()``, which is one of the reasons the
+    # serializer writes via a column-scoped UPDATE instead (see its ``update``).
     queryset = Feedback.objects.defer("ip_address", "user_agent")
 
 

--- a/cases/permissions.py
+++ b/cases/permissions.py
@@ -1,0 +1,40 @@
+"""DRF permissions for the cases app.
+
+Lives here rather than in ``jawafdehi_shared/drf/`` because these wrap
+``cases.rules.predicates``, which knows about the Caseworker group; the shared
+package is cross-service (nes/ngm/jawafdehi) and deliberately knows nothing
+about this platform's role model.
+"""
+
+from rest_framework import permissions
+
+from .rules.predicates import is_admin_or_moderator
+
+
+class IsFeedbackTriager(permissions.BasePermission):
+    """Superuser (admin) or the Caseworker content-staff role.
+
+    The same principal set as ``review.permissions.IsContentStaff``, built on the
+    same ``is_admin_or_moderator`` predicate. Kept as a second class rather than
+    imported from ``review``: that app already imports ``cases``, and the reverse
+    edge would close a cycle. Named for what it gates because triaging public
+    feedback is not casework. **If you change the content-staff principal set,
+    change both** — ``review/permissions.py`` carries a pointer back here.
+
+    ReadOnly is deliberately excluded even though it is an org-wide *read* role
+    and this class also gates reads. The systemwide-read invariant is about
+    platform records; a feedback submission is a message from a member of the
+    public, sometimes naming an official, and its audience is the people who act
+    on it rather than everyone who can read the platform. JobPoller is excluded
+    for the same reason — no machine identity needs to read reporter prose.
+    """
+
+    message = "Reading or triaging feedback requires the Caseworker role."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        # is_admin_or_moderator already carries the is_superuser term (it is
+        # documented as the only predicate that does), so don't re-OR it.
+        return bool(is_admin_or_moderator(user))

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -6,6 +6,7 @@ See: .kiro/specs/accountability-platform-core/design.md
 
 import logging
 
+from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field, inline_serializer
 from rest_framework import serializers
@@ -15,6 +16,7 @@ from .models import (
     CaseEntityRelationship,
     CaseStateChange,
     Feedback,
+    FeedbackType,
 )
 
 logger = logging.getLogger(__name__)
@@ -521,29 +523,30 @@ class FeedbackSerializer(serializers.ModelSerializer):
 
 
 class FeedbackTriageSerializer(serializers.ModelSerializer):
-    """Staff-facing read + triage view of a submission. Deliberately PII-free.
+    """Staff-facing read + triage view of a submission. Carries no reporter PII.
 
-    This is the shape the SPA admin panel reads, and it is NOT
-    ``FeedbackSerializer`` with extra fields — it is narrower on purpose. The
-    reporter's identifying data (``contact_info``, ``ip_address``,
-    ``user_agent``) and the attachment's URL are absent from the field list
-    entirely, so no combination of query params can surface them. A triager
-    sees what was reported and can move it through the workflow; reaching the
-    person who reported it stays a superuser action in Django admin.
+    Narrower than ``FeedbackSerializer`` on purpose: ``contact_info``,
+    ``ip_address``, ``user_agent`` and the attachment's URL are absent from the
+    field list, so no combination of query params surfaces them. A triager sees
+    what was reported and moves it through the workflow; reaching the person who
+    reported it stays a superuser action in Django admin.
 
-    That mirrors the masking already applied to this model's audit trail
-    (``cases.apps``: ``mask_fields=["description", "contact_info",
-    "ip_address"]``) and the submission path's refusal to store an IP at all
-    for ``case_report`` (see ``FeedbackView.post``). Presence booleans are
-    exposed rather than the values, because "there is an attachment you cannot
-    open here" is what tells a triager to escalate.
-
-    Only ``status`` and ``adminNotes`` are writable. Everything the reporter
-    wrote is read-only: triage records a decision about a submission, it does
-    not get to rewrite what was submitted.
+    Writable: ``status``, ``adminNotes``, and ``feedbackType``. Everything the
+    reporter wrote is read-only — triage records a decision about a submission
+    and re-files it, but does not rewrite it.
     """
 
-    feedbackType = serializers.CharField(source="feedback_type", read_only=True)
+    # Reclassification is a triage decision, not a rewrite: the public form lets
+    # anyone pick "general" for what is actually a corruption allegation, and
+    # only ``case_report`` gets the notification and the distinct treatment in
+    # the queue. Writable here because this is now the ONLY surface that can fix
+    # it — Django admin is view-only, and the public endpoint is create-only.
+    feedbackType = serializers.ChoiceField(
+        source="feedback_type",
+        choices=FeedbackType.choices,
+        required=False,
+        help_text="Reclassify the submission (e.g. a corruption report filed as 'general')",
+    )
     relatedPage = serializers.CharField(source="related_page", read_only=True)
     adminNotes = serializers.CharField(
         source="admin_notes",
@@ -560,6 +563,10 @@ class FeedbackTriageSerializer(serializers.ModelSerializer):
     submittedAt = serializers.DateTimeField(source="submitted_at", read_only=True)
     updatedAt = serializers.DateTimeField(source="updated_at", read_only=True)
 
+    #: The only model columns a triage PATCH may touch. Used to scope the write
+    #: (see ``update``) so the statement can never carry a PII column.
+    TRIAGE_FIELDS = ("status", "admin_notes", "feedback_type")
+
     class Meta:
         model = Feedback
         fields = [
@@ -575,18 +582,65 @@ class FeedbackTriageSerializer(serializers.ModelSerializer):
             "submittedAt",
             "updatedAt",
         ]
-        read_only_fields = [
-            "id",
-            "feedbackType",
-            "subject",
-            "description",
-            "relatedPage",
-            "submittedAt",
-            "updatedAt",
-        ]
+        # ONLY the undeclared model fields belong here. DRF short-circuits
+        # declared fields before it consults extra_kwargs (serializers.py:
+        # ``if field_name in declared_fields: ... continue``), so listing
+        # ``relatedPage``/``submittedAt``/``updatedAt`` here would be inert —
+        # their immutability comes from ``read_only=True`` on the declaration
+        # above, and a list that looks like the guard but isn't is worse than no
+        # list. ``id`` is read-only automatically.
+        read_only_fields = ["subject", "description"]
 
     def get_hasAttachment(self, obj) -> bool:
         return bool(obj.attachment)
 
     def get_hasContactInfo(self, obj) -> bool:
-        return bool(obj.contact_info and obj.contact_info.get("contactMethods"))
+        # ``name`` alone counts. ContactInfoSerializer makes both `name` and
+        # `contactMethods` optional, so {"name": "..."} with no methods is a
+        # valid submission — and reporting `false` for it would tell a triager a
+        # report is anonymous while the reporter's name sits in the row.
+        if not obj.contact_info:
+            return False
+        return bool(
+            obj.contact_info.get("contactMethods") or obj.contact_info.get("name")
+        )
+
+    def update(self, instance, validated_data):
+        """Write ONLY the triage columns, without running ``Model.save()``.
+
+        ``Feedback.save()`` calls ``full_clean()``, which is wrong for this path
+        in three ways. It reads every concrete field, so the ``ip_address`` /
+        ``user_agent`` columns this endpoint defers get pulled back into the
+        process on each edit and the resulting UPDATE rewrites them. It calls
+        ``Feedback.clean()``, which evaluates ``self.attachment.size`` — a HEAD
+        request to object storage on every status change, and an unhandled
+        exception (not a ValidationError) if the object has been purged from the
+        bucket, which would make such a row permanently un-triageable now that
+        Django admin cannot edit it either. And it re-validates reporter fields
+        this request never touched, so one legacy row that predates a constraint
+        would 500 a status change.
+
+        A column-scoped ``QuerySet.update()`` avoids all three, and the audit
+        trail survives it: this model's manager mixes in
+        ``jawafdehi_shared.db.audited.AuditedQuerySet``, whose ``update()``
+        already writes the UPDATE entry that ``post_save`` would have, with the
+        actor bound by ``AuditlogActorMixin`` on the viewset. Do NOT add an
+        explicit ``log_bulk_update`` here — that logs the edit a second time.
+        """
+        updates = {
+            field: validated_data[field]
+            for field in self.TRIAGE_FIELDS
+            if field in validated_data
+        }
+        if not updates:
+            return instance
+
+        # auto_now doesn't fire for QuerySet.update(), so stamp it ourselves —
+        # the queue's "last updated" reads this column. AuditedQuerySet omits
+        # auto_now-only columns from the diff, so this doesn't pollute the trail.
+        updates["updated_at"] = timezone.now()
+        Feedback.objects.filter(pk=instance.pk).update(**updates)
+
+        for field, value in updates.items():
+            setattr(instance, field, value)
+        return instance

--- a/cases/serializers.py
+++ b/cases/serializers.py
@@ -518,3 +518,75 @@ class FeedbackSerializer(serializers.ModelSerializer):
             "submittedAt": data["submittedAt"],
             "message": "Thank you for your feedback! We will review it and get back to you if needed.",
         }
+
+
+class FeedbackTriageSerializer(serializers.ModelSerializer):
+    """Staff-facing read + triage view of a submission. Deliberately PII-free.
+
+    This is the shape the SPA admin panel reads, and it is NOT
+    ``FeedbackSerializer`` with extra fields — it is narrower on purpose. The
+    reporter's identifying data (``contact_info``, ``ip_address``,
+    ``user_agent``) and the attachment's URL are absent from the field list
+    entirely, so no combination of query params can surface them. A triager
+    sees what was reported and can move it through the workflow; reaching the
+    person who reported it stays a superuser action in Django admin.
+
+    That mirrors the masking already applied to this model's audit trail
+    (``cases.apps``: ``mask_fields=["description", "contact_info",
+    "ip_address"]``) and the submission path's refusal to store an IP at all
+    for ``case_report`` (see ``FeedbackView.post``). Presence booleans are
+    exposed rather than the values, because "there is an attachment you cannot
+    open here" is what tells a triager to escalate.
+
+    Only ``status`` and ``adminNotes`` are writable. Everything the reporter
+    wrote is read-only: triage records a decision about a submission, it does
+    not get to rewrite what was submitted.
+    """
+
+    feedbackType = serializers.CharField(source="feedback_type", read_only=True)
+    relatedPage = serializers.CharField(source="related_page", read_only=True)
+    adminNotes = serializers.CharField(
+        source="admin_notes",
+        required=False,
+        allow_blank=True,
+        help_text="Internal triage notes (staff-visible only)",
+    )
+    hasAttachment = serializers.SerializerMethodField(
+        help_text="Whether an attachment was supplied (the file itself is not exposed here)"
+    )
+    hasContactInfo = serializers.SerializerMethodField(
+        help_text="Whether contact details were supplied (the details are not exposed here)"
+    )
+    submittedAt = serializers.DateTimeField(source="submitted_at", read_only=True)
+    updatedAt = serializers.DateTimeField(source="updated_at", read_only=True)
+
+    class Meta:
+        model = Feedback
+        fields = [
+            "id",
+            "feedbackType",
+            "subject",
+            "description",
+            "relatedPage",
+            "status",
+            "adminNotes",
+            "hasAttachment",
+            "hasContactInfo",
+            "submittedAt",
+            "updatedAt",
+        ]
+        read_only_fields = [
+            "id",
+            "feedbackType",
+            "subject",
+            "description",
+            "relatedPage",
+            "submittedAt",
+            "updatedAt",
+        ]
+
+    def get_hasAttachment(self, obj) -> bool:
+        return bool(obj.attachment)
+
+    def get_hasContactInfo(self, obj) -> bool:
+        return bool(obj.contact_info and obj.contact_info.get("contactMethods"))

--- a/cases/urls.py
+++ b/cases/urls.py
@@ -9,6 +9,7 @@ from rest_framework.routers import DefaultRouter
 
 from .api_views import (
     CaseViewSet,
+    FeedbackTriageViewSet,
     FeedbackView,
     OEmbedView,
     StatisticsView,
@@ -22,6 +23,12 @@ from .api_views import (
 # JawafEntity-backed entities endpoint was removed with the JawafEntity model.
 router = DefaultRouter()
 router.register(r"cases", CaseViewSet, basename="case")
+# Staff read/triage queue. Registered on a path of its own rather than as a GET
+# on ``feedback/`` because that route is the public, deliberately
+# unauthenticated submission endpoint (see FeedbackTriageViewSet's docstring).
+router.register(
+    r"feedback-submissions", FeedbackTriageViewSet, basename="feedback-submission"
+)
 
 urlpatterns = [
     # NOTE: ``search/`` is no longer mounted here. The platform-wide unified

--- a/review/permissions.py
+++ b/review/permissions.py
@@ -83,6 +83,13 @@ class IsContentStaff(permissions.BasePermission):
     v3 authz model: there is one content role (Caseworker, folding in the old
     Moderator). Used to gate review-wide settings (e.g. the global scoring
     thresholds) to content staff; ReadOnly may read but not change them.
+
+    DUPLICATE: ``cases.permissions.IsFeedbackTriager`` admits the same principals
+    for the feedback queue. It is a separate class because ``cases`` cannot
+    import ``review`` (this module imports ``cases.rules.predicates``, so the
+    reverse edge would close a cycle). **Change both together** — they share the
+    ``is_admin_or_moderator`` predicate, so a change there covers both, but a
+    change to the class logic here does not.
     """
 
     message = "This action requires the Caseworker role."

--- a/tests/api/test_feedback_api.py
+++ b/tests/api/test_feedback_api.py
@@ -412,17 +412,29 @@ class TestCaseReportNotification:
         _, _, html = client.send_email.call_args[0]
         assert "/django-admin/" not in html
 
-    def test_no_notification_without_an_absolute_frontend_url(
-        self, api_client, settings, monkeypatch
+    @pytest.mark.parametrize("configured", ["", "   ", "/admin", None])
+    def test_a_blank_frontend_url_still_sends_using_the_default(
+        self, api_client, settings, monkeypatch, configured
     ):
-        """A relative link cannot be resolved by a mail client, so don't send."""
+        """A blank or relative setting must not silence the alert.
+
+        ``os.getenv``'s default only applies when the variable is ABSENT, so a
+        ConfigMap key rendered as "" arrives blank. Suppressing the mail on
+        blank would be the worst failure mode available: nothing polls the
+        queue, so the report would simply never be read, and the only signal
+        would be a log line. Fall back to the canonical host instead — the same
+        thing ``case_events.notify._base_url`` does with this setting.
+        """
         settings.CASE_REPORT_NOTIFY = True
-        settings.FRONTEND_BASE_URL = ""
+        settings.FRONTEND_BASE_URL = configured
         client = Mock(can_send_email=True)
         monkeypatch.setattr("newsletter.sendpulse.get_client", Mock(return_value=client))
 
-        assert self._submit(api_client).status_code == 201
-        client.send_email.assert_not_called()
+        response = self._submit(api_client)
+        assert response.status_code == 201
+        client.send_email.assert_called_once()
+        _, _, html = client.send_email.call_args[0]
+        assert f'https://jawafdehi.org/admin/feedback/{response.json()["id"]}' in html
 
     def test_notification_link_is_absolute(self, api_client, settings, monkeypatch):
         settings.CASE_REPORT_NOTIFY = True

--- a/tests/api/test_feedback_api.py
+++ b/tests/api/test_feedback_api.py
@@ -397,14 +397,27 @@ class TestCaseReportNotification:
         for leaked in ("Received:", "Contact details supplied:", "Attachment:"):
             assert leaked not in html
 
-        assert "/django-admin/cases/feedback/" in html
+        assert "/admin/feedback/" in html
 
-    def test_no_notification_without_an_absolute_admin_url(
+    def test_notification_links_to_the_spa_queue_not_django_admin(
+        self, api_client, settings, monkeypatch
+    ):
+        """The recipient is the casework inbox, and a caseworker has no Django
+        admin feedback permission — the link has to open for them."""
+        settings.CASE_REPORT_NOTIFY = True
+        client = Mock(can_send_email=True)
+        monkeypatch.setattr("newsletter.sendpulse.get_client", Mock(return_value=client))
+
+        self._submit(api_client)
+        _, _, html = client.send_email.call_args[0]
+        assert "/django-admin/" not in html
+
+    def test_no_notification_without_an_absolute_frontend_url(
         self, api_client, settings, monkeypatch
     ):
         """A relative link cannot be resolved by a mail client, so don't send."""
         settings.CASE_REPORT_NOTIFY = True
-        settings.WAGTAILADMIN_BASE_URL = ""
+        settings.FRONTEND_BASE_URL = ""
         client = Mock(can_send_email=True)
         monkeypatch.setattr("newsletter.sendpulse.get_client", Mock(return_value=client))
 
@@ -413,16 +426,13 @@ class TestCaseReportNotification:
 
     def test_notification_link_is_absolute(self, api_client, settings, monkeypatch):
         settings.CASE_REPORT_NOTIFY = True
-        settings.WAGTAILADMIN_BASE_URL = "https://portal.jawafdehi.org/"
+        settings.FRONTEND_BASE_URL = "https://jawafdehi.org/"
         client = Mock(can_send_email=True)
         monkeypatch.setattr("newsletter.sendpulse.get_client", Mock(return_value=client))
 
         response = self._submit(api_client)
         _, _, html = client.send_email.call_args[0]
-        assert (
-            f'https://portal.jawafdehi.org/django-admin/cases/feedback/{response.json()["id"]}/change/'
-            in html
-        )
+        assert f'https://jawafdehi.org/admin/feedback/{response.json()["id"]}' in html
 
     def test_submission_survives_a_failing_notification(
         self, api_client, settings, monkeypatch

--- a/tests/api/test_feedback_triage.py
+++ b/tests/api/test_feedback_triage.py
@@ -173,6 +173,21 @@ class TestFeedbackTriagePrivacy:
         assert rows[without.pk]["hasContactInfo"] is False
         assert rows[with_contact.pk]["hasAttachment"] is False
 
+    def test_a_name_alone_counts_as_contact_info(self, caseworker):
+        """``name`` without ``contactMethods`` is a valid submission.
+
+        Reporting ``false`` for it would tell a triager the report is anonymous
+        while the reporter's name sits in the row — the exact mistake that leads
+        to forwarding a "safe" report onward, or to answering an erasure request
+        with "we hold no personal data".
+        """
+        named = _feedback(subject="Name only", contact_info={"name": "A Reporter"})
+
+        row = _authed_client(caseworker).get(DETAIL_URL.format(named.pk)).json()
+
+        assert row["hasContactInfo"] is True
+        assert "A Reporter" not in str(row)
+
     def test_reported_content_is_readable(self, caseworker):
         """Triage would be pointless without the report itself."""
         feedback = _feedback()
@@ -227,7 +242,6 @@ class TestFeedbackTriageWrites:
                 "subject": "Rewritten by staff",
                 "description": "Rewritten body",
                 "relatedPage": "Elsewhere",
-                "feedbackType": "general",
                 "status": "in_review",
             },
             format="json",
@@ -238,9 +252,124 @@ class TestFeedbackTriageWrites:
         assert feedback.subject == "Search is broken"
         assert feedback.description == "Searching for a case returns nothing."
         assert feedback.related_page == "Cases page"
-        assert feedback.feedback_type == FeedbackType.BUG
         # The one field that was supposed to move, moved.
         assert feedback.status == FeedbackStatus.IN_REVIEW
+
+    def test_a_submission_can_be_reclassified(self, caseworker):
+        """Re-filing is a triage decision, and this is now the only surface for it.
+
+        The public form lets anyone pick "general" for what is actually a
+        corruption allegation. Only ``case_report`` gets the notification and the
+        distinct treatment in the queue, and Django admin can no longer edit, so
+        without this the misfiling would be permanent.
+        """
+        feedback = _feedback(feedback_type=FeedbackType.GENERAL)
+
+        response = _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk),
+            {"feedbackType": "case_report"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        feedback.refresh_from_db()
+        assert feedback.feedback_type == FeedbackType.CASE_REPORT
+
+    def test_reclassifying_to_an_unknown_type_is_rejected(self, caseworker):
+        feedback = _feedback()
+        response = _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk),
+            {"feedbackType": "not_a_type"},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        feedback.refresh_from_db()
+        assert feedback.feedback_type == FeedbackType.BUG
+
+    def test_triage_never_writes_a_pii_column(self, caseworker, django_assert_num_queries):
+        """The write is column-scoped, so a PATCH cannot touch reporter data.
+
+        ``Feedback.save()`` runs ``full_clean()``, which reads every concrete
+        field — that would un-defer ip_address/user_agent and emit a
+        full-column UPDATE rewriting them. The serializer writes via a scoped
+        QuerySet.update() instead; this asserts the columns survive untouched
+        and that no extra SELECT pulled them into the process.
+        """
+        feedback = _feedback()
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = _authed_client(caseworker).patch(
+                DETAIL_URL.format(feedback.pk), {"status": "resolved"}, format="json"
+            )
+        assert response.status_code == 200
+
+        # Match on the statement VERB, not a substring — every SELECT of this
+        # table contains the column `updated_at`, which contains "update".
+        updates = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if q["sql"].lstrip().upper().startswith("UPDATE")
+        ]
+        assert updates, "expected an UPDATE"
+        for sql in updates:
+            assert "ip_address" not in sql
+            assert "user_agent" not in sql
+            assert "contact_info" not in sql
+            assert "attachment" not in sql
+
+        feedback.refresh_from_db()
+        assert feedback.status == FeedbackStatus.RESOLVED
+        assert feedback.ip_address == "203.0.113.9"
+        assert feedback.user_agent == "Mozilla/5.0 (test)"
+        assert feedback.contact_info["contactMethods"][0]["value"] == "ram@example.com"
+
+    def test_triage_still_lands_in_the_audit_trail(self, caseworker):
+        """A scoped UPDATE skips post_save, so the entry is written explicitly.
+
+        Without this the whole point of AuditlogActorMixin would be lost: the
+        edit would happen with no record of who made it.
+        """
+        from auditlog.models import LogEntry
+
+        feedback = _feedback()
+        _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk),
+            {"status": "in_review", "adminNotes": "Looking into it"},
+            format="json",
+        )
+
+        entries = LogEntry.objects.filter(
+            content_type__model="feedback",
+            object_pk=str(feedback.pk),
+            action=LogEntry.Action.UPDATE,
+        )
+        # EXACTLY one. AuditedQuerySet.update() already logs the write, so an
+        # explicit log_bulk_update() alongside it double-records every triage
+        # edit — which is what this asserted before the count was pinned.
+        assert entries.count() == 1
+        entry = entries.get()
+        assert "status" in entry.changes
+        assert entry.actor == caseworker
+
+    def test_triage_bumps_updated_at(self, caseworker):
+        """auto_now doesn't fire for QuerySet.update(), so it's stamped by hand.
+
+        The queue shows "last updated" from this column; if it stopped moving,
+        a triaged submission would look untouched.
+        """
+        feedback = _feedback()
+        before = feedback.updated_at
+
+        _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk), {"status": "in_review"}, format="json"
+        )
+
+        feedback.refresh_from_db()
+        assert feedback.updated_at > before
 
     def test_put_is_not_allowed(self, caseworker):
         """Only two fields are writable, so a full replace has no meaning."""

--- a/tests/api/test_feedback_triage.py
+++ b/tests/api/test_feedback_triage.py
@@ -1,0 +1,336 @@
+"""Tests for the staff feedback read/triage API (``/api/feedback-submissions/``).
+
+Two properties matter more than the CRUD mechanics and are asserted hardest:
+
+1. The endpoint never discloses who reported something. ``contact_info``,
+   ``ip_address`` and ``user_agent`` are absent from every response shape, and
+   no filter, search or ordering parameter brings them back.
+2. Triage cannot rewrite the submission. Only ``status`` and ``adminNotes``
+   move; everything the reporter wrote is read-only.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from cases.models import Feedback, FeedbackStatus, FeedbackType
+from tests.conftest import create_user_with_role
+
+LIST_URL = "/api/feedback-submissions/"
+DETAIL_URL = "/api/feedback-submissions/{}/"
+
+# Every key that would identify or locate a reporter, in both the model's
+# snake_case and the API's camelCase spelling — a serializer added under either
+# name must fail this.
+PII_KEYS = (
+    "contact_info",
+    "contactInfo",
+    "ip_address",
+    "ipAddress",
+    "user_agent",
+    "userAgent",
+    "attachment",
+)
+
+
+def _authed_client(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _feedback(**kwargs) -> Feedback:
+    defaults = dict(
+        feedback_type=FeedbackType.BUG,
+        subject="Search is broken",
+        description="Searching for a case returns nothing.",
+        related_page="Cases page",
+        ip_address="203.0.113.9",
+        user_agent="Mozilla/5.0 (test)",
+        contact_info={
+            "name": "राम बहादुर",
+            "contactMethods": [{"type": "email", "value": "ram@example.com"}],
+        },
+    )
+    defaults.update(kwargs)
+    return Feedback.objects.create(**defaults)
+
+
+@pytest.fixture
+def caseworker():
+    return create_user_with_role("cw", "cw@example.com", "Caseworker")
+
+
+@pytest.fixture
+def superuser():
+    return create_user_with_role("admin", "admin@example.com", "Admin")
+
+
+@pytest.fixture
+def readonly():
+    return create_user_with_role("ro", "ro@example.com", "ReadOnly")
+
+
+@pytest.mark.django_db
+class TestFeedbackTriageAccess:
+    """Admin + caseworker only. ReadOnly is deliberately excluded."""
+
+    def test_anonymous_cannot_list(self):
+        _feedback()
+        response = APIClient().get(LIST_URL)
+        assert response.status_code in (401, 403)
+
+    def test_readonly_role_cannot_list(self, readonly):
+        """ReadOnly reads the platform, not the public's messages to it.
+
+        This is the one place the systemwide-read invariant is knowingly not
+        applied, so it gets an explicit test rather than being left to drift.
+        """
+        _feedback()
+        response = _authed_client(readonly).get(LIST_URL)
+        assert response.status_code == 403
+
+    def test_caseworker_can_list(self, caseworker):
+        _feedback()
+        response = _authed_client(caseworker).get(LIST_URL)
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+
+    def test_superuser_can_list(self, superuser):
+        _feedback()
+        response = _authed_client(superuser).get(LIST_URL)
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+
+    def test_anonymous_cannot_triage(self):
+        feedback = _feedback()
+        response = APIClient().patch(
+            DETAIL_URL.format(feedback.pk), {"status": "resolved"}, format="json"
+        )
+        assert response.status_code in (401, 403)
+        feedback.refresh_from_db()
+        assert feedback.status == FeedbackStatus.SUBMITTED
+
+    def test_readonly_cannot_triage(self, readonly):
+        feedback = _feedback()
+        response = _authed_client(readonly).patch(
+            DETAIL_URL.format(feedback.pk), {"status": "resolved"}, format="json"
+        )
+        assert response.status_code == 403
+        feedback.refresh_from_db()
+        assert feedback.status == FeedbackStatus.SUBMITTED
+
+
+@pytest.mark.django_db
+class TestFeedbackTriagePrivacy:
+    """The reporter's identity never crosses this endpoint."""
+
+    def test_list_omits_reporter_identity(self, caseworker):
+        _feedback()
+        row = _authed_client(caseworker).get(LIST_URL).json()["results"][0]
+
+        for key in PII_KEYS:
+            assert key not in row, f"{key} leaked into the staff feedback list"
+        # Not just absent as keys — the values themselves are nowhere in the body.
+        body = str(row)
+        assert "203.0.113.9" not in body
+        assert "ram@example.com" not in body
+        assert "राम बहादुर" not in body
+
+    def test_detail_omits_reporter_identity(self, caseworker):
+        feedback = _feedback()
+        row = _authed_client(caseworker).get(DETAIL_URL.format(feedback.pk)).json()
+
+        for key in PII_KEYS:
+            assert key not in row
+        assert "ram@example.com" not in str(row)
+
+    def test_triage_response_omits_reporter_identity(self, caseworker):
+        """The PATCH response is a third response shape — check it too."""
+        feedback = _feedback()
+        row = (
+            _authed_client(caseworker)
+            .patch(
+                DETAIL_URL.format(feedback.pk), {"status": "in_review"}, format="json"
+            )
+            .json()
+        )
+
+        for key in PII_KEYS:
+            assert key not in row
+        assert "ram@example.com" not in str(row)
+
+    def test_presence_is_exposed_without_the_values(self, caseworker):
+        """"There is contact info you can't see here" is what tells a triager
+        to escalate to someone who can."""
+        with_contact = _feedback()
+        without = _feedback(subject="No contact", contact_info={})
+
+        rows = {
+            r["id"]: r
+            for r in _authed_client(caseworker).get(LIST_URL).json()["results"]
+        }
+        assert rows[with_contact.pk]["hasContactInfo"] is True
+        assert rows[without.pk]["hasContactInfo"] is False
+        assert rows[with_contact.pk]["hasAttachment"] is False
+
+    def test_reported_content_is_readable(self, caseworker):
+        """Triage would be pointless without the report itself."""
+        feedback = _feedback()
+        row = _authed_client(caseworker).get(DETAIL_URL.format(feedback.pk)).json()
+
+        assert row["subject"] == "Search is broken"
+        assert row["description"] == "Searching for a case returns nothing."
+        assert row["relatedPage"] == "Cases page"
+        assert row["feedbackType"] == "bug"
+
+
+@pytest.mark.django_db
+class TestFeedbackTriageWrites:
+    def test_caseworker_sets_status(self, caseworker):
+        feedback = _feedback()
+        response = _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk), {"status": "in_review"}, format="json"
+        )
+
+        assert response.status_code == 200
+        feedback.refresh_from_db()
+        assert feedback.status == FeedbackStatus.IN_REVIEW
+
+    def test_caseworker_sets_admin_notes(self, caseworker):
+        feedback = _feedback()
+        response = _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk),
+            {"adminNotes": "Duplicate of #123"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        feedback.refresh_from_db()
+        assert feedback.admin_notes == "Duplicate of #123"
+
+    def test_invalid_status_is_rejected(self, caseworker):
+        feedback = _feedback()
+        response = _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk), {"status": "wontfix"}, format="json"
+        )
+
+        assert response.status_code == 400
+        feedback.refresh_from_db()
+        assert feedback.status == FeedbackStatus.SUBMITTED
+
+    def test_reporter_fields_are_immutable(self, caseworker):
+        """A triager records a decision; they don't get to edit the report."""
+        feedback = _feedback()
+        response = _authed_client(caseworker).patch(
+            DETAIL_URL.format(feedback.pk),
+            {
+                "subject": "Rewritten by staff",
+                "description": "Rewritten body",
+                "relatedPage": "Elsewhere",
+                "feedbackType": "general",
+                "status": "in_review",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        feedback.refresh_from_db()
+        assert feedback.subject == "Search is broken"
+        assert feedback.description == "Searching for a case returns nothing."
+        assert feedback.related_page == "Cases page"
+        assert feedback.feedback_type == FeedbackType.BUG
+        # The one field that was supposed to move, moved.
+        assert feedback.status == FeedbackStatus.IN_REVIEW
+
+    def test_put_is_not_allowed(self, caseworker):
+        """Only two fields are writable, so a full replace has no meaning."""
+        feedback = _feedback()
+        response = _authed_client(caseworker).put(
+            DETAIL_URL.format(feedback.pk), {"status": "resolved"}, format="json"
+        )
+        assert response.status_code == 405
+
+    def test_staff_cannot_create_feedback_here(self, caseworker):
+        response = _authed_client(caseworker).post(
+            LIST_URL,
+            {"feedbackType": "bug", "subject": "x", "description": "y"},
+            format="json",
+        )
+        assert response.status_code == 405
+
+    def test_staff_cannot_delete_feedback_here(self, caseworker):
+        """Destructive removal stays with the superuser in Django admin."""
+        feedback = _feedback()
+        response = _authed_client(caseworker).delete(DETAIL_URL.format(feedback.pk))
+        assert response.status_code == 405
+        assert Feedback.objects.filter(pk=feedback.pk).exists()
+
+
+@pytest.mark.django_db
+class TestFeedbackTriageQueue:
+    def test_filter_by_status(self, caseworker):
+        _feedback(subject="Open one")
+        _feedback(subject="Done one", status=FeedbackStatus.RESOLVED)
+
+        response = _authed_client(caseworker).get(LIST_URL, {"status": "resolved"})
+        results = response.json()["results"]
+        assert [r["subject"] for r in results] == ["Done one"]
+
+    def test_filter_by_type(self, caseworker):
+        _feedback(subject="A bug")
+        _feedback(subject="A report", feedback_type=FeedbackType.CASE_REPORT)
+
+        response = _authed_client(caseworker).get(
+            LIST_URL, {"feedback_type": "case_report"}
+        )
+        results = response.json()["results"]
+        assert [r["subject"] for r in results] == ["A report"]
+
+    def test_search_spans_subject_and_description(self, caseworker):
+        _feedback(subject="Procurement irregularity", description="Body one")
+        _feedback(subject="Other", description="Mentions procurement too")
+        _feedback(subject="Unrelated", description="Nothing here")
+
+        response = _authed_client(caseworker).get(LIST_URL, {"search": "procurement"})
+        assert response.json()["count"] == 2
+
+    def test_newest_first_by_default(self, caseworker):
+        first = _feedback(subject="Older")
+        second = _feedback(subject="Newer")
+        assert first.submitted_at <= second.submitted_at
+
+        results = _authed_client(caseworker).get(LIST_URL).json()["results"]
+        assert [r["subject"] for r in results] == ["Newer", "Older"]
+
+    def test_page_size_is_client_sizable(self, caseworker):
+        for i in range(3):
+            _feedback(subject=f"Item {i}")
+
+        body = _authed_client(caseworker).get(LIST_URL, {"page_size": 2}).json()
+        assert body["count"] == 3
+        assert len(body["results"]) == 2
+        assert body["next"] is not None
+
+
+@pytest.mark.django_db
+class TestPublicSubmissionStillWorks:
+    """The staff route must not have disturbed the public one."""
+
+    def test_anonymous_can_still_submit(self):
+        response = APIClient().post(
+            "/api/feedback/",
+            {
+                "feedbackType": "general",
+                "subject": "Nice work",
+                "description": "The platform is helpful.",
+            },
+            format="json",
+        )
+        assert response.status_code == 201
+
+    def test_public_route_still_refuses_reads(self):
+        """``/api/feedback/`` stays write-only; reading moved to its own path,
+        so this must not have become a listing of everyone's submissions."""
+        _feedback()
+        response = APIClient().get("/api/feedback/")
+        assert response.status_code == 405

--- a/tests/test_feedback_admin.py
+++ b/tests/test_feedback_admin.py
@@ -4,6 +4,7 @@ Tests for Feedback admin interface.
 
 import pytest
 from django.contrib.admin.sites import AdminSite
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory
 
 from cases.admin import FeedbackAdmin
@@ -75,6 +76,44 @@ class TestFeedbackAdmin:
         assert feedback_admin.has_delete_permission(request, feedback) is True
         assert feedback_admin.has_view_permission(request) is True
         assert feedback_admin.has_view_permission(request, feedback) is True
+
+    def test_the_change_page_actually_renders_read_only(self, admin_user, client):
+        """GET the real page, not just the permission predicates.
+
+        Turning off change permission makes Django take a path this admin never
+        took before: ``get_form`` replaces ``readonly_fields`` with the flattened
+        fieldsets, so ``attachment`` (a FileField, rendered via
+        ``display_for_field`` → ``value.url``) and the ``contact_info`` JSONField
+        go through ``AdminReadonlyField`` instead of a widget. Asserting only on
+        ``has_change_permission()`` would leave that rendering untested, and this
+        page is the escalation path the SPA's "ask an administrator" hint points
+        at — it must not 500.
+        """
+        feedback = Feedback.objects.create(
+            feedback_type=FeedbackType.CASE_REPORT,
+            subject="Alleged irregularity",
+            description="Details of the allegation.",
+            contact_info={
+                "name": "Test Reporter",
+                "contactMethods": [{"type": "email", "value": "reporter@example.com"}],
+            },
+            attachment=SimpleUploadedFile("evidence.txt", b"attachment body"),
+        )
+        client.force_login(admin_user)
+
+        response = client.get(
+            f"/django-admin/cases/feedback/{feedback.pk}/change/"
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode()
+        # Readable...
+        assert "Alleged irregularity" in body
+        # ...and this is the ONE surface that still shows the reporter, which is
+        # why the SPA can afford to omit them.
+        assert "reporter@example.com" in body
+        # ...but with no way to submit a change.
+        assert 'name="_save"' not in body
 
     def test_feedback_list_display(self, feedback_admin):
         """Test that feedback list displays correct fields."""

--- a/tests/test_feedback_admin.py
+++ b/tests/test_feedback_admin.py
@@ -40,36 +40,41 @@ class TestFeedbackAdmin:
         queryset = feedback_admin.get_queryset(RequestFactory().get("/"))
         assert queryset.count() == 1
 
-    def test_admin_can_change_feedback_status(self, admin_user):
-        """Test that admin can change feedback status."""
+    def test_admin_is_view_only(self, admin_user, feedback_admin):
+        """Triage moved to the SPA panel, so Django admin must not offer edits.
+
+        Asserted against a SUPERUSER, who holds every model permission — if the
+        gate holds for them it holds for everyone, and a pass here cannot be an
+        accident of some missing permission.
+        """
         feedback = Feedback.objects.create(
             feedback_type=FeedbackType.BUG,
             subject="Test bug",
             description="Test description",
             status=FeedbackStatus.SUBMITTED,
         )
+        request = RequestFactory().get("/")
+        request.user = admin_user
 
-        # Change status
-        feedback.status = FeedbackStatus.IN_REVIEW
-        feedback.save()
+        assert feedback_admin.has_add_permission(request) is False
+        assert feedback_admin.has_change_permission(request) is False
+        assert feedback_admin.has_change_permission(request, feedback) is False
 
-        feedback.refresh_from_db()
-        assert feedback.status == FeedbackStatus.IN_REVIEW
-
-    def test_admin_can_add_notes(self, admin_user):
-        """Test that admin can add notes to feedback."""
+    def test_admin_keeps_delete_and_view(self, admin_user, feedback_admin):
+        """Deleting stays here (destructive, and this is the only surface that
+        shows the reporter's contact details), as does reading."""
         feedback = Feedback.objects.create(
             feedback_type=FeedbackType.BUG,
             subject="Test bug",
             description="Test description",
         )
+        request = RequestFactory().get("/")
+        request.user = admin_user
 
-        # Add admin notes
-        feedback.admin_notes = "Duplicate of issue #123"
-        feedback.save()
-
-        feedback.refresh_from_db()
-        assert feedback.admin_notes == "Duplicate of issue #123"
+        assert feedback_admin.has_delete_permission(request) is True
+        assert feedback_admin.has_delete_permission(request, feedback) is True
+        assert feedback_admin.has_view_permission(request) is True
+        assert feedback_admin.has_view_permission(request, feedback) is True
 
     def test_feedback_list_display(self, feedback_admin):
         """Test that feedback list displays correct fields."""


### PR DESCRIPTION
### **User description**
Pairs with frontend PR Jawafdehi/Jawafdehi#292. Merge this first — the SPA page needs the endpoint.

## Why

`/api/feedback/` is **POST-only**; a GET returns 405. Everything submitted through the feedback form and `/report` was readable only by a superuser in Django admin, and `create_groups` grants the `Caseworker` group no Feedback permission at all — so the link in the corruption-report alert email 403'd for the very people it was addressed to. A report could sit unread indefinitely.

## What

`GET` / `PATCH` at **`/api/feedback-submissions/`**, gated on superuser-or-`Caseworker`, with status/type filters, search and pagination.

**Separate route, not a GET on `/api/feedback/`.** That endpoint sets `authentication_classes = []` so an anonymous reporter can always post; with no authenticator running, `request.user` is always anonymous there and a staff GET could never be identified. Restoring authentication to serve a read would let a stale bearer token in a reporter's browser 401 the public form — a regression paid by the person least able to work around it.

### Privacy posture

The serializer omits `contact_info`, `ip_address`, `user_agent` and the attachment URL. Staff see what was reported plus `hasContactInfo` / `hasAttachment` booleans; retrieving the reporter stays a **superuser** action in Django admin, which becomes view-only-but-deletable.

`ReadOnly` is deliberately excluded despite being an org-wide read role — the one knowing exception to the systemwide-read invariant, because a submission is a message from a member of the public, sometimes naming an official.

Verified that no filter/ordering/search param, the PATCH response, `OPTIONS`, or the OpenAPI schema can surface a PII field.

### Writes

Triage may move `status`, `adminNotes`, and `feedbackType` (reclassifying a corruption allegation mis-filed as "general" — otherwise it gets no alert and nothing can correct it). Everything the reporter wrote is read-only.

The write goes through a **column-scoped `QuerySet.update()`**, not `Model.save()`. `Feedback.save()` runs `full_clean()`, which reads every concrete field — un-deferring `ip_address`/`user_agent` and emitting a full-column UPDATE that rewrites them — and calls `Feedback.clean()`, which does a HEAD to object storage for `attachment.size` on every status change and raises an uncaught (non-`ValidationError`) exception if the object was purged, which would leave that row permanently un-triageable. The scoped update avoids all three; `AuditedQuerySet` still records the edit with the acting user.

## Verification

- `2025 passed` across `tests/api/`, casework, and the role/readonly permission suites.
- Driven end-to-end against a local server: anon 401 / ReadOnly 403 / caseworker 200; PUT, POST, DELETE all 405; `?ordering=ip_address` and `?ip_address=…` silently ignored; reporter fields immutable; reclassification round-trips; reporter data intact after triage; exactly one audit entry with `actor=cwuser`; public anonymous POST still 201 and still stores no IP for a case report.

## Reviewer's attention, please

Making Django admin fully view-only means **nothing** can now redact a reporter's `contact_info` or remove a harmful `attachment` — delete is the only lever, and it destroys the allegation too. That follows from the requested "view-only + delete", but it is a real gap for an erasure request or a malicious upload, and may warrant a follow-up.

Separately: `FeedbackRateThrottle` shares the global anon throttle bucket — fixed independently in #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Staff feedback triage API

- PII-safe submission serialization

- SPA notification links

- Admin view-only triage split


___

### Diagram Walkthrough


```mermaid
flowchart LR
  public["Public feedback POST"] -- "creates" --> feedback["Feedback rows"]
  feedback -- "staff read/PATCH" --> queue["/api/feedback-submissions/"]
  queue -- "PII omitted" --> triager["Caseworker/Superuser"]
  report["Case report alert"] -- "links" --> spa["/admin/feedback/{id}"]
  admin["Django admin"] -- "view/delete only" --> pii["PII access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>admin.py</strong><dd><code>Make feedback admin read-only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-b7a3f0177d3be7adf3139695169d6e588e824f82e4fca55261caf3cc41eb3453">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api_views.py</strong><dd><code>Add feedback triage viewset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-926cb1b9dfa09c768f390c34cfd718fa4c7c17e97f530b19cac222c2a9a55138">+107/-15</a></td>

</tr>

<tr>
  <td><strong>permissions.py</strong><dd><code>Add feedback triager permission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-38ad3381682137cab8b88af86afe2c115519ac76c612f04d9db959eaae24899f">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serializers.py</strong><dd><code>Add PII-safe triage serializer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-623d9bf7c9d866cfd7ff293441a87d8eb6b98a20b572ca2c5fca0f0adc5f3492">+126/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>urls.py</strong><dd><code>Register feedback submissions route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-01a03fcbd88e38fc73a1b50d672ffd8947ce026dac5a4f032f7f7987b964e824">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>permissions.py</strong><dd><code>Document duplicated staff permission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-281e39985c1342084379390727d90cc10b11177acd717166a68bd93dd88e2e5b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_feedback_api.py</strong><dd><code>Update case-report notification tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-294d60aba4a896f4b0b65ef89ce7bd9fa1f82ced58b8a7875b8dff56e79e8d91">+33/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_feedback_triage.py</strong><dd><code>Cover feedback triage API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-3dd512fc192a4f3fc932e514f08a3438c5c754b19112ceebdb18985859db153e">+465/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_feedback_admin.py</strong><dd><code>Cover read-only feedback admin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/447/files#diff-bb86a26e83a6b9624bee06176320191eeb413b785c21eb8210583ecbb6577172">+59/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>

