### PR TITLE
fix(storage): pin image Content-Types instead of guessing them

### DIFF
--- a/content/models.py
+++ b/content/models.py
@@ -141,8 +141,14 @@ class ArticlePage(HeadlessPreviewMixin, Page):  # ty: ignore[invalid-method-over
     # this size is measured in megabytes (1600x900 lands at ~2.7MB as PNG vs
     # ~330KB as WebP — smaller than the 640KB the 800x450 PNG costs today).
     #
-    # NOTE ``fill-`` upscales silently, so a thumbnail uploaded below 1600px wide
-    # yields a soft, needlessly heavy hero rather than an error. Article
+    # NOTE ``fill-`` never upscales — ``FillOperation`` crops to the target ratio
+    # and then only resizes when ``scale < 1.0``. So a source below the target
+    # doesn't error and doesn't blur: it silently returns a SMALLER rendition,
+    # and both specs collapse to the same size. Live example: a 750x400 source
+    # yields 712x400 for `thumbnail` AND `thumbnail_large`, so that article keeps
+    # a soft hero until a bigger source is uploaded. The payload's width/height
+    # report the real size, so the client's intrinsic sizing stays honest —
+    # nothing breaks, you just don't get the resolution you asked for. Article
     # thumbnails want to be >=1600px on the long edge.
     api_fields = [
         APIField("category"),

--- a/jawafdehi_shared/storage.py
+++ b/jawafdehi_shared/storage.py
@@ -34,6 +34,22 @@ from storages.backends.s3boto3 import S3Boto3Storage
 #: module has no dependency on the cases app).
 DEFAULT_LINK_ROLE = "RAW"
 
+#: Content types for the media we serve, pinned rather than guessed. See
+#: :meth:`HashedFilenameS3Boto3Storage.get_object_parameters` — ``mimetypes``
+#: reads a registry that differs between interpreter builds and container base
+#: images, so relying on it makes the stored header environment-dependent.
+#: Anything absent here still falls back to ``mimetypes``.
+MEDIA_CONTENT_TYPES = {
+    ".avif": "image/avif",
+    ".gif": "image/gif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
+    ".pdf": "application/pdf",
+}
+
 
 class HashedFilenameS3Boto3Storage(S3Boto3Storage):
     """
@@ -96,18 +112,32 @@ class HashedFilenameS3Boto3Storage(S3Boto3Storage):
 
     def get_object_parameters(self, name):
         """
-        Ensure text uploads carry an explicit UTF-8 charset.
+        Pin the ContentType for images, and give text uploads a UTF-8 charset.
 
-        django-storages derives ContentType from ``mimetypes.guess_type`` when
-        none is supplied, which yields bare types like ``text/markdown`` with no
-        charset. Browsers opening such a ``text/*`` response with no charset fall
-        back to a legacy locale encoding (Latin-1), turning UTF-8 content (e.g.
-        Devanagari) into mojibake. We append ``; charset=utf-8`` to any text type
-        that lacks a charset so the bytes are decoded correctly.
+        django-storages only guesses ContentType when the caller supplies none:
+        it tries ``mimetypes.guess_type(name)`` and otherwise falls back to
+        ``application/octet-stream``. That guess reads a registry which varies by
+        interpreter build and by whether ``/etc/mime.types`` is present, so the
+        stored header depends on the image the app happens to be running in
+        rather than on the bytes.
+
+        It bit us: after WebP renditions shipped, every ``.webp`` in R2 came back
+        as ``application/octet-stream`` while ``.jpg`` alongside it was correctly
+        ``image/jpeg`` — and the write path reproduces as ``image/webp`` locally,
+        so the divergence is environmental. Rather than chase the registry, map
+        the media extensions we actually serve and only fall back to
+        ``mimetypes`` for everything else. Deterministic across environments.
+
+        Also: a bare ``text/*`` with no charset makes browsers fall back to a
+        legacy locale encoding (Latin-1), turning UTF-8 content (e.g. Devanagari)
+        into mojibake, so those get an explicit ``; charset=utf-8``.
         """
         params = super().get_object_parameters(name)
 
         content_type = params.get("ContentType")
+        if content_type is None:
+            _, extension = os.path.splitext(name)
+            content_type = MEDIA_CONTENT_TYPES.get(extension.lower())
         if content_type is None:
             content_type, _encoding = mimetypes.guess_type(name)
 
@@ -116,7 +146,12 @@ class HashedFilenameS3Boto3Storage(S3Boto3Storage):
             and content_type.startswith("text/")
             and "charset=" not in content_type.lower()
         ):
-            params["ContentType"] = f"{content_type}; charset=utf-8"
+            content_type = f"{content_type}; charset=utf-8"
+
+        # Set it explicitly rather than leaving django-storages to re-derive it,
+        # so a resolved type can't be downgraded to octet-stream downstream.
+        if content_type:
+            params["ContentType"] = content_type
 
         return params
 

--- a/tests/content/test_article_api.py
+++ b/tests/content/test_article_api.py
@@ -15,6 +15,7 @@ list query names `thumbnail` and so must not be charged for the hero rendition.
 import datetime
 
 import pytest
+from django.core.cache import caches
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 
@@ -32,6 +33,19 @@ JSON = {"HTTP_ACCEPT": "application/json"}
 # Exactly what `src/services/cms-api.ts` sends for the /updates grid. Kept
 # verbatim so a rename on either side shows up as a failure here.
 LIST_FIELDS = "title,category,date,excerpt,thumbnail"
+
+
+def _isolate_rendition_cache():
+    """Drop Wagtail's rendition cache between image fixtures.
+
+    Wagtail caches renditions keyed on image pk + filter spec, NOT on the file.
+    Under pytest each test rolls back, so every fixture image is created as pk=1
+    — meaning a second test's image inherits the FIRST one's cached rendition and
+    reports its dimensions. That looked exactly like `fill-` upscaling a small
+    source to 800x450. It isn't: in production images have distinct pks.
+    """
+    for cache in caches.all():
+        cache.clear()
 
 
 @pytest.fixture
@@ -97,6 +111,7 @@ def article_with_thumbnail(db, settings, tmp_path):
     # FileSystemStorage under the test settings (no AWS creds). Point it at tmp
     # so generating them doesn't litter the checkout's MEDIA_ROOT.
     settings.MEDIA_ROOT = str(tmp_path)
+    _isolate_rendition_cache()
 
     image = get_image_model().objects.create(
         title="जलहरी मुद्दाको तस्बिर",
@@ -181,6 +196,60 @@ def test_og_image_is_jpeg_at_social_aspect_ratio(client, article_with_thumbnail)
     og = resp.json()["items"][0]["og_image"]
     assert (og["width"], og["height"]) == (1200, 630)
     assert og["url"].endswith(".jpg")
+
+
+@pytest.fixture
+def article_with_a_small_thumbnail(db, settings, tmp_path):
+    """A thumbnail narrower than the 1600px hero target — the case that revealed
+    `fill-` does not upscale."""
+    settings.MEDIA_ROOT = str(tmp_path)
+    _isolate_rendition_cache()
+
+    image = get_image_model().objects.create(
+        title="सानो तस्बिर",
+        file=get_test_image_file(filename="sano.png", size=(750, 400)),
+    )
+    index = ArticleIndexPage.objects.first()
+    article = ArticlePage(
+        title="Update with a small thumbnail",
+        slug="update-with-a-small-thumbnail",
+        category=ArticleCategory.UPDATE,
+        date=datetime.date(2026, 8, 19),
+        excerpt="Small image",
+        thumbnail=image,
+    )
+    index.add_child(instance=article)
+    article.save_revision().publish()
+    return article
+
+
+@pytest.mark.django_db
+def test_a_small_source_downgrades_rather_than_upscaling(
+    client, article_with_a_small_thumbnail
+):
+    """`fill-` crops to the ratio then resizes only when `scale < 1.0`, so a
+    source below the target yields a SMALLER rendition and both specs collapse to
+    the same size. Pinned because the payload's width/height are what the client
+    reserves space with — if this ever started upscaling, callers would silently
+    get a blurry, much heavier hero instead of an honest small one."""
+    resp = client.get(
+        PAGES_URL,
+        {
+            "type": "content.ArticlePage",
+            "slug": article_with_a_small_thumbnail.slug,
+            "fields": "*",
+        },
+        **JSON,
+    )
+
+    data = resp.json()["items"][0]
+    small = (data["thumbnail"]["width"], data["thumbnail"]["height"])
+    large = (data["thumbnail_large"]["width"], data["thumbnail_large"]["height"])
+
+    assert small == (712, 400)
+    assert large == small
+    # Never larger than the source could honestly support.
+    assert data["og_image"]["width"] <= 750
 
 
 @pytest.mark.django_db

--- a/tests/test_media_content_types.py
+++ b/tests/test_media_content_types.py
@@ -1,0 +1,99 @@
+"""Content-Type pinning for uploads written to object storage.
+
+Guards a bug that only appeared in the deployed image: after WebP renditions
+shipped, every ``.webp`` in R2 was served as ``application/octet-stream`` while
+``.jpg`` written by the same process was correctly ``image/jpeg``. The write path
+resolves ``image/webp`` locally, so the cause was the ``mimetypes`` registry —
+which varies by interpreter build and by whether ``/etc/mime.types`` exists in
+the base image. These tests pin the header to the extension so it can't depend on
+the environment again.
+"""
+
+import pytest
+from wagtail.images import get_image_model
+from wagtail.images.models import Filter
+from wagtail.images.tests.utils import get_test_image_file
+
+from jawafdehi_shared.storage import HashedFilenameS3Boto3Storage
+
+
+@pytest.fixture
+def storage():
+    # Credentials are never used: nothing here performs a request, these tests
+    # only exercise the parameter-building path.
+    return HashedFilenameS3Boto3Storage(
+        bucket_name="test-bucket", access_key="key", secret_key="secret"
+    )
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("case_uploads/abc.webp", "image/webp"),
+        ("case_uploads/abc.WEBP", "image/webp"),
+        ("case_uploads/abc.avif", "image/avif"),
+        ("case_uploads/abc.jpg", "image/jpeg"),
+        ("case_uploads/abc.jpeg", "image/jpeg"),
+        ("case_uploads/abc.png", "image/png"),
+        ("case_uploads/abc.gif", "image/gif"),
+        ("case_uploads/abc.svg", "image/svg+xml"),
+        ("case_uploads/abc.pdf", "application/pdf"),
+    ],
+)
+def test_media_uploads_carry_their_real_content_type(storage, filename, expected):
+    assert storage.get_object_parameters(filename)["ContentType"] == expected
+
+
+def test_content_type_survives_a_mimetypes_registry_that_knows_nothing(
+    storage, monkeypatch
+):
+    """The actual failure mode: a registry missing the extension.
+
+    Simulates the deployed image by making ``guess_type`` blind. Without the
+    pinned map, django-storages would fall through to
+    ``application/octet-stream`` — which is exactly what R2 ended up serving.
+    """
+    monkeypatch.setattr(
+        "jawafdehi_shared.storage.mimetypes.guess_type", lambda *a, **kw: (None, None)
+    )
+
+    assert (
+        storage.get_object_parameters("case_uploads/abc.webp")["ContentType"]
+        == "image/webp"
+    )
+
+
+def test_text_uploads_still_get_an_explicit_utf8_charset(storage):
+    """Pre-existing behaviour: a bare ``text/*`` makes browsers guess Latin-1 and
+    turns Devanagari into mojibake."""
+    params = storage.get_object_parameters("case_uploads/notes.txt")
+
+    assert params["ContentType"] == "text/plain; charset=utf-8"
+
+
+def test_an_unknown_extension_is_left_to_django_storages(storage):
+    """Not our job to invent a type — absent from the map and from mimetypes, no
+    ContentType is set and django-storages applies its own default."""
+    assert "ContentType" not in storage.get_object_parameters("case_uploads/x.zzznope")
+
+
+@pytest.mark.django_db
+def test_wagtail_rendition_filenames_resolve_through_the_map(storage, settings, tmp_path):
+    """End-to-end on the real filenames Wagtail produces, since the map is keyed
+    on the extension and Wagtail packs the whole filter spec into the name
+    (``…fill-1600x900.format-webp.webp``)."""
+    settings.MEDIA_ROOT = str(tmp_path)
+    image = get_image_model().objects.create(
+        title="पशुपतिनाथको जलहरी",
+        file=get_test_image_file(filename="jalahari.png", size=(1800, 1013)),
+    )
+
+    expected = {
+        "fill-800x450|format-webp": "image/webp",
+        "fill-1600x900|format-webp": "image/webp",
+        "fill-1200x630|format-jpeg|jpegquality-85": "image/jpeg",
+    }
+    for spec, content_type in expected.items():
+        rendition_file = image.generate_rendition_file(Filter(spec=spec))
+        key = storage._get_hashed_filename(rendition_file.name)
+        assert storage.get_object_parameters(key)["ContentType"] == content_type


### PR DESCRIPTION
### **User description**
Follow-up to #457, from checking what actually landed in R2 after that deployed.

## The bug

Every WebP rendition is served with the wrong header, while the JPEG written by the same process is correct:

```
$ curl -sI https://s3.jawafdehi.org/case_uploads/c62a443e….webp
content-type: application/octet-stream      # should be image/webp
x-content-type-options: nosniff

$ curl -sI https://s3.jawafdehi.org/case_uploads/….jpg
content-type: image/jpeg                    # correct
```

The bytes are a valid WebP (they decode to 1600x900), so only the metadata is wrong.

**Cause.** django-storages derives ContentType only when the caller supplies none: it tries `mimetypes.guess_type(name)`, else falls back to `application/octet-stream`. That registry varies by interpreter build and by whether `/etc/mime.types` exists in the base image — so the stored header depended on the container rather than on the bytes.

**Honesty about the diagnosis:** I could not reproduce it locally. The exact production path resolves correctly here, including through `generate_rendition_file` on the real Wagtail filenames:

```
spec=fill-1600x900|format-webp
  wagtail name        = probe.2e16d0ba.fill-1600x900.format-webp.webp
  ContentType WRITTEN = 'image/webp'
```

So the divergence is environmental and this fix is deliberately defensive: pin the extensions we serve and fall back to `mimetypes` only for the rest. The outcome stops depending on which image the app runs in, which is the property worth having regardless of the original trigger. I also ruled out `AWS_S3_OBJECT_PARAMETERS` (`build_s3_storage_options` sets none) and the legacy `s3boto3` backend (a shim to `s3.py`).

## Blast radius today

Narrow: `og_image` is JPEG and correct, so **social previews were never affected**. Browsers decode `<img>` from bytes rather than trusting Content-Type, so the page renders. It's still wrong metadata on every image we serve, and it deserves to be deterministic.

## Also: #457 shipped a comment that was wrong

I wrote that `fill-` upscales silently. It does the opposite — `FillOperation` crops to the target ratio and then resizes **only** when `scale < 1.0`:

```python
# Only resize if the image is too big
if scale < 1.0:
    transform = transform.resize((self.width, self.height))
```

So a source below the target doesn't error and doesn't blur — it silently returns a *smaller* rendition, and both specs collapse to the same size. Live, article 109 (a 750x400 source) serves **712x400 for both** `thumbnail` and `thumbnail_large`. Comment corrected and the behaviour pinned in a test, because the payload's `width`/`height` are what the client reserves space with: if this ever started upscaling, callers would silently get a blurry, much heavier hero instead of an honest small one.

The ">=1600px on the long edge" guidance for thumbnails still stands, just for a different reason.

## A test-isolation trap found on the way

Wagtail caches renditions on **image pk + filter spec, not on the file**. Under pytest every fixture image is created as pk=1 after rollback, so a second fixture inherits the first one's cached rendition and reports *its* dimensions. That presented exactly as `fill-` upscaling a 750x400 source to 800x450:

```
PROBE image 1 750 x 400 original_images/sano.png
PROBE thumb url=jalahari.…fill-800x450.format-webp.webp width=800 height=450
```

Not a production bug — real images have distinct pks — but it will bite the next person writing an image fixture, so the fixtures clear the cache and the reason is written down.

## Verification

- `uv run pytest -q --ignore=integration-tests` → **5322 passed, 5 skipped, 1 warning** (5308 on main + 14 new)
- `uv run ruff check .` → clean
- `uv run ty check` → clean
- New `tests/test_media_content_types.py`: every media extension, a monkeypatched blind `mimetypes` registry reproducing the actual failure mode, the pre-existing `text/*` charset behaviour, an unknown extension left to django-storages, and an end-to-end pass over real Wagtail rendition filenames

## Still needs doing after this deploys

**The already-written objects keep the wrong header** — Content-Type is fixed at upload — so this only stops new ones being wrong. Re-uploading the existing ones is a separate operational step, options being either an S3 `CopyObject` with `MetadataDirective=REPLACE` over the affected keys (no DB write), or deleting the affected `wagtailimages_rendition` rows so they regenerate (a DB write, needs sign-off). Not doing either here.

Worth someone with cluster access confirming the root cause in the pod, which would tell us whether the map is belt-and-braces or load-bearing:

```
python -c "import mimetypes; print(mimetypes.guess_type('x.webp'))"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Pin media `ContentType` headers

- Preserve UTF-8 text charset

- Document `fill-` non-upscaling behavior

- Add storage, rendition regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upload filename"] -- "extension" --> B["MEDIA_CONTENT_TYPES"]
  B -- "known media" --> C["explicit ContentType"]
  B -- "unknown" --> D["mimetypes fallback"]
  C -- "stored object" --> E["stable browser header"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Correct Wagtail fill rendition guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/models.py

<ul><li>Corrects <code>fill-</code> comment<br> <li> Notes no upscaling behavior<br> <li> Documents smaller rendition collapse</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/458/files#diff-9ba6beaf306484d6e23bd60611b6b6ce4695187bc0b586931c0ad1dfd490eca8">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.py</strong><dd><code>Pin object storage media headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jawafdehi_shared/storage.py

<ul><li>Adds <code>MEDIA_CONTENT_TYPES</code> extension map<br> <li> Pins image/PDF <code>ContentType</code><br> <li> Keeps text UTF-8 charset logic<br> <li> Falls back to <code>mimetypes</code> for unknowns</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/458/files#diff-59d7863a85532e7bc48f473b8e958d0cd9d4aafca684692583a81f8b351bb0fa">+44/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_article_api.py</strong><dd><code>Test small thumbnail rendition behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/content/test_article_api.py

<ul><li>Clears Wagtail rendition caches between fixtures<br> <li> Adds small-thumbnail fixture<br> <li> Verifies <code>fill-</code> returns smaller renditions<br> <li> Guards honest payload dimensions</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/458/files#diff-e18f7c194fa10a24ab03f5dc7e2188eb4176e0598c6840d2a71e99ee01c77e00">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_media_content_types.py</strong><dd><code>Cover deterministic storage ContentTypes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_media_content_types.py

<ul><li>Tests pinned media content types<br> <li> Simulates missing <code>mimetypes</code> registry<br> <li> Verifies text charset preservation<br> <li> Checks Wagtail rendition filenames</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/458/files#diff-d7d965220ce7b8df4b022e5b81a65d3c53a14387914bd5fa2b6233f33fae0bd4">+99/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 200000
git_provider: github
output_relevant_configurations: True
model: openai/cx/gpt-5.5
ENABLE_AUTO_APPROVAL: True
custom_reasoning_model: False
fallback_models: ['openai/cx/gpt-5.4-mini']
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Small source images now generate appropriately sized thumbnails without upscaling or errors.
  * API responses report the actual dimensions of generated renditions.
  * Uploaded media files now receive accurate content types, including UTF-8 metadata for text files.
  * WebP, JPEG, document, and other common media formats are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->