### PR TITLE
feat(search): rebuild indices behind an alias instead of dropping them

### DIFF
--- a/cases/management/commands/reindex_cases.py
+++ b/cases/management/commands/reindex_cases.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand
 from cases import search_index
 from cases.models import Case, CaseState
 from jawafdehi_shared.search.opensearch import CASE_INDEX
-from jawafdehi_shared.search.reindex import reindex
+from jawafdehi_shared.search.reindex import reindex, summary
 
 
 class Command(BaseCommand):
@@ -36,16 +36,22 @@ class Command(BaseCommand):
         # under .iterator() (ValueError without it on Django 5.x). Using
         # build_indexed_doc (not the pure build_doc) is what makes a rebuild REFRESH
         # entity names rather than blanking the card.
+        def stream(since=None):
+            qs = Case.objects.filter(state=CaseState.PUBLISHED)
+            if since:
+                qs = qs.filter(updated_at__gte=since)
+            return qs.prefetch_related(
+                "courtcase_references", "entity_relationships"
+            ).iterator(chunk_size=200)
+
         result = reindex(
             index=CASE_INDEX,
-            records=Case.objects.filter(state=CaseState.PUBLISHED)
-            .prefetch_related("courtcase_references", "entity_relationships")
-            .iterator(chunk_size=200),
+            records=stream(),
             build_doc=search_index.build_indexed_doc,
             rebuild=options["rebuild"],
+            # Catches a case published during the build. It does NOT catch a card
+            # gone stale because a REFERENCED entity was renamed — Case.updated_at
+            # does not move for that. The daily reconcile run is what fixes those.
+            catchup=stream,
         )
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"jawafdehi-cases: indexed={result['indexed']} skipped={result['skipped']}"
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(summary("jawafdehi-cases", result)))

--- a/cases/management/commands/reindex_cases.py
+++ b/cases/management/commands/reindex_cases.py
@@ -44,14 +44,31 @@ class Command(BaseCommand):
                 "courtcase_references", "entity_relationships"
             ).iterator(chunk_size=200)
 
+        def changed(since):
+            """``(iri, case_or_None)`` for every case written during the build.
+
+            Unfiltered on state, so a case UNPUBLISHED mid-build arrives as a
+            tombstone. ``evictable_iri`` rather than the doc's own IRI because
+            ``public_iri`` returns None once a case leaves PUBLISHED — the doc
+            would otherwise be unaddressable exactly when it needs deleting.
+
+            Does NOT catch a card gone stale because a REFERENCED entity was
+            renamed: Case.updated_at does not move for that. The daily reconcile
+            run is what fixes those.
+            """
+            qs = Case.objects.filter(updated_at__gte=since).prefetch_related(
+                "courtcase_references", "entity_relationships"
+            )
+            for case in qs.iterator(chunk_size=200):
+                iri = search_index.evictable_iri(case)
+                if iri:
+                    yield iri, (case if search_index.should_index(case) else None)
+
         result = reindex(
             index=CASE_INDEX,
             records=stream(),
             build_doc=search_index.build_indexed_doc,
             rebuild=options["rebuild"],
-            # Catches a case published during the build. It does NOT catch a card
-            # gone stale because a REFERENCED entity was renamed — Case.updated_at
-            # does not move for that. The daily reconcile run is what fixes those.
-            catchup=stream,
+            catchup=changed,
         )
         self.stdout.write(self.style.SUCCESS(summary("jawafdehi-cases", result)))

--- a/cases/search_index.py
+++ b/cases/search_index.py
@@ -331,22 +331,30 @@ def index_now(case: Any, *, client=None) -> None:
         delete_now(case, client=cl)
 
 
-def delete_now(case: Any, *, client=None) -> None:
-    """Delete the case's doc from ``jawafdehi-cases``. RAISES.
+def evictable_iri(case: Any) -> str | None:
+    """The IRI a case's doc is keyed by, even once it has LEFT published state.
 
-    Uses the public IRI when the case is (or was) published; falls back to
-    building one from the slug so a case that has just LEFT published state can
-    still be evicted even though ``public_iri`` now returns ``None``."""
+    ``public_iri`` returns None for a non-published case, so eviction has to fall
+    back to rebuilding the IRI from the slug — otherwise a case that has just been
+    unpublished cannot be addressed to delete it. Used by ``delete_now`` and by
+    the rebuild catch-up, which needs the same answer for a tombstone."""
     iri = _case_iri(case)
-    if not iri:
-        slug = getattr(case, "slug", None)
-        if slug:
-            from jawafdehi_shared.entities.ids import build_case_iri
+    if iri:
+        return iri
+    slug = getattr(case, "slug", None)
+    if not slug:
+        return None
+    from jawafdehi_shared.entities.ids import build_case_iri
 
-            try:
-                iri = build_case_iri(slug)
-            except ValueError:
-                iri = None
+    try:
+        return build_case_iri(slug)
+    except ValueError:
+        return None
+
+
+def delete_now(case: Any, *, client=None) -> None:
+    """Delete the case's doc from ``jawafdehi-cases``. RAISES."""
+    iri = evictable_iri(case)
     if iri:
         delete_doc(client or make_client(), CASE_INDEX, iri)
 

--- a/courts/management/commands/reindex_courtcases.py
+++ b/courts/management/commands/reindex_courtcases.py
@@ -2,8 +2,14 @@
 
 Streams every ``CourtCase`` (with its ``court`` selected so the indexer can read
 the English court name without an extra query per row) through the court-case
-indexer. ``--rebuild`` drops + recreates the index. Router pins ``CourtCase`` to
+indexer. ``--rebuild`` builds a new generation and swaps the alias onto it when
+it is complete — no window in which search is empty. Router pins ``CourtCase`` to
 ``ngm``.
