### PR TITLE
feat(casework): let the news enricher write off-loopback under the standard opt-in

### DIFF
--- a/casework/common/api.py
+++ b/casework/common/api.py
@@ -575,9 +575,10 @@ class CaseworkApi:
         the same document instead of minting a duplicate.
 
         A WRITE, so `_request`'s guard applies -- this refuses any non-loopback
-        host unless `allow_remote_writes=True`. The news enricher additionally
-        refuses off-loopback at its own call site regardless of that flag; see
-        `casework/enrich_news_articles.py::_require_loopback`.
+        host unless `allow_remote_writes=True`. That guard is the ONLY thing
+        gating a production write into the shared materials store: the news
+        enricher's own unconditional refusal was removed on 2026-08-11, so do
+        not weaken it, and do not add a write path that bypasses `_request`.
         """
         body = json.dumps({"material": doc, "material_type": material_type},
                           ensure_ascii=False).encode("utf-8")

--- a/casework/enrich_news_articles.py
+++ b/casework/enrich_news_articles.py
@@ -475,6 +475,30 @@ def plan_case(case, etag, outcome, *, client=None, save_permalinks=True):
                         n_current=len(current), outcome=outcome,
                         reason="no article cleared the verification gate")
 
+    # PAST HERE A DESTRUCTIVE WRITE IS ON THE TABLE, so the payload the merge
+    # will be built from has to be trustworthy. Checked here and not at the top
+    # of the function on purpose: with nothing accepted there is no write to
+    # protect, and reporting a payload problem then would bury the real reason.
+    if "evidence" not in case:
+        return NewsPlan(slug=slug, action="NOOP", state=state, if_match=etag,
+                        n_current=len(current), outcome=outcome,
+                        reason="case payload has no 'evidence' key -- absent is "
+                               "not empty, and `PATCH /evidence` is a whole-list "
+                               "replace, so merging an incomplete read would "
+                               "DELETE every entry it omits. Re-read the case "
+                               "(get_case_with_etag) before retrying")
+    # `current_evidence` drops an entry with no `material_iri`, which for a
+    # whole-list replace means deleting it from the case. Better to write
+    # nothing and say so.
+    malformed = len(case["evidence"] or []) - len(current)
+    if malformed:
+        return NewsPlan(slug=slug, action="NOOP", state=state, if_match=etag,
+                        n_current=len(current), outcome=outcome,
+                        reason=f"{malformed} of {len(case['evidence'])} existing "
+                               "evidence entries carry no material_iri, so a "
+                               "whole-list replace built from this read would "
+                               "drop them")
+
     materials, additions = [], []
     for article, verdict in outcome.accepted:
         permalink = (resolve_permalink(client, article.url, save_missing=save_permalinks)

--- a/casework/enrich_news_articles.py
+++ b/casework/enrich_news_articles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Attach verified independent news coverage to a case's `evidence[]`. LOCAL WRITES ONLY.
+"""Attach verified independent news coverage to a case's `evidence[]`.
 
 Ported from the deleted `casework/enrich_news_articles.py` (recovered at donor
 commit `0321a85`, 1,957 lines -- the largest in the donor set), with the
@@ -22,9 +22,20 @@ ethical failure. Production already carries two such binds -- see
 SPLIT IN TWO, AND ONLY ONE HALF CAN WRITE. `casework/news_search.py` does all
 searching, fetching, archive lookup and LLM verification and cannot write
 anything; it does not import `CaseworkApi`. Everything that mutates server state
-is in `apply_plan` below, and `_require_loopback` refuses off-loopback there
-regardless of `--allow-remote-writes`. Between them sits `plan_case`, which is
-pure: it decides, and writes nothing.
+is in `apply_plan` below. Between them sits `plan_case`, which is pure: it
+decides, and writes nothing.
+
+WRITES TO PRODUCTION LIKE ANY OTHER ENRICHER, since 2026-08-11: `--apply
+--allow-remote-writes` and a Bearer token, with the single host write-guard in
+`CaseworkApi._request` as the gate. This stage USED to carry a second,
+unconditional guard that the flag could not open, justified by the production
+credential being "read-only by policy". That premise was false -- the same
+`sa-ingestion` token writes `description`, `title` and `short_description` -- so
+the guard only ever cost a run its writes after it had paid for the searches.
+What the guard was really protecting is unchanged and now stated where it
+belongs: this is the only stage that creates rows in the SHARED materials store,
+a wrong article is visible beyond the case that caused it, and production already
+carries two wrong binds. Read the run's review file before believing it.
 
 Six deliberate deviations from the donor. Two more (the no-publication-date skip
 and the `confidence == "high"` bar) are wholly inside `news_search.py` and are
