### PR TITLE
fix(review): fail the job when the judge is unreachable, don't score around it

### DIFF
--- a/review/judge.py
+++ b/review/judge.py
@@ -30,6 +30,44 @@ class JudgeUnavailable(RuntimeError):
     """
 
 
+# Failures that are NOT evidence the judge is unreachable. A dirty or truncated
+# reply means the call landed and `salvage_json` still could not make an object
+# of it; the rest are our own bugs (a malformed rule dict, a typo in prompt
+# building). Both leave a rule ungraded, and both must keep the lenient
+# degrade-to-neutral path -- failing the job over them would turn every content
+# hiccup into a dead-lettered review. Anything else a provider raises for a real
+# transport fault (a 429 cap wrapped in RuntimeError, an expired token, a
+# timeout, a botocore ClientError) is not enumerable, so transport is the
+# default and this list is the exception.
+_NON_TRANSPORT_ERRORS = (
+    json.JSONDecodeError,
+    TypeError,
+    AttributeError,
+    KeyError,
+    IndexError,
+    NotImplementedError,
+)
+
+
+def _is_transport_error(exc):
+    """Did the call fail to *land*, as opposed to landing badly or hitting a bug?"""
+    return not isinstance(exc, _NON_TRANSPORT_ERRORS)
+
+
+def _task_rule_keys(task):
+    """The rule keys a task is carrying; the narrative task carries none.
+
+    Reachability is per rule, so a failure is only evidence about the rules whose
+    grades that particular call was going to produce.
+    """
+    kind = task[0]
+    if kind == "batch":
+        return [r["key"] for r in task[2]]
+    if kind == "rule":
+        return [task[2]["key"]]
+    return []
+
+
 # Bounded parallelism for LLM calls. Bedrock throttles aggressively, so we
 # keep this modest; with hundreds of rules this is the wall-clock divisor.
 def _api_max_workers():
@@ -363,6 +401,11 @@ def judge_rules(
     last_suggestions = {k: [] for k in keys}
     narrative = ""
     errors = []
+    # Rule key -> the transport error that left it unreached on its LATEST
+    # attempt. Kept per rule rather than as one shared list because a failure
+    # says nothing about a rule that some other call graded: a dead narrative
+    # call, or a bug in one batch, must not mark every ungraded rule unreachable.
+    unreachable = {}
 
     def _apply(key, parsed):
         if key not in samples or not isinstance(parsed, dict):
@@ -410,7 +453,21 @@ def judge_rules(
         return ("rule", rule["key"], parsed)
 
     def _drain(pool_tasks):
+        """Run a round of tasks, then record which rules this round never reached.
+
+        A rule counts as unreached only if EVERY call carrying it in this round
+        failed on transport — one landed reply is enough to say the judge was
+        there, whatever the reply contained. The verdict is per round, because
+        the per-rule retry below is a fresh attempt: it can rescue a rule the
+        batch failed to reach, and it can equally be the call that dies when the
+        quota runs out part-way through a review.
+        """
         nonlocal narrative
+        # rule key -> [calls carrying it, calls that failed on transport, first error]
+        covered = {}
+        for t in pool_tasks:
+            for k in _task_rule_keys(t):
+                covered.setdefault(k, [0, 0, ""])[0] += 1
         with ThreadPoolExecutor(max_workers=_effective_max_workers()) as pool:
             futures = {pool.submit(_run, t): t for t in pool_tasks}
             for fut in as_completed(futures):
@@ -418,6 +475,10 @@ def judge_rules(
                     res = fut.result()
                 except Exception as e:  # noqa: BLE001 - collect, decide later
                     errors.append(str(e))
+                    if _is_transport_error(e):
+                        for k in _task_rule_keys(futures[fut]):
+                            covered[k][1] += 1
+                            covered[k][2] = covered[k][2] or str(e)
                     continue
                 kind = res[0]
                 if kind == "narrative":
@@ -428,6 +489,11 @@ def judge_rules(
                         _apply(k, rr)
                 else:  # per-rule
                     _apply(res[1], res[2])
+        for k, (n_calls, n_dead, err) in covered.items():
+            if n_dead == n_calls:
+                unreachable[k] = err
+            else:
+                unreachable.pop(k, None)
 
     _drain(tasks)
 
@@ -440,27 +506,31 @@ def judge_rules(
     if omitted:
         _drain([("rule", _tier_for_rule(r), r) for r in omitted])
 
-    # If nothing at all came back, surface the failure to the caller.
-    if not any(samples[k] for k in keys) and not narrative:
-        raise JudgeUnavailable(
-            f"All {len(tasks)} judge calls failed: {errors[0] if errors else 'unknown'}"
-        )
-
     # Partial reachability is the dangerous case: the quota/credential can die
     # PART-WAY through a review, so the early rules carry real grades and the
     # rest silently take the neutral 50. That review is not a low score, it is
     # an unfinished one -- and it still lands in the 68-71 band that looks like
-    # a genuine near-miss. Only a transport error counts here: an ungraded rule
-    # with no error behind it is the model omitting a key, which the per-rule
+    # a genuine near-miss. Total failure is just this with every rule in it.
+    #
+    # Only a rule whose OWN last call never landed counts. An ungraded rule with
+    # a landed call behind it is the model omitting a key, which the per-rule
     # retry above already handled and which must stay non-fatal.
-    if errors:
-        ungraded = [k for k in keys if not samples[k]]
-        if ungraded:
-            raise JudgeUnavailable(
-                f"Judge unreachable for {len(ungraded)}/{len(keys)} rule(s) "
-                f"({', '.join(ungraded)}) after {len(errors)} failed call(s): "
-                f"{errors[0]}"
-            )
+    dead = [k for k in keys if not samples[k] and k in unreachable]
+    if dead:
+        raise JudgeUnavailable(
+            f"Judge unreachable for {len(dead)}/{len(keys)} rule(s) "
+            f"({', '.join(dead)}) after {len(errors)} failed call(s): "
+            f"{unreachable[dead[0]]}"
+        )
+
+    # Nothing came back, but the judge was reachable throughout -- unparseable
+    # replies, or a bug of ours. Keep the old lenient handling: the scorer
+    # catches this and records it as `judge_error` over neutral scores, because
+    # dead-lettering a review over a content hiccup is the wrong trade.
+    if not any(samples[k] for k in keys) and not narrative:
+        raise RuntimeError(
+            f"All {len(tasks)} judge calls failed: {errors[0] if errors else 'unknown'}"
+        )
 
     out = {"_narrative": narrative, "_n_samples": n}
     for k in keys:

--- a/review/judge.py
+++ b/review/judge.py
@@ -17,6 +17,19 @@ from django.conf import settings
 
 from llm.invoke import invoke_json
 
+
+class JudgeUnavailable(RuntimeError):
+    """The judge could not be reached, so some rules have no grade at all.
+
+    Distinct from "the model replied but omitted a rule key": that is a content
+    problem the per-rule retry handles, and its neutral 50 must not fail a gate.
+    This one means the *call* never landed -- expired/revoked credentials, a 429
+    session cap, a network fault -- and the review is therefore unscorable. It
+    must reach the queue as a job failure rather than being folded into a score,
+    because a partially-judged review still reads as a plausible ~70.
+    """
+
+
 # Bounded parallelism for LLM calls. Bedrock throttles aggressively, so we
 # keep this modest; with hundreds of rules this is the wall-clock divisor.
 def _api_max_workers():
@@ -429,9 +442,25 @@ def judge_rules(
 
     # If nothing at all came back, surface the failure to the caller.
     if not any(samples[k] for k in keys) and not narrative:
-        raise RuntimeError(
+        raise JudgeUnavailable(
             f"All {len(tasks)} judge calls failed: {errors[0] if errors else 'unknown'}"
         )
+
+    # Partial reachability is the dangerous case: the quota/credential can die
+    # PART-WAY through a review, so the early rules carry real grades and the
+    # rest silently take the neutral 50. That review is not a low score, it is
+    # an unfinished one -- and it still lands in the 68-71 band that looks like
+    # a genuine near-miss. Only a transport error counts here: an ungraded rule
+    # with no error behind it is the model omitting a key, which the per-rule
+    # retry above already handled and which must stay non-fatal.
+    if errors:
+        ungraded = [k for k in keys if not samples[k]]
+        if ungraded:
+            raise JudgeUnavailable(
+                f"Judge unreachable for {len(ungraded)}/{len(keys)} rule(s) "
+                f"({', '.join(ungraded)}) after {len(errors)} failed call(s): "
+                f"{errors[0]}"
+            )
 
     out = {"_narrative": narrative, "_n_samples": n}
     for k in keys:

--- a/review/scorer.py
+++ b/review/scorer.py
@@ -157,6 +157,12 @@ def _run_judge(judge_summary, excerpts, ctype, llm_rules, config, usage):
 
     A judge failure is not fatal: ``judged`` falls back to the neutral shape and
     the error string is threaded through so each rule can explain itself.
+
+    The exception is ``JudgeUnavailable`` -- the judge was unreachable for at
+    least one rule (dead credential, 429 session cap, network) -- which is
+    deliberately NOT caught. Scoring a review whose LLM rules never ran produces
+    a confident-looking ~70 that is indistinguishable from a real near-miss, so
+    it must fail the job instead and let ``on_failure`` mark the review failed.
     """
     judged = {"_narrative": "", "_n_samples": 0}
     if not llm_rules:
