### PR TITLE
feat(content): a hero-sized article rendition, and WebP for all three

### DIFF
--- a/content/models.py
+++ b/content/models.py
@@ -127,11 +127,44 @@ class ArticlePage(HeadlessPreviewMixin, Page):  # ty: ignore[invalid-method-over
         """
         return [rel.case for rel in self.related_cases_through.all()]
 
+    # Two renditions off the one ``thumbnail`` FK, because the same image is
+    # consumed at wildly different sizes: a card in the /updates grid, and a
+    # full-bleed hero on the article page. `thumbnail_large` carries an explicit
+    # ``source`` so it reads the same FK under a different payload key.
+    #
+    # The hero sits in a ``max-w-4xl`` (896px) column at ``w-full``, so 800px was
+    # being upscaled by the browser even at DPR 1. 1600px covers it at ~1.8x;
+    # a true 2x isn't reachable anyway, since the article thumbnails we hold top
+    # out around 1672px wide.
+    #
+    # ``format-webp`` is on both: these are PNG uploads, and a PNG rendition at
+    # this size is measured in megabytes (1600x900 lands at ~2.7MB as PNG vs
+    # ~330KB as WebP — smaller than the 640KB the 800x450 PNG costs today).
+    #
+    # NOTE ``fill-`` upscales silently, so a thumbnail uploaded below 1600px wide
+    # yields a soft, needlessly heavy hero rather than an error. Article
+    # thumbnails want to be >=1600px on the long edge.
     api_fields = [
         APIField("category"),
         APIField("date"),
         APIField("excerpt"),
-        APIField("thumbnail", serializer=ImageRenditionField("fill-800x450")),
+        APIField("thumbnail", serializer=ImageRenditionField("fill-800x450|format-webp")),
+        APIField(
+            "thumbnail_large",
+            serializer=ImageRenditionField(
+                "fill-1600x900|format-webp", source="thumbnail"
+            ),
+        ),
+        # Social preview. Deliberately NOT WebP and NOT 16:9: link unfurlers
+        # want 1200x630 (1.91:1), and WhatsApp/LinkedIn previews are unreliable
+        # with WebP. Without this field the og:image would have silently become
+        # a WebP the moment `thumbnail` did.
+        APIField(
+            "og_image",
+            serializer=ImageRenditionField(
+                "fill-1200x630|format-jpeg|jpegquality-85", source="thumbnail"
+            ),
+        ),
         APIField("body"),
         APIField("related_cases", serializer=RelatedCaseSerializer(many=True)),
     ]

--- a/tests/content/test_article_api.py
+++ b/tests/content/test_article_api.py
@@ -5,11 +5,18 @@ through model, edited via the case chooser) and the inline `case` StreamField
 block. Both serialize a minimal case payload; the Case model has no `case_id`
 column (the slug is the public identifier), so these also guard against
 reintroducing dropped columns into the payload.
+
+Also guards the two thumbnail renditions. The card and the article hero consume
+the same image at very different sizes, and the split only holds because the
+listing serializer returns just the fields the caller asks for — the frontend's
+list query names `thumbnail` and so must not be charged for the hero rendition.
 """
 
 import datetime
 
 import pytest
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
 
 from cases.models import Case, CaseState, CaseType
 from content.models import (
@@ -21,6 +28,10 @@ from content.models import (
 
 PAGES_URL = "/api/cms/v2/pages/"
 JSON = {"HTTP_ACCEPT": "application/json"}
+
+# Exactly what `src/services/cms-api.ts` sends for the /updates grid. Kept
+# verbatim so a rename on either side shows up as a failure here.
+LIST_FIELDS = "title,category,date,excerpt,thumbnail"
 
 
 @pytest.fixture
@@ -78,3 +89,118 @@ def test_article_serializes_related_cases(client, case, article_with_case_links)
         "case": {"id": case.pk, "title": case.title, "slug": case.slug},
         "note": "How this case relates",
     }
+
+
+@pytest.fixture
+def article_with_thumbnail(db, settings, tmp_path):
+    # Renditions are written through the default storage, which is a plain
+    # FileSystemStorage under the test settings (no AWS creds). Point it at tmp
+    # so generating them doesn't litter the checkout's MEDIA_ROOT.
+    settings.MEDIA_ROOT = str(tmp_path)
+
+    image = get_image_model().objects.create(
+        title="जलहरी मुद्दाको तस्बिर",
+        # Wider than the 1600px hero rendition, so `fill-` downscales rather
+        # than upscaling — the shape a real article thumbnail should have.
+        file=get_test_image_file(filename="jalahari.png", size=(1800, 1013)),
+    )
+
+    index = ArticleIndexPage.objects.first()
+    assert index is not None, "ArticleIndexPage missing — content.0002 not applied"
+
+    article = ArticlePage(
+        title="Update with a thumbnail",
+        slug="update-with-a-thumbnail",
+        category=ArticleCategory.UPDATE,
+        date=datetime.date(2026, 8, 19),
+        excerpt="Has an image",
+        thumbnail=image,
+    )
+    index.add_child(instance=article)
+    article.save_revision().publish()
+    return article
+
+
+@pytest.mark.django_db
+def test_detail_serializes_both_thumbnail_renditions(client, article_with_thumbnail):
+    """The hero needs ~1600px; the card rendition is only 800px wide."""
+    resp = client.get(
+        PAGES_URL,
+        {
+            "type": "content.ArticlePage",
+            "slug": article_with_thumbnail.slug,
+            "fields": "*",
+        },
+        **JSON,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()["items"][0]
+
+    assert (data["thumbnail"]["width"], data["thumbnail"]["height"]) == (800, 450)
+    assert (data["thumbnail_large"]["width"], data["thumbnail_large"]["height"]) == (
+        1600,
+        900,
+    )
+    # Distinct renditions, not the same file relabelled.
+    assert data["thumbnail"]["url"] != data["thumbnail_large"]["url"]
+
+
+@pytest.mark.django_db
+def test_both_renditions_are_webp(client, article_with_thumbnail):
+    """A PNG hero at 1600x900 costs megabytes; the source upload is a PNG."""
+    resp = client.get(
+        PAGES_URL,
+        {
+            "type": "content.ArticlePage",
+            "slug": article_with_thumbnail.slug,
+            "fields": "*",
+        },
+        **JSON,
+    )
+
+    data = resp.json()["items"][0]
+    assert data["thumbnail"]["url"].endswith(".webp")
+    assert data["thumbnail_large"]["url"].endswith(".webp")
+
+
+@pytest.mark.django_db
+def test_og_image_is_jpeg_at_social_aspect_ratio(client, article_with_thumbnail):
+    """Link unfurlers want 1200x630 and are unreliable with WebP, so the social
+    rendition must not drift onto the display renditions' format or ratio."""
+    resp = client.get(
+        PAGES_URL,
+        {
+            "type": "content.ArticlePage",
+            "slug": article_with_thumbnail.slug,
+            "fields": "*",
+        },
+        **JSON,
+    )
+
+    og = resp.json()["items"][0]["og_image"]
+    assert (og["width"], og["height"]) == (1200, 630)
+    assert og["url"].endswith(".jpg")
+
+
+@pytest.mark.django_db
+def test_listing_omits_the_hero_rendition(client, article_with_thumbnail):
+    """The /updates grid asks for `thumbnail` only, so it must not pay for the
+    1600px hero — generating it costs a rendition write per article, and
+    shipping its URL invites a client into loading it in a card."""
+    resp = client.get(
+        PAGES_URL,
+        {"type": "content.ArticlePage", "fields": LIST_FIELDS},
+        **JSON,
+    )
+
+    assert resp.status_code == 200
+    data = next(
+        item
+        for item in resp.json()["items"]
+        if item["meta"]["slug"] == article_with_thumbnail.slug
+    )
+
+    assert data["thumbnail"]["width"] == 800
+    assert "thumbnail_large" not in data
+    assert "og_image" not in data


### PR DESCRIPTION
### **User description**
## Why

The article page renders the thumbnail at `w-full` inside a `max-w-4xl` (896px) column, but `fill-800x450` was the only rendition the API exposed — sized for the /updates card, then reused as a hero. At 800px it is **upscaled by the browser even at DPR 1**, and 2.2x short on a retina display. Reported against [/updates/pashupatinath-jalahari-gold-case](https://jawafdehi.org/updates/pashupatinath-jalahari-gold-case).

The sources have the headroom — every article thumbnail we hold is 1672–2560px wide. That article's own source is 1672x941.

## What changed

`content/models.py`, three renditions off the one `thumbnail` FK:

| field | spec | consumer |
|---|---|---|
| `thumbnail` | `fill-800x450\|format-webp` | /updates card (unchanged size) |
| `thumbnail_large` | `fill-1600x900\|format-webp` | article hero (new) |
| `og_image` | `fill-1200x630\|format-jpeg\|jpegquality-85` | link unfurlers (new) |

The two new fields carry an explicit `source="thumbnail"`, so they read the same FK under a different payload key. Verified against the pinned Wagtail 7.4.2: `ImageRenditionField.__init__` forwards `**kwargs` to the DRF `Field`, and Wagtail's serializer resolves values through `field.get_attribute(instance)` (which honours `source`) while keying output by `field_name`.

### The /updates list is unaffected

The listing serializer returns only requested fields, and the frontend's list query names `thumbnail`. So the grid neither generates nor ships the hero rendition. A test pins this, keyed to the same field list `src/services/cms-api.ts` sends, so a rename on either side fails here.

### WebP is what makes the resolution bump cheap

These are PNG uploads, and Wagtail renditions inherit the source format. Measured on the real source for that article:

| rendition | bytes |
|---|---|
| **800x450 PNG — what ships today** | **640 KB** |
| 1600x900 PNG | 2.70 MB |
| **1600x900 WebP** | **332 KB** |
| 800x450 WebP | 95 KB |

So the hero at 4x the pixels costs about half what one card costs today, and the card itself drops from 640 KB to ~95 KB. Six cards on /updates go from roughly 3.8 MB to ~570 KB.

### Why `og_image` is part of this and not a follow-up

Putting `format-webp` on `thumbnail` would have silently turned `og:image` into a WebP, and WhatsApp/LinkedIn previews are unreliable with WebP. So the social rendition is pinned to JPEG here rather than left to regress. 1200x630 is also the ratio unfurlers actually ask for, which 16:9 never was.

## Trap worth knowing

`fill-` upscales without complaint. A thumbnail uploaded below 1600px wide now yields a soft, needlessly heavy hero rather than an error. Current content is safe (1672 / 2560 / 1672). Noted in a comment at the call site; a validator or an editor-facing note is a reasonable follow-up.

## Verification

- `uv run pytest -q --ignore=integration-tests` → **5308 passed, 5 skipped, 1 warning** (the documented shape; the warning is upstream's un-awaited `_drain_tasks`)
- `uv run ruff check .` → clean
- `uv run ty check` → clean
- `manage.py check` → 4 issues, all `treebeard.E001`, confirmed identical on pristine `origin/main`
- 4 new tests in `tests/content/test_article_api.py` covering both dimensions, both WebP URLs, the JPEG social rendition, and the listing omitting both new fields

## Deploy notes

- **No migration.** Serializer-only change.
- Renditions generate lazily on first request and write to R2, so the first hit per article is slow — worth warming the six live articles rather than letting a visitor pay it.
- The old `fill-800x450` PNG renditions stay in R2 as orphans; Wagtail doesn't clean up. Harmless.
- Pairs with Jawafdehi/Jawafdehi#339, but order doesn't matter: the frontend fields are optional and fall back to `thumbnail`.

## Not in scope

Body images inside articles are still capped at `width-1200` PNG (`content/blocks.py`) against the same ~896px column. Same class of problem, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add hero thumbnail rendition

- Convert display thumbnails to WebP

- Add JPEG social preview image

- Pin listing payload behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Article thumbnail FK"]
  B["Card WebP 800x450"]
  C["Hero WebP 1600x900"]
  D["OG JPEG 1200x630"]
  E["CMS API fields"]
  A -- "renders as" --> B
  A -- "source thumbnail" --> C
  A -- "source thumbnail" --> D
  B -- "listed when requested" --> E
  C -- "detail only" --> E
  D -- "detail only" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Add article image renditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/models.py

<ul><li>Switch <code>thumbnail</code> rendition to WebP<br> <li> Add <code>thumbnail_large</code> from <code>thumbnail</code><br> <li> Add <code>og_image</code> JPEG social rendition<br> <li> Document sizing, format tradeoffs</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/457/files#diff-9ba6beaf306484d6e23bd60611b6b6ce4695187bc0b586931c0ad1dfd490eca8">+34/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_article_api.py</strong><dd><code>Cover CMS thumbnail API renditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/content/test_article_api.py

<ul><li>Add thumbnail article fixture<br> <li> Assert card, hero rendition sizes<br> <li> Assert WebP display, JPEG OG formats<br> <li> Assert listing omits extra renditions</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/457/files#diff-e18f7c194fa10a24ab03f5dc7e2188eb4176e0598c6840d2a71e99ee01c77e00">+126/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Article APIs now provide optimized WebP thumbnails in standard and large sizes.
  * Added a JPEG Open Graph image rendition for social media previews.
  * Listing responses remain streamlined by excluding large and social-preview renditions.

* **Bug Fixes**
  * Improved thumbnail formatting and sizing for consistent display across supported contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->