@@ -99,7 +110,6 @@ import logging
 import os
 import sys
 import time
-import urllib.parse
 from dataclasses import dataclass, field
 
 from casework.common.api import CaseworkApi
@@ -164,26 +174,6 @@ WRITABLE_STATE = "DRAFT"
 DEFAULT_MAX_ARTICLES = 5
 #: Retry rounds of broader fallback queries when nothing was accepted (donor:899).
 RETRY_MAX = 3
-
-
-def _require_loopback(api):
-    """Refuse any non-loopback host at the write itself.
-
-    `CaseworkApi._request` already guards writes and `--allow-remote-writes` is
-    its opt-in. This is a SECOND, unconditional guard that flag cannot open, in
-    the style of `casework/convert.py::upload_markdown` -- and for a stronger
-    reason. This stage is the one that creates rows in the SHARED materials
-    store and binds them to public cases; the credential a production run holds
-    is read-only by policy, and a write attempted with it is a policy breach
-    whether or not it succeeds. So the script refuses to try.
-    """
-    host = urllib.parse.urlsplit(api.base_url).hostname
-    if host not in ("127.0.0.1", "localhost"):
-        raise ValueError(
-            f"enrich_news_articles writes to loopback ONLY; refusing to create "
-            f"materials or bind evidence on {api.base_url!r}. Production is "
-            f"read-only for this stage: run without --apply to produce the "
-            f"review file.")
 
 
 # ---------------------------------------------------------------------------
@@ -514,7 +504,6 @@ def apply_plan(api, plan):
 
     Refuses, in order:
       * any plan that is not `WOULD_BIND`;
-      * any non-loopback host, unconditionally (`_require_loopback`);
       * any case not in `WRITABLE_STATE` (deviation 6);
       * a missing ETag -- without `If-Match` the whole-list replace is
         unconditional and silently clobbers a concurrent edit, which is the
