### PR TITLE
feat(courts): backfill the verdicts stranded on hearing rows

### DIFF
--- a/courts/case_status.py
+++ b/courts/case_status.py
@@ -334,7 +334,13 @@ _APPELLATE_REFERRAL = frozenset({
 
 #: ``status`` values that MIGHT be terminal — a necessary condition, never a
 #: sufficient one (see the note above). ``order_type`` decides.
-_HEARING_TERMINAL_STATUSES = ("फैसला", "अन्तिम आदेश")
+#:
+#: Public because it is also the candidate FILTER for the hearing-verdict backfill:
+#: a hearing whose status is outside this set can never dispose of a case, so it
+#: never needs loading. Selecting on it is an optimisation, not a decision —
+#: :func:`outcome_from_hearings` still re-checks it and still requires a
+#: classifiable ``decision_type``.
+HEARING_TERMINAL_STATUSES = ("फैसला", "अन्तिम आदेश")
 
 _DECIDED_MARKERS = ("फैसला", "अन्तिम आदेश", "आदेश")
 
@@ -540,7 +546,7 @@ def outcome_from_hearings(hearings) -> HearingOutcome | None:
         if not isinstance(hearing, dict):
             continue
         status = _ws(hearing.get("case_status") or hearing.get("status"))
-        if status not in _HEARING_TERMINAL_STATUSES:
+        if status not in HEARING_TERMINAL_STATUSES:
             continue
         raw = hearing.get("decision_type") or hearing.get("order_type") or ""
         bucket, verdict = classify_order_type(raw)

--- a/courts/management/commands/promote_hearing_verdicts.py
+++ b/courts/management/commands/promote_hearing_verdicts.py
@@ -1,0 +1,310 @@
+"""Promote a decisive HEARING's verdict onto the case row it belongs to.
+
+The companion backfill to the write-path fix in #459. That PR made
+``upsert_causelist`` promote a disposing sitting onto the parent case row as the
+cause list is ingested, which stops the drift going forward. It cannot repair
+what already drifted: those cause-list dates are in the past, and re-crawling
+them would mean re-fetching years of portal pages for data we already hold.
+
+**The bug this repairs.** Enrichment is one-shot — ``courts.scraper.crawl``
+selects candidates with ``.exclude(status="enriched")`` — and before #459 it was
+the only writer of ``case_status``/``verdict_*``. A case first detail-scraped
+BEFORE it was decided therefore kept ``case_status='चलिरहेको'`` with NULL verdict
+columns permanently, while the listing scraper kept appending hearing rows. The
+verdict was never missing from the database; it was only ever missing from the
+case row. Measured on prod 2026-08-20: **114 Special Court cases**, up from 105 on
+2026-08-04, so the set grew with every verdict until #459 landed. Their
+dispositions are सफाई 46, आंशिक ठहर 37, ठहर 27, खारेज 3, and one with a NULL
+``decision_type`` that is deliberately left alone.
+
+``backfill_case_status`` cannot reach these. Its hearing fallback reads
+``extra_data.enrichment_hearings``, which is frozen in that same one-shot
+enrichment snapshot, never the ``court_case_hearings`` TABLE — and even when it
+does fire it only writes ``verdict_type``/``verdict_date_*``, never
+``case_status``, which is the field the public docket page renders. Hence a
+separate command rather than another DQ rule bolted onto that one.
+
+**What it writes, and what it refuses to.** Conservative by construction: it
+FILLS gaps and corrects a contradiction, it does not restate the record.
+
+- ``verdict_type`` — only when currently NULL.
+- ``verdict_date_bs``/``verdict_date_ad`` — only when ``verdict_date_bs`` is NULL,
+  and only as a pair. Same "never overwrite a date already present" rule as
+  ``backfill_case_status`` DQ-03.
+- ``case_status`` — replaced by the disposing sitting's own label ONLY when the
+  stored value does not already parse as DECIDED. So ``चलिरहेको`` is corrected and
+  an existing ``फैसला (२०८३/०३/२५)`` is left exactly as it is.
+
+Classification is :func:`courts.case_status.outcome_from_hearings` — the same
+function the write path uses — so this inherits its guarantees rather than
+re-deriving them: terminal bucket only (the portal writes ``अन्तिम आदेश`` on
+plainly interlocutory orders), an unrecognised ``decision_type`` yields nothing
+rather than a guess, ``आंशिक`` is matched ahead of ``ठहर`` so a partial conviction
+is never recorded as a full one, and where a case was decided, reopened on review
+and decided again the LAST disposing sitting wins. Hearings are therefore fed in
+ascending date order, which is what makes "last" mean "latest".
+
+SAFETY: dry-run by default. It never writes unless BOTH ``--execute`` and
+``--i-understand-this-writes-prod`` are passed. Prints a projection tally either
+way, so the dry run is the review artifact.
+
+    manage.py promote_hearing_verdicts --court special
+    manage.py promote_hearing_verdicts --court special --case 081-CR-0111
+    manage.py promote_hearing_verdicts --court special --execute --i-understand-this-writes-prod
+
+Like ``backfill_case_status`` this writes via ``bulk_update``, which emits plain
+UPDATEs and so bypasses ``post_save`` — the live OpenSearch upsert and the
+auditlog entry do NOT fire. ``updated_at`` is bumped on every changed row, so
+follow a real run with ``reindex_courtcases --since`` to re-index exactly the rows
+touched.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from courts import case_status as cs
+from courts.models import CourtCase, CourtCaseHearing
+
+NGM_DB = "ngm"
+
+# Mirrors backfill_case_status: bounds each UPDATE's CASE body while still
+# collapsing thousands of round-trips into a handful.
+_WRITE_BATCH_SIZE = 500
+
+
+def compute_promotion(
+    case: CourtCase, hearings: list[dict]
+) -> tuple[dict[str, object], cs.HearingOutcome | None]:
+    """``(column_updates, outcome)`` promoting ``hearings``' disposition onto ``case``.
+
+    Pure — no DB access. An empty dict means nothing to do, and the returned
+    ``outcome`` says which kind of nothing: ``None`` for "no sitting disposed of
+    this case" (so it is not a candidate at all), non-``None`` for "the row already
+    records what the hearings say" — which is what makes a second pass change zero
+    rows.
+
+    ``hearings`` must be in ASCENDING date order: ``outcome_from_hearings`` keeps
+    the last disposing sitting, and "last" is only "latest" if the input is sorted.
+    """
+    outcome = cs.outcome_from_hearings(hearings)
+    if outcome is None:
+        return {}, None
+
+    updates: dict[str, object] = {}
+
+    # Fill a missing outcome; never restate or overwrite one already recorded.
+    if not case.verdict_type:
+        updates["verdict_type"] = outcome.verdict_type
+
+    # Dates come from the disposing sitting, as a pair, and only into a gap. Note
+    # these are the dates outcome_from_hearings derived from the sitting's BS
+    # string — NOT the stored hearing_date_ad, which carries a 1900-01-01 sentinel
+    # when a BS date would not convert (that column is NOT NULL).
+    if not case.verdict_date_bs and outcome.verdict_date_bs:
+        updates["verdict_date_bs"] = outcome.verdict_date_bs
+        updates["verdict_date_ad"] = outcome.verdict_date_ad
+
+    # The contradiction this command exists for: a decided case whose case_status
+    # still reads as pending/unknown. Correct it to the sitting's own label, but
+    # leave a status that already parses as DECIDED completely alone.
+    parsed = cs.parse_case_status(case.case_status)
+    if parsed.lifecycle_status != cs.DECIDED:
+        decisive = _decisive_label(hearings)
+        if decisive and decisive != case.case_status:
+            updates["case_status"] = decisive
+
+    return updates, outcome
+
+
+def _decisive_label(hearings: list[dict]) -> str | None:
+    """The ``case_status`` label of the LAST sitting that could have disposed.
+
+    Kept in step with :func:`courts.case_status.outcome_from_hearings` by walking
+    the same list in the same direction and keeping the last match.
+    """
+    label = None
+    for hearing in hearings:
+        status = " ".join(str(hearing.get("case_status") or "").split())
+        if status in cs.HEARING_TERMINAL_STATUSES:
+            label = status
+    return label
+
+
+def _candidate_case_numbers(court: str, *, using: str = NGM_DB) -> list[str]:
+    """Case numbers in ``court`` holding at least one possibly-terminal sitting.
+
+    A pre-filter, not a decision: a sitting outside
+    :data:`~courts.case_status.HEARING_TERMINAL_STATUSES` can never dispose of a
+    case, so its case never needs loading. Keeps the scan proportional to decided
+    cases (3,084 for special) instead of the court's whole docket (13,165).
+    """
+    return sorted(
+        set(
+            CourtCaseHearing.objects.using(using)
+            .filter(court_id=court, case_status__in=cs.HEARING_TERMINAL_STATUSES)
+            .values_list("case_number", flat=True)
+        )
+    )
+
+
+def _hearings_by_case(
+    court: str, case_numbers: list[str], *, using: str = NGM_DB
+) -> dict[str, list[dict]]:
+    """All hearings for ``case_numbers``, ascending by date, as classifier dicts.
+
+    ALL hearings are loaded, not just the terminal-looking ones, because a case can
+    be decided, reopened on review and decided again — the classifier needs the
+    full sequence to land on the operative disposition.
+
+    ``hearing_date`` carries the BS string so the shared classifier derives the
+    BS/AD pair through its own path, ignoring the stored ``hearing_date_ad`` and
+    its 1900-01-01 sentinel.
+    """
+    grouped: dict[str, list[dict]] = {}
+    rows = (
+        CourtCaseHearing.objects.using(using)
+        .filter(court_id=court, case_number__in=case_numbers)
+        .order_by("case_number", "hearing_date_ad", "id")
+        .values_list("case_number", "case_status", "decision_type", "hearing_date_bs")
+    )
+    for case_number, status, decision, date_bs in rows:
+        grouped.setdefault(case_number, []).append(
+            {"case_status": status, "decision_type": decision, "hearing_date": date_bs}
+        )
+    return grouped
+
+
+def run_promotion(
+    *, court: str, only: list[str] | None = None, batch_size: int = 500,
+    limit: int | None = None, execute: bool = False, using: str = NGM_DB, on_batch=None,
+) -> dict[str, int]:
+    """Scan ``court``'s decided cases, tally (and optionally apply) promotions."""
+    stats = {
+        "candidates": 0,
+        "scanned": 0,
+        "rows_changed": 0,
+        "case_status_fixed": 0,
+        "verdict_type_set": 0,
+        "verdict_date_set": 0,
+        "no_classifiable_outcome": 0,
+    }
+
+    candidates = sorted(set(only)) if only else _candidate_case_numbers(court, using=using)
+    stats["candidates"] = len(candidates)
+    if limit:
+        candidates = candidates[:limit]
+
+    for start in range(0, len(candidates), batch_size):
+        page = candidates[start : start + batch_size]
+        hearings = _hearings_by_case(court, page, using=using)
+        cases = list(
+            CourtCase.objects.using(using)
+            .filter(court_id=court, case_number__in=page)
+            .only(
+                "case_number", "court", "case_status", "verdict_type",
+                "verdict_date_bs", "verdict_date_ad",
+            )
+        )
+
+        # Bucketed by exact changed-column set so each write touches only the
+        # columns it derived — a concurrent scraper write on an untouched column
+        # cannot be clobbered by our stale read.
+        changed: dict[tuple[str, ...], list[CourtCase]] = {}
+        for case in cases:
+            stats["scanned"] += 1
+            rows = hearings.get(case.case_number) or []
+            updates, outcome = compute_promotion(case, rows)
+            if not updates:
+                # No disposition at all (a terminal-looking status whose
+                # decision_type is NULL or outside the vocabulary) vs. already
+                # correct. Only the former is a coverage gap worth reporting.
+                if outcome is None:
+                    stats["no_classifiable_outcome"] += 1
+                continue
+
+            stats["rows_changed"] += 1
+            if "case_status" in updates:
+                stats["case_status_fixed"] += 1
+            if "verdict_type" in updates:
+                stats["verdict_type_set"] += 1
+            if "verdict_date_bs" in updates:
+                stats["verdict_date_set"] += 1
+            for key, value in updates.items():
+                setattr(case, key, value)
+            case.updated_at = timezone.now()
+            changed.setdefault(tuple(sorted(updates)), []).append(case)
+
+        if execute and changed:
+            for group_fields, group in changed.items():
+                CourtCase.objects.using(using).bulk_update(
+                    group, [*group_fields, "updated_at"], batch_size=_WRITE_BATCH_SIZE,
+                )
+
+        if on_batch is not None:
+            on_batch(stats)
+
+    return stats
+
+
+class Command(BaseCommand):
+    help = (
+        "Promote a decisive hearing's verdict onto its case row, for cases decided "
+        "after their one-shot enrichment (dry-run by default)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--court", default="special",
+                            help="court_identifier to scan (default: special).")
+        parser.add_argument("--case", action="append", dest="cases", default=None,
+                            help="limit to these case numbers (repeatable); for smoke tests.")
+        parser.add_argument("--batch-size", type=int, default=500,
+                            help="cases per page (default 500).")
+        parser.add_argument("--limit", type=int, default=None,
+                            help="stop after N candidate cases (smoke tests).")
+        parser.add_argument("--execute", action="store_true",
+                            help="apply changes (default: dry-run, no writes).")
+        parser.add_argument("--i-understand-this-writes-prod", action="store_true",
+                            dest="confirm",
+                            help="required second flag to actually write.")
+
+    def handle(self, *args, **o):
+        execute = o["execute"]
+        if execute and not o["confirm"]:
+            raise CommandError(
+                "Refusing to write: pass --i-understand-this-writes-prod "
+                "alongside --execute."
+            )
+
+        mode = "APPLIED" if execute else "DRY-RUN (no writes)"
+        court = o["court"]
+        self.stdout.write(
+            f"promote_hearing_verdicts [{mode}] db={NGM_DB} court={court}"
+        )
+
+        printed = [0]
+
+        def _progress(stats):
+            if stats["scanned"] - printed[0] >= 2_000:
+                printed[0] = stats["scanned"]
+                self.stdout.write(
+                    f"  … scanned={stats['scanned']:,} changed={stats['rows_changed']:,}"
+                )
+
+        stats = run_promotion(
+            court=court, only=o["cases"], batch_size=o["batch_size"],
+            limit=o["limit"], execute=execute, on_batch=_progress,
+        )
+
+        self.stdout.write(self.style.SUCCESS(f"\n=== promote_hearing_verdicts {mode} ==="))
+        for key in (
+            "candidates", "scanned", "rows_changed", "case_status_fixed",
+            "verdict_type_set", "verdict_date_set", "no_classifiable_outcome",
+        ):
+            self.stdout.write(f"  {key:24s}: {stats[key]:,}")
+        if execute and stats["rows_changed"]:
+            self.stdout.write(
+                "\nbulk_update bypasses post_save: run "
+                "`reindex_courtcases --since <today>` to re-index the changed rows."
+            )

--- a/courts/tests/test_promote_hearing_verdicts.py
+++ b/courts/tests/test_promote_hearing_verdicts.py
@@ -1,0 +1,230 @@
+"""Tests for the promote_hearing_verdicts backfill.
+
+Repairs cases decided AFTER their one-shot enrichment: the verdict sits on a
+``court_case_hearings`` row while the case row still reads ``चलिरहेको`` with NULL
+verdict columns. Companion to the write-path fix in #459, which stops new drift
+but cannot repair the 114 Special Court cases already in that state.
+"""
+
+from datetime import date
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from django.utils import timezone
+
+from courts.case_status import (
+    ACQUITTED,
+    CLAIM_DENIED,
+    CONVICTED,
+    PARTIALLY_CONVICTED,
+)
+from courts.management.commands.promote_hearing_verdicts import run_promotion
+from courts.models import Court, CourtCase, CourtCaseHearing
+
+# The real 081-CR-0111 disposing sitting: BS 2083-03-25 == AD 2026-07-09, सफाई.
+VERDICT_BS = "2083-03-25"
+VERDICT_AD = date(2026, 7, 9)
+
+
+class _Ngm(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        Court.objects.using("ngm").get_or_create(
+            identifier="special",
+            defaults={"court_type": "special", "full_name_nepali": "विशेष अदालत"},
+        )
+
+    def _case(self, cn, *, case_status="चलिरहेको", **kw):
+        return CourtCase.objects.using("ngm").create(
+            court_id="special", case_number=cn, case_status=case_status,
+            status="enriched", **kw,
+        )
+
+    def _hearing(self, cn, date_bs, date_ad, status, decision, serial="1"):
+        return CourtCaseHearing.objects.using("ngm").create(
+            court_id="special", case_number=cn, hearing_date_bs=date_bs,
+            hearing_date_ad=date_ad, serial_no=serial, case_status=status,
+            decision_type=decision, scraped_at=timezone.now(),
+        )
+
+    def _decided(self, cn, *, decision="सफाई", case_status="चलिरहेको", **kw):
+        """The canonical broken shape: ongoing case row, disposing hearing."""
+        case = self._case(cn, case_status=case_status, **kw)
+        self._hearing(cn, "2082-05-03", date(2025, 8, 19), "आदेश", "थुनछेक आदेश (धरौटी)")
+        self._hearing(cn, VERDICT_BS, VERDICT_AD, "फैसला", decision, serial="2")
+        return case
+
+    def _run(self, **kw):
+        return run_promotion(court="special", **kw)
+
+    def _row(self, cn):
+        return CourtCase.objects.using("ngm").get(court_id="special", case_number=cn)
+
+
+class PromotionTests(_Ngm):
+    def test_promotes_verdict_and_corrects_the_ongoing_status(self):
+        self._decided("081-CR-0111")
+        stats = self._run(execute=True)
+        self.assertEqual(stats["rows_changed"], 1)
+        self.assertEqual(stats["case_status_fixed"], 1)
+        self.assertEqual(stats["verdict_type_set"], 1)
+        self.assertEqual(stats["verdict_date_set"], 1)
+        case = self._row("081-CR-0111")
+        self.assertEqual(case.case_status, "फैसला")
+        self.assertEqual(case.verdict_type, ACQUITTED)
+        self.assertEqual(case.verdict_date_bs, VERDICT_BS)
+        self.assertEqual(case.verdict_date_ad, VERDICT_AD)
+
+    def test_dry_run_writes_nothing_but_still_projects(self):
+        self._decided("081-CR-0112")
+        stats = self._run()
+        self.assertEqual(stats["rows_changed"], 1)
+        case = self._row("081-CR-0112")
+        self.assertEqual(case.case_status, "चलिरहेको")
+        self.assertIsNone(case.verdict_type)
+
+    def test_second_pass_changes_nothing(self):
+        self._decided("081-CR-0113")
+        self._run(execute=True)
+        before = self._row("081-CR-0113").updated_at
+        stats = self._run(execute=True)
+        self.assertEqual(stats["rows_changed"], 0)
+        self.assertEqual(self._row("081-CR-0113").updated_at, before)
+
+    def test_each_disposition_maps_through_the_shared_vocabulary(self):
+        # The four dispositions behind the 114: सफाई 46, आंशिक ठहर 37, ठहर 27,
+        # खारेज 3. आंशिक must beat ठहर or a partial conviction becomes a full one.
+        for cn, decision, expected in (
+            ("082-CR-0001", "सफाई", ACQUITTED),
+            ("082-CR-0002", "आंशिक ठहर", PARTIALLY_CONVICTED),
+            ("082-CR-0003", "ठहर", CONVICTED),
+            ("082-CR-0004", "खारेज", CLAIM_DENIED),
+        ):
+            with self.subTest(decision=decision):
+                self._decided(cn, decision=decision)
+        self._run(execute=True)
+        for cn, _, expected in (
+            ("082-CR-0001", "सफाई", ACQUITTED),
+            ("082-CR-0002", "आंशिक ठहर", PARTIALLY_CONVICTED),
+            ("082-CR-0003", "ठहर", CONVICTED),
+            ("082-CR-0004", "खारेज", CLAIM_DENIED),
+        ):
+            self.assertEqual(self._row(cn).verdict_type, expected, cn)
+
+    def test_null_decision_is_left_alone_and_reported(self):
+        # One of the 114 has a NULL decision_type. Record nothing, report it as a
+        # coverage gap rather than guessing from the फैसला label alone.
+        self._decided("082-CR-0005", decision=None)
+        stats = self._run(execute=True)
+        self.assertEqual(stats["rows_changed"], 0)
+        self.assertEqual(stats["no_classifiable_outcome"], 1)
+        case = self._row("082-CR-0005")
+        self.assertEqual(case.case_status, "चलिरहेको")
+        self.assertIsNone(case.verdict_type)
+
+    def test_interlocutory_only_case_is_not_a_candidate(self):
+        self._case("082-CR-0006")
+        self._hearing("082-CR-0006", "2082-05-03", date(2025, 8, 19), "आदेश", "साक्षी बुझ्ने")
+        stats = self._run(execute=True)
+        self.assertEqual(stats["candidates"], 0)
+        self.assertEqual(self._row("082-CR-0006").case_status, "चलिरहेको")
+
+    def test_antim_adesh_with_an_interlocutory_order_promotes_nothing(self):
+        # The portal writes अन्तिम आदेश on plainly interlocutory orders, so the
+        # status label alone must never be treated as a disposition.
+        self._case("082-CR-0007")
+        self._hearing(
+            "082-CR-0007", VERDICT_BS, VERDICT_AD, "अन्तिम आदेश",
+            "कैफियत प्रतिवेदन माग्ने",
+        )
+        stats = self._run(execute=True)
+        self.assertEqual(stats["candidates"], 1)
+        self.assertEqual(stats["rows_changed"], 0)
+        self.assertIsNone(self._row("082-CR-0007").verdict_type)
+
+
+class NeverClobberTests(_Ngm):
+    def test_an_existing_decided_status_is_left_verbatim(self):
+        # ~2,970 special cases already carry the paren form. The command must not
+        # rewrite them to a bare label.
+        self._decided("082-CR-0010", case_status="फैसला (२०८३/०३/२५)")
+        stats = self._run(execute=True)
+        self.assertEqual(stats["case_status_fixed"], 0)
+        self.assertEqual(self._row("082-CR-0010").case_status, "फैसला (२०८३/०३/२५)")
+
+    def test_an_existing_verdict_type_is_never_overwritten(self):
+        self._decided("082-CR-0011", decision="सफाई", verdict_type=CONVICTED)
+        self._run(execute=True)
+        case = self._row("082-CR-0011")
+        self.assertEqual(case.verdict_type, CONVICTED)  # preserved
+        self.assertEqual(case.verdict_date_bs, VERDICT_BS)  # gap still filled
+
+    def test_an_existing_verdict_date_is_never_overwritten(self):
+        self._decided(
+            "082-CR-0012", verdict_date_bs="2080-01-01", verdict_date_ad=date(2023, 4, 14),
+        )
+        self._run(execute=True)
+        case = self._row("082-CR-0012")
+        self.assertEqual(case.verdict_date_bs, "2080-01-01")
+        self.assertEqual(case.verdict_date_ad, date(2023, 4, 14))
+        self.assertEqual(case.verdict_type, ACQUITTED)  # gap still filled
+
+    def test_last_disposing_sitting_wins_on_a_reopened_case(self):
+        # Decided, reopened on review, decided again — only the latest is operative.
+        case = self._case("082-CR-0013")
+        self._hearing(case.case_number, "2081-05-05", date(2024, 8, 20), "फैसला", "सफाई")
+        self._hearing(
+            case.case_number, VERDICT_BS, VERDICT_AD, "फैसला", "ठहर", serial="2",
+        )
+        self._run(execute=True)
+        row = self._row("082-CR-0013")
+        self.assertEqual(row.verdict_type, CONVICTED)
+        self.assertEqual(row.verdict_date_bs, VERDICT_BS)
+
+
+class ScopingAndSafetyTests(_Ngm):
+    def test_case_flag_scopes_to_one_docket(self):
+        self._decided("082-CR-0020")
+        self._decided("082-CR-0021")
+        stats = self._run(only=["082-CR-0020"], execute=True)
+        self.assertEqual(stats["candidates"], 1)
+        self.assertEqual(self._row("082-CR-0020").verdict_type, ACQUITTED)
+        self.assertIsNone(self._row("082-CR-0021").verdict_type)
+
+    def test_execute_without_the_confirm_flag_refuses(self):
+        with self.assertRaises(CommandError):
+            call_command("promote_hearing_verdicts", "--court", "special", "--execute")
+
+    def test_command_dry_run_is_the_default(self):
+        self._decided("082-CR-0022")
+        call_command("promote_hearing_verdicts", "--court", "special", verbosity=0)
+        self.assertIsNone(self._row("082-CR-0022").verdict_type)
+
+    def test_command_applies_with_both_flags(self):
+        self._decided("082-CR-0023")
+        call_command(
+            "promote_hearing_verdicts", "--court", "special", "--execute",
+            "--i-understand-this-writes-prod", verbosity=0,
+        )
+        self.assertEqual(self._row("082-CR-0023").verdict_type, ACQUITTED)
+
+    def test_another_court_is_untouched(self):
+        Court.objects.using("ngm").get_or_create(
+            identifier="patanhc",
+            defaults={"court_type": "high", "full_name_nepali": "पाटन"},
+        )
+        CourtCase.objects.using("ngm").create(
+            court_id="patanhc", case_number="082-CR-0030", case_status="चलिरहेको",
+        )
+        CourtCaseHearing.objects.using("ngm").create(
+            court_id="patanhc", case_number="082-CR-0030", hearing_date_bs=VERDICT_BS,
+            hearing_date_ad=VERDICT_AD, serial_no="1", case_status="फैसला",
+            decision_type="सफाई", scraped_at=timezone.now(),
+        )
+        self._run(execute=True)
+        other = CourtCase.objects.using("ngm").get(
+            court_id="patanhc", case_number="082-CR-0030"
+        )
+        self.assertIsNone(other.verdict_type)


### PR DESCRIPTION
### **User description**
Follow-up to #459. That PR fixed the write path — a decisive cause-list sitting now promotes onto the parent case row as it's ingested — but it can't repair the cases that already drifted, because their cause-list dates are in the past. Re-crawling them would mean re-fetching years of portal pages for data we already hold.

## Why not `backfill_case_status`

It can't reach these rows. Its hearing fallback reads `extra_data.enrichment_hearings` — frozen in the very one-shot enrichment snapshot that caused the bug — never the `court_case_hearings` table. And even when it does fire it only writes `verdict_type`/`verdict_date_*`, never `case_status`, which is the field the public docket page renders.

## What it writes, and what it refuses to

Conservative by construction — it fills gaps and corrects one contradiction, it does not restate the record.

| column | rule |
|---|---|
| `verdict_type` | only when currently NULL |
| `verdict_date_bs` / `_ad` | only when `verdict_date_bs` is NULL, and only as a pair |
| `case_status` | replaced by the disposing sitting's own label **only** when the stored value doesn't already parse as `DECIDED` |

So `चलिरहेको` is corrected, and an existing `फैसला (२०८३/०३/२५)` is left verbatim — that last rule matters because ~2,970 special cases already carry the paren form and must not be rewritten to a bare label.

Classification is the shared `outcome_from_hearings`, so this inherits its guarantees rather than re-deriving them: terminal bucket only, an unrecognised `decision_type` yields nothing rather than a guess, `आंशिक` beats `ठहर`, and the **last** disposing sitting wins where a case was decided, reopened on review and decided again. Hearings are fed in ascending date order, which is what makes "last" mean "latest".

## Projection against the real 114

I pulled the actual rows off prod and ran them through this classifier rather than trusting the tests alone:

- **113 change** — सफाई 46, आंशिक ठहर 37, ठहर 27, खारेज 3
- **1 left alone** — `072-OA-0112`, whose `decision_type` is NULL. Reported as `no_classifiable_outcome`, not guessed from the `फैसला` label
- all 114 currently have `verdict_type` and `verdict_date_bs` NULL, so nothing here is an overwrite

Two edge cases I checked specifically:

- `081-CR-0058` has `hearing_date_bs=2083-03-32`. Day 32 is legitimate in some BS months, and it converts to 2026-07-16 → `CONVICTED` — which matches an independent spot-check of that docket from 2026-08-04.
- The most recent verdicts (`2083-05-03` → 2026-08-19) convert fine, so nothing is lost at the leading edge.

## Deployment sequence

This can't be dry-run against prod until it's merged and deployed — the command doesn't exist in the running image. Once it is:

1. `promote_hearing_verdicts --court special` — dry run, confirm 113/1
2. same with `--execute --i-understand-this-writes-prod`, as a **Job** not `kubectl exec`
3. `reindex_courtcases --since <today>` — `bulk_update` emits plain UPDATEs, so `post_save` never fires and the OpenSearch upsert is skipped. `updated_at` is bumped on every changed row precisely so this picks up exactly what was touched.

`--court` defaults to `special`; `--case` scopes to individual dockets for a smoke test on `081-CR-0111` first if you'd prefer.

## Testing

16 tests + 4 subtests in `courts/tests/test_promote_hearing_verdicts.py`: each of the four dispositions, the NULL-decision case, interlocutory-only cases not being candidates, `अन्तिम आदेश` with an interlocutory order promoting nothing, all three never-clobber rules, last-sitting-wins on a reopened case, court scoping, dry-run default, and the two-flag write guard. Full `courts/` suite green (582 passed), `ruff check .` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add hearing verdict promotion backfill

- Reuse shared outcome classification

- Guard writes with dry-run confirmation

- Cover promotion, safety, scoping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CourtCaseHearing rows"] -- "filter terminal statuses" --> B["promotion scanner"]
  B -- "classify outcomes" --> C["case row updates"]
  C -- "bulk_update when confirmed" --> D["CourtCase verdict fields"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>case_status.py</strong><dd><code>Expose terminal hearing statuses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/case_status.py

<ul><li>Exposes <code>HEARING_TERMINAL_STATUSES</code><br> <li> Documents candidate-filter purpose<br> <li> Updates classifier reference</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/460/files#diff-8bf1463436bf52616a4c94fcc833984531ee8ca5f1f864322fbdb345eee6a5aa">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>promote_hearing_verdicts.py</strong><dd><code>Promote hearing verdicts onto cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/management/commands/promote_hearing_verdicts.py

<ul><li>Adds dry-run default backfill command<br> <li> Promotes decisive hearing outcomes to cases<br> <li> Fills missing verdict fields conservatively<br> <li> Requires double confirmation for writes</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/460/files#diff-5db3b6fe61eee050d514fb1f622622546c906b2abf051724593f740d713f7f47">+310/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_promote_hearing_verdicts.py</strong><dd><code>Cover hearing verdict backfill behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

courts/tests/test_promote_hearing_verdicts.py

<ul><li>Tests verdict promotion paths<br> <li> Verifies non-clobbering rules<br> <li> Covers dry-run and confirmation safety<br> <li> Checks court and case scoping</ul>


</details>


  </td>
  <td><a href="https://github.com/Jawafdehi/JawafdehiAPI/pull/460/files#diff-357f35436cec2c95c6244ecca31b43d0351a84a1d22b64a68249bea9332acf15">+230/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

model: openai/cx/gpt-5.5
git_provider: github
custom_reasoning_model: False
output_relevant_configurations: True
custom_model_max_tokens: 200000
fallback_models: ['openai/cx/gpt-5.4-mini']
ENABLE_AUTO_APPROVAL: True
is_auto_command: True
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
extra_config_url: 
disable_auto_feedback: False
ai_timeout: 120
response_language: en-US
repo_context_files: ['AGENTS.md']
repo_context_from_default_branch: True
repo_context_max_lines: 500
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto', '^Bump ', '^chore\\(deps\\)']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
restricted_mode: False
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
claude_extended_thinking_models_override: []
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: True
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
