### PR TITLE
fix(courts): promote a decisive cause-list sitting onto the case row

### DIFF
--- a/courts/management/commands/scrape_courtcases.py
+++ b/courts/management/commands/scrape_courtcases.py
@@ -64,7 +64,8 @@ class Command(BaseCommand):
             for s in stats:
                 self.stdout.write(
                     f"  {key}/{s.court_id}: dates={s.dates} cases={s.cases} "
-                    f"hearings={s.hearings} enriched={s.enriched}"
+                    f"hearings={s.hearings} enriched={s.enriched} "
+                    f"verdicts_promoted={s.verdicts_promoted}"
                 )
 
     @staticmethod

--- a/courts/scraper/base.py
+++ b/courts/scraper/base.py
@@ -22,8 +22,11 @@ from courts.scraper.rows import ParsedCase, ParsedEnrichment, ParsedHearing
 
 NGM_DB = "ngm"
 
-# Court-owned typed columns the enrichment may set (never touched by the cause-list
-# upsert, which only writes listing fields).
+# Court-owned typed columns the enrichment may set. The cause-list upsert writes
+# listing fields only, with ONE exception: a decisive sitting promotes
+# case_status/verdict_* onto the case row (see _causelist_verdict). Enrichment
+# runs once per case and the verdict usually lands later, so without that
+# promotion a decided case reads as ongoing forever.
 _ENRICH_COLUMNS = {
     "case_status", "verdict_type", "verdict_date_bs", "verdict_date_ad",
     "verdict_judge", "case_subject", "hearing_count", "registration_number",
@@ -84,16 +87,72 @@ def _ensure_court(court_id: str, *, using: str) -> None:
     )
 
 
+def _causelist_verdict(
+    phearing: ParsedHearing, existing: CourtCase | None
+) -> dict[str, object] | None:
+    """Verdict columns to promote from a decisive cause-list sitting, else ``None``.
+
+    The cause list already carries the disposition — for the Special Court it is
+    cells 9 and 10 of the row, e.g. ``फैसला`` / ``सफाई``. We were writing that pair
+    onto the hearing and dropping it from the case row, so a case decided after
+    its one-shot enrichment kept ``case_status='चलिरहेको'`` with NULL verdicts
+    permanently (measured 2026-08-20: 114 Special Court cases).
+
+    Classification goes through :func:`courts.case_status.outcome_from_hearings`
+    rather than a local substring test, so this inherits the shared vocabulary and
+    its guarantees: only the terminal bucket counts (the portal writes
+    ``अन्तिम आदेश`` on plainly interlocutory orders), an unrecognised decision
+    yields nothing rather than a guess, and ``आंशिक`` is matched ahead of ``ठहर``
+    so a PARTIAL conviction is never recorded as a full one.
+
+    Returns ``None`` when the sitting decided nothing, and also when promoting it
+    would REGRESS the row. That second guard matters because the lookback horizons
+    reach back years (BS 2070 for special), so historical dates are re-crawled
+    routinely — and a case can be decided, reopened on review and decided again,
+    where only the latest disposition is operative. So an older sitting never
+    overwrites a newer verdict, and an undated sitting is promoted only onto a row
+    with no verdict date to lose.
+    """
+    outcome = cs.outcome_from_hearings(
+        [{"case_status": phearing.case_status, "decision_type": phearing.decision_type}]
+    )
+    if outcome is None:
+        return None
+
+    # The sitting's date comes from the parser's typed fields, never from
+    # re-parsing text. Both must be present: hearing_date_ad falls back to
+    # 1900-01-01 on the hearing row (that column is NOT NULL) and that sentinel
+    # must never become a verdict date.
+    dated = bool(phearing.hearing_date_bs and phearing.hearing_date_ad)
+    verdict_date_ad = phearing.hearing_date_ad if dated else None
+
+    held = existing.verdict_date_ad if existing else None
+    if held is not None and (verdict_date_ad is None or verdict_date_ad < held):
+        return None
+
+    promoted: dict[str, object] = {
+        # The court's own label for the sitting ("फैसला"), which parse_case_status
+        # reads as DECIDED. The typed columns below carry the structured outcome.
+        "case_status": phearing.case_status,
+        "verdict_type": outcome.verdict_type,
+    }
+    if dated:
+        promoted["verdict_date_bs"] = phearing.hearing_date_bs
+        promoted["verdict_date_ad"] = phearing.hearing_date_ad
+    return promoted
+
+
 @transaction.atomic(using=NGM_DB)
 def upsert_causelist(rows: list[tuple[ParsedCase, ParsedHearing]], *, using: str = NGM_DB) -> dict[str, int]:
     """Persist one date's cause-list ``(case, hearing)`` rows.
 
-    Cases are upserted on the natural key ``(court, case_number)`` writing only
-    listing fields; ``extra_data`` is UNIONed onto any existing row so an already
-    enriched row's payload is never clobbered by a re-list. Hearings are appended
-    (deduped on court/case/date/serial).
+    Cases are upserted on the natural key ``(court, case_number)`` writing listing
+    fields, plus ``case_status``/``verdict_*`` when the sitting disposed of the case
+    (:func:`_causelist_verdict`); ``extra_data`` is UNIONed onto any existing row so
+    an already enriched row's payload is never clobbered by a re-list. Hearings are
+    appended (deduped on court/case/date/serial).
     """
