### PR TITLE
fix(search): type a hit by its alias, not the generation it happens to sit in

### DIFF
--- a/search/service.py
+++ b/search/service.py
@@ -21,6 +21,7 @@ import json
 import logging
 from typing import Any
 
+from jawafdehi_shared.search.aliases import generation_ordinal
 from jawafdehi_shared.search.opensearch import (
     CASE_INDEX,
     COURTCASE_INDEX,
@@ -42,6 +43,27 @@ TYPE_TO_INDEX: dict[str, str] = {
 }
 INDEX_TO_TYPE: dict[str, str] = {v: k for k, v in TYPE_TO_INDEX.items()}
 ALL_TYPES: tuple[str, ...] = ("entity", "material", "courtcase", "case")
+
+
+def type_for_index(index: str) -> str | None:
+    """Result type for the index a hit came from, or None if it isn't ours.
+
+    We QUERY the four public names, but every name is now an ALIAS over a
+    numbered generation, and OpenSearch reports the CONCRETE backing index on
+    both a hit's ``_index`` and an ``_index`` aggregation bucket — never the
+    alias we asked for. So a straight ``INDEX_TO_TYPE`` lookup started missing
+    the moment the aliases landed: ``jawafdehi-cases-000001`` is not a key.
+
+    Strip a trailing generation suffix and retry, so both the aliased and the
+    pre-alias plain-index shapes resolve. Anything else is not one of ours.
+    """
+    result_type = INDEX_TO_TYPE.get(index)
+    if result_type is not None:
+        return result_type
+    for alias, candidate in INDEX_TO_TYPE.items():
+        if generation_ordinal(alias, index) is not None:
+            return candidate
+    return None
 
 # ── Relevance weights (the ONE place to tune ranking) ───────────────────────────
 #
@@ -358,7 +380,11 @@ def build_query(
         # filters (OpenSearch aggregates over the post-filter result set; that's the
         # accepted behaviour for these refine-style facets).
         "aggs": {
-            "by_index": {"terms": {"field": "_index", "size": len(ALL_TYPES)}},
+            # Sized 2x the type count, not 1x: the bucket key is the CONCRETE
+            # backing index, and mid-swap an alias can briefly resolve to two
+            # generations. At exactly len(ALL_TYPES) the extra bucket would push
+            # a real one out and silently zero that type's facet count.
+            "by_index": {"terms": {"field": "_index", "size": 2 * len(ALL_TYPES)}},
             "entity_type": {"terms": {"field": "type", "size": 50}},
             "case_type": {"terms": {"field": "case_type", "size": 50}},
             "tags": {"terms": {"field": "keywords", "size": 50}},
@@ -481,7 +507,7 @@ def _serialize_hit(hit: dict[str, Any]) -> dict[str, Any]:
     """One OpenSearch hit → the common result envelope."""
     source = hit.get("_source") or {}
     index = hit.get("_index", "")
-    result_type = INDEX_TO_TYPE.get(index, source.get("source_app", "unknown"))
+    result_type = type_for_index(index) or source.get("source_app", "unknown")
     highlight = hit.get("highlight") or {}
 
     extra: dict[str, Any] = {}
@@ -528,9 +554,13 @@ def _facets_from_aggs(aggs: dict[str, Any]) -> dict[str, int]:
     counts: dict[str, int] = {}
     buckets = (aggs.get("by_index") or {}).get("buckets") or []
     for bucket in buckets:
-        result_type = INDEX_TO_TYPE.get(bucket.get("key"))
+        # Buckets are keyed by the CONCRETE backing index, not the alias we
+        # queried — so this needs the same generation-aware resolution as a hit.
+        result_type = type_for_index(bucket.get("key") or "")
         if result_type:
-            counts[result_type] = bucket.get("doc_count", 0)
+            counts[result_type] = counts.get(result_type, 0) + bucket.get(
+                "doc_count", 0
+            )
     return counts
 
 

--- a/search/tests/test_search_service.py
+++ b/search/tests/test_search_service.py
@@ -610,3 +610,77 @@ def test_non_case_result_has_no_card_key():
     entity = out["results"][0]
     assert entity["type"] == "entity"
     assert "card" not in entity
+
+
+# ── alias generations: a hit reports the CONCRETE index, never the alias ─────
+#
+# Regression (#453): the public index names became ALIASES over numbered
+# generations, but a hit's ``_index`` and an ``_index`` agg bucket both report
+# the backing index (``jawafdehi-cases-000001``). The type lookup was keyed by
+# the alias only, so every result fell through to ``source_app`` — search
+# results came back typed "jawafdehi"/"ngm" instead of case/material, the FE
+# could no longer build a /case/<slug> link from them, and every per-type facet
+# count went to zero.
+
+
+def test_type_for_index_resolves_a_plain_alias():
+    assert svc.type_for_index("jawafdehi-cases") == "case"
+
+
+def test_type_for_index_resolves_a_generation_backing_index():
+    assert svc.type_for_index("jawafdehi-cases-000001") == "case"
+    assert svc.type_for_index("ngm-courtcases-000042") == "courtcase"
+    assert svc.type_for_index("nes-entities-000007") == "entity"
+    assert svc.type_for_index("ngm-materials-000123") == "material"
+
+
+def test_type_for_index_ignores_a_neighbour_that_merely_shares_the_prefix():
+    # Mirrors the anchoring guarantee in aliases._GENERATION_RE: an unrelated
+    # index must not be typed as a case just because the name starts the same.
+    assert svc.type_for_index("jawafdehi-cases-archive-000001") is None
+    assert svc.type_for_index("jawafdehi-cases-000001-restored") is None
+    assert svc.type_for_index("some-other-index") is None
+
+
+def test_serialize_hit_types_a_generation_backed_case_as_case():
+    hit = {
+        "_index": "jawafdehi-cases-000001",
+        "_source": {
+            "iri": "https://jawafdehi.org/case/seed-published",
+            "source_app": "jawafdehi",
+        },
+    }
+    # Not "jawafdehi" — the source_app fallback is for docs we can't place, and
+    # a generation-backed hit is not one of those.
+    assert svc._serialize_hit(hit)["type"] == "case"
+
+
+def test_facets_count_generation_backed_buckets():
+    aggs = {
+        "by_index": {
+            "buckets": [
+                {"key": "jawafdehi-cases-000002", "doc_count": 3},
+                {"key": "nes-entities-000001", "doc_count": 5},
+            ]
+        }
+    }
+    assert svc._facets_from_aggs(aggs) == {"case": 3, "entity": 5}
+
+
+def test_facets_sum_two_generations_of_the_same_alias():
+    # Mid-swap an alias can briefly resolve to two generations; the counts must
+    # add up rather than the last bucket overwriting the first.
+    aggs = {
+        "by_index": {
+            "buckets": [
+                {"key": "jawafdehi-cases-000001", "doc_count": 2},
+                {"key": "jawafdehi-cases-000002", "doc_count": 3},
+            ]
+        }
+    }
+    assert svc._facets_from_aggs(aggs) == {"case": 5}
+
+
+def test_by_index_agg_is_sized_above_the_type_count_for_mid_swap_generations():
+    agg = build_query(q="x")["aggs"]["by_index"]["terms"]
+    assert agg["size"] > len(svc.ALL_TYPES)


### PR DESCRIPTION
### **User description**
Fixes a regression from #453 that is currently **failing the e2e gate on `main`, so no image can be published**. Found while trying to ship #454.

## What broke

#453 made each public index name an **alias** over a numbered generation. But OpenSearch reports the **concrete backing index** on both a hit's `_index` and an `_index` aggregation bucket — never the alias that was queried. `INDEX_TO_TYPE` is keyed by the alias, so every lookup has been missing since the aliases landed: `jawafdehi-cases-000001` is not a key.

The blast radius is bigger than the failing test suggests:

- `_serialize_hit` fell through to its `source_app` fallback, so **every unified-search result came back typed `"jawafdehi"` / `"ngm"` / `"nes"`** instead of `case` / `material` / `courtcase` / `entity`. The frontend switches on that token to build a result URL, so **public search results stopped rendering a link at all**.
- `_facets_from_aggs` matched nothing, so **every per-type facet count went to zero**.

The docs were indexed correctly and still scored correctly — only their *type* was lost — which is why this reads as "search is fine" until you click something.

## Evidence

Same frontend trunk, same seeded case, `q=embezzlement`, from the two runs' compose logs:

| | `counts_by_type` | `top_type` | `top_score` | e2e |
|---|---|---|---|---|
| pre-#453 ([run](https://github.com/Jawafdehi/JawafdehiAPI/actions/runs/31962760451)) | `{'case': 1}` | `case` | 5.7536416 | 19/19 ✅ |
| `main` today | `{}` | `jawafdehi` | 5.7536416 | 18/19 ❌ |

Identical score, so the doc is indexed and matching; only the type is wrong. I dispatched that pre-#453 baseline against today's frontend `main` specifically to rule the frontend out — it's green, which pins this to #453 rather than to any FE change in the same window.

## The fix

Resolve the concrete name back to its alias before the lookup, reusing the **anchored** generation grammar from `aliases.py` so a neighbour that merely shares the prefix (`jawafdehi-cases-archive-000001`) is still not typed as a case. Both the plain and generation-backed shapes resolve, so it's correct before and after a rebuild.

Two smaller things found alongside, both mid-swap windows where an alias briefly spans two generations:
- facet counts now **sum** per type, rather than the last bucket overwriting the first;
- the `by_index` agg is sized **2x** the type count — at exactly `len(ALL_TYPES)`, one extra generation bucket would push a real one out and silently zero that type's count.

## Tests

7 new regression tests in `search/tests/test_search_service.py`, covering alias and generation resolution, the prefix-neighbour guard, hit typing, facet counting, two-generation summing, and the agg size. **All 7 fail without the service change** (verified by stashing it) and pass with it.

Full CI gate locally: `ruff check .` clean, `ty check` clean, `pytest -q --ignore=integration-tests` → 5130 passed, 5 skipped.

## Why this matters beyond the gate

This would have shipped the next time the platform image deployed: unified search returns results whose type the frontend can't map, so the public search page renders unclickable results and empty facet counts. The e2e gate is the only thing that caught it — worth keeping that gate hard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Resolve search aliases to result types

- Restore generation-backed facet counts

- Size index aggregation for swaps

- Cover alias-generation regressions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OpenSearch concrete index"] -- "resolve generation" --> B["Public alias"]
  B -- "map" --> C["Result type"]
  C -- "serialize" --> D["Links and facets restored"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.py</strong><dd><code>Resolve concrete search indexes to types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/service.py

<ul><li>Add <code>type_for_index</code> alias-generation resolver.<br> <li> Use resolver for hit serialization.<br> <li> Use resolver plus summing for index facets.<br> <li> Expand <code>_index</code> aggregation size for mid-swap generations.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/455/files#diff-52c30e0a17f93cd7790d0d4d46cb659e0877ac2ee8a34d8df108d0f514999a54">+34/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_search_service.py</strong><dd><code>Cover alias-backed search typing regressions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

search/tests/test_search_service.py

<ul><li>Test plain alias and generation-backed index typing.<br> <li> Test unrelated prefix rejection.<br> <li> Test serialized case type restoration.<br> <li> Test facet counting, summing, aggregation sizing.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/455/files#diff-1f576ebe7e344116d1b8dca4d5f698e3a4b220d1c03a67e252bf07fc497b1475">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search results from aliased indices by correctly identifying their result types.
  * Facet counts now combine results across multiple index generations instead of replacing counts.
  * Updated result serialization to preserve the correct type for aliased search hits.

* **Tests**
  * Added coverage for index-generation resolution, malformed index names, hit types, facet aggregation, and expanded index aggregation limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->