@@ -528,7 +517,8 @@ def apply_plan(api, plan):
     """
     if plan.action != "WOULD_BIND":
         raise ValueError(f"apply_plan called on a {plan.action} plan for {plan.slug!r}")
-    _require_loopback(api)
+    # No host check here. `CaseworkApi._request` guards every write below and
+    # `--allow-remote-writes` is its opt-in, same as every other enricher.
     if plan.state != WRITABLE_STATE:
         raise RuntimeError(
             f"refusing to write news evidence to {plan.slug!r} in state "
@@ -567,7 +557,9 @@ def build_parser():
     parser = argparse.ArgumentParser(
         description="Attach LLM-verified news coverage to a case's evidence.",
         epilog="Reads cases and writes materials/evidence over the Jawafdehi HTTP "
-               "API. Writes are refused off-loopback unconditionally.")
+               "API. Writing off-loopback needs --apply, --allow-remote-writes and "
+               "a Bearer --api-token together. This stage creates rows in the "
+               "shared materials store -- read the run's review file.")
     add_common_args(parser)
     parser.add_argument("--max-articles", type=int, default=DEFAULT_MAX_ARTICLES,
                         help=f"Max news articles to bind per case "

--- a/tests/casework/test_api.py
+++ b/tests/casework/test_api.py
@@ -667,6 +667,31 @@ def test_request_post_allowed_for_non_loopback_with_opt_in(monkeypatch):
     assert len(calls) == 1
 
 
+def test_create_material_raises_for_non_loopback_without_opt_in(monkeypatch):
+    # Through the PUBLIC method the news enricher actually calls, not `_request`
+    # directly. Since 2026-08-11 that enricher has no host guard of its own, so
+    # this is the only thing standing between a production run and an unopted
+    # write into the SHARED materials store.
+    monkeypatch.setattr(urllib.request, "urlopen", _failing_urlopen)
+    api = CaseworkApi(base_url="https://example.invalid", token="t")
+
+    with pytest.raises(RuntimeError, match="example.invalid"):
+        api.create_material({"@id": "https://jawafdehi.org/material/news/x"}, "news")
+
+
+def test_create_material_allowed_for_non_loopback_with_opt_in(monkeypatch):
+    calls = []
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen_spy(calls))
+    api = CaseworkApi(
+        base_url="https://example.invalid", token="t", allow_remote_writes=True
+    )
+
+    api.create_material({"@id": "https://jawafdehi.org/material/news/x"}, "news")
+
+    assert len(calls) == 1
+    assert calls[0].method == "POST"
+
+
 def test_request_get_is_never_guarded_against_non_loopback(monkeypatch):
     calls = []
     monkeypatch.setattr(urllib.request, "urlopen", _urlopen_spy(calls))

--- a/tests/casework/test_enrich_news_articles.py
+++ b/tests/casework/test_enrich_news_articles.py
@@ -765,6 +765,54 @@ def _bindable_plan(state="DRAFT", etag='W/"1"'):
     return plan
 
 
+def _accepting_outcome():
+    """A `SearchOutcome` with one accepted article, so a write is on the table.
+
+    Built directly rather than through `collect_for_case`: these tests are about
+    what `plan_case` does with the CASE payload, and driving the search half
+    would only add ways for them to fail for an unrelated reason.
+    """
+    outcome = ns.SearchOutcome(queries=["q"], n_candidates=1)
+    outcome.accepted = [(
+        ns.Article(url="https://example.np/a", title="शीर्षक",
+                   text="विवरण " * 60, published=date(2022, 1, 5)),
+        ns.Verdict(relevant=True, confidence="high", event_type="filing",
+                   summary="यो समाचार लेख यस मुद्दासँग सम्बन्धित छ। " * 8),
+    )]
+    return outcome
+
+
+def test_a_payload_with_no_evidence_key_is_refused_not_merged():
+    # `case.get("evidence") or []` cannot tell "no evidence" from "this payload
+    # does not carry evidence at all". Merged, the second reads as empty and the
+    # whole-list replace DELETES every real entry -- the same hole
+    # `plan_case_entities` already refuses for `entities`. Now that this stage
+    # writes to production, that is live data loss, not a hypothetical.
+    case = case_payload()
+    del case["evidence"]
+
+    plan = en.plan_case(case, 'W/"1"', _accepting_outcome(),
+                        client=None, save_permalinks=False)
+
+    assert plan.action == "NOOP"
+    assert not plan.patch_items
+    assert "absent is not empty" in plan.reason
+
+
+def test_an_evidence_entry_with_no_material_iri_is_refused_not_dropped():
+    # `current_evidence` filters these out. Silently: the entry then vanishes
+    # from the merged list, and the replace deletes it from the case.
+    case = case_payload()
+    case["evidence"] = list(case["evidence"]) + [{"additional_details": "no iri"}]
+
+    plan = en.plan_case(case, 'W/"1"', _accepting_outcome(),
+                        client=None, save_permalinks=False)
+
+    assert plan.action == "NOOP"
+    assert not plan.patch_items
+    assert "material_iri" in plan.reason
+
+
 def test_the_writer_writes_off_loopback_when_remote_writes_are_allowed():
     # 2026-08-11: this stage used to carry a SECOND, unconditional host guard
     # that `--allow-remote-writes` could not open, on the reasoning that the

--- a/tests/casework/test_enrich_news_articles.py
+++ b/tests/casework/test_enrich_news_articles.py
@@ -30,12 +30,14 @@ import pathlib
 import sys
 import types
 import urllib.parse
+import urllib.request
 from datetime import date
 
 import pytest
 
 from casework import bind_materials
 from casework import enrich_news_articles as en
+from casework.common.api import CaseworkApi
 from casework import news_search as ns
 from tests.casework.fakes import FakeUsage
 from tests.casework.news_labelled_set import LABELLED_PAIRS, MATCHES, NON_MATCHES
@@ -763,12 +765,38 @@ def _bindable_plan(state="DRAFT", etag='W/"1"'):
     return plan
 
 
-def test_the_writer_refuses_a_non_loopback_host_even_with_remote_writes_allowed():
+def test_the_writer_writes_off_loopback_when_remote_writes_are_allowed():
+    # 2026-08-11: this stage used to carry a SECOND, unconditional host guard
+    # that `--allow-remote-writes` could not open, on the reasoning that the
+    # production credential was read-only by policy. It is not -- the same
+    # `sa-ingestion` token writes `description`, `title` and `short_description`
+    # to production. The stage now behaves like every other enricher: the single
+    # host write-guard in `CaseworkApi._request` governs, and the operator opts
+    # in with --apply --allow-remote-writes.
     api = FakeApi(case_payload(), base_url="https://api.jawafdehi.org/api")
     api.allow_remote_writes = True
-    with pytest.raises(ValueError, match="loopback ONLY"):
+
+    written = en.apply_plan(api, _bindable_plan())
+
+    assert written == 1
+    assert [mt for _, mt in api.materials] == ["news"]
+    assert api.replaced and api.replaced[0]["path"] == en.EVIDENCE_PATH
+
+
+def test_the_writer_still_refuses_off_loopback_without_the_opt_in(monkeypatch):
+    # THE PROTECTION THAT REPLACED THE UNCONDITIONAL GUARD. `FakeApi` cannot
+    # prove this -- it is a double with no guard of its own -- so this drives a
+    # REAL client and pins that the refusal still happens, one layer down, and
+    # still before any request leaves the process.
+    def _fail(*a, **k):
+        pytest.fail("no request may be attempted when the write-guard blocks")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fail)
+    api = CaseworkApi("https://api.jawafdehi.org/api", token="t")
+    api.get_case_with_etag = lambda slug, timeout=60: (case_payload(), 'W/"1"')
+
+    with pytest.raises(RuntimeError, match="refusing to write to non-loopback"):
         en.apply_plan(api, _bindable_plan())
-    assert api.materials == [] and api.replaced == []
 
 
 @pytest.mark.parametrize("state", ["IN_REVIEW", "PUBLISHED", ""])


### PR DESCRIPTION
## What changed

`enrich_news_articles` now writes off-loopback under the same opt-in as every other
enricher: `--apply` **and** `--allow-remote-writes` **and** a Bearer `--api-token`. The
host check in `CaseworkApi._request` is the gate.

It used to carry a second host check of its own that `--allow-remote-writes` could not
open, on the reasoning that the run's credential was read-only by policy. It isn't — the
same `sa-ingestion` token already writes `description`, `missing_details`, `title` and
`short_description`. So a run searched, fetched and LLM-verified every case and then threw
the result away at the write.

## Two evidence bugs fixed on the way

`PATCH /evidence` replaces the whole list, so anything missing from the merged list is
deleted. Both of these were harmless while the stage couldn't write off-loopback, and are
live data loss once it can. Found by driving `plan_case` with the real payloads for
078-CR-0038 and 078-CR-0073.

| Case payload | Old behaviour | Now |
|---|---|---|
| no `evidence` key at all | merged as "no evidence", sent only the new article — deleting 2 real entries | NOOP with a re-read-the-case reason |
| an entry with no `material_iri` | filtered by `current_evidence`, so the replace dropped it | NOOP naming the count |

The checks sit after `outcome.accepted`, not at the top: with nothing accepted there is no
write to protect, and a payload complaint would bury the real reason a case bound nothing.

## What still refuses

- a plan that is not `WOULD_BIND`
- any state but `DRAFT` — `/evidence` is a destructive whole-list replace
- a missing ETag — an unconditional replace clobbers a concurrent edit
- `convert`, which stays loopback-only: it has no remote-write escape and uploads hundreds
  of materials at a time

## Read the review file before an `--apply` run

This is the only stage that creates news materials shared beyond the case that caused
them, so a wrong match is visible elsewhere. No mocked test catches a high-confidence
false positive — that's a prompt property, and production already carries two wrong binds
(080-CR-0174).

`create_material` had no test for the `_request` guard and is now the only thing between a
production run and an unopted write, so two were added through the public method rather
than `_request`, and the news-side test drives a real `CaseworkApi` instead of `FakeApi`,
which has no guard of its own.

## Follow-ups, deliberately not bundled

- Gate the bind on explicit approval in the review file, so only articles a human has read
  get written. That is what the loopback rule was standing in for.
- `casework/bind_materials.py` shares the absent-`evidence`-key hole — same
  `current_evidence`, no absent-key check, and it can already write off-loopback.
- A review file's header reads `Mode: **APPLIED**` whenever `--apply` was passed, even when
  every write failed. It's derived from the flag, not from what happened.

## Tests

```bash
uv run pytest --ignore=integration-tests   # 5064 passed, 5 skipped (1871 casework)
uv run ruff check .
```

On top of `main` @ 60cc723.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote material writes are now supported when explicitly enabled with the remote-write option.
  - News enrichment validates evidence data before replacing existing materials.
  - CLI guidance now documents required apply mode, remote-write permission, authentication, and shared storage requirements.

- **Bug Fixes**
  - Prevented destructive replacements when evidence is missing or malformed.
  - Added safeguards against unintended remote writes when explicit permission is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->