-    stats = {"cases": 0, "hearings": 0}
+    stats = {"cases": 0, "hearings": 0, "verdicts_promoted": 0}
     for pcase, phearing in rows:
         _ensure_court(pcase.court_identifier, using=using)
         existing = (
@@ -116,6 +175,12 @@ def upsert_causelist(rows: list[tuple[ParsedCase, ParsedHearing]], *, using: str
             "defendant": pcase.defendant,
             "extra_data": merged_extra or None,
         }
+        # A sitting that disposed of the case promotes its outcome onto the case
+        # row — the one place the cause list may write enrichment-owned columns.
+        promoted = _causelist_verdict(phearing, existing)
+        if promoted is not None:
+            listing.update(promoted)
+            stats["verdicts_promoted"] += 1
         CourtCase.objects.using(using).update_or_create(
             court_id=pcase.court_identifier,
             case_number=pcase.case_number,

--- a/courts/scraper/base.py
+++ b/courts/scraper/base.py
@@ -111,7 +111,7 @@ def _causelist_verdict(
     routinely — and a case can be decided, reopened on review and decided again,
     where only the latest disposition is operative. So an older sitting never
     overwrites a newer verdict, and an undated sitting is promoted only onto a row
-    with no verdict date to lose.
+    holding no verdict date at all.
     """
     outcome = cs.outcome_from_hearings(
         [{"case_status": phearing.case_status, "decision_type": phearing.decision_type}]
@@ -124,11 +124,27 @@ def _causelist_verdict(
     # 1900-01-01 on the hearing row (that column is NOT NULL) and that sentinel
     # must never become a verdict date.
     dated = bool(phearing.hearing_date_bs and phearing.hearing_date_ad)
-    verdict_date_ad = phearing.hearing_date_ad if dated else None
 
-    held = existing.verdict_date_ad if existing else None
-    if held is not None and (verdict_date_ad is None or verdict_date_ad < held):
-        return None
+    held_ad = existing.verdict_date_ad if existing else None
+    held_bs = existing.verdict_date_bs if existing else None
+
+    # An undated sitting must not touch a row that already holds a dated verdict:
+    # it writes verdict_type without a date, leaving this sitting's outcome beside
+    # another sitting's date. Both columns are checked because a row can hold a BS
+    # date whose AD conversion failed (bs_to_ad returns None on a date outside the
+    # calendar tables, and DQ-03 stores the pair regardless).
+    if not dated:
+        if held_ad is not None or held_bs:
+            return None
+    elif held_ad is not None:
+        if phearing.hearing_date_ad < held_ad:
+            return None
+    elif held_bs:
+        # AD is missing but BS is held, so order on BS. Safe because the stored
+        # form is canonical zero-padded ``YYYY-MM-DD`` (measured corpus-wide: zero
+        # malformed), which sorts lexicographically.
+        if phearing.hearing_date_bs < held_bs:
+            return None
 
     promoted: dict[str, object] = {
         # The court's own label for the sitting ("फैसला"), which parse_case_status
@@ -177,8 +193,14 @@ def upsert_causelist(rows: list[tuple[ParsedCase, ParsedHearing]], *, using: str
         }
         # A sitting that disposed of the case promotes its outcome onto the case
         # row — the one place the cause list may write enrichment-owned columns.
+        # Only write (and only count) when a column actually changes: the same
+        # decisive sitting is re-listed on every lookback pass, and a re-crawl that
+        # changes nothing must not report thousands of recovered verdicts.
         promoted = _causelist_verdict(phearing, existing)
-        if promoted is not None:
+        if promoted is not None and (
+            existing is None
+            or any(getattr(existing, col) != value for col, value in promoted.items())
+        ):
             listing.update(promoted)
             stats["verdicts_promoted"] += 1
         CourtCase.objects.using(using).update_or_create(

--- a/courts/scraper/crawl.py
+++ b/courts/scraper/crawl.py
@@ -20,9 +20,10 @@ class CrawlStats:
     cases: int = 0
     hearings: int = 0
     enriched: int = 0
-    #: Case rows whose verdict was promoted from a decisive sitting. Reported so a
-    #: run that recovers verdicts is distinguishable from one that only re-lists;
-    #: dry-run (write=False) always leaves this 0, since nothing is promoted.
+    #: Case rows whose verdict CHANGED because a decisive sitting was promoted onto
+    #: them. Reported so a run that recovers verdicts is distinguishable from one
+    #: that only re-lists — re-listing the same sitting counts 0, not a fresh
+    #: recovery. Dry-run (write=False) always leaves this 0: nothing is promoted.
     verdicts_promoted: int = 0
     per_date: list[str] = field(default_factory=list)
 

--- a/courts/scraper/crawl.py
+++ b/courts/scraper/crawl.py
@@ -20,6 +20,10 @@ class CrawlStats:
     cases: int = 0
     hearings: int = 0
     enriched: int = 0
+    #: Case rows whose verdict was promoted from a decisive sitting. Reported so a
+    #: run that recovers verdicts is distinguishable from one that only re-lists;
+    #: dry-run (write=False) always leaves this 0, since nothing is promoted.
+    verdicts_promoted: int = 0
     per_date: list[str] = field(default_factory=list)
 
 
@@ -69,6 +73,7 @@ def run_crawl(
                 counts = base.upsert_causelist(rows)
                 stats.cases += counts["cases"]
                 stats.hearings += counts["hearings"]
+                stats.verdicts_promoted += counts["verdicts_promoted"]
                 touched.update(c.case_number for c, _ in rows)
                 base.mark_scraped(court_id, date_bs, note=f"{len(rows)} rows")
             else:

--- a/courts/tests/test_scraper_base.py
+++ b/courts/tests/test_scraper_base.py
@@ -171,10 +171,48 @@ class CauselistVerdictPromotionTests(_NgmTestCase):
     def test_relist_of_the_same_sitting_is_idempotent(self):
         self._decided("083-CR-0008")
         before = self._row("083-CR-0008").verdict_date_ad
-        self._decided("083-CR-0008")
+        # The same sitting is re-listed on every lookback pass. The row must not
+        # change AND the run must not claim a fresh recovery, or a re-crawl reports
+        # thousands of verdicts it did not actually recover.
+        stats = self._decided("083-CR-0008")
+        self.assertEqual(stats["verdicts_promoted"], 0)
         case = self._row("083-CR-0008")
         self.assertEqual(case.verdict_type, ACQUITTED)
         self.assertEqual(case.verdict_date_ad, before)
+
+    def test_undated_sitting_spares_a_bs_only_verdict_date(self):
+        # bs_to_ad returns None for a date outside the calendar tables and DQ-03
+        # stores the pair regardless, so a row can hold BS with a NULL AD. An
+        # undated sitting must not strand this row's date beside a new outcome.
+        upsert_causelist([(_case("083-CR-0010"), _hearing("083-CR-0010"))])
+        case = self._row("083-CR-0010")
+        case.verdict_type, case.verdict_date_bs = CONVICTED, "2083-03-25"
+        case.verdict_date_ad = None
+        case.save(using="ngm")
+        stats = self._decided(
+            "083-CR-0010", date_bs="", decision="सफाई",
+            hearing_date_ad=None, serial="4",
+        )
+        self.assertEqual(stats["verdicts_promoted"], 0)
+        case.refresh_from_db()
+        self.assertEqual(case.verdict_type, CONVICTED)
+        self.assertEqual(case.verdict_date_bs, "2083-03-25")
+
+    def test_older_sitting_does_not_regress_a_bs_only_verdict_date(self):
+        # Same BS-without-AD row, but the candidate IS dated and older. Ordering
+        # falls back to the canonical zero-padded BS string.
+        upsert_causelist([(_case("083-CR-0011"), _hearing("083-CR-0011"))])
+        case = self._row("083-CR-0011")
+        case.verdict_type, case.verdict_date_bs = CONVICTED, "2083-03-25"
+        case.verdict_date_ad = None
+        case.save(using="ngm")
+        stats = self._decided(
+            "083-CR-0011", date_bs="2082-05-03", decision="सफाई",
+            hearing_date_ad=date(2025, 8, 19), serial="5",
+        )
+        self.assertEqual(stats["verdicts_promoted"], 0)
+        case.refresh_from_db()
+        self.assertEqual(case.verdict_type, CONVICTED)
 
     def test_promotion_still_unions_extra_data(self):
         # The promotion must not cost us the never-clobber rule.

--- a/courts/tests/test_scraper_base.py
+++ b/courts/tests/test_scraper_base.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from django.test import TestCase
 
-from courts.case_status import ACQUITTED
+from courts.case_status import ACQUITTED, CONVICTED, PARTIALLY_CONVICTED
 from courts.models import CaseEntity, Court, CourtCase, CourtCaseHearing, ScrapedDate
 from courts.scraper.base import (
     apply_enrichment,
@@ -29,16 +29,19 @@ def _case(cn="082-CR-0015", **extra):
 
 
 def _hearing(cn="082-CR-0015", date_bs="2082-01-05", serial="1", **kw):
+    # hearing_date_ad is overridable (via kw) so the verdict-promotion tests can
+    # pin a BS/AD pair, or drop the AD date to exercise the undated path.
     return ParsedHearing(
         case_number=cn, court_identifier="special", hearing_date_bs=date_bs,
-        hearing_date_ad=date(2025, 4, 18), serial_no=serial, **kw,
+        hearing_date_ad=kw.pop("hearing_date_ad", date(2025, 4, 18)),
+        serial_no=serial, **kw,
     )
 
 
 class CauselistUpsertTests(_NgmTestCase):
     def test_upsert_creates_case_and_hearing(self):
         stats = upsert_causelist([(_case(), _hearing(case_status="पेशी"))])
-        self.assertEqual(stats, {"cases": 1, "hearings": 1})
+        self.assertEqual(stats, {"cases": 1, "hearings": 1, "verdicts_promoted": 0})
         case = CourtCase.objects.using("ngm").get(court_id="special", case_number="082-CR-0015")
         self.assertEqual(case.case_type, "भ्रष्टाचार")
         self.assertEqual(case.extra_data["category"], "फाँट क")
@@ -72,6 +75,117 @@ class CauselistUpsertTests(_NgmTestCase):
         case.refresh_from_db()
         self.assertEqual(case.extra_data["division"], "रिट १")
         self.assertEqual(case.extra_data["new"], "x")
+
+
+class CauselistVerdictPromotionTests(_NgmTestCase):
+    """A decisive sitting must land on the CASE row, not just the hearing row.
+
+    Regression: enrichment runs once per case (crawl excludes status="enriched")
+    and is the only writer of case_status/verdict_*, so a case decided after that
+    one pass read as ongoing forever — 114 Special Court cases held a फैसला
+    hearing while their case row still said चलिरहेको.
+    """
+
+    # The real 081-CR-0111 disposing sitting: BS 2083-03-25 == AD 2026-07-09,
+    # decided सफाई. Kept a true BS/AD pair so the fixtures can't teach a wrong one.
+    _VERDICT_BS = "2083-03-25"
+    _VERDICT_AD = date(2026, 7, 9)
+
+    def _decided(self, cn, date_bs=_VERDICT_BS, decision="सफाई", **kw):
+        kw.setdefault("hearing_date_ad", self._VERDICT_AD)
+        return upsert_causelist(
+            [(_case(cn), _hearing(cn, date_bs=date_bs, case_status="फैसला",
+                                  decision_type=decision, **kw))]
+        )
+
+    def _row(self, cn):
+        return CourtCase.objects.using("ngm").get(court_id="special", case_number=cn)
+
+    def test_faisala_promotes_onto_the_case_row(self):
+        stats = self._decided("083-CR-0001")
+        self.assertEqual(stats["verdicts_promoted"], 1)
+        case = self._row("083-CR-0001")
+        self.assertEqual(case.case_status, "फैसला")
+        self.assertEqual(case.verdict_type, ACQUITTED)
+        self.assertEqual(case.verdict_date_bs, self._VERDICT_BS)
+        self.assertEqual(case.verdict_date_ad, self._VERDICT_AD)
+
+    def test_promotion_overwrites_an_ongoing_status_from_enrichment(self):
+        # The exact 081-CR-0111 shape: enriched pre-verdict, so the case row says
+        # ongoing with NULL verdicts, then the deciding sitting is listed.
+        upsert_causelist([(_case("083-CR-0002"), _hearing("083-CR-0002"))])
+        case = self._row("083-CR-0002")
+        case.case_status, case.status = "चलिरहेको", "enriched"
+        case.save(using="ngm")
+        self._decided("083-CR-0002")
+        case.refresh_from_db()
+        self.assertEqual(case.case_status, "फैसला")
+        self.assertEqual(case.verdict_type, ACQUITTED)
+
+    def test_interlocutory_sitting_promotes_nothing(self):
+        stats = upsert_causelist([
+            (_case("083-CR-0003"),
+             _hearing("083-CR-0003", case_status="आदेश", decision_type="साक्षी बुझ्ने")),
+        ])
+        self.assertEqual(stats["verdicts_promoted"], 0)
+        case = self._row("083-CR-0003")
+        self.assertIsNone(case.case_status)
+        self.assertIsNone(case.verdict_type)
+
+    def test_unrecognised_decision_is_not_guessed(self):
+        # Terminal status, but a decision_type outside the vocabulary: record
+        # nothing rather than a guess.
+        stats = self._decided("083-CR-0004", decision="कुनै अज्ञात व्यहोरा")
+        self.assertEqual(stats["verdicts_promoted"], 0)
+        self.assertIsNone(self._row("083-CR-0004").verdict_type)
+
+    def test_partial_conviction_is_not_recorded_as_full(self):
+        # आंशिक must be matched ahead of ठहर — 593 rows once carried CONVICTED
+        # when their own hearing said आंशिक ठहर.
+        self._decided("083-CR-0005", decision="आंशिक ठहर")
+        self.assertEqual(self._row("083-CR-0005").verdict_type, PARTIALLY_CONVICTED)
+
+    def test_older_relist_does_not_regress_a_newer_verdict(self):
+        # Lookbacks re-crawl historical dates, and a case can be decided, reopened
+        # and decided again. The earlier sitting must not overwrite the later one.
+        self._decided("083-CR-0006", decision="ठहर")
+        self._decided(
+            "083-CR-0006", date_bs="2082-05-03", decision="सफाई",
+            hearing_date_ad=date(2025, 8, 19), serial="2",
+        )
+        case = self._row("083-CR-0006")
+        self.assertEqual(case.verdict_type, CONVICTED)
+        self.assertEqual(case.verdict_date_bs, self._VERDICT_BS)
+
+    def test_undated_sitting_never_clobbers_a_held_verdict_date(self):
+        self._decided("083-CR-0007", decision="ठहर")
+        stats = self._decided(
+            "083-CR-0007", date_bs="", decision="सफाई",
+            hearing_date_ad=None, serial="3",
+        )
+        self.assertEqual(stats["verdicts_promoted"], 0)
+        case = self._row("083-CR-0007")
+        self.assertEqual(case.verdict_type, CONVICTED)
+        self.assertEqual(case.verdict_date_ad, self._VERDICT_AD)
+
+    def test_relist_of_the_same_sitting_is_idempotent(self):
+        self._decided("083-CR-0008")
+        before = self._row("083-CR-0008").verdict_date_ad
+        self._decided("083-CR-0008")
+        case = self._row("083-CR-0008")
+        self.assertEqual(case.verdict_type, ACQUITTED)
+        self.assertEqual(case.verdict_date_ad, before)
+
+    def test_promotion_still_unions_extra_data(self):
+        # The promotion must not cost us the never-clobber rule.
+        upsert_causelist([(_case("083-CR-0009"), _hearing("083-CR-0009"))])
+        case = self._row("083-CR-0009")
+        case.extra_data = {"category": "फाँट क", "enrichment_hearings": [{"d": "2081"}]}
+        case.save(using="ngm")
+        self._decided("083-CR-0009")
+        case.refresh_from_db()
+        self.assertEqual(case.extra_data["enrichment_hearings"], [{"d": "2081"}])
+        self.assertEqual(case.verdict_type, ACQUITTED)
 
 
 class FrontierTests(_NgmTestCase):


### PR DESCRIPTION
### **User description**
## What Niroj hit

`jawafdehi.org/courtcase/special/081-cr-0111` says the case is **चलिरहेको** although the Special Court acquitted (**सफाई**) on 2083-03-25 / 2026-07-09. As he put it, once a court has decided, that same court can't be hearing it — so the page is asserting something legally impossible.

Verified on prod:

| | value |
|---|---|
| `court_cases` row | `case_status='चलिरहेको'`, `verdict_type`/`verdict_date_bs`/`verdict_date_ad` all NULL |
| `court_case_hearings` 2083-03-25 | `case_status='फैसला'`, `decision_type='सफाई'`, scraped 2026-07-22 |
| live API | serves the stale case row verbatim |

**114 Special Court cases** are in this state — up from 105 on 2026-08-04, so it grows with every verdict.

## Why — the verdict was never missing

The daily cause list *carries* the disposition. For special it's cells 9 and 10 of the row (`फैसला` / `सफाई`, `courts/scraper/special.py:_parse_row`). And `upsert_causelist` writes the hearing row **and** upserts the parent case row in the same transaction.

It just wrote five listing fields and dropped the disposition on the floor, because `case_status`/`verdict_*` are contractually enrichment-owned. But enrichment is **one-shot** — `crawl.py` selects candidates with `.exclude(status="enriched")` — and it runs before the verdict exists. Nothing ever revisits the field. An ownership rule with a hole in it.

`backfill_case_status` can't reach these either: its hearing fallback reads `extra_data.enrichment_hearings`, frozen in that same one-shot snapshot, never the `court_case_hearings` table. And even when it fires it only writes `verdict_type`/`verdict_date_*` — never `case_status`, which is the field the page renders.

## The change

Promote the disposition at cause-list ingest, where the data is already in hand.

Classification goes through the shared `outcome_from_hearings` rather than a local substring test, so it inherits that function's guarantees:

- **terminal bucket only** — the portal writes `अन्तिम आदेश` on plainly interlocutory orders, so the status label alone isn't trusted
- **an unrecognised decision yields nothing**, not a guess
- **`आंशिक` is matched ahead of `ठहर`**, so a partial conviction is never recorded as a full one — the ordering bug that once put 593 rows in wrong

Guarded against regression on a re-list: lookbacks reach back years (BS 2070 for special) and a case can be decided, reopened on review and decided again, so an older sitting never overwrites a newer verdict, and an undated one is promoted only onto a row with no date to lose. Dates come from the parser's typed fields, never re-parsed from text, so the `NOT NULL` 1900-01-01 hearing sentinel can't become a verdict date.

`verdicts_promoted` is surfaced in `CrawlStats` and the scrape command so a run that recovers verdicts is distinguishable from one that only re-lists.

## Two things for the reviewer to weigh

1. **This applies to all four court families, not just special.** The write path is shared. District and high are trial courts using the same `आंशिक`/`सफाई`/`ठहर` vocabulary so it should be right for them, and supreme is inert (its cause-list `case_status` is NULL, so nothing hits the terminal set). Say so if you'd rather gate it to `special` for a first run.
2. **`case_status` is written as the court's own label**, bare `फैसला`, which `parse_case_status` reads as `DECIDED`. I did not synthesise the paren form (`फैसला (२०८३/०३/२५)`) that ~465k existing rows carry — the typed columns hold the structured date, and inventing a new spelling of that format seemed worse than not writing it. Easy to change if you'd rather match the corpus.

## Not in this PR

The existing 114 still need a backfill, and it has to read the hearings **table**. Happy to follow up; it writes prod so it wants a Job and a separate review.

Also unaddressed, and arguably the worse public exposure: the Jawafdehi case `ntc-081-cr-0111-82b9028f` still has `case_end_date=null` and all 19 accused at `outcome: charged` six weeks after a full acquittal. That's the `case-badges.ts` / `case_end_date` derivation, and Jawafdehi#281 (the progress rail) is still unmerged.

## Testing

9 new DB tests in `courts/tests/test_scraper_base.py` covering the promotion, the ongoing→decided overwrite in the exact 081-CR-0111 shape, interlocutory sittings, unrecognised decisions, `आंशिक ठहर`, the older-re-list and undated regression guards, idempotence, and that the `extra_data` never-clobber rule still holds. Full `courts/` suite green (564 passed), `ruff check .` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Promote cause-list verdicts

- Prevent older verdict regression

- Report promoted verdict counts

- Cover verdict promotion paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cause-list hearing"] -- "classify outcome" --> B["Verdict promotion"]
  B -- "update if non-regressive" --> C["CourtCase row"]
  C -- "count" --> D["Crawl stats"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Promote verdicts during cause-list upsert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/scraper/base.py

<ul><li>Adds <code>_causelist_verdict</code>.<br> <li> Promotes decisive hearings to <code>case_status</code>/<code>verdict_*</code>.<br> <li> Blocks unknown, interlocutory, older, undated regressions.<br> <li> Tracks <code>verdicts_promoted</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/459/files#diff-ffb586961a49ecdc9cac23b5eeaedf6682373e6ccde407cf3e5f2b32213ccd47">+72/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crawl.py</strong><dd><code>Add verdict promotion crawl statistics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/scraper/crawl.py

<ul><li>Adds <code>verdicts_promoted</code> to <code>CrawlStats</code>.<br> <li> Accumulates promotion counts from <code>upsert_causelist</code>.<br> <li> Keeps dry-run promotions at zero.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/459/files#diff-930209ea5655fb546bc6bc3fda4e0349668aba8d98e14fbd42d760c26b1ec995">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scrape_courtcases.py</strong><dd><code>Display promoted verdict count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/management/commands/scrape_courtcases.py

<ul><li>Prints <code>verdicts_promoted</code> in scrape summary.<br> <li> Surfaces recovered verdict activity in CLI output.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/459/files#diff-7ff9b2ff8f284ece2d75f153cc7512526f3b7654e1e1021afed0df64ae90229d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scraper_base.py</strong><dd><code>Test cause-list verdict promotion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_scraper_base.py

<ul><li>Updates expected upsert stats shape.<br> <li> Adds decisive verdict promotion tests.<br> <li> Covers ongoing overwrite, idempotency, non-regression.<br> <li> Verifies extra-data union preserved.</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/459/files#diff-eb0e22d4d8a9aa00bb0a071a665a9a2d2e477caed79f55e7859ccac5e2acb3b3">+117/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

model: openai/cx/gpt-5.5
git_provider: github
custom_reasoning_model: False
output_relevant_configurations: True
custom_model_max_tokens: 200000
fallback_models: ['openai/cx/gpt-5.4-mini']
ENABLE_AUTO_APPROVAL: True
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Case records now automatically reflect decisive hearing outcomes, including full and partial convictions.
  * Newer verdict information is preserved, while outdated, undated, or non-terminal outcomes are not promoted.
* **Improvements**
  * Crawl summaries now report how many verdicts were promoted.
  * Verdict updates remain consistent when records are enriched or processed repeatedly.
  * Re-running crawls avoids reporting duplicate promotions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->