+
+This is the heaviest of the four: a ~2.2M-row sequential scan, of which ~27k rows
+pass the visibility gate. The scan is the cost, not the indexing, and the weekly
+cron already pays it — so running it as a rebuild (the only mode that EVICTS a
+doc whose case has since become hidden) is close to free.
 """
 
 from __future__ import annotations
@@ -11,7 +17,7 @@ from __future__ import annotations
 from django.core.management.base import BaseCommand
 
 from jawafdehi_shared.search.opensearch import COURTCASE_INDEX
-from jawafdehi_shared.search.reindex import reindex
+from jawafdehi_shared.search.reindex import reindex, summary
 from courts import search_index
 from courts.models import CourtCase
 from courts.search_visibility import (
@@ -27,7 +33,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--rebuild",
             action="store_true",
-            help="Drop and recreate the index before reindexing.",
+            help="Build a new generation and swap the alias onto it (no downtime). "
+            "The only mode that evicts docs whose case is no longer visible.",
         )
         parser.add_argument(
             "--since",
@@ -44,22 +51,30 @@ class Command(BaseCommand):
         # reindex_materials' is_deleted+LISTED gate. Refresh the publish-link cache
         # once up front so this bulk run sees the current PUBLISHED references.
         published_referenced_iris(refresh=True)
-        qs = CourtCase.objects.select_related("court").filter(is_deleted=False)
-        if options.get("since") and not options["rebuild"]:
-            qs = qs.filter(updated_at__gte=options["since"])
-        records = (
-            case
-            for case in qs.order_by("court_id", "case_number").iterator()
-            if court_case_public_visible(case)
-        )
+
+        def stream(since=None):
+            qs = CourtCase.objects.select_related("court").filter(is_deleted=False)
+            if since is not None:
+                # Re-read the publish-link cache: the catch-up pass runs an hour
+                # after the refresh above, and a case published in between changes
+                # which court cases the gate lets through.
+                published_referenced_iris(refresh=True)
+                qs = qs.filter(updated_at__gte=since)
+            return (
+                case
+                for case in qs.order_by("court_id", "case_number").iterator()
+                if court_case_public_visible(case)
+            )
+
         result = reindex(
             index=COURTCASE_INDEX,
-            records=records,
+            records=stream(None if options["rebuild"] else options.get("since")),
             build_doc=search_index.build_doc,
             rebuild=options["rebuild"],
+            # Cases the importer touched during the scan land on the OLD generation
+            # and would be lost at the swap. The scan is ~1h wide and the court
+            # scrapers run every 12h, so this is a real overlap, not a theoretical
+            # one.
+            catchup=stream,
         )
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"ngm-courtcases: indexed={result['indexed']} skipped={result['skipped']}"
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(summary("ngm-courtcases", result)))

--- a/courts/management/commands/reindex_courtcases.py
+++ b/courts/management/commands/reindex_courtcases.py
@@ -54,17 +54,32 @@ class Command(BaseCommand):
 
         def stream(since=None):
             qs = CourtCase.objects.select_related("court").filter(is_deleted=False)
-            if since is not None:
-                # Re-read the publish-link cache: the catch-up pass runs an hour
-                # after the refresh above, and a case published in between changes
-                # which court cases the gate lets through.
-                published_referenced_iris(refresh=True)
+            if since:
                 qs = qs.filter(updated_at__gte=since)
             return (
                 case
                 for case in qs.order_by("court_id", "case_number").iterator()
                 if court_case_public_visible(case)
             )
+
+        def changed(since):
+            """``(iri, case_or_None)`` for every case written during the build.
+
+            NOT filtered on is_deleted or on the gate: a case that became hidden
+            (or was soft-deleted) mid-build must come through as a TOMBSTONE. The
+            live signal evicted it from the old generation, and without the
+            tombstone the swap would put it back — which for a case reclassified
+            to a SENSITIVE type means the sensitive floor is undone by a reindex.
+            """
+            # Re-read the publish-link cache: this runs an hour after the refresh
+            # above, and a case published in between changes which court cases the
+            # gate lets through.
+            published_referenced_iris(refresh=True)
+            qs = CourtCase.objects.select_related("court").filter(
+                updated_at__gte=since
+            )
+            for case in qs.order_by("court_id", "case_number").iterator():
+                yield case.iri, (case if court_case_public_visible(case) else None)
 
         result = reindex(
             index=COURTCASE_INDEX,
@@ -75,6 +90,6 @@ class Command(BaseCommand):
             # and would be lost at the swap. The scan is ~1h wide and the court
             # scrapers run every 12h, so this is a real overlap, not a theoretical
             # one.
-            catchup=stream,
+            catchup=changed,
         )
         self.stdout.write(self.style.SUCCESS(summary("ngm-courtcases", result)))

--- a/entities/management/commands/reindex_entities.py
+++ b/entities/management/commands/reindex_entities.py
@@ -37,19 +37,26 @@ class Command(BaseCommand):
         # Mirror the live indexer's gate (entities.signals): index ONLY the rows
         # still on the read plane. Without this a reindex re-adds soft-deleted
         # entities to public search — the exact rows the signal evicted.
-        def stream(since=None):
-            qs = StoredEntity.objects.filter(is_deleted=False)
-            if since:
-                # updated_at is NOT auto_now here — entities.persistence sets it on
-                # every re-publish, which is exactly the write we need to catch.
-                qs = qs.filter(updated_at__gte=since)
-            return qs.iterator()
+        def changed(since):
+            """``(iri, entity_or_None)`` for everything written during the build.
+
+            Unfiltered on is_deleted so a DELETE landing mid-build arrives as a
+            TOMBSTONE. NES delete is a soft delete, so without this the swap
+            resurrects the very tombstone the signal evicted — the failure this
+            command's is_deleted gate already exists to prevent, reintroduced
+            through a different door.
+
+            ``updated_at`` is NOT auto_now here; entities.persistence sets it on
+            every re-publish, which is exactly the write we need to catch.
+            """
+            for e in StoredEntity.objects.filter(updated_at__gte=since).iterator():
+                yield e.iri, (None if e.is_deleted else e)
 
         result = reindex(
             index=ENTITY_INDEX,
-            records=stream(),
+            records=StoredEntity.objects.filter(is_deleted=False).iterator(),
             build_doc=search_index.build_doc,
             rebuild=options["rebuild"],
-            catchup=stream,
+            catchup=changed,
         )
         self.stdout.write(self.style.SUCCESS(summary("nes-entities", result)))

--- a/entities/management/commands/reindex_entities.py
+++ b/entities/management/commands/reindex_entities.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from django.core.management.base import BaseCommand
 
 from jawafdehi_shared.search.opensearch import ENTITY_INDEX
-from jawafdehi_shared.search.reindex import reindex
+from jawafdehi_shared.search.reindex import reindex, summary
 from entities import search_index
 from entities.models import StoredEntity
 
@@ -37,15 +37,19 @@ class Command(BaseCommand):
         # Mirror the live indexer's gate (entities.signals): index ONLY the rows
         # still on the read plane. Without this a reindex re-adds soft-deleted
         # entities to public search — the exact rows the signal evicted.
-        records = StoredEntity.objects.filter(is_deleted=False).iterator()
+        def stream(since=None):
+            qs = StoredEntity.objects.filter(is_deleted=False)
+            if since:
+                # updated_at is NOT auto_now here — entities.persistence sets it on
+                # every re-publish, which is exactly the write we need to catch.
+                qs = qs.filter(updated_at__gte=since)
+            return qs.iterator()
+
         result = reindex(
             index=ENTITY_INDEX,
-            records=records,
+            records=stream(),
             build_doc=search_index.build_doc,
             rebuild=options["rebuild"],
+            catchup=stream,
         )
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"nes-entities: indexed={result['indexed']} skipped={result['skipped']}"
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(summary("nes-entities", result)))

--- a/jawafdehi_shared/search/aliases.py
+++ b/jawafdehi_shared/search/aliases.py
@@ -1,0 +1,156 @@
+"""Generation-based index aliasing, so a full rebuild costs no downtime.
+
+THE PROBLEM. ``reindex(rebuild=True)`` used to DELETE the index and immediately
+recreate it empty, then refill it over the length of the scan. For
+``ngm-courtcases`` that is a ~1h sequential pass over 2.2M rows, during which
+public search returned zero court-case results — not an error anyone would
+notice, just a silently empty index. Because a rebuild cost that outage, it was
+never put on a schedule, and the four weekly crons run WITHOUT ``--rebuild``.
+That mode only ever adds, so a doc whose row has since become hidden is never
+evicted and staleness accrues until somebody rebuilds by hand.
+
+THE SHAPE OF THE FIX. The public name becomes an ALIAS over a numbered
+generation:
+
+    ngm-courtcases           (alias)
+      └── ngm-courtcases-000002   (concrete, serving)
+
+A rebuild creates ``-000003`` alongside, fills it while ``-000002`` keeps
+serving every read and write, and then moves the alias in ONE cluster-state
+update. There is no instant at which the name resolves to nothing.
+
+WHAT THIS ALSO BUYS. ``create_index`` no-ops on an existing index, so a mapping
+change could only reach a live index through a rebuild — which is why
+``search.service._sort_spec`` carries ``unmapped_type`` for ``weight``, a field
+the live index does not have. Each generation is created fresh from the current
+``common_mappings()``, so a mapping migration is now just the next rebuild.
+
+VERIFIED AGAINST THE LIVE CLUSTER (2026-08-14), because two of these are the
+kind of thing that reads as obviously-true and is not:
+
+* an alias can replace a concrete index of the SAME NAME atomically, via
+  ``remove_index`` + ``add`` in one action list — so even the one-time
+  bootstrap has no gap;
+* ``client.index()`` / ``client.delete()`` against a single-index alias resolve
+  to the backing index, so the live signal path needs no ``is_write_index`` and
+  no dual-write.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A generation is the alias name plus a zero-padded ordinal. Six digits is
+# arbitrary but fixed: the width is part of the name, so it cannot be widened
+# later without orphaning every existing generation.
+GENERATION_WIDTH = 6
+
+# Anchored on BOTH ends and checked against the alias exactly, so a neighbouring
+# index that merely starts with the alias name (``ngm-courtcases-archive-000001``)
+# is NOT mistaken for a generation and pruned.
+_GENERATION_RE = re.compile(r"^(?P<base>.+)-(?P<ordinal>\d{%d})$" % GENERATION_WIDTH)
+
+
+def generation_name(alias: str, ordinal: int) -> str:
+    """``("ngm-courtcases", 3)`` -> ``"ngm-courtcases-000003"``."""
+    return f"{alias}-{ordinal:0{GENERATION_WIDTH}d}"
+
+
+def generation_ordinal(alias: str, index: str) -> int | None:
+    """The generation number of ``index``, or None if it is not one of ``alias``."""
+    match = _GENERATION_RE.match(index)
+    if match is None or match.group("base") != alias:
+        return None
+    return int(match.group("ordinal"))
+
+
+def _generation_indices(client, alias: str) -> dict[str, int]:
+    """Every existing generation of ``alias``, as ``{index name: ordinal}``."""
+    try:
+        names = client.indices.get(index=f"{alias}-*", ignore_unavailable=True) or {}
+    except Exception:  # noqa: BLE001 — a wildcard with no matches must read as none.
+        return {}
+    found: dict[str, int] = {}
+    for name in names:
+        ordinal = generation_ordinal(alias, name)
+        if ordinal is not None:
+            found[name] = ordinal
+    return found
+
+
+def alias_targets(client, alias: str) -> list[str]:
+    """The concrete indices ``alias`` points at (empty if it is not an alias).
+
+    Normally one. The list form exists so ``swap_alias`` detaches ALL of them:
+    an alias left pointing at two generations by a half-finished swap would make
+    every search return each doc twice.
+    """
+    try:
+        if not client.indices.exists_alias(name=alias):
+            return []
+        return sorted(client.indices.get_alias(name=alias) or {})
+    except Exception:  # noqa: BLE001 — absent alias reads as "not aliased yet".
+        return []
+
+
+def resolve_alias(client, alias: str) -> str | None:
+    """The generation currently serving ``alias``, or None if it is not an alias."""
+    targets = alias_targets(client, alias)
+    if not targets:
+        return None
+    # Highest generation wins if a stale swap left more than one attached.
+    return max(targets, key=lambda n: (generation_ordinal(alias, n) or 0, n))
+
+
+def next_generation(client, alias: str) -> str:
+    """The name to build into next.
+
+    One past the HIGHEST generation that exists, not one past the one currently
+    serving: a crashed run leaves an orphan, and reusing its name would build
+    into a half-filled index instead of a clean one.
+    """
+    ordinals = _generation_indices(client, alias).values()
+    return generation_name(alias, (max(ordinals) if ordinals else 0) + 1)
+
+
+def swap_alias(client, alias: str, new_index: str) -> list[str]:
+    """Point ``alias`` at ``new_index`` in ONE atomic cluster-state update.
+
+    Returns the names displaced (the old generation, or the concrete index
+    consumed by the bootstrap). Handles all three states the cluster can be in:
+
+    * ``alias`` is already an alias — detach the old generation, attach the new;
+    * ``alias`` is still a CONCRETE index (the pre-swap world, and the state all
+      four indices are in today) — ``remove_index`` DELETES it in the same action
+      list, because a name cannot be both an index and an alias;
+    * ``alias`` does not exist at all (cold start) — just attach.
+
+    The bootstrap branch is the only destructive step in a rebuild, it runs
+    exactly once per index, and it is atomic with the add. Callers must not
+    reach it until the new generation is built and non-empty — see the
+    ``RebuildAborted`` guard in ``reindex``.
+    """
+    actions: list[dict] = []
+    displaced = alias_targets(client, alias)
+    if displaced:
+        actions.extend({"remove": {"index": old, "alias": alias}} for old in displaced)
+    elif client.indices.exists(index=alias):
+        actions.append({"remove_index": {"index": alias}})
+        displaced = [alias]
+    actions.append({"add": {"index": new_index, "alias": alias}})
+    client.indices.update_aliases(body={"actions": actions})
+    return displaced
+
+
+def prune_generations(client, alias: str, keep: str) -> list[str]:
+    """Delete every generation of ``alias`` except ``keep``.
+
+    Runs only AFTER a successful swap, never before one: pruning up front would
+    race a concurrent build for the same alias, and the disk a stale generation
+    holds is not worth that. An orphan from a crashed run therefore survives
+    until the next successful rebuild, which is the intended trade.
+    """
+    doomed = sorted(n for n in _generation_indices(client, alias) if n != keep)
+    for name in doomed:
+        client.indices.delete(index=name, ignore_unavailable=True)
+    return doomed

--- a/jawafdehi_shared/search/aliases.py
+++ b/jawafdehi_shared/search/aliases.py
@@ -40,6 +40,8 @@ from __future__ import annotations
 
 import re
 
+from jawafdehi_shared.search.indexing import is_not_found
+
 # A generation is the alias name plus a zero-padded ordinal. Six digits is
 # arbitrary but fixed: the width is part of the name, so it cannot be widened
 # later without orphaning every existing generation.
@@ -68,7 +70,12 @@ def _generation_indices(client, alias: str) -> dict[str, int]:
     """Every existing generation of ``alias``, as ``{index name: ordinal}``."""
     try:
         names = client.indices.get(index=f"{alias}-*", ignore_unavailable=True) or {}