@@ -185,6 +191,8 @@ def _run_judge(judge_summary, excerpts, ctype, llm_rules, config, usage):
             ),
             None,
         )
+    except judge.JudgeUnavailable:
+        raise
     except Exception as e:  # noqa: BLE001 - judge failure degrades to neutral scores
         return judged, str(e)
 

--- a/tests/test_judge_batch_robustness.py
+++ b/tests/test_judge_batch_robustness.py
@@ -58,6 +58,11 @@ def test_batch_omitted_rule_is_regraded_per_rule(settings):
 
 
 def test_still_ungraded_rule_has_no_fabricated_sample(settings):
+    """The model ANSWERED but returned no usable score — a content problem.
+
+    Every call lands, so there is nothing unavailable; the rule just ends up
+    ungraded. That stays non-fatal, and must not fabricate a sample.
+    """
     _cli_settings(settings)
 
     def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
@@ -66,7 +71,7 @@ def test_still_ungraded_rule_has_no_fabricated_sample(settings):
         text = content if isinstance(content, str) else content[-1]["text"]
         if "EACH of the" in text:
             return {"rules": {}}  # batch answers nothing
-        raise RuntimeError("per-rule retry also failed")
+        return {"rationale": "cannot assess this one"}  # replies, but no score
 
     with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
         judged = judge.judge_rules(
@@ -78,6 +83,100 @@ def test_still_ungraded_rule_has_no_fabricated_sample(settings):
     # "the judge said 50" apart from "the judge never answered".
     assert judged["hard_gate"]["samples"] == []
     assert judged["hard_gate"]["mean"] == 50.0
+
+
+def test_unreachable_judge_raises_instead_of_neutral_scoring(settings):
+    """A rule left ungraded by a FAILED CALL is unavailability, not a low score."""
+    _cli_settings(settings)
+
+    def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
+        if max_tokens == 300:
+            return {"narrative": "n"}
+        text = content if isinstance(content, str) else content[-1]["text"]
+        if "EACH of the" in text:
+            return {"rules": {}}
+        raise RuntimeError("claude_cli failed (rc=1): api_error_status 429")
+
+    with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
+        try:
+            judge.judge_rules(
+                "case", "excerpts", "label", [_rule("hard_gate", is_gate=True)],
+                n_samples=1,
+            )
+        except judge.JudgeUnavailable as e:
+            assert "429" in str(e) and "hard_gate" in str(e)
+        else:
+            raise AssertionError("expected JudgeUnavailable")
+
+
+def test_quota_death_partway_through_fails_the_whole_review(settings):
+    """The real 2026-08-12 shape: early rules grade, then the session cap hits.
+
+    The surviving grades made this look like a finished review scoring in the
+    low 70s. It is an unfinished one, and must not be scored at all.
+    """
+    _cli_settings(settings)
+    seen = []
+
+    def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
+        if max_tokens == 300:
+            return {"narrative": "n"}
+        text = content if isinstance(content, str) else content[-1]["text"]
+        seen.append(text)
+        if len(seen) > 1:  # quota dies after the first call lands
+            raise RuntimeError("You've hit your session limit")
+        return {"rules": {"early": {"score": 85, "rationale": "graded fine"}}}
+
+    # batch_size 1 => one call per rule, so the first grades and the rest die.
+    settings.REVIEW_RULE_BATCH_SIZE = 1
+    with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
+        try:
+            judge.judge_rules(
+                "case", "excerpts", "label",
+                [_rule("early"), _rule("late_one"), _rule("late_two")],
+                n_samples=1,
+            )
+        except judge.JudgeUnavailable as e:
+            assert "session limit" in str(e)
+        else:
+            raise AssertionError("expected JudgeUnavailable on partial failure")
+
+
+def test_scorer_propagates_unavailable_instead_of_scoring():
+    """score_case must not turn unavailability into a ~70 with low confidence."""
+    gate = CodeRule(0, {
+        "key": "hard_gate", "title": "Hard gate", "kind": CodeRule.KIND_LLM,
+        "is_gate": True, "gate_min": 60, "weight": 1.0,
+    })
+
+    class _Cfg:
+        pass_threshold, revise_threshold, llm_samples = 80, 40, 1
+
+    boom = judge.JudgeUnavailable("All 3 judge calls failed: 429 session limit")
+    with mock.patch.object(scorer.judge, "judge_rules", side_effect=boom):
+        try:
+            scorer.score_case({"title": "t"}, [], [gate], _Cfg(), source_analyses=[])
+        except judge.JudgeUnavailable:
+            pass
+        else:
+            raise AssertionError("score_case swallowed JudgeUnavailable")
+
+
+def test_scorer_still_degrades_on_an_unexpected_judge_bug():
+    """Non-transport judge bugs keep the old lenient behaviour, not a hard fail."""
+    gate = CodeRule(0, {
+        "key": "hard_gate", "title": "Hard gate", "kind": CodeRule.KIND_LLM,
+        "is_gate": True, "gate_min": 60, "weight": 1.0,
+    })
+
+    class _Cfg:
+        pass_threshold, revise_threshold, llm_samples = 80, 40, 1
+
+    with mock.patch.object(
+        scorer.judge, "judge_rules", side_effect=TypeError("bug in prompt building")
+    ):
+        result = scorer.score_case({"title": "t"}, [], [gate], _Cfg(), source_analyses=[])
+    assert result["judge_error"] and "bug in prompt building" in result["judge_error"]
 
 
 def test_ungraded_gate_rule_does_not_reject_the_case():

--- a/tests/test_judge_batch_robustness.py
+++ b/tests/test_judge_batch_robustness.py
@@ -116,18 +116,16 @@ def test_quota_death_partway_through_fails_the_whole_review(settings):
     low 70s. It is an unfinished one, and must not be scored at all.
     """
     _cli_settings(settings)
-    seen = []
 
     def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
         if max_tokens == 300:
             return {"narrative": "n"}
         text = content if isinstance(content, str) else content[-1]["text"]
-        seen.append(text)
-        if len(seen) > 1:  # quota dies after the first call lands
-            raise RuntimeError("You've hit your session limit")
-        return {"rules": {"early": {"score": 85, "rationale": "graded fine"}}}
+        if "early" in text:  # this one got in before the cap
+            return {"score": 85, "rationale": "graded fine"}
+        raise RuntimeError("You've hit your session limit")
 
-    # batch_size 1 => one call per rule, so the first grades and the rest die.
+    # batch_size 1 => one call per rule, so one grades and the rest die.
     settings.REVIEW_RULE_BATCH_SIZE = 1
     with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
         try:
@@ -137,9 +135,92 @@ def test_quota_death_partway_through_fails_the_whole_review(settings):
                 n_samples=1,
             )
         except judge.JudgeUnavailable as e:
+            # Only the rules whose own call died are named — `early` graded.
             assert "session limit" in str(e)
+            assert "2/3" in str(e)
+            assert "late_one" in str(e) and "late_two" in str(e)
+            assert "early" not in str(e)
         else:
             raise AssertionError("expected JudgeUnavailable on partial failure")
+
+
+def test_dead_narrative_call_does_not_condemn_an_ungraded_rule(settings):
+    """A failed narrative call is not evidence about any rule's reachability.
+
+    The narrative is one cheap call alongside the grading ones. When it dies and
+    a rule separately comes back scoreless, the rule was still reached — the two
+    facts are unrelated, and treating them as one failure would dead-letter a
+    review over a cosmetic call.
+    """
+    _cli_settings(settings)
+    settings.REVIEW_RULE_BATCH_SIZE = 1
+
+    def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
+        if max_tokens == 300:  # narrative task
+            raise RuntimeError("claude_cli failed (rc=1): api_error_status 429")
+        text = content if isinstance(content, str) else content[-1]["text"]
+        if "graded" in text:
+            return {"score": 77, "rationale": "fine"}
+        return {"rationale": "cannot assess this one"}  # replies, but no score
+
+    with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
+        judged = judge.judge_rules(
+            "case", "excerpts", "label", [_rule("graded"), _rule("scoreless")],
+            n_samples=1,
+        )
+
+    assert judged["graded"]["samples"] == [77]
+    assert judged["scoreless"]["samples"] == [] and judged["scoreless"]["mean"] == 50.0
+
+
+def test_unexpected_bug_in_a_rule_call_is_not_unavailability(settings):
+    """A TypeError is our bug, not a dead credential — keep degrading leniently.
+
+    It leaves the rule ungraded exactly as a 429 would, so classifying by "was
+    there an error" alone would fail the job over a code defect. Only a call that
+    never landed is fatal.
+    """
+    _cli_settings(settings)
+    settings.REVIEW_RULE_BATCH_SIZE = 1
+
+    def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
+        if max_tokens == 300:
+            return {"narrative": "n"}
+        raise TypeError("bug in prompt building")
+
+    with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
+        judged = judge.judge_rules(
+            "case", "excerpts", "label", [_rule("hard_gate", is_gate=True)],
+            n_samples=1,
+        )
+
+    assert judged["hard_gate"]["samples"] == [] and judged["hard_gate"]["mean"] == 50.0
+
+
+def test_total_content_failure_is_not_reported_as_unavailability(settings):
+    """Every call landed and every one was useless — that is not unreachable.
+
+    It still raises, so the scorer records `judge_error` over neutral scores, but
+    as a plain RuntimeError the scorer catches rather than a job-killing one.
+    """
+    _cli_settings(settings)
+    settings.REVIEW_RULE_BATCH_SIZE = 1
+
+    def fake_invoke_json(system, content, max_tokens=900, tier="premium", usage=None):
+        return {}  # answers everything, says nothing
+
+    with mock.patch.object(judge, "invoke_json", side_effect=fake_invoke_json):
+        try:
+            judge.judge_rules(
+                "case", "excerpts", "label", [_rule("hard_gate", is_gate=True)],
+                n_samples=1,
+            )
+        except judge.JudgeUnavailable:
+            raise AssertionError("content failure misreported as unavailability")
+        except RuntimeError as e:
+            assert "judge calls failed" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError")
 
 
 def test_scorer_propagates_unavailable_instead_of_scoring():


### PR DESCRIPTION
### **User description**
## Problem

A review whose LLM rules never ran was still finalized as `done`. Each ungraded rule took a neutral 50 at low confidence, so the case scored **68–71** — squarely inside the band a genuine near-miss occupies. The result even carried `judge_error`; nothing acted on it.

On **2026-08-12** a 429 session cap (`You've hit your session limit`) did exactly this to eleven reviews (jobs 4324–4334). The CronJob was green for every tick, `job.status` was `done`, and `job.error` was empty. The only reliable tell was `token_usage.calls == 0`.

This is the third way in-cluster inference has failed silently, after an org-side 403 (2026-07-31) and a token expiry (2026-08-01). All three left a green CronJob and a plausible-looking score.

## Change

`JudgeUnavailable` is raised when a rule ends ungraded **and** a transport error is behind it:

- **Total failure** — the existing "all calls failed" raise, now typed.
- **Partial failure** — new, and the more dangerous shape. The credential can die part-way through, so the rules that already graded make the result look complete. Previously this didn't raise at all.

`_run_judge` deliberately does not catch it. The poller's existing handler reports it to the queue and Sentry, so the job retries once (`max_attempts=2`) and dead-letters, with `on_failure` marking the review failed.

## What is deliberately unchanged

An ungraded rule with **no error behind it** is the model omitting a key from a batch reply. The per-rule retry handles that, and its placeholder 50 still must not fail a gate — the spurious-REJECT fix from 092744a. Only the transport case is fatal. Unexpected non-transport judge bugs also keep the old lenient degrade-and-record behavior.

## Tests

`tests/test_judge_batch_robustness.py`, 7 passing:

- ungraded-by-failed-call now raises (both total and part-way-through)
- scorer propagates rather than scoring
- ungraded-by-scoreless-reply stays non-fatal and fabricates no sample
- non-transport judge bugs still degrade to `judge_error`

`test_still_ungraded_rule_has_no_fabricated_sample` previously simulated the omission with a raising retry, which conflated the two cases; it now returns a scoreless reply so it tests content omission specifically.

Full judge/review/LLM suites green (49 passed). The ~149 unrelated failures in this local env (slug redirect, preview, statistics) reproduce on pristine `origin/main` and are not from this change. `ruff check` clean; `ruff format` intentionally not run, since CI does not gate it.

## Reviewer note

Failing means a quota outage now dead-letters reviews after 2 attempts instead of persisting a wrong score. That is the intent — a failed review is recoverable by re-enqueueing, a silently wrong one is not — but it does make outages louder, and worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fail unreachable judge reviews

- Preserve content-omission fallback

- Propagate `JudgeUnavailable`

- Cover total, partial failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Judge call failure"] -- "leaves ungraded rules" --> B["JudgeUnavailable"]
  B -- "propagates" --> C["Review job failure"]
  D["Model omits rule key"] -- "no transport error" --> E["Neutral ungraded fallback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>judge.py</strong><dd><code>Detect unreachable judge during grading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

review/judge.py

<ul><li>Adds <code>JudgeUnavailable</code><br> <li> Raises on total judge failure<br> <li> Raises on partial ungraded transport failure<br> <li> Keeps non-transport omissions non-fatal</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/452/files#diff-e3dc486824cbbb61acef0abc88bd8731e29561c1776ac7ec3e341f39caa6d46c">+30/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scorer.py</strong><dd><code>Propagate fatal judge unavailability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

review/scorer.py

<ul><li>Documents <code>JudgeUnavailable</code> fatal path<br> <li> Re-raises unavailable judge errors<br> <li> Keeps unexpected judge bugs neutralized</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/452/files#diff-2a2d5db8ccac46614f5e968abe446782919ed41e40fae78488a91ba3a1dd9105">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_judge_batch_robustness.py</strong><dd><code>Cover judge unavailability failure modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_judge_batch_robustness.py

<ul><li>Adjusts ungraded content-response test<br> <li> Adds total unavailability coverage<br> <li> Adds partial quota-death coverage<br> <li> Verifies scorer propagation, fallback split</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/452/files#diff-226703de991e7b5965371d3e1a8edb140d274ba88516c4b013bffb339967c159">+100/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable automated evaluations by reporting judge service failures explicitly.
  * Prevented failed evaluation calls from being silently converted into neutral scores.
  * Preserved graceful handling for unexpected evaluation errors and unanswered rules.

* **Reliability**
  * Added clearer distinction between unavailable evaluation services and rules that simply lack scores.
  * Improved robustness for partial failures during batch evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->