-    except Exception:  # noqa: BLE001 — a wildcard with no matches must read as none.
+    except Exception as exc:  # noqa: BLE001
+        # ONLY a 404 means "no generations". Swallowing a timeout here would
+        # restart the numbering at -000001 and rebuild into an index that already
+        # exists and is possibly the one still serving.
+        if not is_not_found(exc):
+            raise
         return {}
     found: dict[str, int] = {}
     for name in names:
@@ -89,7 +96,13 @@ def alias_targets(client, alias: str) -> list[str]:
         if not client.indices.exists_alias(name=alias):
             return []
         return sorted(client.indices.get_alias(name=alias) or {})
-    except Exception:  # noqa: BLE001 — absent alias reads as "not aliased yet".
+    except Exception as exc:  # noqa: BLE001
+        # Fail CLOSED. "Not an alias" routes swap_alias into its destructive
+        # bootstrap branch, which issues remove_index against the name — so a
+        # timeout read as "absent" would delete the live index instead of
+        # detaching an alias from it.
+        if not is_not_found(exc):
+            raise
         return []
 
 
@@ -143,14 +156,30 @@ def swap_alias(client, alias: str, new_index: str) -> list[str]:
 
 
 def prune_generations(client, alias: str, keep: str) -> list[str]:
-    """Delete every generation of ``alias`` except ``keep``.
+    """Delete generations of ``alias`` OLDER than ``keep``.
 
-    Runs only AFTER a successful swap, never before one: pruning up front would
-    race a concurrent build for the same alias, and the disk a stale generation
-    holds is not worth that. An orphan from a crashed run therefore survives
-    until the next successful rebuild, which is the intended trade.
+    Two rules, both about not deleting something that is still in use:
+
+    * only AFTER a successful swap, never before one — the disk a stale
+      generation holds is not worth racing a concurrent build for it;
+    * only strictly-lower ordinals. A HIGHER generation is not garbage, it is a
+      rebuild that started after this one and is still filling its index.
+      Deleting it would leave that run bulk-writing into nothing and then
+      swapping the alias onto an index that no longer exists. ``concurrencyPolicy:
+      Forbid`` stops one cron overlapping itself, not a manual run overlapping
+      the cron.
+
+    An orphan from a crashed run therefore survives until a LATER generation
+    goes live, which is the next rebuild. That is the intended trade.
     """
-    doomed = sorted(n for n in _generation_indices(client, alias) if n != keep)
+    keep_ordinal = generation_ordinal(alias, keep)
+    if keep_ordinal is None:  # pragma: no cover — keep is always a generation.
+        return []
+    doomed = sorted(
+        name
+        for name, ordinal in _generation_indices(client, alias).items()
+        if ordinal < keep_ordinal
+    )
     for name in doomed:
         client.indices.delete(index=name, ignore_unavailable=True)
     return doomed

--- a/jawafdehi_shared/search/indexing.py
+++ b/jawafdehi_shared/search/indexing.py
@@ -173,6 +173,19 @@ def best_effort(action: str) -> Callable[[Callable], Callable]:
     return decorator
 
 
+def is_not_found(exc: Exception) -> bool:
+    """True for a 404 from the cluster, False for every other failure.
+
+    opensearch-py raises NotFoundError (a TransportError subclass with
+    ``status_code`` 404) for an absent index/alias/doc. Callers that mean
+    "absent" must test for THAT, not for ``Exception``: a timeout, a 5xx or an
+    auth failure is not an empty result, and treating it as one is how a
+    rebuild ends up deciding a live alias does not exist.
+    """
+    status = getattr(exc, "status_code", None)
+    return status == 404 or str(status) == "404"
+
+
 def upsert_doc(client, index: str, doc: dict[str, Any]) -> None:
     """Upsert ``doc`` into ``index`` keyed by its ``iri`` (the document ``_id``).
 
@@ -194,11 +207,9 @@ def delete_doc(client, index: str, iri: str) -> None:
     try:
         client.delete(index=index, id=iri)
     except Exception as exc:  # noqa: BLE001
-        # opensearch-py raises NotFoundError (a subclass of TransportError with
-        # status_code 404). Treat "already gone" as success; re-raise anything
-        # else so best_effort / the command can see a real failure.
-        status = getattr(exc, "status_code", None)
-        if status == 404 or str(status) == "404":
+        # Treat "already gone" as success; re-raise anything else so
+        # best_effort / the command can see a real failure.
+        if is_not_found(exc):
             return
         raise
 
@@ -226,3 +237,32 @@ def stream_bulk(client, index: str, docs: Iterable[dict[str, Any]]) -> int:
 
     bulk(client, counting())
     return count
+
+
+def stream_bulk_delete(client, index: str, iris: Iterable[str]) -> int:
+    """Bulk-delete ``iris`` from ``index``. Returns the number submitted.
+
+    Batched rather than per-doc because the caller (the rebuild catch-up) issues
+    a tombstone for every changed row its gate rejects, and rejection is the
+    COMMON case — only ~1.2% of court cases are public, so a busy window is tens
+    of thousands of tombstones for docs that were mostly never indexed.
+
+    Those per-item 404s are the expected result, not a failure, so errors are
+    collected instead of raised; anything that is NOT a 404 is re-raised, since
+    that means the eviction genuinely did not happen.
+    """
+    from opensearchpy.helpers import bulk  # lazy: optional dependency
+
+    ids = list(iris)
+    if not ids:
+        return 0
+    actions = [{"_op_type": "delete", "_index": index, "_id": iri} for iri in ids]
+    _, errors = bulk(client, actions, raise_on_error=False, stats_only=False)
+    real = [
+        err
+        for err in errors
+        if str((err.get("delete") or {}).get("status")) not in ("404", "200")
+    ]
+    if real:
+        raise RuntimeError(f"bulk delete from {index} failed: {real[:3]}")
+    return len(ids)

--- a/jawafdehi_shared/search/reindex.py
+++ b/jawafdehi_shared/search/reindex.py
@@ -32,7 +32,11 @@ from jawafdehi_shared.search.aliases import (
     resolve_alias,
     swap_alias,
 )
-from jawafdehi_shared.search.indexing import stream_bulk
+from jawafdehi_shared.search.indexing import (
+    is_not_found,
+    stream_bulk,
+    stream_bulk_delete,
+)
 from jawafdehi_shared.search.opensearch import create_index, make_client
 
 
@@ -47,11 +51,18 @@ class RebuildAborted(RuntimeError):
 
 
 def _doc_count(client, index: str) -> int:
-    """Docs currently in ``index`` (0 if it is missing or unreadable)."""
+    """Docs currently in ``index``; 0 if it is MISSING, raise if it is unreadable.
+
+    The distinction is the whole point. This number decides whether a
+    destructive swap is safe, so a timeout or a 5xx must not be allowed to read
+    as "the old index was empty anyway".
+    """
     try:
         return int(client.count(index=index)["count"])
-    except Exception:  # noqa: BLE001 — a missing index is legitimately zero.
-        return 0
+    except Exception as exc:  # noqa: BLE001
+        if is_not_found(exc):
+            return 0
+        raise
 
 
 def _refresh(client, index: str) -> None:
@@ -92,6 +103,51 @@ def _stream(
     return indexed, skipped
 
 
+def _catch_up(
+    client,
+    index: str,
+    pairs: Iterable[tuple[str, Any]],
+    build_doc: Callable[[Any], dict[str, Any]],
+    batch_size: int,
+) -> tuple[int, int]:
+    """Apply post-build changes to ``index``. Returns ``(upserted, evicted)``.
+
+    ``pairs`` is ``(iri, record_or_None)``: the command has already applied its
+    own visibility gate, and a ``None`` record means "this one no longer belongs
+    in the index". Evicting on None is not optional. Without it a row that became
+    hidden DURING the build stays in the new generation — and since the live
+    signal's delete went to the OLD generation, the swap would RESURRECT a doc
+    the platform had already evicted. For court cases that is the sensitive-type
+    floor being undone by a reindex.
+    """
+    upserted = 0
+    evicted = 0
+    batch: list[dict[str, Any]] = []
+    tombstones: list[str] = []
+
+    def flush() -> None:
+        nonlocal upserted, evicted
+        if batch:
+            upserted += stream_bulk(client, index, batch)
+            batch.clear()
+        if tombstones:
+            evicted += stream_bulk_delete(client, index, tombstones)
+            tombstones.clear()
+
+    for iri, record in pairs:
+        # A tombstone for a doc the scan never indexed is a no-op, not an error —
+        # and it is the common case, so both sides are batched.
+        doc = {} if record is None else build_doc(record)
+        if not doc.get("iri"):
+            tombstones.append(iri)
+        else:
+            batch.append(doc)
+        if len(batch) >= batch_size or len(tombstones) >= batch_size:
+            flush()
+    flush()
+    return upserted, evicted
+
+
 def reindex(
     *,
     index: str,
@@ -100,20 +156,22 @@ def reindex(
     rebuild: bool = False,
     client=None,
     batch_size: int = 500,
-    catchup: Callable[[datetime], Iterable[Any]] | None = None,
+    catchup: Callable[[datetime], Iterable[tuple[str, Any]]] | None = None,
 ) -> dict[str, Any]:
     """Bulk-(re)index ``records`` into ``index``.
 
     * ``rebuild``: build a new generation and swap the alias onto it when it is
       complete (no downtime, and the only mode that evicts).
-    * ``catchup``: called with the UTC time the build started, and must return the
-      records written since. Only meaningful with ``rebuild``. The alias flips
-      BEFORE this runs, so anything written after the swap already lands on the
-      new generation and this only has to cover the build window itself.
+    * ``catchup``: called with the UTC time the build started, and must yield
+      ``(iri, record_or_None)`` for everything written since — ``None`` meaning
+      the row no longer belongs in the index, which is EVICTED rather than
+      skipped. Only meaningful with ``rebuild``. The alias flips BEFORE this
+      runs, so anything written after the swap already lands on the new
+      generation and this only has to cover the build window itself.
     * Records whose ``build_doc`` yields no ``iri`` are skipped (e.g. a
       non-published case).
 
-    Returns ``{"indexed", "skipped", "index", "swapped", "caught_up",
+    Returns ``{"indexed", "skipped", "index", "swapped", "caught_up", "evicted",
     "displaced", "pruned"}`` — ``index`` being the generation actually written,
     which is not ``index`` when a swap happened.
     """
@@ -129,6 +187,7 @@ def reindex(
             "index": index,
             "swapped": False,
             "caught_up": 0,
+            "evicted": 0,
             "displaced": [],
             "pruned": [],
         }
@@ -144,20 +203,25 @@ def reindex(
     indexed, skipped = _stream(client, target, records, build_doc, batch_size)
     _refresh(client, target)
 
+    # Count what actually LANDED, not what was submitted: `indexed` is the number
+    # of docs handed to the bulk helper, which is an upper bound on the number
+    # the cluster stored. The swap is destructive, so it is gated on the real one.
     live = resolve_alias(client, index)
-    if indexed == 0 and _doc_count(client, live or index) > 0:
+    live_count = _doc_count(client, live or index)
+    if _doc_count(client, target) == 0 and live_count > 0:
         client.indices.delete(index=target, ignore_unavailable=True)
         raise RebuildAborted(
             f"{index}: rebuild produced 0 documents while the live index holds "
-            f"{_doc_count(client, live or index)}; refusing to swap. The old "
-            f"index is untouched and still serving."
+            f"{live_count}; refusing to swap. The old index is untouched and "
+            f"still serving."
         )
 
     displaced = swap_alias(client, index, target)
 
     caught_up = 0
+    evicted = 0
     if catchup is not None:
-        caught_up, _ = _stream(
+        caught_up, evicted = _catch_up(
             client, target, catchup(started_at), build_doc, batch_size
         )
         _refresh(client, target)
@@ -169,6 +233,7 @@ def reindex(
         "index": target,
         "swapped": True,
         "caught_up": caught_up,
+        "evicted": evicted,
         "displaced": displaced,
         "pruned": pruned,
     }
@@ -180,6 +245,7 @@ def summary(label: str, result: dict[str, Any]) -> str:
     if result.get("swapped"):
         line += (
             f" swapped->{result['index']} caught_up={result['caught_up']}"
+            f" evicted={result.get('evicted', 0)}"
             f" pruned={len(result['pruned'])}"
         )
     return line

--- a/jawafdehi_shared/search/reindex.py
+++ b/jawafdehi_shared/search/reindex.py
@@ -2,43 +2,74 @@
 
 Each app's ``reindex_<x>`` command supplies (index name, a queryset/iterable of
 records, the app's ``build_doc``) and this driver does the rest: ensure the index
-exists (optionally drop+recreate on ``--rebuild``), stream records through
-``build_doc``, and bulk-index them. Records that ``build_doc`` skips (return a doc
-with no ``iri``) are not indexed — this is how the case command drops
-non-published cases.
+exists, stream records through ``build_doc``, and bulk-index them. Records that
+``build_doc`` skips (return a doc with no ``iri``) are not indexed — this is how
+the case command drops non-published cases.
+
+``rebuild=True`` no longer drops the live index. It builds a NEW generation
+beside it and moves the alias when the generation is complete, so a rebuild is
+invisible to readers and writers; see ``jawafdehi_shared.search.aliases`` for the
+naming and the atomic swap. Two consequences worth knowing before touching this:
+
+* A rebuild is now safe to schedule. It is the ONLY mode that evicts a doc whose
+  row has since become hidden — an incremental pass can only ever add — so the
+  drift that used to need a manual rebuild is now something a cron can fix.
+* Writes that land DURING the build go to the old generation and would die at
+  the swap. That would be a regression: the old in-place rebuild refilled the
+  very index the live path was writing to, so those writes survived. ``catchup``
+  closes it (see ``reindex``), and a command that passes ``records`` without a
+  matching ``catchup`` is accepting that loss.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Callable, Iterable
 
+from jawafdehi_shared.search.aliases import (
+    next_generation,
+    prune_generations,
+    resolve_alias,
+    swap_alias,
+)
 from jawafdehi_shared.search.indexing import stream_bulk
 from jawafdehi_shared.search.opensearch import create_index, make_client
 
 
-def reindex(
-    *,
+class RebuildAborted(RuntimeError):
+    """A rebuild produced no documents while the live index still had some.
+
+    Raised INSTEAD of swapping, so the old generation keeps serving. This is the
+    guard against a bug in a visibility gate silently emptying public search: the
+    swap is atomic and the bootstrap branch deletes the old index, so without it
+    one inverted predicate would wipe an index with no warning and no undo.
+    """
+
+
+def _doc_count(client, index: str) -> int:
+    """Docs currently in ``index`` (0 if it is missing or unreadable)."""
+    try:
+        return int(client.count(index=index)["count"])
+    except Exception:  # noqa: BLE001 — a missing index is legitimately zero.
+        return 0
+
+
+def _refresh(client, index: str) -> None:
+    """Make freshly-indexed docs searchable now (for the caller's verification)."""
+    try:
+        client.indices.refresh(index=index)
+    except Exception:  # noqa: BLE001 — refresh is a nicety, not a contract.
+        pass
+
+
+def _stream(
+    client,
     index: str,
     records: Iterable[Any],
     build_doc: Callable[[Any], dict[str, Any]],
-    rebuild: bool = False,
-    client=None,
-    batch_size: int = 500,
-) -> dict[str, int]:
-    """Bulk-(re)index ``records`` into ``index``.
-
-    * ``rebuild``: drop the index first (then recreate with the bilingual config).
-    * Records whose ``build_doc`` yields no ``iri`` are skipped (e.g. a
-      non-published case).
-
-    Returns ``{"indexed": n, "skipped": m}``.
-    """
-    client = client or make_client()
-
-    if rebuild and client.indices.exists(index=index):
-        client.indices.delete(index=index)
-    create_index(client, index)
-
+    batch_size: int,
+) -> tuple[int, int]:
+    """Bulk-index ``records`` into ``index``. Returns ``(indexed, skipped)``."""
     indexed = 0
     skipped = 0
     batch: list[dict[str, Any]] = []
@@ -58,12 +89,97 @@ def reindex(
         if len(batch) >= batch_size:
             flush()
     flush()
+    return indexed, skipped
 
-    # Make freshly-indexed docs searchable immediately (useful for the caller's
-    # post-reindex verification / a follow-on count).
-    try:
-        client.indices.refresh(index=index)
-    except Exception:  # noqa: BLE001 — refresh is a nicety, not a contract.
-        pass
 
-    return {"indexed": indexed, "skipped": skipped}
+def reindex(
+    *,
+    index: str,
+    records: Iterable[Any],
+    build_doc: Callable[[Any], dict[str, Any]],
+    rebuild: bool = False,
+    client=None,
+    batch_size: int = 500,
+    catchup: Callable[[datetime], Iterable[Any]] | None = None,
+) -> dict[str, Any]:
+    """Bulk-(re)index ``records`` into ``index``.
+
+    * ``rebuild``: build a new generation and swap the alias onto it when it is
+      complete (no downtime, and the only mode that evicts).
+    * ``catchup``: called with the UTC time the build started, and must return the
+      records written since. Only meaningful with ``rebuild``. The alias flips
+      BEFORE this runs, so anything written after the swap already lands on the
+      new generation and this only has to cover the build window itself.
+    * Records whose ``build_doc`` yields no ``iri`` are skipped (e.g. a
+      non-published case).
+
+    Returns ``{"indexed", "skipped", "index", "swapped", "caught_up",
+    "displaced", "pruned"}`` — ``index`` being the generation actually written,
+    which is not ``index`` when a swap happened.
+    """
+    client = client or make_client()
+
+    if not rebuild:
+        create_index(client, index)
+        indexed, skipped = _stream(client, index, records, build_doc, batch_size)
+        _refresh(client, index)
+        return {
+            "indexed": indexed,
+            "skipped": skipped,
+            "index": index,
+            "swapped": False,
+            "caught_up": 0,
+            "displaced": [],
+            "pruned": [],
+        }
+
+    # Stamped BEFORE the scan so the catch-up window cannot miss a row written
+    # while the first batch was still being built.
+    started_at = datetime.now(timezone.utc)
+    target = next_generation(client, index)
+    # A fresh generation is created from the CURRENT mappings — this is what makes
+    # a mapping migration land, since create_index no-ops on an existing index.
+    create_index(client, target)
+
+    indexed, skipped = _stream(client, target, records, build_doc, batch_size)
+    _refresh(client, target)
+
+    live = resolve_alias(client, index)
+    if indexed == 0 and _doc_count(client, live or index) > 0:
+        client.indices.delete(index=target, ignore_unavailable=True)
+        raise RebuildAborted(
+            f"{index}: rebuild produced 0 documents while the live index holds "
+            f"{_doc_count(client, live or index)}; refusing to swap. The old "
+            f"index is untouched and still serving."
+        )
+
+    displaced = swap_alias(client, index, target)
+
+    caught_up = 0
+    if catchup is not None:
+        caught_up, _ = _stream(
+            client, target, catchup(started_at), build_doc, batch_size
+        )
+        _refresh(client, target)
+
+    pruned = prune_generations(client, index, keep=target)
+    return {
+        "indexed": indexed,
+        "skipped": skipped,
+        "index": target,
+        "swapped": True,
+        "caught_up": caught_up,
+        "displaced": displaced,
+        "pruned": pruned,
+    }
+
+
+def summary(label: str, result: dict[str, Any]) -> str:
+    """The one-line command output, identical in shape across the four commands."""
+    line = f"{label}: indexed={result['indexed']} skipped={result['skipped']}"
+    if result.get("swapped"):
+        line += (
+            f" swapped->{result['index']} caught_up={result['caught_up']}"
+            f" pruned={len(result['pruned'])}"
+        )
+    return line

--- a/jawafdehi_shared/search/tests/fakes.py
+++ b/jawafdehi_shared/search/tests/fakes.py
@@ -1,0 +1,150 @@
+"""A minimal in-memory stand-in for the OpenSearch indices/alias API.
+
+A MagicMock is the wrong tool for the swap tests: every attribute it returns is
+truthy, so a test would pass against code that resolved aliases incorrectly. This
+fake instead enforces the ONE cluster rule the whole design turns on — a name
+cannot be both a concrete index and an alias — so a bootstrap that forgets to
+``remove_index`` fails here rather than in production.
+
+Behaviour is modelled on what was verified against the live cluster on
+2026-08-14 (see ``jawafdehi_shared.search.aliases``), not on the docs. In
+particular ``exists`` answers True for an alias name, matching the live
+``HEAD /<alias>`` -> 200.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+
+
+class NotFoundError(Exception):
+    """Stands in for opensearchpy.NotFoundError (status 404)."""
+
+    status_code = 404
+
+
+class AliasNameConflict(Exception):
+    """An alias was pointed at a name that is still a concrete index."""
+
+
+class Store:
+    """The cluster state: ``indices`` maps name -> {doc id: doc}."""
+
+    def __init__(self, indices=None, aliases=None):
+        self.indices: dict[str, dict] = indices or {}
+        self.aliases: dict[str, list[str]] = aliases or {}
+
+    def resolve(self, name: str) -> str:
+        """The concrete index a read/write against ``name`` lands on."""
+        if name in self.aliases:
+            targets = self.aliases[name]
+            if len(targets) != 1:
+                raise ValueError(f"{name} points at {len(targets)} indices")
+            return targets[0]
+        return name
+
+
+class FakeIndices:
+    """The ``client.indices`` namespace."""
+
+    def __init__(self, store: Store):
+        self.store = store
+        # Names passed to create(), in order — lets a test assert that a rebuild
+        # built a FRESH index (the only way a mapping change reaches the cluster)
+        # rather than reusing one.
+        self.created: list[str] = []
+
+    def exists(self, index: str) -> bool:
+        return index in self.store.indices or index in self.store.aliases
+
+    def exists_alias(self, name: str) -> bool:
+        return name in self.store.aliases
+
+    def get_alias(self, name: str) -> dict:
+        if name not in self.store.aliases:
+            raise NotFoundError(name)
+        return {i: {"aliases": {name: {}}} for i in self.store.aliases[name]}
+
+    def get(self, index: str, ignore_unavailable: bool = False) -> dict:
+        if "*" in index:
+            return {
+                name: {"settings": {}, "mappings": {}}
+                for name in sorted(self.store.indices)
+                if fnmatch.fnmatch(name, index)
+            }
+        if index not in self.store.indices:
+            if ignore_unavailable:
+                return {}
+            raise NotFoundError(index)
+        return {index: {"settings": {}, "mappings": {}}}
+
+    def create(self, index: str, body: dict | None = None) -> dict:
+        if index in self.store.aliases:
+            raise AliasNameConflict(f"{index} is an alias, not an index")
+        self.created.append(index)
+        self.store.indices.setdefault(index, {})
+        return {"acknowledged": True}
+
+    def delete(self, index: str, ignore_unavailable: bool = False) -> dict:
+        if index not in self.store.indices and not ignore_unavailable:
+            raise NotFoundError(index)
+        self.store.indices.pop(index, None)
+        return {"acknowledged": True}
+
+    def refresh(self, index: str | None = None) -> dict:
+        return {"_shards": {"failed": 0}}
+
+    def update_aliases(self, body: dict) -> dict:
+        """Apply the action list: validate against a copy, then commit at once."""
+        aliases = {k: list(v) for k, v in self.store.aliases.items()}
+        indices = dict(self.store.indices)
+        for action in body["actions"]:
+            ((verb, spec),) = action.items()
+            if verb == "remove":
+                aliases.get(spec["alias"], []).remove(spec["index"])
+                if not aliases[spec["alias"]]:
+                    del aliases[spec["alias"]]
+            elif verb == "remove_index":
+                if spec["index"] not in indices:
+                    raise NotFoundError(spec["index"])
+                del indices[spec["index"]]
+            elif verb == "add":
+                if spec["alias"] in indices:
+                    # The rule the bootstrap branch exists to satisfy.
+                    raise AliasNameConflict(
+                        f"{spec['alias']} is a concrete index; it cannot also "
+                        f"be an alias"
+                    )
+                aliases.setdefault(spec["alias"], []).append(spec["index"])
+            else:  # pragma: no cover — an action the driver never emits.
+                raise ValueError(verb)
+        self.store.aliases = aliases
+        self.store.indices = indices
+        return {"acknowledged": True}
+
+
+class Client:
+    """What the driver is handed: ``.indices`` is the API, ``.store`` the data."""
+
+    def __init__(self, indices=None, aliases=None):
+        self.store = Store(indices=indices, aliases=aliases)
+        self.indices = FakeIndices(self.store)
+
+    def count(self, index: str) -> dict:
+        target = self.store.resolve(index)
+        if target not in self.store.indices:
+            raise NotFoundError(index)
+        return {"count": len(self.store.indices[target])}
+
+    def bulk_write(self, index: str, docs) -> int:
+        """Test-side stand-in for ``stream_bulk`` (which the tests patch out)."""
+        target = self.store.resolve(index)
+        if target not in self.store.indices:
+            raise NotFoundError(index)
+        for doc in docs:
+            self.store.indices[target][doc["iri"]] = doc
+        return len(docs)
+
+    def search_ids(self, index: str) -> list[str]:
+        """The doc ids a search through ``index`` would return."""
+        return sorted(self.store.indices[self.store.resolve(index)])

--- a/jawafdehi_shared/search/tests/fakes.py
+++ b/jawafdehi_shared/search/tests/fakes.py
@@ -27,6 +27,14 @@ class AliasNameConflict(Exception):
     """An alias was pointed at a name that is still a concrete index."""
 
 
+class TransportError(Exception):
+    """A non-404 cluster failure: timeout, 5xx, auth. NOT an empty result."""
+
+    def __init__(self, status_code: int = 503):
+        super().__init__(f"transport error {status_code}")
+        self.status_code = status_code
+
+
 class Store:
     """The cluster state: ``indices`` maps name -> {doc id: doc}."""
 
@@ -47,25 +55,36 @@ class Store:
 class FakeIndices:
     """The ``client.indices`` namespace."""
 
-    def __init__(self, store: Store):
+    def __init__(self, store: Store, fail_on: dict[str, Exception] | None = None):
         self.store = store
         # Names passed to create(), in order — lets a test assert that a rebuild
         # built a FRESH index (the only way a mapping change reaches the cluster)
         # rather than reusing one.
         self.created: list[str] = []
+        # {method name: exception} — injects the cluster failures the driver has
+        # to fail CLOSED on, which is otherwise untestable without a real outage.
+        self.fail_on = fail_on or {}
+
+    def _maybe_fail(self, method: str) -> None:
+        if method in self.fail_on:
+            raise self.fail_on[method]
 
     def exists(self, index: str) -> bool:
+        self._maybe_fail("exists")
         return index in self.store.indices or index in self.store.aliases
 
     def exists_alias(self, name: str) -> bool:
+        self._maybe_fail("exists_alias")
         return name in self.store.aliases
 
     def get_alias(self, name: str) -> dict:
+        self._maybe_fail("get_alias")
         if name not in self.store.aliases:
             raise NotFoundError(name)
         return {i: {"aliases": {name: {}}} for i in self.store.aliases[name]}
 
     def get(self, index: str, ignore_unavailable: bool = False) -> dict:
+        self._maybe_fail("get")
         if "*" in index:
             return {
                 name: {"settings": {}, "mappings": {}}
@@ -126,15 +145,26 @@ class FakeIndices:
 class Client:
     """What the driver is handed: ``.indices`` is the API, ``.store`` the data."""
 
-    def __init__(self, indices=None, aliases=None):
+    def __init__(self, indices=None, aliases=None, fail_on=None):
         self.store = Store(indices=indices, aliases=aliases)
-        self.indices = FakeIndices(self.store)
+        self.fail_on = fail_on or {}
+        self.indices = FakeIndices(self.store, fail_on=self.fail_on)
 
     def count(self, index: str) -> dict:
+        if "count" in self.fail_on:
+            raise self.fail_on["count"]
         target = self.store.resolve(index)
         if target not in self.store.indices:
             raise NotFoundError(index)
         return {"count": len(self.store.indices[target])}
+
+    def delete(self, index: str, id: str) -> dict:  # noqa: A002 — opensearch-py's name
+        """Doc-level delete, as ``indexing.delete_doc`` calls it."""
+        target = self.store.resolve(index)
+        if target not in self.store.indices or id not in self.store.indices[target]:
+            raise NotFoundError(id)
+        del self.store.indices[target][id]
+        return {"result": "deleted"}
 
     def bulk_write(self, index: str, docs) -> int:
         """Test-side stand-in for ``stream_bulk`` (which the tests patch out)."""
@@ -144,6 +174,14 @@ class Client:
         for doc in docs:
             self.store.indices[target][doc["iri"]] = doc
         return len(docs)
+
+    def bulk_delete(self, index: str, iris) -> int:
+        """Stand-in for ``stream_bulk_delete``; an absent doc is a no-op."""
+        target = self.store.resolve(index)
+        ids = list(iris)
+        for iri in ids:
+            self.store.indices.get(target, {}).pop(iri, None)
+        return len(ids)
 
     def search_ids(self, index: str) -> list[str]:
         """The doc ids a search through ``index`` would return."""

--- a/jawafdehi_shared/search/tests/test_aliases.py
+++ b/jawafdehi_shared/search/tests/test_aliases.py
@@ -1,0 +1,158 @@
+"""Tests for generation naming and the atomic alias swap.
+
+The swap is the step that makes a rebuild safe, and its bootstrap branch is
+destructive (``remove_index`` deletes the pre-swap concrete index), so each of
+the three cluster states it has to handle is pinned here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jawafdehi_shared.search import aliases
+from jawafdehi_shared.search.tests.fakes import AliasNameConflict, Client
+
+ALIAS = "ngm-courtcases"
+
+
+def test_generation_name_is_zero_padded():
+    assert aliases.generation_name(ALIAS, 3) == "ngm-courtcases-000003"
+    assert aliases.generation_name(ALIAS, 42) == "ngm-courtcases-000042"
+
+
+def test_generation_ordinal_round_trips():
+    assert aliases.generation_ordinal(ALIAS, "ngm-courtcases-000003") == 3
+
+
+def test_generation_ordinal_rejects_a_neighbouring_index():
+    # Starts with the alias AND ends in six digits, but is not a generation of it.
+    # If this were misread the pruner would delete somebody else's index.
+    assert aliases.generation_ordinal(ALIAS, "ngm-courtcases-archive-000001") is None
+    assert aliases.generation_ordinal(ALIAS, "ngm-materials-000001") is None
+    assert aliases.generation_ordinal(ALIAS, ALIAS) is None
+    assert aliases.generation_ordinal(ALIAS, "ngm-courtcases-0003") is None
+
+
+def test_next_generation_from_cold_start():
+    assert aliases.next_generation(Client(), ALIAS) == "ngm-courtcases-000001"
+
+
+def test_next_generation_follows_the_highest_not_the_live_one():
+    # -000004 is an orphan from a run that crashed before its swap. Building into
+    # its name again would fill a half-built index instead of a clean one.
+    client = Client(
+        indices={"ngm-courtcases-000002": {}, "ngm-courtcases-000004": {}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+    )
+    assert aliases.next_generation(client, ALIAS) == "ngm-courtcases-000005"
+
+
+def test_resolve_alias_returns_none_for_a_concrete_index():
+    client = Client(indices={ALIAS: {}})
+    assert aliases.resolve_alias(client, ALIAS) is None
+
+
+def test_resolve_alias_returns_the_backing_generation():
+    client = Client(
+        indices={"ngm-courtcases-000002": {}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+    )
+    assert aliases.resolve_alias(client, ALIAS) == "ngm-courtcases-000002"
+
+
+def test_swap_bootstraps_over_a_concrete_index():
+    """The one-time migration: every index is in this state today."""
+    client = Client(indices={ALIAS: {"old": {}}, "ngm-courtcases-000001": {"new": {}}})
+
+    displaced = aliases.swap_alias(client, ALIAS, "ngm-courtcases-000001")
+
+    assert displaced == [ALIAS]
+    # The concrete index is gone and the name is now an alias onto the new one.
+    assert ALIAS not in client.store.indices
+    assert client.store.aliases == {ALIAS: ["ngm-courtcases-000001"]}
+    # A read through the name serves the NEW generation.
+    assert client.search_ids(ALIAS) == ["new"]
+
+
+def test_swap_in_steady_state_detaches_the_old_generation():
+    client = Client(
+        indices={"ngm-courtcases-000002": {"old": {}}, "ngm-courtcases-000003": {"new": {}}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+    )
+
+    displaced = aliases.swap_alias(client, ALIAS, "ngm-courtcases-000003")
+
+    assert displaced == ["ngm-courtcases-000002"]
+    assert client.store.aliases == {ALIAS: ["ngm-courtcases-000003"]}
+    # Detached, but NOT deleted — deleting is the pruner's job, after the swap.
+    assert "ngm-courtcases-000002" in client.store.indices
+    assert client.search_ids(ALIAS) == ["new"]
+
+
+def test_swap_on_a_cold_cluster_just_attaches():
+    client = Client(indices={"ngm-courtcases-000001": {"new": {}}})
+
+    assert aliases.swap_alias(client, ALIAS, "ngm-courtcases-000001") == []
+    assert client.store.aliases == {ALIAS: ["ngm-courtcases-000001"]}
+
+
+def test_swap_leaves_exactly_one_backing_index():
+    """Two attached generations would make every search return each doc twice."""
+    client = Client(
+        indices={
+            "ngm-courtcases-000001": {},
+            "ngm-courtcases-000002": {},
+            "ngm-courtcases-000003": {},
+        },
+        aliases={ALIAS: ["ngm-courtcases-000001", "ngm-courtcases-000002"]},
+    )
+
+    aliases.swap_alias(client, ALIAS, "ngm-courtcases-000003")
+
+    assert client.store.aliases[ALIAS] == ["ngm-courtcases-000003"]
+
+
+def test_a_name_cannot_be_both_index_and_alias():
+    """Guards the fake itself: without remove_index the bootstrap must fail."""
+    client = Client(indices={ALIAS: {}, "ngm-courtcases-000001": {}})
+    with pytest.raises(AliasNameConflict):
+        client.indices.update_aliases(
+            body={"actions": [{"add": {"index": "ngm-courtcases-000001", "alias": ALIAS}}]}
+        )
+
+
+def test_create_index_no_ops_when_the_name_is_already_an_alias():
+    """``reindex_all`` calls ensure_indices() on the four public names. Once those
+    are aliases, creating a concrete index over one would be a hard conflict —
+    the live cluster answers HEAD /<alias> with 200, so create_index skips."""
+    from jawafdehi_shared.search.opensearch import create_index
+
+    client = Client(
+        indices={"ngm-courtcases-000002": {}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+    )
+
+    assert create_index(client, ALIAS) is False
+    assert client.indices.created == []
+
+
+def test_prune_keeps_the_live_generation_and_spares_neighbours():
+    client = Client(
+        indices={
+            "ngm-courtcases-000001": {},
+            "ngm-courtcases-000002": {},
+            "ngm-courtcases-000003": {},
+            "ngm-courtcases-archive-000001": {},
+            "ngm-materials": {},
+        },
+        aliases={ALIAS: ["ngm-courtcases-000003"]},
+    )
+
+    pruned = aliases.prune_generations(client, ALIAS, keep="ngm-courtcases-000003")
+
+    assert pruned == ["ngm-courtcases-000001", "ngm-courtcases-000002"]
+    assert set(client.store.indices) == {
+        "ngm-courtcases-000003",
+        "ngm-courtcases-archive-000001",
+        "ngm-materials",
+    }

--- a/jawafdehi_shared/search/tests/test_aliases.py
+++ b/jawafdehi_shared/search/tests/test_aliases.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 import pytest
 
 from jawafdehi_shared.search import aliases
-from jawafdehi_shared.search.tests.fakes import AliasNameConflict, Client
+from jawafdehi_shared.search.tests.fakes import (
+    AliasNameConflict,
+    Client,
+    NotFoundError,
+    TransportError,
+)
 
 ALIAS = "ngm-courtcases"
 
@@ -156,3 +161,50 @@ def test_prune_keeps_the_live_generation_and_spares_neighbours():
         "ngm-courtcases-archive-000001",
         "ngm-materials",
     }
+
+
+def test_prune_spares_a_newer_generation_still_being_built():
+    """A HIGHER ordinal is not garbage — it is a rebuild that started later and
+    is still filling. Deleting it leaves that run bulk-writing into nothing and
+    then swapping the alias onto an index that no longer exists. `Forbid` stops a
+    cron overlapping itself, not a manual run overlapping the cron."""
+    client = Client(
+        indices={
+            "ngm-courtcases-000001": {},
+            "ngm-courtcases-000002": {},
+            "ngm-courtcases-000003": {},  # in flight, started after this run
+        },
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+    )
+
+    pruned = aliases.prune_generations(client, ALIAS, keep="ngm-courtcases-000002")
+
+    assert pruned == ["ngm-courtcases-000001"]
+    assert "ngm-courtcases-000003" in client.store.indices
+
+
+def test_alias_targets_propagates_a_non_404_failure():
+    """Fail CLOSED: "not an alias" routes swap_alias into the branch that DELETES
+    the index, so a timeout must never be read as an empty result."""
+    client = Client(
+        indices={"ngm-courtcases-000002": {}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+        fail_on={"exists_alias": TransportError(503)},
+    )
+    with pytest.raises(TransportError):
+        aliases.alias_targets(client, ALIAS)
+
+
+def test_generation_listing_propagates_a_non_404_failure():
+    client = Client(
+        indices={"ngm-courtcases-000002": {}},
+        fail_on={"get": TransportError(500)},
+    )
+    with pytest.raises(TransportError):
+        aliases.next_generation(client, ALIAS)
+
+
+def test_a_genuine_404_still_reads_as_absent():
+    """The fail-closed change must not break the cold-start path."""
+    client = Client(fail_on={"get": NotFoundError("nope")})
+    assert aliases.next_generation(client, ALIAS) == "ngm-courtcases-000001"

--- a/jawafdehi_shared/search/tests/test_reindex_swap.py
+++ b/jawafdehi_shared/search/tests/test_reindex_swap.py
@@ -1,0 +1,207 @@
+"""Tests for the no-downtime rebuild path of the shared reindex driver.
+
+The property under test is not "the new index ends up correct" — it is that the
+OLD one keeps serving every read until the instant it is replaced, and that no
+write is lost in the swap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from jawafdehi_shared.search import reindex as reindex_mod
+from jawafdehi_shared.search.reindex import RebuildAborted, reindex, summary
+from jawafdehi_shared.search.tests.fakes import Client
+
+ALIAS = "ngm-courtcases"
+
+
+def build_doc(record):
+    """Records are bare IRIs; an empty record stands for a row that fails the gate."""
+    return {"iri": record} if record else {}
+
+
+def run(client, records, **kwargs):
+    """Drive the real reindex with bulk writes landing in the fake."""
+    with patch.object(
+        reindex_mod, "stream_bulk", lambda c, index, docs: c.bulk_write(index, docs)
+    ):
+        return reindex(
+            index=ALIAS,
+            records=records,
+            build_doc=build_doc,
+            client=client,
+            **kwargs,
+        )
+
+
+def test_incremental_path_writes_through_the_name_and_never_swaps():
+    client = Client(indices={ALIAS: {"a": {}}})
+
+    result = run(client, ["b"])
+
+    assert result["swapped"] is False
+    assert result["index"] == ALIAS
+    # Additive, as before: "a" survives even though it was not re-streamed.
+    assert client.search_ids(ALIAS) == ["a", "b"]
+
+
+def test_rebuild_serves_the_old_index_throughout_the_build():
+    """The whole point. Mid-stream, a reader must still see the old corpus."""
+    client = Client(indices={ALIAS: {"old-1": {}, "old-2": {}}})
+    seen_mid_build = []
+
+    def records():
+        for iri in ("new-1", "new-2", "new-3"):
+            seen_mid_build.append(client.search_ids(ALIAS))
+            yield iri
+
+    run(client, records(), rebuild=True, batch_size=1)
+
+    # At every point during the build the name still served the OLD docs.
+    assert seen_mid_build == [["old-1", "old-2"]] * 3
+    # And only after it completed did the name flip to the new corpus.
+    assert client.search_ids(ALIAS) == ["new-1", "new-2", "new-3"]
+
+
+def test_rebuild_evicts_a_doc_the_stream_no_longer_yields():
+    """The reason rebuilds exist: incremental passes can only ever add."""
+    client = Client(indices={ALIAS: {"stale": {}, "keep": {}}})
+
+    run(client, ["keep"], rebuild=True)
+
+    assert client.search_ids(ALIAS) == ["keep"]
+
+
+def test_rebuild_bootstraps_a_concrete_index_into_an_alias():
+    client = Client(indices={ALIAS: {"old": {}}})
+
+    result = run(client, ["new"], rebuild=True)
+
+    assert result["swapped"] is True
+    assert result["index"] == "ngm-courtcases-000001"
+    assert result["displaced"] == [ALIAS]
+    assert client.store.aliases == {ALIAS: ["ngm-courtcases-000001"]}
+
+
+def test_rebuild_on_a_cold_cluster():
+    client = Client()
+
+    result = run(client, ["new"], rebuild=True)
+
+    assert result["displaced"] == []
+    assert client.search_ids(ALIAS) == ["new"]
+
+
+def test_second_rebuild_advances_the_generation_and_prunes_the_first():
+    client = Client(indices={ALIAS: {"old": {}}})
+    run(client, ["a"], rebuild=True)
+
+    result = run(client, ["b"], rebuild=True)
+
+    assert result["index"] == "ngm-courtcases-000002"
+    assert result["pruned"] == ["ngm-courtcases-000001"]
+    assert list(client.store.indices) == ["ngm-courtcases-000002"]
+
+
+def test_catchup_recovers_writes_made_during_the_build():
+    """Without this a rebuild silently drops an hour of live writes."""
+    client = Client(indices={ALIAS: {"old": {}}})
+    written_during_build = []
+
+    def records():
+        yield "a"
+        # The importer upserts a case while the scan is still running. It lands on
+        # the OLD generation, which the swap is about to detach.
+        client.bulk_write(ALIAS, [{"iri": "mid-build"}])
+        written_during_build.append("mid-build")
+        yield "b"
+
+    result = run(
+        client,
+        records(),
+        rebuild=True,
+        catchup=lambda since: list(written_during_build),
+    )
+
+    assert result["caught_up"] == 1
+    assert client.search_ids(ALIAS) == ["a", "b", "mid-build"]
+
+
+def test_without_catchup_the_mid_build_write_is_lost():
+    """Pins the cost of omitting catchup, so nobody drops it by accident."""
+    client = Client(indices={ALIAS: {"old": {}}})
+
+    def records():
+        yield "a"
+        client.bulk_write(ALIAS, [{"iri": "mid-build"}])
+        yield "b"
+
+    run(client, records(), rebuild=True)
+
+    assert client.search_ids(ALIAS) == ["a", "b"]
+
+
+def test_empty_rebuild_is_refused_and_leaves_the_old_index_serving():
+    """A broken visibility gate must not be able to wipe public search."""
+    client = Client(indices={ALIAS: {"old-1": {}, "old-2": {}}})
+
+    with pytest.raises(RebuildAborted, match="refusing to swap"):
+        run(client, [], rebuild=True)
+
+    # Old index untouched and still the one the name resolves to...
+    assert client.search_ids(ALIAS) == ["old-1", "old-2"]
+    assert client.store.aliases == {}
+    # ...and the half-built generation is cleaned up rather than left as an orphan.
+    assert "ngm-courtcases-000001" not in client.store.indices
+
+
+def test_empty_rebuild_is_allowed_when_the_index_is_also_empty():
+    """A genuinely empty corpus is not an error — only a REGRESSION to empty is."""
+    client = Client(indices={ALIAS: {}})
+
+    result = run(client, [], rebuild=True)
+
+    assert result["swapped"] is True
+    assert result["indexed"] == 0
+
+
+def test_skipped_records_are_counted_not_indexed():
+    client = Client(indices={ALIAS: {}})
+
+    result = run(client, ["a", "", "b"], rebuild=True)
+
+    assert (result["indexed"], result["skipped"]) == (2, 1)
+
+
+def test_each_generation_is_created_fresh_so_mappings_can_change():
+    """create_index no-ops on an existing index, so a mapping change can only
+    reach the cluster through a NEW one. Two rebuilds, two creations."""
+    client = Client(indices={ALIAS: {"old": {}}})
+
+    run(client, ["a"], rebuild=True)
+    run(client, ["b"], rebuild=True)
+
+    assert client.indices.created == [
+        "ngm-courtcases-000001",
+        "ngm-courtcases-000002",
+    ]
+
+
+def test_summary_reports_the_swap():
+    swapped = {
+        "indexed": 27222,
+        "skipped": 0,
+        "index": "ngm-courtcases-000003",
+        "swapped": True,
+        "caught_up": 4,
+        "pruned": ["ngm-courtcases-000002"],
+    }
+    assert summary("ngm-courtcases", swapped) == (
+        "ngm-courtcases: indexed=27222 skipped=0 "
+        "swapped->ngm-courtcases-000003 caught_up=4 pruned=1"
+    )
+    plain = {"indexed": 5, "skipped": 1, "index": ALIAS, "swapped": False}
+    assert summary("ngm-courtcases", plain) == "ngm-courtcases: indexed=5 skipped=1"

--- a/jawafdehi_shared/search/tests/test_reindex_swap.py
+++ b/jawafdehi_shared/search/tests/test_reindex_swap.py
@@ -13,7 +13,7 @@ import pytest
 
 from jawafdehi_shared.search import reindex as reindex_mod
 from jawafdehi_shared.search.reindex import RebuildAborted, reindex, summary
-from jawafdehi_shared.search.tests.fakes import Client
+from jawafdehi_shared.search.tests.fakes import Client, TransportError
 
 ALIAS = "ngm-courtcases"
 
@@ -24,9 +24,16 @@ def build_doc(record):
 
 
 def run(client, records, **kwargs):
-    """Drive the real reindex with bulk writes landing in the fake."""
-    with patch.object(
-        reindex_mod, "stream_bulk", lambda c, index, docs: c.bulk_write(index, docs)
+    """Drive the real reindex with bulk writes/deletes landing in the fake."""
+    with (
+        patch.object(
+            reindex_mod, "stream_bulk", lambda c, index, docs: c.bulk_write(index, docs)
+        ),
+        patch.object(
+            reindex_mod,
+            "stream_bulk_delete",
+            lambda c, index, iris: c.bulk_delete(index, iris),
+        ),
     ):
         return reindex(
             index=ALIAS,
@@ -123,11 +130,61 @@ def test_catchup_recovers_writes_made_during_the_build():
         client,
         records(),
         rebuild=True,
-        catchup=lambda since: list(written_during_build),
+        catchup=lambda since: [(iri, iri) for iri in written_during_build],
     )
 
-    assert result["caught_up"] == 1
+    assert (result["caught_up"], result["evicted"]) == (1, 0)
     assert client.search_ids(ALIAS) == ["a", "b", "mid-build"]
+
+
+def test_catchup_evicts_a_record_that_became_ineligible_during_the_build():
+    """The regression that made catch-up mandatory rather than upsert-only.
+
+    A case indexed early in the scan is reclassified SENSITIVE while the scan is
+    still running. The live signal deletes it — but from the OLD generation. If
+    catch-up only upserted, the swap would put the doc back and a reindex would
+    undo the sensitive floor.
+    """
+    client = Client(indices={ALIAS: {"old": {}}})
+
+    def records():
+        yield "keep"
+        yield "goes-sensitive"
+
+    result = run(
+        client,
+        records(),
+        rebuild=True,
+        # The command's own gate rejected it, so it arrives as a tombstone.
+        catchup=lambda since: [("goes-sensitive", None)],
+    )
+
+    assert (result["caught_up"], result["evicted"]) == (0, 1)
+    assert client.search_ids(ALIAS) == ["keep"]
+
+
+def test_catchup_evicts_when_build_doc_disagrees_with_the_gate():
+    """Belt and braces: a record the gate passed but build_doc will not index."""
+    client = Client(indices={ALIAS: {"old": {}}})
+
+    result = run(
+        client, ["a"], rebuild=True, catchup=lambda since: [("a", "")]
+    )
+
+    assert result["evicted"] == 1
+    assert client.search_ids(ALIAS) == []
+
+
+def test_evicting_an_absent_doc_is_not_an_error():
+    """A row hidden mid-build that the scan never reached has nothing to delete."""
+    client = Client(indices={ALIAS: {"old": {}}})
+
+    result = run(
+        client, ["a"], rebuild=True, catchup=lambda since: [("never-indexed", None)]
+    )
+
+    assert result["evicted"] == 1
+    assert client.search_ids(ALIAS) == ["a"]
 
 
 def test_without_catchup_the_mid_build_write_is_lost():
@@ -190,6 +247,53 @@ def test_each_generation_is_created_fresh_so_mappings_can_change():
     ]
 
 
+def test_an_unreadable_cluster_aborts_instead_of_swapping():
+    """A 5xx on the doc count must not read as "the old index was empty".
+
+    That is the path that turns a transient outage into a destructive swap onto
+    a generation nobody has verified.
+    """
+    client = Client(
+        indices={ALIAS: {"old": {}}}, fail_on={"count": TransportError(503)}
+    )
+
+    with pytest.raises(TransportError):
+        run(client, ["a"], rebuild=True)
+
+    # Untouched: still a concrete index, still serving its docs.
+    assert client.store.aliases == {}
+    assert client.search_ids(ALIAS) == ["old"]
+
+
+def test_an_unreadable_alias_lookup_aborts_before_the_destructive_branch():
+    """`remove_index` DELETES. Reading a timeout as "not an alias" would send a
+    live alias into that branch."""
+    client = Client(
+        indices={"ngm-courtcases-000002": {"old": {}}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+        fail_on={"exists_alias": TransportError(503)},
+    )
+
+    with pytest.raises(TransportError):
+        run(client, ["a"], rebuild=True)
+
+    assert client.store.aliases == {ALIAS: ["ngm-courtcases-000002"]}
+
+
+def test_an_unreadable_generation_listing_aborts_before_reusing_a_name():
+    """Restarting the numbering would build into the index still serving."""
+    client = Client(
+        indices={"ngm-courtcases-000002": {"old": {}}},
+        aliases={ALIAS: ["ngm-courtcases-000002"]},
+        fail_on={"get": TransportError(503)},
+    )
+
+    with pytest.raises(TransportError):
+        run(client, ["a"], rebuild=True)
+
+    assert client.search_ids(ALIAS) == ["old"]
+
+
 def test_summary_reports_the_swap():
     swapped = {
         "indexed": 27222,
@@ -197,11 +301,12 @@ def test_summary_reports_the_swap():
         "index": "ngm-courtcases-000003",
         "swapped": True,
         "caught_up": 4,
+        "evicted": 2,
         "pruned": ["ngm-courtcases-000002"],
     }
     assert summary("ngm-courtcases", swapped) == (
         "ngm-courtcases: indexed=27222 skipped=0 "
-        "swapped->ngm-courtcases-000003 caught_up=4 pruned=1"
+        "swapped->ngm-courtcases-000003 caught_up=4 evicted=2 pruned=1"
     )
     plain = {"indexed": 5, "skipped": 1, "index": ALIAS, "swapped": False}
     assert summary("ngm-courtcases", plain) == "ngm-courtcases: indexed=5 skipped=1"

--- a/materials/management/commands/reindex_materials.py
+++ b/materials/management/commands/reindex_materials.py
@@ -51,13 +51,23 @@ class Command(BaseCommand):
                 qs = qs.filter(updated_at__gte=since)
             return qs.order_by("iri").iterator()
 
+        def changed(since):
+            """``(iri, material_or_None)`` for everything written during the build.
+
+            Unfiltered, so a material soft-deleted or moved off LISTED mid-build
+            arrives as a TOMBSTONE rather than simply going missing from the
+            stream — otherwise the swap re-exposes a draft case's evidence that
+            the live signal had already evicted.
+            """
+            for m in Material.objects.filter(updated_at__gte=since).iterator():
+                listed = not m.is_deleted and m.visibility == Visibility.LISTED
+                yield m.iri, (m if listed else None)
+
         result = reindex(
             index=MATERIAL_INDEX,
             records=stream(None if options["rebuild"] else options.get("since")),
             build_doc=search_index.build_doc,
             rebuild=options["rebuild"],
-            # Materials uploaded while the new generation was building land on the
-            # OLD one and would be lost at the swap.
-            catchup=stream,
+            catchup=changed,
         )
         self.stdout.write(self.style.SUCCESS(summary("ngm-materials", result)))

--- a/materials/management/commands/reindex_materials.py
+++ b/materials/management/commands/reindex_materials.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from django.core.management.base import BaseCommand
 
 from jawafdehi_shared.search.opensearch import MATERIAL_INDEX
-from jawafdehi_shared.search.reindex import reindex
+from jawafdehi_shared.search.reindex import reindex, summary
 from materials import search_index
 from materials.models import Material, Visibility
 
@@ -43,19 +43,21 @@ class Command(BaseCommand):
         # Mirror the live indexer's gate (materials.signals): index ONLY the
         # searchable set (live + LISTED). A --rebuild otherwise resurrects
         # soft-deleted rows and leaks non-LISTED (draft/in-review) evidence.
-        qs = Material.objects.filter(
-            is_deleted=False, visibility=Visibility.LISTED
-        )
-        if options.get("since") and not options["rebuild"]:
-            qs = qs.filter(updated_at__gte=options["since"])
+        def stream(since=None):
+            qs = Material.objects.filter(
+                is_deleted=False, visibility=Visibility.LISTED
+            )
+            if since:
+                qs = qs.filter(updated_at__gte=since)
+            return qs.order_by("iri").iterator()
+
         result = reindex(
             index=MATERIAL_INDEX,
-            records=qs.order_by("iri").iterator(),
+            records=stream(None if options["rebuild"] else options.get("since")),
             build_doc=search_index.build_doc,
             rebuild=options["rebuild"],
+            # Materials uploaded while the new generation was building land on the
+            # OLD one and would be lost at the swap.
+            catchup=stream,
         )
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"ngm-materials: indexed={result['indexed']} skipped={result['skipped']}"
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(summary("ngm-materials", result)))


### PR DESCRIPTION
### **User description**
## The problem

`reindex(rebuild=True)` deleted the index and **immediately recreated it empty**, then refilled it over the length of the scan ([`reindex.py:38-40`](https://github.com/Jawafdehi/JawafdehiAPI/blob/main/jawafdehi_shared/search/reindex.py#L38-L40)). For `ngm-courtcases` that is a ~1h sequential pass over 2.2M rows, during which public search returned **zero court-case results** — not an error anyone would notice, just a silently empty index.

Because a rebuild cost that outage, it was never scheduled. All four weekly crons run **without** `--rebuild`, and that mode can only ever *add*: a doc whose row has since become hidden is never evicted. Staleness accrues until somebody rebuilds by hand. The manual rebuild on 2026-08-14 evicted 3,978 stale docs, 3,851 of them Supreme cases that predated the corruption-forum gate.

This is not a new idea — `docs/unified-search-plan.md` §4.2 already specifies "full rebuild into a new index with an **alias swap** (zero-downtime reindex)". The implementation never did it.

## The change

The public name becomes an alias over a numbered generation:

```
ngm-courtcases              (alias)
  └── ngm-courtcases-000002 (concrete, serving)
```

A rebuild creates `-000003` alongside, fills it while `-000002` keeps serving every read and write, then moves the alias in **one cluster-state update**. There is no instant at which the name resolves to nothing.

New `jawafdehi_shared/search/aliases.py` owns generation naming, resolution, the swap and the pruner. `reindex()` orchestrates. The four commands each gain a `catchup=` stream; nothing else changes for callers, since all of them already address the index through the shared constants.

## Verified against the live cluster

Two of these read as obviously-true and are not, so I tested them on a throwaway index name (`zz-swaptest`, cleaned up, nothing real touched):

| check | result |
|---|---|
| alias replaces a **concrete index of the same name**, atomically | `remove_index` + `add` in one action list → `{"acknowledged":true}`, search served the new generation immediately |
| write through a single-index alias | `PUT /zz-swaptest/_doc/live1` → routed to `zz-swaptest-000002`, `"created"` |
| delete through the alias | `"deleted"` |
| `HEAD /<alias>` | `200` — so `create_index` no-ops rather than clobbering |
| steady-state swap | `{"acknowledged":true}`, alias flipped |

The first is what makes the **one-time bootstrap** safe: all four indices are concrete today, with no aliases anywhere, and converting them has no gap. The second is what means the live signal path needs no `is_write_index` and no dual-write.

## Two things that are not incidental

**`catchup` is required, not a nicety.** Writes landing *during* the build go to the old generation and would die at the swap — a regression the old in-place rebuild did not have, because it refilled the very index the live path was writing to. Each command now passes an `updated_at`-windowed re-stream, run *after* the swap so it only has to cover the build window itself. `test_without_catchup_the_mid_build_write_is_lost` pins the cost of dropping it.

**`RebuildAborted` refuses to swap on an empty result** when the live index is non-empty. The swap is atomic and its bootstrap branch *deletes* the old index, so without this guard one inverted visibility predicate would wipe public search with no warning and no undo. A genuinely empty corpus is still allowed — only a *regression* to empty is refused.

## Also fixes

`search.service._sort_spec` carries `unmapped_type` for `weight` because "create_index no-ops on an existing index, so no live index carries `weight` until the next reindex". Mapping changes could only land through a rebuild nobody could afford to run. Each generation is now created fresh from current mappings, so a mapping migration is just the next rebuild. (I have left the `unmapped_type` guard in place — removing it is a separate change.)

## Testing

- `uv run pytest -q --tb=short --ignore=integration-tests` → **5106 passed, 5 skipped, 0 failed**
- `uv run ty check` → **All checks passed!**
- 27 new tests across `test_aliases.py` / `test_reindex_swap.py`, driven through a fake client that enforces the one cluster rule this design turns on — *a name cannot be both an index and an alias* — so a bootstrap that forgets `remove_index` fails in tests rather than in production. A MagicMock would pass either way.
- The headline test is `test_rebuild_serves_the_old_index_throughout_the_build`: it reads through the alias at every step of the stream and asserts the old corpus is still what comes back.
- The `integration.yml` workflow already runs `manage.py reindex_all --rebuild` against a live stack, so the bootstrap path gets exercised end-to-end against a real OpenSearch on this PR.

## Deploy order — please read before merging

**The four cron manifests are deliberately NOT changed here.** Adding `--rebuild` to them before this ships would run the *old* destructive path on a schedule. Sequence:

1. Merge + deploy this.
2. Run `reindex_courtcases --rebuild` once by hand. This performs the one-time bootstrap (concrete index → alias) and is the step to watch.
3. Only then add `--rebuild` to the four crons in the infra repo.

## Known residual

A case that becomes **hidden** during the build can leave one stale doc until the following week: the main stream may have already indexed it while it was still visible, and the catch-up skips it rather than deleting it. Bounded by one rebuild cycle, and strictly better than today's unbounded drift. Closing it properly means teaching the catch-up to evict, which needs the gate to yield an IRI for rows it rejects — worth doing, but not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add zero-downtime reindex rebuilds

- Swap OpenSearch aliases atomically

- Catch up mid-build writes

- Cover alias swap behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rebuild command"] -- "creates" --> B["New generation index"]
  B["New generation index"] -- "fills while" --> C["Old index serves traffic"]
  B["New generation index"] -- "atomic swap" --> D["Public alias"]
  D["Public alias"] -- "catchup writes" --> E["Fresh searchable index"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>reindex_cases.py</strong><dd><code>Add rebuild catchup stream</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-6a064b620fc86772b4ac72ce9a104e8e3163a89f61e8e6f48e530b0dc624a7a3">+15/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reindex_courtcases.py</strong><dd><code>Add alias rebuild catchup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-cf25fef592a8627f243d0d0dff5c9699df165ba1050f977e70ecdbaa8a5ae0bf">+32/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>reindex_entities.py</strong><dd><code>Add entity rebuild catchup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-0c4a3da2698172a3c5d4eaf37b8bea54b4e0f12cd89241faab13223b2de0d8f1">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>aliases.py</strong><dd><code>Implement generation alias management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-a24aad0c01fccfe6cc93e2360f6a81b6c2b2989f015bb6f6d56e071c41799a70">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>reindex.py</strong><dd><code>Rebuild through alias swap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-7f3d4f9ef84ab0eae4c47f64857b41e68437ebe635a5b3112aa4b5c220a847f0">+146/-30</a></td>

</tr>

<tr>
  <td><strong>reindex_materials.py</strong><dd><code>Add material rebuild catchup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-51d258b708484f4127c121da23f724a54256b95aeb32032dab49bca136ccb613">+14/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>fakes.py</strong><dd><code>Add fake OpenSearch client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-6aa614fa98702042ab1d69ceccbe4ef3d0eea76ad00b59065d4162d98c6cf523">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_aliases.py</strong><dd><code>Test alias generation swapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-1a3dff051b162f4272aeed593893e2224cc4e9404982b20607d1c80167e85a46">+158/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_reindex_swap.py</strong><dd><code>Test zero-downtime rebuild path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/453/files#diff-41b4aa6ca993aff63e3710a860a0ec469f4367e1a5bc0eec4bf7bfe7d0f564e2">+207/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search indexes can now be rebuilt with minimal disruption through zero-downtime generation swaps.
  * Updates, deletions, and unpublished records changed during a rebuild are captured automatically.
  * Rebuilds remove outdated records and clean up obsolete index generations.
  * Reindexing now provides consistent completion summaries across supported content types.

* **Bug Fixes**
  * Prevented an empty rebuild from replacing a populated live index.
  * Improved handling of missing indexes and aliases during setup.
  * Ensured records no longer visible in search are promptly removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->